### PR TITLE
Change copyWithZone: method signatures to return id

### DIFF
--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLProtocolHeader.h
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLProtocolHeader.h
@@ -43,7 +43,6 @@ typedef NS_ENUM(UInt8, SDLFrameData) {
 @property (assign) UInt32 bytesInPayload;
 
 - (instancetype)init;
-- (instancetype)copyWithZone:(NSZone *)zone;
 - (NSData *)data;
 - (void)parse:(NSData *)data;
 - (NSString *)description;

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLProtocolHeader.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLProtocolHeader.m
@@ -19,7 +19,7 @@
 	return self;
 }
 
-- (instancetype)copyWithZone:(NSZone *)zone {
+- (id)copyWithZone:(NSZone *)zone {
     [self doesNotRecognizeSelector:_cmd];
     return 0;
 }

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLV1ProtocolHeader.h
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLV1ProtocolHeader.h
@@ -8,7 +8,6 @@
 
 - (instancetype)init;
 - (NSData *)data;
-- (instancetype)copyWithZone:(NSZone *)zone;
 - (void)parse:(NSData *)data;
 - (NSString *)description;
 

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLV1ProtocolHeader.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLV1ProtocolHeader.m
@@ -39,7 +39,7 @@ const int V1PROTOCOL_HEADERSIZE = 8;
     return dataOut;
 }
 
-- (instancetype)copyWithZone:(NSZone *)zone
+- (id)copyWithZone:(NSZone *)zone
 {
     SDLV1ProtocolHeader *newHeader = [[SDLV1ProtocolHeader allocWithZone: zone] init];
     newHeader.compressed = self.compressed;

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLV2ProtocolHeader.h
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLV2ProtocolHeader.h
@@ -9,7 +9,6 @@
 @property (assign) UInt32 messageID;
 
 - (instancetype)init;
-- (instancetype)copyWithZone:(NSZone *)zone;
 - (NSData *)data;
 - (void)parse:(NSData *)data;
 - (NSString *)description;

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLV2ProtocolHeader.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLV2ProtocolHeader.m
@@ -42,7 +42,7 @@ const int V2PROTOCOL_HEADERSIZE = 12;
     return dataOut;
 }
 
-- (instancetype)copyWithZone:(NSZone *)zone
+- (id)copyWithZone:(NSZone *)zone
 {
     SDLV2ProtocolHeader *newHeader = [[SDLV2ProtocolHeader allocWithZone: zone] init];
     newHeader.compressed = self.compressed;


### PR DESCRIPTION
Remove `copyWithZone:` method declarations (already declared by NSCopying protocol).

Note: This is not a call-review change because it fixes a regression. The last released version of the API uses `(id)` return types, and they were altered by an earlier, unreleased change. The `copyWithZone:` method definition removals also are not feature-level changes because the calls are still declared, just in the protocol instead of within the class itself.

Closes #197 