### PR TITLE
Add description method for RPC structs

### DIFF
--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLRPCStruct.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLRPCStruct.m
@@ -78,7 +78,7 @@
 }
 
 - (NSString *)description {
-    return [store description];
+    return [NSString stringWithFormat:@"RPC Struct (%@) %@", [self class], [store description]];
 }
 
 -(void) dealloc {

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLRPCStruct.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLRPCStruct.m
@@ -77,6 +77,10 @@
     }
 }
 
+- (NSString *)description {
+    return [store description];
+}
+
 -(void) dealloc {
     store = nil;
 }


### PR DESCRIPTION
This adds the ability to log out SDLRPCStruct objects. It logs out a description of the form

```
RPC Struct (Class) {
  key: value
}
```

Fixes #224 