### PR TITLE
SDLProxy start transport on initialization

### DIFF
--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLProxy.h
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLProxy.h
@@ -23,10 +23,10 @@
 
 @property (strong) SDLAbstractProtocol *protocol;
 @property (strong) SDLAbstractTransport *transport;
-@property (readonly, copy) NSSet *proxyListeners;
+@property (strong) NSMutableArray *proxyListeners;
 @property (strong) SDLTimer *startSessionTimer;
-@property (readonly, copy) NSString *debugConsoleGroupName;
-@property (readonly, copy) NSString *proxyVersion;
+@property (strong) NSString *debugConsoleGroupName;
+@property (readonly) NSString *proxyVersion;
 
 - (id)initWithTransport:(SDLAbstractTransport *)transport
                protocol:(SDLAbstractProtocol *)protocol
@@ -34,7 +34,6 @@
 - (void)dispose;
 
 - (void)addDelegate:(NSObject<SDLProxyListener> *)delegate;
-- (void)removeDelegate:(NSObject<SDLProxyListener> *)delegate;
 
 - (void)sendRPC:(SDLRPCMessage *)message;
 - (void)sendRPCRequest:(SDLRPCMessage*) msg __deprecated_msg("use -sendRPC: instead");

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLProxy.h
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLProxy.h
@@ -23,10 +23,10 @@
 
 @property (strong) SDLAbstractProtocol *protocol;
 @property (strong) SDLAbstractTransport *transport;
-@property (strong) NSMutableArray *proxyListeners;
+@property (readonly, copy) NSSet *proxyListeners;
 @property (strong) SDLTimer *startSessionTimer;
-@property (strong) NSString *debugConsoleGroupName;
-@property (readonly) NSString *proxyVersion;
+@property (readonly, copy) NSString *debugConsoleGroupName;
+@property (readonly, copy) NSString *proxyVersion;
 
 - (id)initWithTransport:(SDLAbstractTransport *)transport
                protocol:(SDLAbstractProtocol *)protocol
@@ -34,6 +34,7 @@
 - (void)dispose;
 
 - (void)addDelegate:(NSObject<SDLProxyListener> *)delegate;
+- (void)removeDelegate:(NSObject<SDLProxyListener> *)delegate;
 
 - (void)sendRPC:(SDLRPCMessage *)message;
 - (void)sendRPCRequest:(SDLRPCMessage*) msg __deprecated_msg("use -sendRPC: instead");

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLProxy.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLProxy.m
@@ -56,6 +56,7 @@ const int POLICIES_CORRELATION_ID = 65535;
 }
 
 @property (strong, nonatomic) NSMutableSet *activeSystemRequestTasks;
+@property (strong, nonatomic) NSMutableSet *mutableProxyListeners;
 
 @end
 
@@ -66,23 +67,21 @@ const int POLICIES_CORRELATION_ID = 65535;
 - (instancetype)initWithTransport:(SDLAbstractTransport *)transport protocol:(SDLAbstractProtocol *)protocol delegate:(NSObject<SDLProxyListener> *)theDelegate {
     if (self = [super init]) {
         _debugConsoleGroupName = @"default";
-        
-
         _lsm = [[SDLLockScreenManager alloc] init];
-
         _alreadyDestructed = NO;
                 
-        self.proxyListeners = [[NSMutableArray alloc] initWithObjects:theDelegate, nil];
-        self.protocol = protocol;
-        self.transport = transport;
-        self.transport.delegate = protocol;
-        self.protocol.protocolDelegate = self;
-        self.protocol.transport = transport;
+        _mutableProxyListeners = [NSMutableSet setWithObject:theDelegate];
+        _protocol = protocol;
+        _transport = transport;
+        _transport.delegate = protocol;
+        
+        _protocol.protocolDelegate = self;
+        _protocol.transport = transport;
 
-        [self.transport performSelector:@selector(connect) withObject:nil afterDelay:0];
-
-        [SDLDebugTool logInfo:@"SDLProxy initWithTransport"];
+        [self.transport connect];
         [[EAAccessoryManager sharedAccessoryManager] registerForLocalNotifications];
+        
+        [SDLDebugTool logInfo:@"SDLProxy initWithTransport"];
     }
     
     return self;
@@ -108,7 +107,7 @@ const int POLICIES_CORRELATION_ID = 65535;
 
         self.transport = nil;
         self.protocol = nil;
-        self.proxyListeners = nil;
+        self.mutableProxyListeners = nil;
     }
 }
 
@@ -131,6 +130,14 @@ const int POLICIES_CORRELATION_ID = 65535;
         [self invokeMethodOnDelegates:@selector(onProxyClosed) withObject:nil];
     }
 }
+
+#pragma mark - Accessors
+
+- (NSSet *)proxyListeners {
+    return [self.mutableProxyListeners copy];
+}
+
+#pragma mark - Methods
 
 - (void)sendMobileHMIState {
     UIApplicationState appState = [UIApplication sharedApplication].applicationState;
@@ -596,16 +603,25 @@ const int POLICIES_CORRELATION_ID = 65535;
 #pragma mark - Delegate management
 -(void) addDelegate:(NSObject<SDLProxyListener>*) delegate {
     @synchronized(self.proxyListeners) {
-        [self.proxyListeners addObject:delegate];
+        [self.mutableProxyListeners addObject:delegate];
+    }
+}
+
+- (void)removeDelegate:(NSObject<SDLProxyListener> *)delegate {
+    @synchronized(self.proxyListeners) {
+        [self.mutableProxyListeners removeObject:delegate];
     }
 }
 
 - (void)invokeMethodOnDelegates:(SEL)aSelector withObject:(id)object {
-    [self.proxyListeners enumerateObjectsUsingBlock:^(id listener, NSUInteger idx, BOOL *stop) {
-        if ([(NSObject *)listener respondsToSelector:aSelector]) {
-            [(NSObject *)listener performSelectorOnMainThread:aSelector withObject:object waitUntilDone:NO];
-        }
-    }];
+    for (id<SDLProxyListener> listener in self.proxyListeners) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if ([listener respondsToSelector:aSelector]) {
+                // HAX: http://stackoverflow.com/questions/7017281/performselector-may-cause-a-leak-because-its-selector-is-unknown
+                ((void (*)(id, SEL))[(NSObject *)listener methodForSelector:aSelector])(listener, aSelector);
+            }
+        });
+    }
 }
 
 

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLProxy.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLProxy.m
@@ -79,7 +79,7 @@ const int POLICIES_CORRELATION_ID = 65535;
         self.protocol.protocolDelegate = self;
         self.protocol.transport = transport;
 
-        [self.transport performSelector:@selector(connect) withObject:nil afterDelay:0];
+        [self.transport connect];
 
         [SDLDebugTool logInfo:@"SDLProxy initWithTransport"];
         [[EAAccessoryManager sharedAccessoryManager] registerForLocalNotifications];


### PR DESCRIPTION
* Start up transport using a simple `connect` method call instead of adding the call to the end of the run loop.

* Fixes #211 