### PR TITLE
SDLProtocolHeaderSpec unknown version test checks for exception instead of header

### DIFF
--- a/SmartDeviceLink-iOS/SmartDeviceLinkTests/ProtocolSpecs/HeaderSpecs/SDLProtocolHeaderSpec.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLinkTests/ProtocolSpecs/HeaderSpecs/SDLProtocolHeaderSpec.m
@@ -22,7 +22,7 @@ describe(@"HeaderForVersion Tests", ^ {
     });
     
     it(@"Should return latest version for unknown version", ^ {
-        expect([SDLProtocolHeader headerForVersion:5]).to(beAKindOf(SDLV2ProtocolHeader.class));
+        expect([SDLProtocolHeader headerForVersion:5]).to(raiseException().named(NSInvalidArgumentException));
     });
 });
 


### PR DESCRIPTION
Fixes #262 