### PR TITLE
SDLGlobals for global version & MTU size handling

### DIFF
--- a/SmartDeviceLink-iOS/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
+++ b/SmartDeviceLink-iOS/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
@@ -760,6 +760,7 @@
 		5DB92D2F1AC59F0000C15BB0 /* SDLObjectWithPrioritySpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DB92D2E1AC59F0000C15BB0 /* SDLObjectWithPrioritySpec.m */; };
 		5DB92D321AC9C8BA00C15BB0 /* SDLRPCStruct.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DB92D301AC9C8BA00C15BB0 /* SDLRPCStruct.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5DB92D331AC9C8BA00C15BB0 /* SDLRPCStruct.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DB92D311AC9C8BA00C15BB0 /* SDLRPCStruct.m */; };
+		5DC978261B7A38640012C2F1 /* SDLGlobalsSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DC978251B7A38640012C2F1 /* SDLGlobalsSpec.m */; };
 		5DCF76F51ACDBAD300BB647B /* SDLSendLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DCF76F31ACDBAD300BB647B /* SDLSendLocation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5DCF76F61ACDBAD300BB647B /* SDLSendLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DCF76F41ACDBAD300BB647B /* SDLSendLocation.m */; };
 		5DCF76F91ACDD7CD00BB647B /* SDLSendLocationResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DCF76F71ACDD7CD00BB647B /* SDLSendLocationResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1610,6 +1611,7 @@
 		5DB92D2E1AC59F0000C15BB0 /* SDLObjectWithPrioritySpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SDLObjectWithPrioritySpec.m; path = "UtilitiesSpecs/Prioritized Objects/SDLObjectWithPrioritySpec.m"; sourceTree = "<group>"; };
 		5DB92D301AC9C8BA00C15BB0 /* SDLRPCStruct.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDLRPCStruct.h; sourceTree = "<group>"; };
 		5DB92D311AC9C8BA00C15BB0 /* SDLRPCStruct.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLRPCStruct.m; sourceTree = "<group>"; };
+		5DC978251B7A38640012C2F1 /* SDLGlobalsSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SDLGlobalsSpec.m; path = UtilitiesSpecs/SDLGlobalsSpec.m; sourceTree = "<group>"; };
 		5DCF76F31ACDBAD300BB647B /* SDLSendLocation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDLSendLocation.h; sourceTree = "<group>"; };
 		5DCF76F41ACDBAD300BB647B /* SDLSendLocation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLSendLocation.m; sourceTree = "<group>"; };
 		5DCF76F71ACDD7CD00BB647B /* SDLSendLocationResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDLSendLocationResponse.h; sourceTree = "<group>"; };
@@ -2874,6 +2876,7 @@
 				5DB92D2B1AC4A32A00C15BB0 /* Prioritized Objects */,
 				5DB92D231AC47B2C00C15BB0 /* SDLHexUtilitySpec.m */,
 				5DB92D251AC4836F00C15BB0 /* SDLJingleSpec.m */,
+				5DC978251B7A38640012C2F1 /* SDLGlobalsSpec.m */,
 			);
 			name = UtilitiesSpecs;
 			sourceTree = "<group>";
@@ -3780,6 +3783,7 @@
 				162E83471A9BDE8B00906325 /* SDLUnsubscribeVehicleDataSpec.m in Sources */,
 				162E839A1A9BDE8B00906325 /* SDLRPCMessageSpec.m in Sources */,
 				162E83311A9BDE8B00906325 /* SDLListFilesSpec.m in Sources */,
+				5DC978261B7A38640012C2F1 /* SDLGlobalsSpec.m in Sources */,
 				162E82FF1A9BDE8B00906325 /* SDLTextAlignmentSpec.m in Sources */,
 				162E831F1A9BDE8B00906325 /* SDLOnTouchEventSpec.m in Sources */,
 				162E83921A9BDE8B00906325 /* SDLTouchEventCapabilitiesSpec.m in Sources */,

--- a/SmartDeviceLink-iOS/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
+++ b/SmartDeviceLink-iOS/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
@@ -253,6 +253,8 @@
 		5D4832A51A94F90D00252386 /* ConnectionTransitionContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D4832A41A94F90D00252386 /* ConnectionTransitionContext.m */; };
 		5D4832A81A95191B00252386 /* ConnectionAnimatedTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D4832A71A95191B00252386 /* ConnectionAnimatedTransition.m */; };
 		5D4AB7A21B21EC16004C1AB0 /* SmartDeviceLink.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5D61FA1C1A84237100846EE7 /* SmartDeviceLink.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		5D535DC51B72473800CF7760 /* SDLGlobals.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D535DC31B72473800CF7760 /* SDLGlobals.h */; };
+		5D535DC61B72473800CF7760 /* SDLGlobals.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D535DC41B72473800CF7760 /* SDLGlobals.m */; };
 		5D59350F1A855EB300687FB9 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D59350C1A855EB300687FB9 /* AppDelegate.m */; };
 		5D5935121A855EBE00687FB9 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D5935111A855EBE00687FB9 /* main.m */; };
 		5D59DD471B14FDEE00BE744D /* SDLLockScreenManagerSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D59DD461B14FDEE00BE744D /* SDLLockScreenManagerSpec.m */; };
@@ -1096,6 +1098,8 @@
 		5D4832A41A94F90D00252386 /* ConnectionTransitionContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ConnectionTransitionContext.m; path = SmartDeviceLink_Example/Classes/ConnectionTransitionContext.m; sourceTree = SOURCE_ROOT; };
 		5D4832A61A95191B00252386 /* ConnectionAnimatedTransition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ConnectionAnimatedTransition.h; path = SmartDeviceLink_Example/Classes/ConnectionAnimatedTransition.h; sourceTree = SOURCE_ROOT; };
 		5D4832A71A95191B00252386 /* ConnectionAnimatedTransition.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ConnectionAnimatedTransition.m; path = SmartDeviceLink_Example/Classes/ConnectionAnimatedTransition.m; sourceTree = SOURCE_ROOT; };
+		5D535DC31B72473800CF7760 /* SDLGlobals.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDLGlobals.h; sourceTree = "<group>"; };
+		5D535DC41B72473800CF7760 /* SDLGlobals.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLGlobals.m; sourceTree = "<group>"; };
 		5D59350B1A855EB300687FB9 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = SmartDeviceLink_Example/Classes/AppDelegate.h; sourceTree = SOURCE_ROOT; };
 		5D59350C1A855EB300687FB9 /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = SmartDeviceLink_Example/Classes/AppDelegate.m; sourceTree = SOURCE_ROOT; };
 		5D5935111A855EBE00687FB9 /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = SmartDeviceLink_Example/Classes/main.m; sourceTree = SOURCE_ROOT; };
@@ -2644,6 +2648,8 @@
 				E9C32B8E1AB20BA200F283AF /* SDLTimer.h */,
 				E9C32B8F1AB20BA200F283AF /* SDLTimer.m */,
 				5D61FB0F1A84238A00846EE7 /* SDLNames.h */,
+				5D535DC31B72473800CF7760 /* SDLGlobals.h */,
+				5D535DC41B72473800CF7760 /* SDLGlobals.m */,
 			);
 			name = Utilities;
 			sourceTree = "<group>";
@@ -3104,6 +3110,7 @@
 				5D61FCE41A84238C00846EE7 /* SDLKeyboardProperties.h in Headers */,
 				5D61FDED1A84238C00846EE7 /* SDLUnsubscribeVehicleDataResponse.h in Headers */,
 				5D61FCCF1A84238C00846EE7 /* SDLImageField.h in Headers */,
+				5D535DC51B72473800CF7760 /* SDLGlobals.h in Headers */,
 				5D61FD231A84238C00846EE7 /* SDLParameterPermissions.h in Headers */,
 				5D61FCB91A84238C00846EE7 /* SDLGlobalProperty.h in Headers */,
 				5D61FE051A84238C00846EE7 /* SDLVehicleDataResultCode.h in Headers */,
@@ -3354,6 +3361,7 @@
 				5D61FC461A84238C00846EE7 /* SDLAudioPassThruCapabilities.m in Sources */,
 				5D61FD301A84238C00846EE7 /* SDLPermissionStatus.m in Sources */,
 				5D61FDEE1A84238C00846EE7 /* SDLUnsubscribeVehicleDataResponse.m in Sources */,
+				5D535DC61B72473800CF7760 /* SDLGlobals.m in Sources */,
 				5D61FCAE1A84238C00846EE7 /* SDLFunctionID.m in Sources */,
 				5D61FC421A84238C00846EE7 /* SDLAppHMIType.m in Sources */,
 				5D61FD421A84238C00846EE7 /* SDLPRNDL.m in Sources */,

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLGlobals.h
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLGlobals.h
@@ -10,8 +10,9 @@
 
 @interface SDLGlobals : NSObject
 
-@property (assign, nonatomic) NSUInteger protocolVersion;
+@property (assign, nonatomic, readonly) NSUInteger protocolVersion;
 @property (assign, nonatomic, readonly) NSUInteger maxMTUSize;
+@property (assign, nonatomic) NSUInteger maxHeadUnitVersion;
 
 + (instancetype)globals;
 

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLGlobals.h
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLGlobals.h
@@ -1,0 +1,18 @@
+//
+//  SDLGlobals.h
+//  SmartDeviceLink-iOS
+//
+//  Created by Joel Fischer on 8/5/15.
+//  Copyright (c) 2015 smartdevicelink. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface SDLGlobals : NSObject
+
+@property (assign, nonatomic) NSUInteger protocolVersion;
+@property (assign, nonatomic, readonly) NSUInteger maxMTUSize;
+
++ (instancetype)globals;
+
+@end

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLGlobals.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLGlobals.m
@@ -37,8 +37,6 @@ static const NSUInteger maxProxyVersion = 4;
     }
     
     _protocolVersion = 1;
-    
-    // This will cause maxMTUSize to assert unless changed before maxMTUSize is called. This is by design.
     _maxHeadUnitVersion = 0;
     
     return self;

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLGlobals.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLGlobals.m
@@ -8,6 +8,16 @@
 
 #import "SDLGlobals.h"
 
+static const NSUInteger maxProxyVersion = 4;
+
+
+@interface SDLGlobals ()
+
+@property (assign, nonatomic) NSUInteger protocolVersion;
+
+@end
+
+
 @implementation SDLGlobals
 
 + (instancetype)globals {
@@ -32,7 +42,13 @@
 }
 
 
-#pragma mark - Custom Getters
+#pragma mark - Custom Getters / Setters
+
+- (void)setMaxHeadUnitVersion:(NSUInteger)maxHeadUnitVersion {
+    self.protocolVersion = MIN(maxHeadUnitVersion, maxProxyVersion);
+    
+    _maxHeadUnitVersion = maxHeadUnitVersion;
+}
 
 - (NSUInteger)maxMTUSize {
     switch (self.protocolVersion) {
@@ -46,6 +62,11 @@
             return 128000;
         } break;
         default: {
+            // If the head unit isn't running v3/4, but that's the connection scheme we're using, then we have to know that they could be running an MTU that's not 128k, so we default back to the v1/2 MTU for safety.
+            if (self.maxHeadUnitVersion > maxProxyVersion) {
+                return 1024;
+            }
+            
             NSAssert(NO, @"Unknown version number: %@", @(self.protocolVersion));
             return 0;
         }

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLGlobals.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLGlobals.m
@@ -1,0 +1,55 @@
+//
+//  SDLGlobals.m
+//  SmartDeviceLink-iOS
+//
+//  Created by Joel Fischer on 8/5/15.
+//  Copyright (c) 2015 smartdevicelink. All rights reserved.
+//
+
+#import "SDLGlobals.h"
+
+@implementation SDLGlobals
+
++ (instancetype)globals {
+    static SDLGlobals *sharedGlobals = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedGlobals = [[SDLGlobals alloc] init];
+    });
+    
+    return sharedGlobals;
+}
+
+- (instancetype)init {
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+    
+    _protocolVersion = 1;
+    
+    return self;
+}
+
+
+#pragma mark - Custom Getters
+
+- (NSUInteger)maxMTUSize {
+    switch (self.protocolVersion) {
+        case 1:
+        case 2: {
+            // HAX: This was set to 1024 at some point, for an unknown reason. We can't change it because of backward compatibility & validation concerns. The actual MTU for v1/2 is 1500 bytes.
+            return 1024;
+        } break;
+        case 3:
+        case 4: {
+            return 128000;
+        } break;
+        default: {
+            NSAssert(NO, @"Unknown version number: %@", @(self.protocolVersion));
+            return 0;
+        }
+    }
+}
+
+@end

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLGlobals.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLGlobals.m
@@ -65,10 +65,10 @@ static const NSUInteger maxProxyVersion = 4;
             // If the head unit isn't running v3/4, but that's the connection scheme we're using, then we have to know that they could be running an MTU that's not 128k, so we default back to the v1/2 MTU for safety.
             if (self.maxHeadUnitVersion > maxProxyVersion) {
                 return 1024;
+            } else {
+                NSAssert(NO, @"Unknown version number: %@", @(self.protocolVersion));
+                return 0;
             }
-            
-            NSAssert(NO, @"Unknown version number: %@", @(self.protocolVersion));
-            return 0;
         }
     }
 }

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLGlobals.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLGlobals.m
@@ -53,23 +53,23 @@ static const NSUInteger maxProxyVersion = 4;
 
 - (NSUInteger)maxMTUSize {
     switch (self.protocolVersion) {
-        case 1:
+        case 1: // fallthrough
         case 2: {
             // HAX: This was set to 1024 at some point, for an unknown reason. We can't change it because of backward compatibility & validation concerns. The actual MTU for v1/2 is 1500 bytes.
             return 1024;
         } break;
-        case 3:
+        case 3: // fallthrough
         case 4: {
-            return 128000;
-        } break;
-        default: {
             // If the head unit isn't running v3/4, but that's the connection scheme we're using, then we have to know that they could be running an MTU that's not 128k, so we default back to the v1/2 MTU for safety.
             if (self.maxHeadUnitVersion > maxProxyVersion) {
                 return 1024;
             } else {
-                NSAssert(NO, @"Unknown version number: %@", @(self.protocolVersion));
-                return 0;
+                return 128000;
             }
+        } break;
+        default: {
+            NSAssert(NO, @"Unknown version number: %@", @(self.protocolVersion));
+            return 0;
         }
     }
 }

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLGlobals.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLGlobals.m
@@ -38,6 +38,9 @@ static const NSUInteger maxProxyVersion = 4;
     
     _protocolVersion = 1;
     
+    // This will cause maxMTUSize to assert unless changed before maxMTUSize is called. This is by design.
+    _maxHeadUnitVersion = 0;
+    
     return self;
 }
 

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLIAPTransport.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLIAPTransport.m
@@ -7,6 +7,7 @@
 
 #import "SDLIAPTransport.h"
 #import "SDLDebugTool.h"
+#import "SDLGlobals.h"
 #import "SDLSiphonServer.h"
 #import "SDLIAPTransport.h"
 #import "SDLStreamDelegate.h"
@@ -20,7 +21,6 @@ NSString *const legacyProtocolString = @"com.ford.sync.prot0";
 NSString *const controlProtocolString = @"com.smartdevicelink.prot0";
 NSString *const indexedProtocolStringPrefix = @"com.smartdevicelink.prot";
 
-int const iapInputBufferSize = 1024;
 int const createSessionRetries = 1;
 int const protocolIndexTimeoutSeconds = 20;
 int const streamOpenTimeoutSeconds = 2;
@@ -394,9 +394,9 @@ int const streamOpenTimeoutSeconds = 2;
     return ^(NSInputStream *istream) {
         typeof(self) strongSelf = weakSelf;
         
-        uint8_t buf[iapInputBufferSize];
+        uint8_t buf[[SDLGlobals globals].maxMTUSize];
         while ([istream hasBytesAvailable]) {
-            NSInteger bytesRead = [istream read:buf maxLength:iapInputBufferSize];
+            NSInteger bytesRead = [istream read:buf maxLength:[SDLGlobals globals].maxMTUSize];
             NSData *dataIn = [NSData dataWithBytes:buf length:bytesRead];
             
             if (bytesRead > 0) {

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLProtocol.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLProtocol.m
@@ -160,7 +160,7 @@ const UInt8 MAX_VERSION_TO_SEND = 4;
     SDLProtocolMessage *protocolMessage = [SDLProtocolMessage messageWithHeader:header andPayload:messagePayload];
 
     // See if the message is small enough to send in one transmission. If not, break it up into smaller messages and send.
-    if (protocolMessage.size < [SDLGlobals globals].protocolVersion) {
+    if (protocolMessage.size < [SDLGlobals globals].maxMTUSize) {
         [self logRPCSend:protocolMessage];
         [self sendDataToTransport:protocolMessage.data withPriority:SDLServiceType_RPC];
     } else {

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLProtocol.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLProtocol.m
@@ -33,7 +33,6 @@ const UInt8 MAX_VERSION_TO_SEND = 4;
     BOOL _alreadyDestructed;
 }
 
-@property (assign) UInt8 maxVersionSupportedByHeadUnit;
 @property (assign) UInt8 sessionID;
 @property (strong) NSMutableData *receiveBuffer;
 @property (strong) SDLProtocolReceivedMessageRouter *messageRouter;
@@ -45,7 +44,6 @@ const UInt8 MAX_VERSION_TO_SEND = 4;
 
 - (instancetype)init {
     if (self = [super init]) {
-        [SDLGlobals globals].protocolVersion = 1;
         _messageID = 0;
         _sessionID = 0;
         _receiveQueue = dispatch_queue_create("com.sdl.protocol.receive", DISPATCH_QUEUE_SERIAL);
@@ -290,9 +288,8 @@ const UInt8 MAX_VERSION_TO_SEND = 4;
 #pragma mark - SDLProtocolListener Implementation
 - (void)handleProtocolSessionStarted:(SDLServiceType)serviceType sessionID:(Byte)sessionID version:(Byte)version {
     [self storeSessionID:sessionID forServiceType:serviceType];
-
-    self.maxVersionSupportedByHeadUnit = version;
-    [SDLGlobals globals].protocolVersion = MIN(self.maxVersionSupportedByHeadUnit, MAX_VERSION_TO_SEND);
+    
+    [SDLGlobals globals].maxHeadUnitVersion = version;
 
     if ([SDLGlobals globals].protocolVersion >= 3) {
         // start hearbeat

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLProxy.h
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLProxy.h
@@ -51,7 +51,7 @@
  * @abstract Performs a putFile for a given input stream, performed in chunks, for handling very large files.
  * @param inputStream A stream containing the data to put to the module.
  * @param putFileRPCRequest A SDLPutFile object containing the parameters for the put(s)
- * @discussion  The proxy will read from the stream up to 1024 bytes at a time and send them in individual putFile requests.
+ * @discussion  The proxy will read from the stream based on the max MTU size and send them in individual putFile requests.
  * This may result in multiple responses being received, one for each request.
  * Note: the length parameter of the putFileRPCRequest will be ignored. The proxy will substitute the number of bytes read from the stream.
  */

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLProxy.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLProxy.m
@@ -202,13 +202,7 @@ const int POLICIES_CORRELATION_ID = 65535;
     NSString *logMessage = [NSString stringWithFormat:@"StartSession (response)\nSessionId: %d for serviceType %d", sessionID, serviceType];
     [SDLDebugTool logInfo:logMessage withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
 
-    if (_version <= 1) {
-        if (maxVersionForModule >= 2) {
-            _version = maxVersionForModule;
-        }
-    }
-
-    if (serviceType == SDLServiceType_RPC || _version >= 2) {
+    if (serviceType == SDLServiceType_RPC || [SDLGlobals globals].protocolVersion >= 2) {
         [self invokeMethodOnDelegates:@selector(onProxyOpened) withObject:nil];
     }
 }

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLProxy.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLProxy.m
@@ -12,6 +12,7 @@
 #import "SDLEncodedSyncPData.h"
 #import "SDLFileType.h"
 #import "SDLFunctionID.h"
+#import "SDLGlobals.h"
 #import "SDLHMILevel.h"
 #import "SDLJsonDecoder.h"
 #import "SDLJsonEncoder.h"
@@ -682,9 +683,8 @@ const int POLICIES_CORRELATION_ID = 65535;
         case NSStreamEventHasBytesAvailable: {
             // Grab some bytes from the stream and send them in a SDLPutFile RPC Request
             NSUInteger currentStreamOffset = [[stream propertyForKey:NSStreamFileCurrentOffsetKey] unsignedIntegerValue];
-
-            const int bufferSize = 1024;
-            NSMutableData *buffer = [NSMutableData dataWithLength:bufferSize];
+            
+            NSMutableData *buffer = [NSMutableData dataWithLength:[SDLGlobals globals].protocolVersion];
             NSUInteger nBytesRead = [(NSInputStream *)stream read:(uint8_t *)buffer.mutableBytes maxLength:buffer.length];
             if (nBytesRead > 0) {
                 NSData *data = [buffer subdataWithRange:NSMakeRange(0, nBytesRead)];

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLProxy.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLProxy.m
@@ -678,7 +678,7 @@ const int POLICIES_CORRELATION_ID = 65535;
             // Grab some bytes from the stream and send them in a SDLPutFile RPC Request
             NSUInteger currentStreamOffset = [[stream propertyForKey:NSStreamFileCurrentOffsetKey] unsignedIntegerValue];
             
-            NSMutableData *buffer = [NSMutableData dataWithLength:[SDLGlobals globals].protocolVersion];
+            NSMutableData *buffer = [NSMutableData dataWithLength:[SDLGlobals globals].maxMTUSize];
             NSUInteger nBytesRead = [(NSInputStream *)stream read:(uint8_t *)buffer.mutableBytes maxLength:buffer.length];
             if (nBytesRead > 0) {
                 NSData *data = [buffer subdataWithRange:NSMakeRange(0, nBytesRead)];

--- a/SmartDeviceLink-iOS/SmartDeviceLinkTests/ProtocolSpecs/SDLProtocolMessageDisassemblerSpec.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLinkTests/ProtocolSpecs/SDLProtocolMessageDisassemblerSpec.m
@@ -9,6 +9,8 @@
 #import <Nimble/Nimble.h>
 #import <OCMock/OCMock.h>
 
+#import "SDLGlobals.h"
+#import "SDLProtocol.h"
 #import "SDLProtocolMessageDisassembler.h"
 #import "SDLV2ProtocolHeader.h"
 #import "SDLV2ProtocolMessage.h"
@@ -39,10 +41,10 @@ describe(@"Disassemble Tests", ^ {
         testMessage.header = testHeader;
         testMessage.payload = payloadData;
         
-        NSArray* messageList = [SDLProtocolMessageDisassembler disassemble:testMessage withLimit:512];
+        NSArray* messageList = [SDLProtocolMessageDisassembler disassemble:testMessage withLimit:1024];
         
         //Payload length per message
-        UInt32 payloadLength = 500;//MTU(512)-header length(12)
+        UInt32 payloadLength = 1012; // v1/2 MTU(1024) - header length(12)
         
         const char firstPayload[8] = {(payloadData.length >> 24) & 0xFF, (payloadData.length >> 16) & 0xFF, (payloadData.length >> 8) & 0xFF, payloadData.length & 0xFF, 0x00, 0x00, 0x00, ceil(1.0 * payloadData.length / payloadLength)};
         

--- a/SmartDeviceLink-iOS/SmartDeviceLinkTests/ProtocolSpecs/SDLProtocolMessageDisassemblerSpec.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLinkTests/ProtocolSpecs/SDLProtocolMessageDisassemblerSpec.m
@@ -9,6 +9,7 @@
 #import <Nimble/Nimble.h>
 #import <OCMock/OCMock.h>
 
+#import "SDLGlobals.h"
 #import "SDLProtocolMessageDisassembler.h"
 #import "SDLV2ProtocolHeader.h"
 #import "SDLV2ProtocolMessage.h"
@@ -21,6 +22,9 @@ describe(@"Disassemble Tests", ^ {
         //Allocate 2000 bytes, and use it as sample data
         const NSUInteger dataLength = 2000;
         char dummyBytes[dataLength];
+        
+        SDLGlobals *globals = [[SDLGlobals alloc] init];
+        globals.maxHeadUnitVersion = 2;
         
         const char testPayloadHeader[12] = {0x20, 0x55, 0x64, 0x73, 0x12, 0x34, 0x43, 0x21, (dataLength >> 24) & 0xFF, (dataLength >> 16) & 0xFF, (dataLength >> 8) & 0xFF, dataLength & 0xFF};
         
@@ -39,7 +43,7 @@ describe(@"Disassemble Tests", ^ {
         testMessage.header = testHeader;
         testMessage.payload = payloadData;
         
-        NSArray* messageList = [SDLProtocolMessageDisassembler disassemble:testMessage withLimit:1024];
+        NSArray* messageList = [SDLProtocolMessageDisassembler disassemble:testMessage withLimit:globals.maxMTUSize];
         
         //Payload length per message
         UInt32 payloadLength = 1012; // v1/2 MTU(1024) - header length(12)

--- a/SmartDeviceLink-iOS/SmartDeviceLinkTests/ProtocolSpecs/SDLProtocolMessageDisassemblerSpec.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLinkTests/ProtocolSpecs/SDLProtocolMessageDisassemblerSpec.m
@@ -9,8 +9,6 @@
 #import <Nimble/Nimble.h>
 #import <OCMock/OCMock.h>
 
-#import "SDLGlobals.h"
-#import "SDLProtocol.h"
 #import "SDLProtocolMessageDisassembler.h"
 #import "SDLV2ProtocolHeader.h"
 #import "SDLV2ProtocolMessage.h"

--- a/SmartDeviceLink-iOS/SmartDeviceLinkTests/UtilitiesSpecs/SDLGlobalsSpec.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLinkTests/UtilitiesSpecs/SDLGlobalsSpec.m
@@ -7,6 +7,9 @@ QuickSpecBegin(SDLGlobalsSpec)
 
 describe(@"The SDLGlobals class", ^{
     __block SDLGlobals *testGlobals = nil;
+    __block NSNumber *v1And2MTUSize = @1024;
+    __block NSNumber *v3And4MTUSize = @128000;
+    
     beforeEach(^{
         testGlobals = [[SDLGlobals alloc] init];
     });
@@ -21,7 +24,60 @@ describe(@"The SDLGlobals class", ^{
         });
         
         it(@"should throw an exception trying to get max MTU size", ^{
-            expect(@(testGlobals.maxMTUSize)).to(equal(@1024));
+            expect(@(testGlobals.maxMTUSize)).to(equal(v1And2MTUSize));
+        });
+    });
+    
+    describe(@"setting maxHeadUnitVersion should alter negotiated protocol version", ^{
+        it(@"should use the max head unit version when lower than max proxy version", ^{
+            NSUInteger someIntLowerThanMaxProxyVersion = 2;
+            testGlobals.maxHeadUnitVersion = someIntLowerThanMaxProxyVersion;
+            expect(@(testGlobals.protocolVersion)).to(equal(@(someIntLowerThanMaxProxyVersion)));
+            expect(@(testGlobals.maxHeadUnitVersion)).to(equal(@(someIntLowerThanMaxProxyVersion)));
+        });
+        
+        it(@"should use the max proxy version when lower than max head unit version", ^{
+            NSUInteger someIntHigherThanMaxProxyVersion = 1000;
+            testGlobals.maxHeadUnitVersion = someIntHigherThanMaxProxyVersion;
+            expect(@(testGlobals.protocolVersion)).to(beLessThan(@(someIntHigherThanMaxProxyVersion)));
+            expect(@(testGlobals.maxHeadUnitVersion)).to(equal(@(someIntHigherThanMaxProxyVersion)));
+        });
+    });
+    
+    describe(@"getting the max MTU version", ^{
+        context(@"when protocol version is 1 - 2", ^{
+            it(@"should return the correct value when protocol version is 1", ^{
+                testGlobals.maxHeadUnitVersion = 1;
+                expect(@(testGlobals.maxMTUSize)).to(equal(v1And2MTUSize));
+            });
+            
+            it(@"should return the correct value when protocol version is 2", ^{
+                testGlobals.maxHeadUnitVersion = 2;
+                expect(@(testGlobals.maxMTUSize)).to(equal(v1And2MTUSize));
+            });
+        });
+        
+        context(@"when protocol version is 3 - 4", ^{
+            it(@"should return the correct value when protocol version is 3", ^{
+                testGlobals.maxHeadUnitVersion = 3;
+                expect(@(testGlobals.maxMTUSize)).to(equal(v3And4MTUSize));
+            });
+            
+            it(@"should return the correct value when protocol version is 4", ^{
+                testGlobals.maxHeadUnitVersion = 4;
+                expect(@(testGlobals.maxMTUSize)).to(equal(v3And4MTUSize));
+            });
+            
+            describe(@"when the max proxy version is lower than max head unit version", ^{
+                beforeEach(^{
+                    NSUInteger someIntHigherThanMaxProxyVersion = 1000;
+                    testGlobals.maxHeadUnitVersion = someIntHigherThanMaxProxyVersion;
+                });
+                
+                it(@"should return the v1 - 2 value", ^{
+                    expect(@(testGlobals.maxMTUSize)).to(equal(v1And2MTUSize));
+                });
+            });
         });
     });
 });

--- a/SmartDeviceLink-iOS/SmartDeviceLinkTests/UtilitiesSpecs/SDLGlobalsSpec.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLinkTests/UtilitiesSpecs/SDLGlobalsSpec.m
@@ -1,0 +1,29 @@
+#import <Quick/Quick.h>
+#import <Nimble/Nimble.h>
+
+#import "SDLGlobals.h"
+
+QuickSpecBegin(SDLGlobalsSpec)
+
+describe(@"The SDLGlobals class", ^{
+    __block SDLGlobals *testGlobals = nil;
+    beforeEach(^{
+        testGlobals = [[SDLGlobals alloc] init];
+    });
+    
+    describe(@"when just initialized", ^{
+        it(@"should properly set protocol version", ^{
+            expect(@(testGlobals.protocolVersion)).to(equal(@1));
+        });
+        
+        it(@"should properly set max head unit version", ^{
+            expect(@(testGlobals.maxHeadUnitVersion)).to(equal(@0));
+        });
+        
+        it(@"should throw an exception trying to get max MTU size", ^{
+            expect(@(testGlobals.maxMTUSize)).to(equal(@1024));
+        });
+    });
+});
+
+QuickSpecEnd


### PR DESCRIPTION
:cat: Ready for Review :cat:

#### Summary
This creates a new singleton class that has as project (not public level) global instance that stores the connected protocol version and can currently also be used to retrieve the maxMTU size based on that version.

#### Detail
This separates out version handling into a separate class called SDLGlobals. It is a singleton class that can be accessed from anywhere in the code. It defaults to a protocol version of 1. When a head unit version is set, it will automatically calculate the protocol version and the max MTU size based on that.

- [x] Needs to be updated based on new MTU discussions
- [x] Needs tests

Fixes #256 