### PR TITLE
onOnLockscreenNotification bugfix

### DIFF
--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLProxyListener.h
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLProxyListener.h
@@ -57,6 +57,7 @@
 @class SDLUnregisterAppInterfaceResponse;
 @class SDLUnsubscribeButtonResponse;
 @class SDLUnsubscribeVehicleDataResponse;
+@class SDLOnLockscreenStatus;
 
 @protocol SDLProxyListener <NSObject>
 
@@ -92,7 +93,7 @@
 -(void) onOnEncodedSyncPData:(SDLOnEncodedSyncPData*) notification;
 -(void) onOnHashChange:(SDLOnHashChange*) notification;
 -(void) onOnLanguageChange:(SDLOnLanguageChange*) notification;
--(void) onOnLockScreenNotification:(SDLLockScreenStatus*) notification;
+-(void) onOnLockScreenNotification:(SDLOnLockscreenStatus*) notification;
 -(void) onOnPermissionsChange:(SDLOnPermissionsChange*) notification;
 -(void) onOnSyncPData:(SDLOnSyncPData*) notification;
 -(void) onOnSystemRequest:(SDLOnSystemRequest*) notification;
@@ -121,5 +122,4 @@
 -(void) onUnregisterAppInterfaceResponse:(SDLUnregisterAppInterfaceResponse*) response;
 -(void) onUnsubscribeButtonResponse:(SDLUnsubscribeButtonResponse*) response;
 -(void) onUnsubscribeVehicleDataResponse:(SDLUnsubscribeVehicleDataResponse*) response;
-
 @end


### PR DESCRIPTION
The proxy passes the notification object (SDLOnLockscreenStatus), but the SDLProxyListener protocol currently defines the method as expecting the enum (SDLLockScreenStatus).

Fixes issue #267 