### PR TITLE
Feature/heartbeat

### DIFF
--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLProtocol.h
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLProtocol.h
@@ -13,7 +13,6 @@
 - (void)sendEndSessionWithType:(SDLServiceType)serviceType sessionID:(Byte)sessionID;
 - (void)sendRPC:(SDLRPCMessage *)message;
 - (void)sendRPCRequest:(SDLRPCRequest *)rpcRequest __deprecated_msg(("Use sendRPC: instead"));
-- (void)sendHeartbeat;
 - (void)sendRawData:(NSData *)data withServiceType:(SDLServiceType)serviceType;
 
 // Recieving

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLProtocol.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLProtocol.m
@@ -326,7 +326,6 @@ const UInt8 MAX_VERSION_TO_SEND = 4;
 
 #pragma mark - SDLProtocolListener Implementation
 - (void)handleProtocolSessionStarted:(SDLServiceType)serviceType sessionID:(Byte)sessionID version:(Byte)version {
-    NSLog(@"Handle session started for service Type: %@", @(serviceType));
     self.sessionID = sessionID;
     [self storeSessionID:sessionID forServiceType:serviceType];
 

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLProtocol.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLProtocol.m
@@ -257,12 +257,24 @@ const UInt8 MAX_VERSION_TO_SEND = 4;
 - (void)sendHeartbeat {
     SDLProtocolHeader *header = [SDLProtocolHeader headerForVersion:self.version];
     header.frameType = SDLFrameType_Control;
-    header.serviceType = 0;
+    header.serviceType = SDLServiceType_Control;
     header.frameData = SDLFrameData_Heartbeat;
     header.sessionID = self.sessionID;
 
     SDLProtocolMessage *message = [SDLProtocolMessage messageWithHeader:header andPayload:nil];
 
+    [self sendDataToTransport:message.data withPriority:header.serviceType];
+}
+
+- (void)handleHeartbeat {
+    SDLProtocolHeader *header = [SDLProtocolHeader headerForVersion:self.version];
+    header.frameType = SDLFrameType_Control;
+    header.serviceType = SDLServiceType_Control;
+    header.frameData = SDLFrameData_HeartbeatACK;
+    header.sessionID = self.sessionID;
+    
+    SDLProtocolMessage *message = [SDLProtocolMessage messageWithHeader:header andPayload:nil];
+    
     [self sendDataToTransport:message.data withPriority:header.serviceType];
 }
 
@@ -296,7 +308,7 @@ const UInt8 MAX_VERSION_TO_SEND = 4;
     self.version = MIN(self.maxVersionSupportedByHeadUnit, MAX_VERSION_TO_SEND);
 
     if (self.version >= 3) {
-        // start hearbeat
+        // start heartbeat
     }
 
     [self.protocolDelegate handleProtocolSessionStarted:serviceType sessionID:sessionID version:version];

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLProtocol.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLProtocol.m
@@ -278,7 +278,6 @@ const UInt8 MAX_VERSION_TO_SEND = 4;
             NSString *logMessage = [NSString stringWithFormat:@"Heartbeat ack not received. Goodbye."];
             [SDLDebugTool logInfo:logMessage withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:strongSelf.debugConsoleGroupName];
             [strongSelf onProtocolClosed];
-            [strongSelf dispose];
         }
     };
     // Send a first heartbeat

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLProtocol.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLProtocol.m
@@ -362,10 +362,7 @@ const UInt8 MAX_VERSION_TO_SEND = 4;
         self.messageRouter = nil;
         self.transport = nil;
         self.protocolDelegate = nil;
-        if (self.heartbeatTimer != nil) {
-            [self.heartbeatTimer cancel];
-            self.heartbeatTimer = nil;
-        }
+        self.heartbeatTimer = nil;
     }
 }
 

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLProtocol.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLProtocol.m
@@ -280,9 +280,6 @@ const UInt8 MAX_VERSION_TO_SEND = 4;
             [strongSelf onProtocolClosed];
         }
     };
-    // Send a first heartbeat
-    [self sendHeartbeat];
-
     [self.heartbeatTimer start];
 }
 
@@ -332,6 +329,7 @@ const UInt8 MAX_VERSION_TO_SEND = 4;
     self.version = MIN(self.maxVersionSupportedByHeadUnit, MAX_VERSION_TO_SEND);
 
     if (self.version >= 3) {
+        self.heartbeatACKed = YES; // Ensures a first heartbeat is sent
         [self startHeartbeatTimerWithDuration:5.0];
     }
 

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLProtocolHeader.h
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLProtocolHeader.h
@@ -12,6 +12,7 @@ typedef NS_ENUM(UInt8, SDLFrameType) {
 };
 
 typedef NS_ENUM(UInt8, SDLServiceType) {
+    SDLServiceType_Control = 0,
     SDLServiceType_RPC = 7,
     SDLServiceType_Audio = 10,
     SDLServiceType_Video = 11,
@@ -20,6 +21,7 @@ typedef NS_ENUM(UInt8, SDLServiceType) {
 
 typedef NS_ENUM(UInt8, SDLFrameData) {
     SDLFrameData_Heartbeat = 0,
+    SDLFrameData_HeartbeatACK = 0xFF,
     SDLFrameData_StartSession = 1,
     SDLFrameData_StartSessionACK = 2,
     SDLFrameData_StartSessionNACK = 3,

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLProtocolHeader.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLProtocolHeader.m
@@ -51,7 +51,8 @@
             return [[SDLV2ProtocolHeader alloc] initWithVersion:version];
         } break;
         default: {
-            @throw [NSException exceptionWithName:NSInvalidArgumentException reason:@"The version of header that is being created is unknown" userInfo:@{ @"requestedVersion" : @(version) }];
+            NSString *reason = [NSString stringWithFormat:@"The version of header that is being created is unknown: %@", @(version)];
+            @throw [NSException exceptionWithName:NSInvalidArgumentException reason:reason userInfo:@{ @"requestedVersion" : @(version) }];
         } break;
     }
 }

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLProtocolListener.h
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLProtocolListener.h
@@ -9,7 +9,8 @@
 @protocol SDLProtocolListener <NSObject>
 
 - (void)handleProtocolSessionStarted:(SDLServiceType)serviceType sessionID:(Byte)sessionID version:(Byte)version;
-- (void)handleHeartbeat;
+- (void)handleHeartbeatForSession:(Byte)session;
+- (void)handleHeartbeatACK;
 - (void)onProtocolMessageReceived:(SDLProtocolMessage *)msg;
 - (void)onProtocolOpened;
 - (void)onProtocolClosed;

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLProtocolListener.h
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLProtocolListener.h
@@ -9,6 +9,7 @@
 @protocol SDLProtocolListener <NSObject>
 
 - (void)handleProtocolSessionStarted:(SDLServiceType)serviceType sessionID:(Byte)sessionID version:(Byte)version;
+- (void)handleHeartbeat;
 - (void)onProtocolMessageReceived:(SDLProtocolMessage *)msg;
 - (void)onProtocolOpened;
 - (void)onProtocolClosed;

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLProtocolReceivedMessageRouter.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLProtocolReceivedMessageRouter.m
@@ -47,7 +47,6 @@
         case SDLFrameType_Consecutive:
             [self dispatchMultiPartMessage:message];
             break;
-
         default:
             break;
     }
@@ -62,6 +61,9 @@
         [self.delegate handleProtocolSessionStarted:message.header.serviceType
                                           sessionID:message.header.sessionID
                                             version:message.header.version];
+    }
+    else if (message.header.frameData == SDLFrameData_Heartbeat) {
+        [self.delegate handleHeartbeat];
     }
 }
 

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLProtocolReceivedMessageRouter.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLProtocolReceivedMessageRouter.m
@@ -63,7 +63,10 @@
                                             version:message.header.version];
     }
     else if (message.header.frameData == SDLFrameData_Heartbeat) {
-        [self.delegate handleHeartbeat];
+        [self.delegate handleHeartbeatForSession:message.header.sessionID];
+    }
+    else if (message.header.frameData == SDLFrameData_HeartbeatACK) {
+        [self.delegate handleHeartbeatACK];
     }
 }
 

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLTimer.h
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLTimer.h
@@ -10,8 +10,8 @@
 @property (nonatomic, copy) void (^canceledBlock)(void);
 @property (assign) float duration;
 
-- (id)init;
-- (id)initWithDuration:(float)duration __deprecated;
+- (instancetype)init;
+- (instancetype)initWithDuration:(float)duration __deprecated;
 - (instancetype)initWithDuration:(float)duration repeat:(BOOL)repeat;
 - (void)start;
 - (void)cancel;

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLTimer.h
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLTimer.h
@@ -11,7 +11,8 @@
 @property (assign) float duration;
 
 - (id)init;
-- (id)initWithDuration:(float)duration;
+- (id)initWithDuration:(float)duration __deprecated;
+- (instancetype)initWithDuration:(float)duration repeat:(BOOL)repeat;
 - (void)start;
 - (void)cancel;
 

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLTimer.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLTimer.m
@@ -56,8 +56,10 @@
 }
 
 - (void)timerElapsed {
-    [self stopAndDestroyTimer];
-    self.timerRunning = NO;
+    if (self.repeat == NO) {
+        [self stopAndDestroyTimer];
+        self.timerRunning = NO;
+    }
     if (self.elapsedBlock != nil) {
         self.elapsedBlock();
     }

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLTimer.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLTimer.m
@@ -15,7 +15,7 @@
 
 @implementation SDLTimer
 
-- (id)init {
+- (instancetype)init {
     if (self = [super init]) {
         _duration = 0;
         _timerRunning = NO;
@@ -23,7 +23,7 @@
     return self;
 }
 
-- (id)initWithDuration:(float)duration {
+- (instancetype)initWithDuration:(float)duration {
     return [self initWithDuration:duration repeat:NO];
 }
 

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLTimer.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLTimer.m
@@ -40,7 +40,7 @@
 - (void)start {
     if (self.duration > 0) {
         [self stopAndDestroyTimer];
-        self.timer = [NSTimer timerWithTimeInterval:self.duration target:self selector:@selector(timerElapsed) userInfo:nil repeats:NO];
+        self.timer = [NSTimer timerWithTimeInterval:self.duration target:self selector:@selector(timerElapsed) userInfo:nil repeats:self.repeat];
         [[NSRunLoop mainRunLoop] addTimer:self.timer forMode:NSRunLoopCommonModes];
         self.timerRunning = YES;
     }

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLTimer.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLTimer.m
@@ -9,7 +9,7 @@
 
 @property (strong) NSTimer *timer;
 @property (assign) BOOL timerRunning;
-
+@property (nonatomic) BOOL repeat;
 @end
 
 
@@ -24,8 +24,14 @@
 }
 
 - (id)initWithDuration:(float)duration {
-    if (self = [super init]) {
+    return [self initWithDuration:duration repeat:NO];
+}
+
+- (instancetype)initWithDuration:(float)duration repeat:(BOOL)repeat {
+    self = [super init];
+    if (self) {
         _duration = duration;
+        _repeat = repeat;
         _timerRunning = NO;
     }
     return self;


### PR DESCRIPTION
[READY FOR REVIEW]

  * Updates the SDLTimer class to support repeat
  * Implements responding to heartbeats with heartbeat ACK independent of version
  * If version is 3 or greater, the proxy will now send a heartbeat every 5 seconds. If a heartbeat ACK is received, when the timer fires at 5 seconds the proxy will send another heartbeat. If the timer fires and no heartbeat ACK has been received, the proxy is disposed.
  * Any protocol message that is received on the transport (except for heartbeat and heartbeat ACK) will reset the heartbeat timer back to 5 seconds.

Resolves #264 