### PR TITLE
Add abstraction for NSURLSession and NSURLConnection to support earlier iOS versions

### DIFF
--- a/SmartDeviceLink-iOS/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
+++ b/SmartDeviceLink-iOS/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
@@ -238,6 +238,15 @@
 		1680B11C1A9CD7AD00DBD79E /* SDLProtocolMessageAssemblerSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 1680B1101A9CD7AD00DBD79E /* SDLProtocolMessageAssemblerSpec.m */; };
 		1680B11D1A9CD7AD00DBD79E /* SDLProtocolMessageDisassemblerSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 1680B1111A9CD7AD00DBD79E /* SDLProtocolMessageDisassemblerSpec.m */; };
 		1680B11E1A9CD7AD00DBD79E /* SDLProtocolReceivedMessageRouterSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 1680B1121A9CD7AD00DBD79E /* SDLProtocolReceivedMessageRouterSpec.m */; };
+		1EB302EC1B79D383007A58D3 /* SDLConnectionProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 1EB302EA1B79D383007A58D3 /* SDLConnectionProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1EB302ED1B79D383007A58D3 /* SDLConnectionProtocol.m in Sources */ = {isa = PBXBuildFile; fileRef = 1EB302EB1B79D383007A58D3 /* SDLConnectionProtocol.m */; };
+		1EB302EE1B79D383007A58D3 /* SDLConnectionProtocol.m in Sources */ = {isa = PBXBuildFile; fileRef = 1EB302EB1B79D383007A58D3 /* SDLConnectionProtocol.m */; };
+		1EB302F11B79D3A5007A58D3 /* SDLURLConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 1EB302EF1B79D3A5007A58D3 /* SDLURLConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1EB302F21B79D3A5007A58D3 /* SDLURLConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 1EB302F01B79D3A5007A58D3 /* SDLURLConnection.m */; };
+		1EB302F31B79D3A5007A58D3 /* SDLURLConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 1EB302F01B79D3A5007A58D3 /* SDLURLConnection.m */; };
+		1EB302F61B79D3B9007A58D3 /* SDLURLSession.h in Headers */ = {isa = PBXBuildFile; fileRef = 1EB302F41B79D3B9007A58D3 /* SDLURLSession.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1EB302F71B79D3B9007A58D3 /* SDLURLSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 1EB302F51B79D3B9007A58D3 /* SDLURLSession.m */; };
+		1EB302F81B79D3B9007A58D3 /* SDLURLSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 1EB302F51B79D3B9007A58D3 /* SDLURLSession.m */; };
 		5D0218F61A8E79C400D1BF62 /* ConnectionTCPTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D0218F51A8E79C400D1BF62 /* ConnectionTCPTableViewController.m */; };
 		5D0218F91A8E7A7300D1BF62 /* ConnectionTCPTableViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5D0218F71A8E7A7300D1BF62 /* ConnectionTCPTableViewController.storyboard */; };
 		5D0218FC1A8E7E1700D1BF62 /* ConnectionContainerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D0218FB1A8E7E1700D1BF62 /* ConnectionContainerViewController.m */; };
@@ -1073,6 +1082,12 @@
 		1680B1101A9CD7AD00DBD79E /* SDLProtocolMessageAssemblerSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLProtocolMessageAssemblerSpec.m; sourceTree = "<group>"; };
 		1680B1111A9CD7AD00DBD79E /* SDLProtocolMessageDisassemblerSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLProtocolMessageDisassemblerSpec.m; sourceTree = "<group>"; };
 		1680B1121A9CD7AD00DBD79E /* SDLProtocolReceivedMessageRouterSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLProtocolReceivedMessageRouterSpec.m; sourceTree = "<group>"; };
+		1EB302EA1B79D383007A58D3 /* SDLConnectionProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDLConnectionProtocol.h; sourceTree = "<group>"; };
+		1EB302EB1B79D383007A58D3 /* SDLConnectionProtocol.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLConnectionProtocol.m; sourceTree = "<group>"; };
+		1EB302EF1B79D3A5007A58D3 /* SDLURLConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDLURLConnection.h; sourceTree = "<group>"; };
+		1EB302F01B79D3A5007A58D3 /* SDLURLConnection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLURLConnection.m; sourceTree = "<group>"; };
+		1EB302F41B79D3B9007A58D3 /* SDLURLSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDLURLSession.h; sourceTree = "<group>"; };
+		1EB302F51B79D3B9007A58D3 /* SDLURLSession.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLURLSession.m; sourceTree = "<group>"; };
 		5D0218F41A8E79C400D1BF62 /* ConnectionTCPTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ConnectionTCPTableViewController.h; path = SmartDeviceLink_Example/Classes/ConnectionTCPTableViewController.h; sourceTree = SOURCE_ROOT; };
 		5D0218F51A8E79C400D1BF62 /* ConnectionTCPTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ConnectionTCPTableViewController.m; path = SmartDeviceLink_Example/Classes/ConnectionTCPTableViewController.m; sourceTree = SOURCE_ROOT; };
 		5D0218F81A8E7A7300D1BF62 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = SmartDeviceLink_Example/Base.lproj/ConnectionTCPTableViewController.storyboard; sourceTree = SOURCE_ROOT; };
@@ -2166,6 +2181,12 @@
 				5D61FB601A84238B00846EE7 /* SDLProtocolMessageDisassembler.m */,
 				5D61FB611A84238B00846EE7 /* SDLProtocolReceivedMessageRouter.h */,
 				5D61FB621A84238B00846EE7 /* SDLProtocolReceivedMessageRouter.m */,
+				1EB302EA1B79D383007A58D3 /* SDLConnectionProtocol.h */,
+				1EB302EB1B79D383007A58D3 /* SDLConnectionProtocol.m */,
+				1EB302EF1B79D3A5007A58D3 /* SDLURLConnection.h */,
+				1EB302F01B79D3A5007A58D3 /* SDLURLConnection.m */,
+				1EB302F41B79D3B9007A58D3 /* SDLURLSession.h */,
+				1EB302F51B79D3B9007A58D3 /* SDLURLSession.m */,
 			);
 			name = Protocol;
 			sourceTree = "<group>";
@@ -2909,6 +2930,9 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1EB302F11B79D3A5007A58D3 /* SDLURLConnection.h in Headers */,
+				1EB302F61B79D3B9007A58D3 /* SDLURLSession.h in Headers */,
+				1EB302EC1B79D383007A58D3 /* SDLConnectionProtocol.h in Headers */,
 				5DE5ABB71B0E38C90067BB02 /* SDLSystemRequest.h in Headers */,
 				E9C32B931AB20BA200F283AF /* SDLIAPSessionDelegate.h in Headers */,
 				5DE5ABB81B0E38C90067BB02 /* SDLSystemRequestResponse.h in Headers */,
@@ -3341,6 +3365,7 @@
 				5D61FC441A84238C00846EE7 /* SDLAppInterfaceUnregisteredReason.m in Sources */,
 				5D61FD531A84238C00846EE7 /* SDLProxyFactory.m in Sources */,
 				5D61FDCA1A84238C00846EE7 /* SDLTextField.m in Sources */,
+				1EB302ED1B79D383007A58D3 /* SDLConnectionProtocol.m in Sources */,
 				5D61FC9D1A84238C00846EE7 /* SDLEmergencyEventType.m in Sources */,
 				5D61FCAC1A84238C00846EE7 /* SDLFuelCutoffStatus.m in Sources */,
 				5D61FC871A84238C00846EE7 /* SDLDeviceStatus.m in Sources */,
@@ -3480,6 +3505,7 @@
 				5DCF76F61ACDBAD300BB647B /* SDLSendLocation.m in Sources */,
 				5D61FC771A84238C00846EE7 /* SDLDeleteFile.m in Sources */,
 				5D61FC811A84238C00846EE7 /* SDLDeleteSubMenuResponse.m in Sources */,
+				1EB302F21B79D3A5007A58D3 /* SDLURLConnection.m in Sources */,
 				5D61FC7B1A84238C00846EE7 /* SDLDeleteInteractionChoiceSet.m in Sources */,
 				5D61FDC01A84238C00846EE7 /* SDLSystemRequest.m in Sources */,
 				5D61FD021A84238C00846EE7 /* SDLOnAudioPassThru.m in Sources */,
@@ -3493,6 +3519,7 @@
 				5D61FD121A84238C00846EE7 /* SDLOnKeyboardInput.m in Sources */,
 				5D61FCCA1A84238C00846EE7 /* SDLIgnitionStableStatus.m in Sources */,
 				5D61FCFB1A84238C00846EE7 /* SDLMyKey.m in Sources */,
+				1EB302F71B79D3B9007A58D3 /* SDLURLSession.m in Sources */,
 				5D61FCAA1A84238C00846EE7 /* SDLFileType.m in Sources */,
 				5DE372A21ACB2ED300849FAA /* SDLHMICapabilities.m in Sources */,
 				5D61FDD41A84238C00846EE7 /* SDLTouchEvent.m in Sources */,
@@ -3642,6 +3669,7 @@
 				162E83661A9BDE8B00906325 /* SDLShowResponseSpec.m in Sources */,
 				162E83221A9BDE8B00906325 /* SDLAddCommandSpec.m in Sources */,
 				162E83121A9BDE8B00906325 /* SDLOnButtonPressSpec.m in Sources */,
+				1EB302EE1B79D383007A58D3 /* SDLConnectionProtocol.m in Sources */,
 				162E838D1A9BDE8B00906325 /* SDLStartTimeSpec.m in Sources */,
 				162E836E1A9BDE8B00906325 /* SDLUnsubscribeButtonResponseSpec.m in Sources */,
 				162E835B1A9BDE8B00906325 /* SDLPerformInteractionResponseSpec.m in Sources */,
@@ -3720,6 +3748,7 @@
 				162E830D1A9BDE8B00906325 /* SDLWiperStatusSpec.m in Sources */,
 				162E832C1A9BDE8B00906325 /* SDLDiagnosticMessageSpec.m in Sources */,
 				162E83381A9BDE8B00906325 /* SDLScrollableMessageSpec.m in Sources */,
+				1EB302F81B79D3B9007A58D3 /* SDLURLSession.m in Sources */,
 				162E82E81A9BDE8B00906325 /* SDLKeyboardLayoutSpec.m in Sources */,
 				162E83541A9BDE8B00906325 /* SDLEncodedSyncPDataResponseSpec.m in Sources */,
 				162E83161A9BDE8B00906325 /* SDLOnHashChangeSpec.m in Sources */,
@@ -3750,6 +3779,7 @@
 				162E83651A9BDE8B00906325 /* SDLShowConstantTBTResponseSpec.m in Sources */,
 				162E82F91A9BDE8B00906325 /* SDLSamplingRateSpec.m in Sources */,
 				162E82CB1A9BDE8A00906325 /* SDLAppHMITypeSpec.m in Sources */,
+				1EB302F31B79D3A5007A58D3 /* SDLURLConnection.m in Sources */,
 				162E83031A9BDE8B00906325 /* SDLTriggerSource.m in Sources */,
 				162E82D61A9BDE8A00906325 /* SDLComponentVolumeStatusSpec.m in Sources */,
 				162E835C1A9BDE8B00906325 /* SDLPutFileResponseSpec.m in Sources */,
@@ -4004,6 +4034,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -4040,6 +4071,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
 				INFOPLIST_FILE = SmartDeviceLink/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
@@ -4069,6 +4101,7 @@
 					"$(inherited)",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -4109,6 +4142,7 @@
 					"$(inherited)",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLConnectionProtocol.h
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLConnectionProtocol.h
@@ -1,0 +1,30 @@
+//
+//  SDLConnectionProtocol.h
+//  SmartDeviceLink-iOS
+//
+//  Created by CHDSEZ318988DADM on 11/08/15.
+//  Copyright (c) 2015 smartdevicelink. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@protocol SDLConnectionDelegate
+
+- (void)SyncPDataNetworkRequestCompleteWithData:(NSData*) data;
+- (void)handleSystemResponseProprietary:(NSData*) data;
+- (void)handleSystemQueryAppsResponse:(NSData *)data andTask:(id)connectionTask ;
+
+@end
+
+@interface SDLConnectionProtocol : NSObject
+
+- (id) initWithDelegate:(id<SDLConnectionDelegate>)delegate withDebugConsoleGroup:(NSString*)debugConsoleGroupName ;
+
+- (void) uploadTaskWithPData:(NSData*)data withRequest:(NSMutableURLRequest*)request withTimeout:(NSNumber *)timeout;
+
+- (void) uploadTaskWithSystemProprietaryDictionary:(NSDictionary*)dictionary withURLString:(NSString*) urlString;
+
+- (void) dataTaskForSystemRequestURLString:(NSString *)urlString;
+
+- (void) cancelAndInvalidate;
+@end

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLConnectionProtocol.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLConnectionProtocol.m
@@ -1,0 +1,74 @@
+//
+//  SDLConnectionProtocol.m
+//  SmartDeviceLink-iOS
+//
+//  Created by CHDSEZ318988DADM on 11/08/15.
+//  Copyright (c) 2015 smartdevicelink. All rights reserved.
+//
+
+#import "SDLConnectionProtocol.h"
+#import "SDLDebugTool.h"
+#import "SDLURLConnection.h"
+#import "SDLURLSession.h"
+#import <UIKit/UIKit.h>
+
+
+@interface SDLConnectionProtocol () {
+    id _delegate;
+}
+@property (nonatomic,strong) id connectionObject;
+
+@end
+
+@implementation SDLConnectionProtocol
+- (id)initWithDelegate:(id<SDLConnectionDelegate>)delegate withDebugConsoleGroup:(NSString *)debugConsoleGroupName{
+    self = [super init];
+    if(self) {
+        _delegate = delegate;
+    }
+    if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 7.0f) {
+        self.connectionObject = [[SDLURLSession alloc] initWithDelegate:(id)self withDebugConsoleGroup:debugConsoleGroupName];
+    }
+    else {
+        self.connectionObject = [[SDLURLConnection alloc] initWithDelegate:(id)self withDebugConsoleGroup:debugConsoleGroupName];
+        
+    }
+    return self;
+}
+
+- (void)uploadTaskWithPData:(NSData *)data withRequest:(NSMutableURLRequest *)request withTimeout:(NSNumber*) timeout{
+    [self.connectionObject uploadTaskWithPData:data withRequest:request withTimeout:timeout];
+}
+
+- (void)uploadTaskWithSystemProprietaryDictionary:(NSDictionary *)dictionary withURLString:(NSString *)urlString {
+    [self.connectionObject uploadTaskWithSystemProprietaryDictionary:dictionary withURLString:urlString];
+}
+
+
+- (void) dataTaskForSystemRequestURLString:(NSString *)urlString {
+    [self.connectionObject dataTaskForSystemRequestURLString:urlString];
+}
+
+- (void)cancelAndInvalidate {
+    [self.connectionObject cancelAndInvalidate];
+}
+#pragma mark - connection delegate
+-(void)syncPDatadataReady:(NSData*)data {
+    if (_delegate && [_delegate respondsToSelector:@selector(SyncPDataNetworkRequestCompleteWithData:)]) {
+        [_delegate SyncPDataNetworkRequestCompleteWithData:data];
+    }
+}
+
+-(void) systemProprietarydataReady:(NSData*)data {
+    if (_delegate && [_delegate respondsToSelector:@selector(handleSystemResponseProprietary:)]) {
+        [_delegate  handleSystemResponseProprietary:data];
+    }
+}
+
+-(void) systemQueueAppDataReady:(NSData*)data {
+    if (_delegate && [_delegate respondsToSelector:@selector(handleSystemQueryAppsResponse:andTask:)]) {
+        [_delegate  handleSystemQueryAppsResponse:data andTask:self];
+    }
+}
+
+@end

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLProxy.h
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLProxy.h
@@ -12,9 +12,10 @@
 #import "SDLProtocolListener.h"
 #import "SDLProxyListener.h"
 #import "SDLRPCRequestFactory.h"
+#import "SDLConnectionProtocol.h"
 
 
-@interface SDLProxy : NSObject <SDLProtocolListener, NSStreamDelegate> {
+@interface SDLProxy : NSObject <SDLProtocolListener, NSStreamDelegate,SDLConnectionDelegate> {
     Byte _version;
     Byte _bulkSessionID;
     BOOL _isConnected;

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLProxy.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLProxy.m
@@ -39,7 +39,6 @@
 #import "SDLProtocolMessage.h"
 #import "SDLTimer.h"
 
-
 typedef void (^URLSessionTaskCompletionHandler)(NSData *data, NSURLResponse *response, NSError *error);
 
 NSString *const SDLProxyVersion = @"4.0.0-alpha.3";
@@ -47,11 +46,9 @@ const float startSessionTime = 10.0;
 const float notifyProxyClosedDelay = 0.1;
 const int POLICIES_CORRELATION_ID = 65535;
 
-
 @interface SDLProxy () {
     SDLLockScreenManager *_lsm;
-    NSURLSession *_systemRequestSession;
-    NSURLSession *_encodedSyncPDataSession;
+    SDLConnectionProtocol *connectionProtocol;
 }
 
 @property (strong, nonatomic) NSMutableSet *activeSystemRequestTasks;
@@ -94,13 +91,8 @@ const int POLICIES_CORRELATION_ID = 65535;
 
         [[NSNotificationCenter defaultCenter] removeObserver:self];
         [[EAAccessoryManager sharedAccessoryManager] unregisterForLocalNotifications];
-
-        if (_systemRequestSession != nil) {
-            [_systemRequestSession invalidateAndCancel];
-        }
-
-        if (_encodedSyncPDataSession != nil) {
-            [_encodedSyncPDataSession invalidateAndCancel];
+        if (connectionProtocol != nil) {
+            [connectionProtocol cancelAndInvalidate];
         }
 
         [self.protocol dispose];
@@ -408,86 +400,82 @@ const int POLICIES_CORRELATION_ID = 65535;
         [SDLDebugTool logInfo:logMessage withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
     }
 
-    // Send the HTTP Request
-    NSURLSessionUploadTask *task = [self uploadTaskForBodyDataDictionary:JSONDictionary URLString:request.url completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-        NSString *logMessage = nil;
-        
-        if (error) {
-            logMessage = [NSString stringWithFormat:@"OnSystemRequest (HTTP response) = ERROR: %@", error];
+    if (!connectionProtocol) {
+        connectionProtocol = [[SDLConnectionProtocol alloc]initWithDelegate:self withDebugConsoleGroup:self.debugConsoleGroupName];
+    }
+    [connectionProtocol uploadTaskWithSystemProprietaryDictionary:JSONDictionary withURLString:request.url];
+}
+
+// Handle the OnSystemRequest HTTP Response
+-(void)handleSystemResponseProprietary:(NSData*)data {
+    NSString *logMessage = nil;
+    
+    if (data == nil || data.length == 0) {
+        [SDLDebugTool logInfo:@"OnSystemRequest (HTTP response) failure: no data returned" withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
+        return;
+    }
+    
+    // Show the HTTP response
+    [SDLDebugTool logInfo:@"OnSystemRequest (HTTP response)" withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
+    
+    // Create the SystemRequest RPC to send to module.
+    SDLSystemRequest *request = [[SDLSystemRequest alloc] init];
+    request.correlationID = [NSNumber numberWithInt:POLICIES_CORRELATION_ID];
+    request.requestType = [SDLRequestType PROPRIETARY];
+    request.bulkData = data;
+    
+    // Parse and display the policy data.
+    SDLPolicyDataParser *pdp = [[SDLPolicyDataParser alloc] init];
+    NSData *policyData = [pdp unwrap:data];
+    if (policyData) {
+        [pdp parsePolicyData:policyData];
+        logMessage = [NSString stringWithFormat:@"Policy Data from Cloud\n%@", pdp];
+        [SDLDebugTool logInfo:logMessage withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
+    }
+    
+    // Send and log RPC Request
+    logMessage = [NSString stringWithFormat:@"SystemRequest (request)\n%@\nData length=%lu", [request serializeAsDictionary:2], (unsigned long)data.length ];
+    [SDLDebugTool logInfo:logMessage withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
+    [self sendRPC:request];
+}
+
+
+
+- (void)handleSystemRequestQueryApps:(SDLOnSystemRequest *)request {
+    SDLConnectionProtocol *task = [[SDLConnectionProtocol alloc]initWithDelegate:self withDebugConsoleGroup:self.debugConsoleGroupName];
+    [self.activeSystemRequestTasks addObject:task];
+    [task dataTaskForSystemRequestURLString:request.url ];
+}
+
+// Handle the systemRequestQueryApps HTTP Response
+- (void) handleSystemQueryAppsResponse:(NSData *)data andTask:(SDLConnectionProtocol *)connectionTask {
+    if ([self.activeSystemRequestTasks containsObject:connectionTask]) {
+        [self.activeSystemRequestTasks removeObject:connectionTask];
+    }
+    
+    NSError *JSONError = nil;
+    NSDictionary *responseDictionary = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:&JSONError];
+    if (JSONError != nil) {
+        NSString *logMessage = [NSString stringWithFormat:@"OnSystemRequest failure (HTTP response), data parsing failed: %@", JSONError.localizedDescription];
+        [SDLDebugTool logInfo:logMessage withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
+        return;
+    }
+    
+    [SDLQueryAppsManager filterQueryResponse:responseDictionary completionBlock:^(NSData *filteredResponseData, NSError *error) {
+        if (error != nil) {
+            NSString *logMessage = [NSString stringWithFormat:@"OnSystemRequest failure, filtering response failed: %@", error.localizedDescription];
             [SDLDebugTool logInfo:logMessage withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
             return;
         }
         
-        if (data == nil || data.length == 0) {
-            [SDLDebugTool logInfo:@"OnSystemRequest (HTTP response) failure: no data returned" withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
-            return;
-        }
-        
-        // Show the HTTP response
-        [SDLDebugTool logInfo:@"OnSystemRequest (HTTP response)" withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
-        
-        // Create the SystemRequest RPC to send to module.
         SDLSystemRequest *request = [[SDLSystemRequest alloc] init];
-        request.correlationID = [NSNumber numberWithInt:POLICIES_CORRELATION_ID];
-        request.requestType = [SDLRequestType PROPRIETARY];
-        request.bulkData = data;
+        request.requestType = [SDLRequestType QUERY_APPS];
+        request.bulkData = filteredResponseData;
         
-        // Parse and display the policy data.
-        SDLPolicyDataParser *pdp = [[SDLPolicyDataParser alloc] init];
-        NSData *policyData = [pdp unwrap:data];
-        if (policyData) {
-            [pdp parsePolicyData:policyData];
-            logMessage = [NSString stringWithFormat:@"Policy Data from Cloud\n%@", pdp];
-            [SDLDebugTool logInfo:logMessage withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
-        }
-        
-        // Send and log RPC Request
-        logMessage = [NSString stringWithFormat:@"SystemRequest (request)\n%@\nData length=%lu", [request serializeAsDictionary:2], (unsigned long)data.length ];
+        NSString *logMessage = [NSString stringWithFormat:@"SystemRequest (request)\n%@\nData length=%lu", [request serializeAsDictionary:2], (unsigned long)data.length];
         [SDLDebugTool logInfo:logMessage withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
         [self sendRPC:request];
     }];
-    [task resume];
-}
-
-- (void)handleSystemRequestQueryApps:(SDLOnSystemRequest *)request {
-    NSURLSessionDataTask *task = nil;
-    task = [self dataTaskForSystemRequestURLString:request.url completionHandler:^(NSData *data, NSURLResponse *response, NSError *requestError) {
-        if ([self.activeSystemRequestTasks containsObject:task]) {
-            [self.activeSystemRequestTasks removeObject:task];
-        }
-        
-        if (requestError != nil) {
-            NSString *logMessage = [NSString stringWithFormat:@"OnSystemRequest failure (HTTP response), upload task failed: %@", requestError.localizedDescription];
-            [SDLDebugTool logInfo:logMessage withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
-            return;
-        }
-        
-        NSError *JSONError = nil;
-        NSDictionary *responseDictionary = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:&JSONError];
-        if (JSONError != nil) {
-            NSString *logMessage = [NSString stringWithFormat:@"OnSystemRequest failure (HTTP response), data parsing failed: %@", JSONError.localizedDescription];
-            [SDLDebugTool logInfo:logMessage withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
-            return;
-        }
-        
-        [SDLQueryAppsManager filterQueryResponse:responseDictionary completionBlock:^(NSData *filteredResponseData, NSError *error) {
-            if (error != nil) {
-                NSString *logMessage = [NSString stringWithFormat:@"OnSystemRequest failure, filtering response failed: %@", error.localizedDescription];
-                [SDLDebugTool logInfo:logMessage withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
-                return;
-            }
-            
-            SDLSystemRequest *request = [[SDLSystemRequest alloc] init];
-            request.requestType = [SDLRequestType QUERY_APPS];
-            request.bulkData = filteredResponseData;
-            
-            NSString *logMessage = [NSString stringWithFormat:@"SystemRequest (request)\n%@\nData length=%lu", [request serializeAsDictionary:2], (unsigned long)data.length];
-            [SDLDebugTool logInfo:logMessage withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
-            [self sendRPC:request];
-        }];
-    }];
-    [self.activeSystemRequestTasks addObject:task];
-    [task resume];
 }
 
 - (void)handleSystemRequestLaunchApp:(SDLOnSystemRequest *)request {
@@ -535,64 +523,6 @@ const int POLICIES_CORRELATION_ID = 65535;
     return JSONDictionary;
 }
 
-/**
- *  Generate an NSURLSessionUploadTask for System Request
- *
- *  @param dictionary        The system request dictionary that contains the HTTP data to be sent
- *  @param urlString         A string containing the URL to send the upload to
- *  @param completionHandler A completion handler returning the response from the server to the upload task
- *
- *  @return The upload task, which can be started by calling -[resume]
- */
-- (NSURLSessionUploadTask *)uploadTaskForBodyDataDictionary:(NSDictionary *)dictionary URLString:(NSString *)urlString completionHandler:(URLSessionTaskCompletionHandler)completionHandler {
-    NSParameterAssert(dictionary != nil);
-    NSParameterAssert(urlString != nil);
-    NSParameterAssert(completionHandler != NULL);
-
-    // Extract data from the dictionary
-    NSDictionary *requestData = dictionary[@"HTTPRequest"];
-    NSDictionary *headers = requestData[@"headers"];
-    NSString *contentType = headers[@"ContentType"];
-    NSTimeInterval timeout = [headers[@"ConnectTimeout"] doubleValue];
-    NSString *method = headers[@"RequestMethod"];
-    NSString *bodyString = requestData[@"body"];
-    NSData *bodyData = [bodyString dataUsingEncoding:NSUTF8StringEncoding];
-
-    // NSURLSession configuration
-    NSURL *url = [NSURL URLWithString:urlString];
-    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
-    [request setValue:contentType forHTTPHeaderField:@"content-type"];
-    request.timeoutInterval = timeout;
-    request.HTTPMethod = method;
-
-    // Logging
-    NSString *logMessage = [NSString stringWithFormat:@"OnSystemRequest (HTTP Request) to URL %@", urlString];
-    [SDLDebugTool logInfo:logMessage withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
-
-    // Create the upload task
-    return [[NSURLSession sharedSession] uploadTaskWithRequest:request fromData:bodyData completionHandler:completionHandler];
-}
-
-/**
- *  Generate an NSURLSessionDataTask for System Requests
- *
- *  @param urlString         A string containing the URL to request data from
- *  @param completionHandler A completion handler returning the response from the server to the data task
- *
- *  @return The data task, which can be started by calling -[resume]
- */
-- (NSURLSessionDataTask *)dataTaskForSystemRequestURLString:(NSString *)urlString completionHandler:(URLSessionTaskCompletionHandler)completionHandler {
-    NSParameterAssert(urlString != nil);
-    NSParameterAssert(completionHandler != nil);
-
-    NSString *logMessage = [NSString stringWithFormat:@"OnSystemRequest (HTTP Request to URL: %@", urlString];
-    [SDLDebugTool logInfo:logMessage withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
-
-    // Create and return the data task
-    return [[NSURLSession sharedSession] dataTaskWithURL:[NSURL URLWithString:urlString]];
-}
-
-
 #pragma mark - Delegate management
 - (void)addDelegate:(NSObject<SDLProxyListener> *)delegate {
     @synchronized(self.proxyListeners) {
@@ -615,13 +545,7 @@ const int POLICIES_CORRELATION_ID = 65535;
     NSURL *url = [NSURL URLWithString:urlString];
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
     request.HTTPMethod = @"POST";
-
-    // Configure HTTP Session
-    NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
-    config.HTTPAdditionalHeaders = @{ @"Content-Type" : @"application/json" };
-    config.timeoutIntervalForRequest = 60;
-    NSURLSession *session = [NSURLSession sessionWithConfiguration:config];
-
+    
     // Prepare the data in the required format
     NSString *encodedSyncPDataString = [[NSString stringWithFormat:@"%@", encodedSyncPData] componentsSeparatedByString:@"\""][1];
     NSArray *array = [NSArray arrayWithObject:encodedSyncPDataString];
@@ -635,16 +559,16 @@ const int POLICIES_CORRELATION_ID = 65535;
     }
 
     // Send the HTTP Request
-    NSURLSessionUploadTask *uploadTask = [session uploadTaskWithRequest:request fromData:data completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-        [self SyncPDataNetworkRequestCompleteWithData:data response:response error:error];
-    }];
-    [uploadTask resume];
+    if (!connectionProtocol) {
+        connectionProtocol = [[SDLConnectionProtocol alloc]initWithDelegate:self withDebugConsoleGroup:self.debugConsoleGroupName];
+    }
+    [connectionProtocol uploadTaskWithPData:data withRequest:request withTimeout:timeout];
 
     [SDLDebugTool logInfo:@"OnEncodedSyncPData (HTTP request)" withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
 }
 
 // Handle the OnEncodedSyncPData HTTP Response
-- (void)SyncPDataNetworkRequestCompleteWithData:(NSData *)data response:(NSURLResponse *)response error:(NSError *)error {
+- (void)SyncPDataNetworkRequestCompleteWithData:(NSData *)data{
     // Sample of response: {"data":["SDLKGLSDKFJLKSjdslkfjslkJLKDSGLKSDJFLKSDJF"]}
     [SDLDebugTool logInfo:@"OnEncodedSyncPData (HTTP response)" withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
 
@@ -665,7 +589,6 @@ const int POLICIES_CORRELATION_ID = 65535;
         [self sendRPC:request];
     }
 }
-
 
 #pragma mark - PutFile Streaming
 - (void)putFileStream:(NSInputStream *)inputStream withRequest:(SDLPutFile *)putFileRPCRequest {

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLURLConnection.h
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLURLConnection.h
@@ -1,0 +1,30 @@
+//
+//  SDLURLConnection.h
+//  SmartDeviceLink-iOS
+//
+//  Created by CHDSEZ318988DADM on 11/08/15.
+//  Copyright (c) 2015 smartdevicelink. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@protocol SDLURLConnectionDelegate
+
+-(void)syncPDatadataReady:(NSData*)data;
+-(void)systemProprietarydataReady:(NSData*)data;
+-(void)systemQueueAppDataReady:(NSData*)data;
+
+@end
+
+@interface SDLURLConnection : NSObject<NSURLConnectionDataDelegate>
+
+-(id)initWithDelegate:(id<SDLURLConnectionDelegate>)delegate withDebugConsoleGroup:(NSString*)debugConsoleGroupName ;
+
+- (void) uploadTaskWithPData:(NSData*)data withRequest:(NSMutableURLRequest*)request withTimeout:(NSNumber*) timeout;
+
+- (void)uploadTaskWithSystemProprietaryDictionary:(NSDictionary *)dictionary withURLString:(NSString *)urlString;
+
+- (void) dataTaskForSystemRequestURLString:(NSString *)urlString;
+
+- (void) cancelAndInvalidate;
+@end

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLURLConnection.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLURLConnection.m
@@ -1,0 +1,197 @@
+//
+//  SDLURLConnection.m
+//  SmartDeviceLink-iOS
+//
+//  Created by CHDSEZ318988DADM on 11/08/15.
+//  Copyright (c) 2015 smartdevicelink. All rights reserved.
+//
+
+#import "SDLURLConnection.h"
+
+#import "SDLDebugTool.h"
+
+@interface SDLURLConnection () {
+    id _delegate;
+    NSURLConnection* _encodedSyncPDataConnection;
+    NSURLConnection* _systemRequestProprietaryConnection;
+    NSURLConnection* _queryAppConnection;
+    
+    NSMutableData *encodedSyncPResponseData;
+    NSMutableData *systemProprietaryResponseData;
+    NSMutableData *queryAppData;
+    
+}
+@property (strong) NSString *debugConsoleGroupName;
+
+@end
+
+@implementation SDLURLConnection
+-(id)initWithDelegate:(id<SDLURLConnectionDelegate>)delegate withDebugConsoleGroup:(NSString *)debugConsoleGroupName{
+    self = [super init];
+    if(self) {
+        _delegate = delegate;
+    }
+    self.debugConsoleGroupName = [[NSString alloc] initWithString:debugConsoleGroupName];
+    return self;
+}
+
+-(void)uploadTaskWithPData:(NSData *)data withRequest:(NSMutableURLRequest *)request withTimeout:(NSNumber*) timeout{
+    request.HTTPBody = data;
+    [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
+    request.timeoutInterval = [timeout doubleValue];
+    
+    _encodedSyncPDataConnection = [[NSURLConnection alloc] initWithRequest:request delegate:self startImmediately:NO];
+    [_encodedSyncPDataConnection scheduleInRunLoop:[NSRunLoop mainRunLoop]
+                                           forMode:NSDefaultRunLoopMode];
+    [_encodedSyncPDataConnection start];
+    
+    if (_encodedSyncPDataConnection == nil) {
+        NSString *logString = [NSString stringWithFormat:@"%s: Error creating NSURLConnection", __PRETTY_FUNCTION__];
+        [SDLDebugTool logInfo:logString withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
+    }
+    
+}
+- (void)uploadTaskWithSystemProprietaryDictionary:(NSDictionary *)dictionary withURLString:(NSString *)urlString {
+    
+    // Extract data from the dictionary
+    NSDictionary *requestData = dictionary[@"HTTPRequest"];
+    NSDictionary *headers = requestData[@"headers"];
+    NSString *contentType = headers[@"ContentType"];
+    NSTimeInterval timeout = [headers[@"ConnectTimeout"] doubleValue];
+    NSString *method = headers[@"RequestMethod"];
+    NSString *bodyString = requestData[@"body"];
+    NSData *bodyData = [bodyString dataUsingEncoding:NSUTF8StringEncoding];
+    
+    // NSURLConnection configuration
+    NSURL *url = [NSURL URLWithString:urlString];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
+    [request setValue:contentType forHTTPHeaderField:@"content-type"];
+    request.timeoutInterval = timeout;
+    request.HTTPMethod = method;
+    request.HTTPBody = bodyData;
+    
+    
+    // Logging
+    NSString *logMessage = [NSString stringWithFormat:@"OnSystemRequest (HTTP Request) to URL %@", request.URL];
+    [SDLDebugTool logInfo:logMessage withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
+    _systemRequestProprietaryConnection = [[NSURLConnection alloc] initWithRequest:request delegate:self startImmediately:NO];
+    [_systemRequestProprietaryConnection scheduleInRunLoop:[NSRunLoop mainRunLoop]
+                                                   forMode:NSDefaultRunLoopMode];
+    [_systemRequestProprietaryConnection start];
+    
+    if (_systemRequestProprietaryConnection == nil) {
+        NSString *logString = [NSString stringWithFormat:@"%s: Error creating NSURLConnection", __PRETTY_FUNCTION__];
+        [SDLDebugTool logInfo:logString withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
+    }
+    
+}
+
+- (void) dataTaskForSystemRequestURLString:(NSString *)urlString {
+    NSParameterAssert(urlString != nil);
+    
+    NSString *logMessage = [NSString stringWithFormat:@"OnSystemRequest (HTTP Request to URL: %@", urlString];
+    [SDLDebugTool logInfo:logMessage withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
+     NSURL *url = [NSURL URLWithString:urlString];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
+
+    _queryAppConnection = [[NSURLConnection alloc] initWithRequest:request delegate:self startImmediately:NO];
+    [_queryAppConnection scheduleInRunLoop:[NSRunLoop mainRunLoop]
+                                                   forMode:NSDefaultRunLoopMode];
+    [_queryAppConnection start];
+}
+
+- (void) cancelAndInvalidate {
+    
+    if (encodedSyncPResponseData != nil) {
+        encodedSyncPResponseData = nil;
+    }
+    if (systemProprietaryResponseData != nil) {
+        systemProprietaryResponseData = nil;
+    }
+    if (_encodedSyncPDataConnection != nil) {
+        [_encodedSyncPDataConnection cancel];
+    }
+    if (_systemRequestProprietaryConnection != nil) {
+        [_systemRequestProprietaryConnection cancel];
+    }
+    if (_queryAppConnection != nil) {
+        [_queryAppConnection cancel];
+    }
+    if (queryAppData != nil) {
+        queryAppData = nil;
+    }
+    
+}
+
+
+#pragma mark - NSURL Methods
+
+- (void)connection:(NSURLConnection *)connection didReceiveResponse:(NSURLResponse *)response {
+    // Can be called multiple times, such as a server redirect, so reset the data each time
+    if (connection == _encodedSyncPDataConnection) {
+        encodedSyncPResponseData = [[NSMutableData alloc] init];
+    }
+    else if (connection == _systemRequestProprietaryConnection) {
+        systemProprietaryResponseData = [[NSMutableData alloc] init];
+    }
+    else if (connection == _queryAppConnection) {
+        queryAppData = [[NSMutableData alloc] init];
+    }
+}
+
+- (void)connection:(NSURLConnection *)connection didReceiveData:(NSData *)data {
+    if (connection == _encodedSyncPDataConnection) {
+        [encodedSyncPResponseData appendData:data];
+    }
+    else if (connection == _systemRequestProprietaryConnection) {
+        [systemProprietaryResponseData appendData:data];
+    }
+    else if (connection == _queryAppConnection) {
+        [queryAppData appendData:data];
+    }
+}
+
+- (NSCachedURLResponse *)connection:(NSURLConnection *)connection willCacheResponse:(NSCachedURLResponse*)cachedResponse {
+    // Return nil to indicate not necessary to store a cached response for this connection
+    return nil;
+}
+
+-(void)connectionDidFinishLoading:(NSURLConnection *)connection {
+    if (connection == _encodedSyncPDataConnection) {
+        if (_delegate && [_delegate respondsToSelector:@selector(syncPDatadataReady:)]) {
+            [_delegate syncPDatadataReady:encodedSyncPResponseData];
+        }
+    }
+    else if (connection == _systemRequestProprietaryConnection) {
+        if (_delegate && [_delegate respondsToSelector:@selector(systemProprietarydataReady:)]) {
+            [_delegate systemProprietarydataReady:systemProprietaryResponseData];
+        }
+    }
+    else if (connection == _queryAppConnection) {
+        if (_delegate && [_delegate respondsToSelector:@selector(systemQueueAppDataReady:)]) {
+            [_delegate systemQueueAppDataReady:queryAppData];
+        }
+    }
+
+}
+
+- (void)connection:(NSURLConnection *)connection didFailWithError:(NSError *)error {
+    NSString *logString;
+    if (connection == _encodedSyncPDataConnection) {
+        logString = [NSString stringWithFormat:@"%s, OnEncodedSyncPData (HTTP response) failure = ERROR: %@ ", __PRETTY_FUNCTION__, [error localizedDescription]];
+        
+        [SDLDebugTool logInfo:logString withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
+    }
+    else if (connection == _systemRequestProprietaryConnection) {
+        logString = [NSString stringWithFormat:@"OnSystemRequest (HTTP response) = ERROR: %@", error];
+        [SDLDebugTool logInfo:logString withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
+    }
+    else if (connection == _queryAppConnection) {
+        logString = [NSString stringWithFormat:@"OnSystemRequest failure (HTTP response), upload task failed: %@", error];
+        [SDLDebugTool logInfo:logString withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
+        return;
+    }
+    
+}
+
+@end

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLURLSession.h
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLURLSession.h
@@ -1,0 +1,29 @@
+//
+//  SDLURLSession.h
+//  SmartDeviceLink-iOS
+//
+//  Created by CHDSEZ318988DADM on 11/08/15.
+//  Copyright (c) 2015 smartdevicelink. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@protocol SDLURLSessionDelegate
+
+-(void)syncPDatadataReady:(NSData*)data;
+-(void)systemProprietarydataReady:(NSData*)data;
+-(void)systemQueueAppDataReady:(NSData*)data;
+
+@end
+
+@interface SDLURLSession : NSObject
+-(id)initWithDelegate:(id<SDLURLSessionDelegate>)delegate withDebugConsoleGroup:(NSString*)debugConsoleGroupName ;
+
+- (void) uploadTaskWithPData:(NSData*)data withRequest:(NSMutableURLRequest*)request withTimeout:(NSNumber*) timeout;
+
+- (void)uploadTaskWithSystemProprietaryDictionary:(NSDictionary *)dictionary withURLString:(NSString *)urlString;
+
+- (void) dataTaskForSystemRequestURLString:(NSString *)urlString;
+
+- (void) cancelAndInvalidate;
+@end

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLURLSession.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLURLSession.m
@@ -1,0 +1,122 @@
+//
+//  SDLURLSession.m
+//  SmartDeviceLink-iOS
+//
+//  Created by CHDSEZ318988DADM on 11/08/15.
+//  Copyright (c) 2015 smartdevicelink. All rights reserved.
+//
+
+#import "SDLURLSession.h"
+
+#import "SDLDebugTool.h"
+
+@interface SDLURLSession () {
+    NSURLSession *systemRequestSession;
+    NSURLSession *encodedSyncPDataSession;
+    id _delegate;
+}
+@property (strong) NSString *debugConsoleGroupName;
+
+@end
+
+@implementation SDLURLSession
+-(id)initWithDelegate:(id<SDLURLSessionDelegate>)delegate withDebugConsoleGroup:(NSString *)debugConsoleGroupName{
+    self = [super init];
+    if(self) {
+        _delegate = delegate;
+    }
+    self.debugConsoleGroupName = [[NSString alloc] initWithString:debugConsoleGroupName];
+    return self;
+}
+
+-(void)uploadTaskWithPData:(NSData *)data withRequest:(NSMutableURLRequest *)request withTimeout:(NSNumber*) timeout{
+    
+    NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
+    config.HTTPAdditionalHeaders = @{@"Content-Type": @"application/json"};
+    config.timeoutIntervalForRequest = 60;
+    encodedSyncPDataSession = [NSURLSession sessionWithConfiguration:config];
+    
+    NSURLSessionUploadTask *uploadTask = [encodedSyncPDataSession uploadTaskWithRequest:request fromData:data completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        if (_delegate && [_delegate respondsToSelector:@selector(syncPDatadataReady:)]) {
+            [_delegate syncPDatadataReady:data];
+        }
+    }];
+    [uploadTask resume];
+}
+
+- (void)uploadTaskWithSystemProprietaryDictionary:(NSDictionary *)dictionary withURLString:(NSString *)urlString {
+    NSParameterAssert(dictionary != nil);
+    NSParameterAssert(urlString != nil);
+    
+    // Extract data from the dictionary
+    NSDictionary *requestData = dictionary[@"HTTPRequest"];
+    NSDictionary *headers = requestData[@"headers"];
+    NSString *contentType = headers[@"ContentType"];
+    NSTimeInterval timeout = [headers[@"ConnectTimeout"] doubleValue];
+    NSString *method = headers[@"RequestMethod"];
+    NSString *bodyString = requestData[@"body"];
+    NSData *bodyData = [bodyString dataUsingEncoding:NSUTF8StringEncoding];
+    
+    // NSURLSession configuration
+    NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
+    systemRequestSession = [NSURLSession sessionWithConfiguration:config];
+    NSURL *url = [NSURL URLWithString:urlString];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
+    [request setValue:contentType forHTTPHeaderField:@"content-type"];
+    request.timeoutInterval = timeout;
+    request.HTTPMethod = method;
+    
+    // Logging
+    NSString *logMessage = [NSString stringWithFormat:@"OnSystemRequest (HTTP Request) to URL %@", urlString];
+    [SDLDebugTool logInfo:logMessage withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
+    
+    // Create the upload task
+    NSURLSessionUploadTask *task =  [systemRequestSession uploadTaskWithRequest:request fromData:bodyData completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        NSString *logMessage = nil;
+        
+        if (error) {
+            logMessage = [NSString stringWithFormat:@"OnSystemRequest (HTTP response) = ERROR: %@", error];
+            [SDLDebugTool logInfo:logMessage withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
+            
+        }
+        if (_delegate && [_delegate respondsToSelector:@selector(systemProprietarydataReady:)]) {
+            [_delegate  systemProprietarydataReady:data];
+        }
+    }];
+    [task resume];
+    
+}
+
+- (void) dataTaskForSystemRequestURLString:(NSString *)urlString {
+    NSParameterAssert(urlString != nil);
+    
+    NSString *logMessage = [NSString stringWithFormat:@"OnSystemRequest (HTTP Request to URL: %@", urlString];
+    [SDLDebugTool logInfo:logMessage withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
+
+    // Create and return the data task
+     [[NSURLSession sharedSession] dataTaskWithURL:[NSURL URLWithString:urlString]completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+         if (error) {
+             NSString *logString = nil;
+
+             logString = [NSString stringWithFormat:@"OnSystemRequest (HTTP response) = ERROR: %@", error];
+             [SDLDebugTool logInfo:logString withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
+             
+         }
+         if (_delegate && [_delegate respondsToSelector:@selector(systemQueueAppDataReady:)]) {
+             [_delegate systemQueueAppDataReady:data];
+         }
+
+     }];
+}
+
+- (void) cancelAndInvalidate {
+    
+    if (systemRequestSession != nil) {
+        [systemRequestSession invalidateAndCancel];
+    }
+    if (encodedSyncPDataSession != nil) {
+        [encodedSyncPDataSession invalidateAndCancel];
+    }
+    
+}
+@end


### PR DESCRIPTION
Fixes item 1 of issue #268 

Changes SDLProxy to use a connection object that checks iOS version and uses either:

* SDLURLConnection handles NSURLConnection (for iOS 6 and below)
* SDLURLSession handles NSURLSession (for iOS 7 and above)
