### PR TITLE
SDLTCPTransport hangs on invalid IP Address.

### DIFF
--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLTCPTransport.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLTCPTransport.m
@@ -14,6 +14,7 @@
 #import <sys/wait.h>
 #import <netinet/in.h>
 #import <netdb.h>
+#import <SystemConfiguration/SystemConfiguration.h>
 
 
 // C function forward declarations.
@@ -127,7 +128,15 @@ int call_socket(const char *hostname, const char *port) {
         gethostname(localhost, sizeof localhost);
         hostname = (const char *)&localhost;
     }
-
+    
+    // check if hostname address is valid before we attempt to connect.
+    SCNetworkReachabilityRef reachability = SCNetworkReachabilityCreateWithAddress(kCFAllocatorDefault, (const struct sockaddr *)hostname);
+    if (reachability == NULL) {
+        return (-1);
+    } else {
+        CFRelease(reachability);
+    }
+    
     //getaddrinfo setup
     if ((status = getaddrinfo(hostname, port, &hints, &servinfo)) != 0) {
         fprintf(stderr, "getaddrinfo error: %s\n", gai_strerror(status));


### PR DESCRIPTION
Fixes #356

This PR is ready for review.

This PR makes no API changes.

### Summary
Adds the ability for us to check the provided hostname using `SystemConfiguration`'s `SCNetworkReachability` API. If the hostname is invalid, we return back -1 (error) instead of still attempting to connect, which inevitably causes the main thread to lock.

### Changelog

##### Bug Fixes
* Fix issue with SDLTCPTransport attempting to connect to an IP Address that is invalid.