### PR TITLE
Handle System Request type HTTP according to PTU

### DIFF
--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLProxy.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLProxy.m
@@ -322,6 +322,8 @@ const int POLICIES_CORRELATION_ID = 65535;
         [self handleSystemRequestProprietary:systemRequest];
     } else if (requestType == [SDLRequestType LOCK_SCREEN_ICON_URL]) {
         [self handleSystemRequestLockScreenIconURL:systemRequest];
+    } else if (requestType == [SDLRequestType HTTP]) {
+        [self handleSystemRequestHttp:systemRequest];
     }
 }
 
@@ -425,6 +427,51 @@ const int POLICIES_CORRELATION_ID = 65535;
                                   UIImage *icon = [UIImage imageWithData:data];
                                   [self invokeMethodOnDelegates:@selector(onReceivedLockScreenIcon:) withObject:icon];
                               }];
+}
+
+- (void)handleSystemRequestHttp:(SDLOnSystemRequest *)request {
+    if (nil == request.bulkData) {
+        // TODO: not sure how we want to handle http requests that don't have bulk data (maybe as GET?)
+        return;
+    }
+    
+    NSError *error = nil;
+    NSDictionary *body = [NSJSONSerialization JSONObjectWithData:request.bulkData options:kNilOptions error:&error];
+    if (error) {
+        NSLog(@"error creating body from bulk data: %@", error.localizedDescription);
+        return;
+    }
+    
+    [self uploadForBodyDataDictionary:body
+                            URLString:request.url
+                    completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+                        NSString *logMessage = nil;
+                        if (error) {
+                            logMessage = [NSString stringWithFormat:@"OnSystemRequest (HTTP response) = ERROR: %@", error];
+                            [SDLDebugTool logInfo:logMessage withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
+                            return;
+                        }
+                        
+                        if (data == nil || data.length == 0) {
+                            [SDLDebugTool logInfo:@"OnSystemRequest (HTTP response) failure: no data returned" withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
+                            return;
+                        }
+                        
+                        // Show the HTTP response
+                        [SDLDebugTool logInfo:@"OnSystemRequest (HTTP response)" withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
+                        
+                        // Create the SystemRequest RPC to send to module.
+                        SDLPutFile *putFile = [[SDLPutFile alloc] init];
+                        putFile.fileType = [SDLFileType JSON];
+                        putFile.correlationID = [NSNumber numberWithInt:POLICIES_CORRELATION_ID];
+                        putFile.syncFileName = @"pt.json";
+                        putFile.bulkData = data;
+                        
+                        // Send and log RPC Request
+                        logMessage = [NSString stringWithFormat:@"SystemRequest (request)\n%@\nData length=%lu", [request serializeAsDictionary:2], (unsigned long)data.length];
+                        [SDLDebugTool logInfo:logMessage withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
+                        [self sendRPC:putFile];
+                    }];
 }
 
 /**

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLProxy.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLProxy.m
@@ -323,7 +323,7 @@ const int POLICIES_CORRELATION_ID = 65535;
     } else if (requestType == [SDLRequestType LOCK_SCREEN_ICON_URL]) {
         [self handleSystemRequestLockScreenIconURL:systemRequest];
     } else if (requestType == [SDLRequestType HTTP]) {
-        [self handleSystemRequestHttp:systemRequest];
+        [self handleSystemRequestHTTP:systemRequest];
     }
 }
 
@@ -429,8 +429,8 @@ const int POLICIES_CORRELATION_ID = 65535;
                               }];
 }
 
-- (void)handleSystemRequestHttp:(SDLOnSystemRequest *)request {
-    if (nil == request.bulkData) {
+- (void)handleSystemRequestHTTP:(SDLOnSystemRequest *)request {
+    if (request.bulkData.length == 0) {
         // TODO: not sure how we want to handle http requests that don't have bulk data (maybe as GET?)
         return;
     }
@@ -452,7 +452,7 @@ const int POLICIES_CORRELATION_ID = 65535;
                             return;
                         }
                         
-                        if (data == nil || data.length == 0) {
+                        if (data.length == 0) {
                             [SDLDebugTool logInfo:@"OnSystemRequest (HTTP response) failure: no data returned" withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
                             return;
                         }
@@ -463,8 +463,8 @@ const int POLICIES_CORRELATION_ID = 65535;
                         // Create the SystemRequest RPC to send to module.
                         SDLPutFile *putFile = [[SDLPutFile alloc] init];
                         putFile.fileType = [SDLFileType JSON];
-                        putFile.correlationID = [NSNumber numberWithInt:POLICIES_CORRELATION_ID];
-                        putFile.syncFileName = @"pt.json";
+                        putFile.correlationID = @(POLICIES_CORRELATION_ID);
+                        putFile.syncFileName = @"response_data";
                         putFile.bulkData = data;
                         
                         // Send and log RPC Request

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLV2ProtocolMessage.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLV2ProtocolMessage.m
@@ -21,8 +21,9 @@
 
 // Convert RPC payload to dictionary (for consumption by RPC layer)
 - (NSDictionary *)rpcDictionary {
+    
     // Only applicable to RPCs
-    if (self.header.serviceType != SDLServiceType_RPC) {
+    if (self.header.serviceType != SDLServiceType_RPC && self.header.serviceType != SDLServiceType_BulkData) {
         return nil;
     }
 

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLV2ProtocolMessage.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLV2ProtocolMessage.m
@@ -21,9 +21,8 @@
 
 // Convert RPC payload to dictionary (for consumption by RPC layer)
 - (NSDictionary *)rpcDictionary {
-    
     // Only applicable to RPCs
-    if (self.header.serviceType != SDLServiceType_RPC && self.header.serviceType != SDLServiceType_BulkData) {
+    if ((self.header.serviceType != SDLServiceType_RPC) && (self.header.serviceType != SDLServiceType_BulkData)) {
         return nil;
     }
 


### PR DESCRIPTION
Fixes #364 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Jack and I tested this to make sure policy tables are updated

### Summary
* Now builds dictionaries for bulk data request types rather than returning nil
* Handles HTTP system requests by uploading bulk data as body of POST to specified URL and returning the response as a putFile according to HMI Integration Guidelines GENIVI Policy Table Update

### Changelog

##### Bug Fixes
* fixes #364 

### Tasks Remaining:
- [x] Fix the thing
