### PR TITLE
Instead of checking the reachability object for nullability, we need …

### DIFF
--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLTCPTransport.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLTCPTransport.m
@@ -130,14 +130,16 @@ int call_socket(const char *hostname, const char *port) {
     }
     
     // check if hostname address is valid before we attempt to connect.
-    SCNetworkReachabilityRef reachability = SCNetworkReachabilityCreateWithAddress(kCFAllocatorDefault, (const struct sockaddr *)hostname);
-    if (reachability == NULL) {
+    SCNetworkReachabilityRef reachability = SCNetworkReachabilityCreateWithName(kCFAllocatorDefault, hostname);
+    SCNetworkReachabilityFlags flags = kSCNetworkReachabilityFlagsReachable;
+    SCNetworkReachabilityGetFlags(reachability, &flags);
+    CFRelease(reachability);
+    if (!((flags & kSCNetworkReachabilityFlagsReachable)
+        && (flags & kSCNetworkReachabilityFlagsIsLocalAddress))) {
         NSString* hostnameString =  [NSString stringWithUTF8String:hostname];
         NSString* error = [NSString stringWithFormat:@"Invalid IP address of %@. Cancelling connection.", hostnameString];
         [SDLDebugTool logInfo:error withType:SDLDebugType_Transport_TCP];
         return (-1);
-    } else {
-        CFRelease(reachability);
     }
     
     //getaddrinfo setup


### PR DESCRIPTION
Fixes #365 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
No way (to my knowledge) to unit test specific network connectivity.

### Summary
Using SCNetworkReachabilityCreateWithName instead of SCNetworkReachabilityCreateWithAddress and checking it's reachability flags.

### Changelog
##### Bug Fixes
* Fixes SDLTCPTransport to properly connect and also present error to log when incorrect IP address used.