### PR TITLE
Remove a session id after the service is disconnected

### DIFF
--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLProtocol.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLProtocol.m
@@ -62,9 +62,7 @@
 }
 
 - (void)sdl_removeSessionIdForServiceType:(SDLServiceType)serviceType {
-    if (_sessionIDs[@(serviceType)] != nil) {
-        [_sessionIDs removeObjectForKey:@(serviceType)];
-    }
+    [_sessionIDs removeObjectForKey:@(serviceType)];
 }
 
 - (UInt8)sdl_retrieveSessionIDforServiceType:(SDLServiceType)serviceType {


### PR DESCRIPTION
Fixes #349 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
This change will not be tested as it does not change any public API calls that can be tested

### Summary
This PR removes session ids from the `sessionId` dictionary within the `SDLProtocol` class when an `endServiceACK` is received.

### Changelog
##### Bug Fixes
* Properly remove session ids from tracking when their service has ended.