### PR TITLE
Sending application state to SDL

### DIFF
--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLProxy.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLProxy.m
@@ -130,6 +130,33 @@ const int POLICIES_CORRELATION_ID = 65535;
     return [self.mutableProxyListeners copy];
 }
 
+#pragma mark - Methods
+
+- (void)sendMobileHMIState {
+    UIApplicationState appState = [UIApplication sharedApplication].applicationState;
+    SDLOnHMIStatus *HMIStatusRPC = [[SDLOnHMIStatus alloc] init];
+    
+    HMIStatusRPC.audioStreamingState = [SDLAudioStreamingState NOT_AUDIBLE];
+    HMIStatusRPC.systemContext = [SDLSystemContext MAIN];
+    
+    switch (appState) {
+        case UIApplicationStateActive: {
+            HMIStatusRPC.hmiLevel = [SDLHMILevel FULL];
+        } break;
+        case UIApplicationStateBackground: // Fallthrough
+        case UIApplicationStateInactive: {
+            HMIStatusRPC.hmiLevel = [SDLHMILevel BACKGROUND];
+        } break;
+        default:
+            break;
+    }
+    
+    NSString *log = [NSString stringWithFormat:@"Sending new mobile hmi state: %@", HMIStatusRPC.hmiLevel.value];
+    [SDLDebugTool logInfo:log withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
+    
+    [self sendRPC:HMIStatusRPC];
+}
+
 
 #pragma mark - Setters / Getters
 
@@ -295,6 +322,12 @@ const int POLICIES_CORRELATION_ID = 65535;
     //Print Proxy Version To Console
     NSString *logMessage = [NSString stringWithFormat:@"Framework Version: %@", self.proxyVersion];
     [SDLDebugTool logInfo:logMessage withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
+    if (_version >= 4) {
+        [self sendMobileHMIState];
+        // Send SDL updates to application state
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sendMobileHMIState) name:UIApplicationDidBecomeActiveNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sendMobileHMIState) name:UIApplicationDidEnterBackgroundNotification object:nil];
+    }
 }
 
 - (void)handleSyncPData:(SDLRPCMessage *)message {

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLProxy.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLProxy.m
@@ -322,7 +322,7 @@ const int POLICIES_CORRELATION_ID = 65535;
     //Print Proxy Version To Console
     NSString *logMessage = [NSString stringWithFormat:@"Framework Version: %@", self.proxyVersion];
     [SDLDebugTool logInfo:logMessage withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
-    if (_version >= 4) {
+    if ([SDLGlobals globals].protocolVersion >= 4) {
         [self sendMobileHMIState];
         // Send SDL updates to application state
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sendMobileHMIState) name:UIApplicationDidBecomeActiveNotification object:nil];


### PR DESCRIPTION
Fixes #377 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Tested registering with SDL >= 4 (SDL Receives FULL) and backgrounding the connected app (SDL Receives BACKGROUND)

### Summary
Added a method to send the current application case to SDL in the form of an HMI Status notification

### Changelog

##### Enchancements
* Tells SDL the application state when registering as well as when entering foreground and background application states