### PR TITLE
Restructure of heartbeat to only respond to heartbeats with acknowledgement

### DIFF
--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLAbstractProtocol.h
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLAbstractProtocol.h
@@ -20,7 +20,7 @@
 - (void)sendEndSessionWithType:(SDLServiceType)serviceType;
 - (void)sendRPC:(SDLRPCMessage *)message;
 - (void)sendRPCRequest:(SDLRPCRequest *)rpcRequest __deprecated_msg(("Use sendRPC: instead"));
-- (void)sendHeartbeat;
+- (void)sendHeartbeat __deprecated_msg("Heartbeat is no longer used.");
 - (void)sendRawDataStream:(NSInputStream *)inputStream withServiceType:(SDLServiceType)serviceType;
 - (void)sendRawData:(NSData *)data withServiceType:(SDLServiceType)serviceType;
 

--- a/SmartDeviceLink-iOS/SmartDeviceLinkTests/ProtocolSpecs/MessageSpecs/SDLProtocolSpec.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLinkTests/ProtocolSpecs/MessageSpecs/SDLProtocolSpec.m
@@ -381,6 +381,31 @@ describe(@"HandleProtocolSessionStarted Tests", ^ {
     });
 });
 
+describe(@"HandleHeartbeatForSession Tests", ^{
+    // TODO: Test automatically sending data to head unit (dependency injection?)
+    it(@"Should pass information along to delegate", ^ {
+        SDLProtocol* testProtocol = [[SDLProtocol alloc] init];
+        
+        id delegateMock = OCMProtocolMock(@protocol(SDLProtocolListener));
+        
+        __block BOOL verified = NO;
+        [[[[delegateMock stub] andDo:^(NSInvocation* invocation) {
+            verified = YES;
+            Byte sessionID;
+            
+            [invocation getArgument:&sessionID atIndex:2];
+            
+            expect(@(sessionID)).to(equal(@0x44));
+        }] ignoringNonObjectArgs] handleHeartbeatForSession:0];
+        
+        [testProtocol.protocolDelegateTable addObject:delegateMock];
+        
+        [testProtocol handleHeartbeatForSession:0x44];
+        
+        expect(@(verified)).to(beTruthy());
+    });
+});
+
 describe(@"OnProtocolMessageReceived Tests", ^ {
     it(@"Should pass information along to delegate", ^ {
         SDLProtocol* testProtocol = [[SDLProtocol alloc] init];

--- a/SmartDeviceLink-iOS/SmartDeviceLinkTests/ProtocolSpecs/MessageSpecs/SDLProtocolSpec.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLinkTests/ProtocolSpecs/MessageSpecs/SDLProtocolSpec.m
@@ -317,8 +317,11 @@ describe(@"SendHeartbeat Tests", ^ {
                 expect(dataSent).to(equal([NSData dataWithBytes:testHeader length:8]));
             }] sendData:[OCMArg any]];
             testProtocol.transport = transportMock;
-            
+           
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             [testProtocol sendHeartbeat];
+#pragma clang diagnostic pop
             
             expect(@(verified)).toEventually(beTruthy());
         });
@@ -344,7 +347,10 @@ describe(@"SendHeartbeat Tests", ^ {
             }] sendData:[OCMArg any]];
             testProtocol.transport = transportMock;
             
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             [testProtocol sendHeartbeat];
+#pragma clang diagnostic pop
             
             expect(@(verified)).toEventually(beTruthy());
         });


### PR DESCRIPTION
Fixes #368 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Testing plan will require making sure changes relating removing heartbeat do not in-advertantly affect other components.

### Summary
Removal of in-proxy sending of heartbeats. SDL for iOS will only respond to heartbeats from Core.

### Changelog
##### Bug Fixes
* Heartbeats are no longer actively sent, but only ACKed. This fixes the issues we've faced regarding timers and backgrounding.

### Tasks Remaining:
- [x] Validation that changes relating to heartbeat removal do not break current messaging.
- [x] Validate that `[SDLProtocolReceivedMessageRouter dispatchControlMessage:]` still works as intended.