### PR TITLE
Fixed mistyped SDLStreamingVideoError enum value.

### DIFF
--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLStreamingMediaManager.h
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLStreamingMediaManager.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef NS_ENUM(NSInteger, SDLStreamingVideoError) {
     SDLStreamingVideoErrorHeadUnitNACK,
-    SDLSTreamingVideoErrorInvalidOperatingSystemVersion,
+    SDLStreamingVideoErrorInvalidOperatingSystemVersion,
     SDLStreamingVideoErrorConfigurationCompressionSessionCreationFailure,
     SDLStreamingVideoErrorConfigurationAllocationFailure,
     SDLStreamingVideoErrorConfigurationCompressionSessionSetPropertyFailure

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLStreamingMediaManager.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLStreamingMediaManager.m
@@ -66,7 +66,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)startVideoSessionWithStartBlock:(SDLStreamingStartBlock)startBlock {
     if (SDL_SYSTEM_VERSION_LESS_THAN(@"8.0")) {
         NSAssert(NO, @"SDL Video Sessions can only be run on iOS 8+ devices");
-        startBlock(NO, [NSError errorWithDomain:SDLErrorDomainStreamingMediaVideo code:SDLSTreamingVideoErrorInvalidOperatingSystemVersion userInfo:nil]);
+        startBlock(NO, [NSError errorWithDomain:SDLErrorDomainStreamingMediaVideo code:SDLStreamingVideoErrorInvalidOperatingSystemVersion userInfo:nil]);
 
         return;
     }


### PR DESCRIPTION
Fixes #383 

This PR is **ready** for review.

### Risk
This PR makes **major** API changes.

### Summary
Fixed mistyped enum value `SDLSTreamingVideoErrorInvalidOperatingSystemVersion`.

### Changelog
##### Bug Fixes
* `SDLSTreamingVideoErrorInvalidOperatingSystemVersion` renamed to `SDLStreamingVideoErrorInvalidOperatingSystemVersion`.