### PR TITLE
Fix SDLRPCStruct log printing

### DIFF
--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLRPCStruct.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLRPCStruct.m
@@ -38,7 +38,7 @@
             [ret setObject:[self serializeDictionary:(NSDictionary *)value version:version] forKey:key];
         } else if ([value isKindOfClass:NSArray.class]) {
             NSArray *arrayVal = (NSArray *)value;
-
+            
             if (arrayVal.count > 0 && ([[arrayVal objectAtIndex:0] isKindOfClass:SDLRPCStruct.class])) {
                 NSMutableArray *serializedList = [NSMutableArray arrayWithCapacity:arrayVal.count];
                 for (SDLRPCStruct *serializeable in arrayVal) {
@@ -79,7 +79,7 @@
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"RPC Struct (%@) %@", [self class], [store description]];
+    return [store description];
 }
 
 - (void)dealloc {


### PR DESCRIPTION
Fixes #355

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
This PR makes a simple change to allow `SDLRPCStruct` classes to print correctly by fixing the `description` method to only return the backing store's description.

### Changelog
##### Bug Fixes
* When printing an `SDLRPCStruct`, e.g. through a log method, it will now print correctly.