### PR TITLE
Ignore a possilbe ./Carthage/Build folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ Carthage.pkg
 SmartDeviceLink-iOS/Carthage/Build
 SmartDeviceLink-iOS/Carthage/Checkouts
 SmartDeviceLink-iOS/infer-out
+# This ignore here is prevent projects fetching sdl_ios as a submodule using
+# Carthage from resulting as `-dirty` in the `git status`.
+Carthage/Build


### PR DESCRIPTION
This PR is **ready** for review.


### Summary
This PR updates the `.gitignore` so that is prevent projects fetching sdl_ios as a submodule using Carthage from resulting as `-dirty` in the `git diff`.

The _dirtiness_ is due to Carthage copying its Build folder in every submodule in order to make the whole framework building system work.

### Risk
This PR makes **no** API changes.

### Testing Plan
This PR doesn't change the framework code, but rather the repository setup.

To verify the fix create an empty folder with a `Cartfile` containing this line

```
github "smartdevicelink/sdl_ios"
```

Then run `carthage bootstrap --use-submodules`. Once the process run `git diff` you should see an output like:

```
diff --git a/Carthage/Checkouts/sdl_ios b/Carthage/Checkouts/sdl_ios
--- a/Carthage/Checkouts/sdl_ios
+++ b/Carthage/Checkouts/sdl_ios
@@ -1 +1 @@
-Subproject commit e5a5a208aca82baf54e64d2ffca8d09a3f9dd3e9
+Subproject commit e5a5a208aca82baf54e64d2ffca8d09a3f9dd3e9-dirty
```

This is due to Carthage having created a `Carthage/Build` folder in the fetched `sdl_ios` repo which results as an untracked file.

Now create a new folder repeat the same process but with this `Cartfile`:

```
github "mokagio/sdl_ios" "mokagio/gitignore-carthage"
```

The submodule folder is not marked as dirty anymore.


### Changelog

##### Enchancements
* Easier integration in development workflows fetching the framework using Carthage + git submodules.
