### PR TITLE
Create codecov settings to repository

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  ignore:
+  - Carthage/.*
+  - SmartDeviceLinkTests/.*
+  - SmartDeviceLinkExample/.*
+  status:
+    patch: false
+    project: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,19 @@
 coverage:
+  precision: 2
+  round: down
+
   ignore:
   - Carthage/.*
   - SmartDeviceLinkTests/.*
   - SmartDeviceLinkExample/.*
   status:
-    patch: false
     project: false
+    patch:
+      default:
+          enabled: yes
+          target: 80%
+
+comment:
+  layout: "header, diff, changes, suggestions"
+  branches: !hotfix*
+  behavior: default


### PR DESCRIPTION
Fixes #414

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Put codecov.io settings in `.codecov.yml`.

### Changelog
##### Enchancements
* codecov.io settings are now encased in `.codecov.yml`