### PR TITLE
add id attribute to section headers for linking in Jazzy docs

### DIFF
--- a/theme/templates/task.mustache
+++ b/theme/templates/task.mustache
@@ -1,5 +1,5 @@
 {{#items}}
-<h3>
+<h3 id="section-{{name}}">
     {{name}}
     {{#default_impl_abstract}}
         Default implementation


### PR DESCRIPTION
Fixes issue with section content links not actually linking to the section in the documentation on https://smartdevicelink.com/docs/iOS/master/Classes/SDLAbstractProtocol/#section-debugConsoleGroupName

Fixes Mobelux/livio-web#478

This PR is **ready** for review.

### Risk
This PR makes **no** API changes. Only adds ID attribute to HTML docs template.

### Testing Plan

Generate documentation and confirm links are correct.

### Summary
Adds `id` attribute to section headers for linking purposes.

