### PR TITLE
HTTP alterations in SDLURLSession to use NSURLComponents

### DIFF
--- a/SmartDeviceLink/SDLURLSession.m
+++ b/SmartDeviceLink/SDLURLSession.m
@@ -64,7 +64,7 @@ static float DefaultConnectionTimeout = 45.0;
 - (void)dataFromURL:(NSURL *)url completionHandler:(SDLURLConnectionRequestCompletionHandler)completionHandler {
     // Apple no longer allows HTTP URLs without a special exception as of Jan. 2017
     if ([url.scheme isEqualToString:@"http"]) {
-         url = [NSURL URLWithString:[url.absoluteString stringByReplacingCharactersInRange:NSMakeRange(0, 4) withString:@"https"]];
+        url = [NSURL URLWithString:[url.absoluteString stringByReplacingCharactersInRange:NSMakeRange(0, 4) withString:@"https"]];
     }
 
     NSURLRequest *request = [NSURLRequest requestWithURL:url cachePolicy:self.cachePolicy timeoutInterval:self.connectionTimeout];

--- a/SmartDeviceLink/SDLURLSession.m
+++ b/SmartDeviceLink/SDLURLSession.m
@@ -63,11 +63,12 @@ static float DefaultConnectionTimeout = 45.0;
 
 - (void)dataFromURL:(NSURL *)url completionHandler:(SDLURLConnectionRequestCompletionHandler)completionHandler {
     // Apple no longer allows HTTP URLs without a special exception as of Jan. 2017
-    if ([url.scheme isEqualToString:@"http"]) {
-        url = [NSURL URLWithString:[url.absoluteString stringByReplacingOccurrencesOfString:@"http" withString:@"https"]];
+    NSURLComponents *urlComponents = [NSURLComponents componentsWithString:url.absoluteString];
+    if ([urlComponents.scheme isEqualToString:@"http"]) {
+        urlComponents.scheme = @"https";
     }
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:url cachePolicy:self.cachePolicy timeoutInterval:self.connectionTimeout];
+    NSURLRequest *request = [NSURLRequest requestWithURL:urlComponents.URL cachePolicy:self.cachePolicy timeoutInterval:self.connectionTimeout];
 
     SDLURLRequestTask *task = [[SDLURLRequestTask alloc] initWithURLRequest:request completionHandler:completionHandler];
     task.delegate = self;
@@ -76,13 +77,13 @@ static float DefaultConnectionTimeout = 45.0;
 }
 
 - (void)uploadWithURLRequest:(NSURLRequest *)request data:(NSData *)data completionHandler:(SDLURLConnectionRequestCompletionHandler)completionHandler {
-    NSURL *newURL = nil;
-    if ([request.URL.scheme isEqualToString:@"http"]) {
-        newURL = [NSURL URLWithString:[request.URL.absoluteString stringByReplacingOccurrencesOfString:@"http" withString:@"https"]];
+    NSURLComponents *urlComponents = [NSURLComponents componentsWithString:request.URL.absoluteString];
+    if ([urlComponents.scheme isEqualToString:@"http"]) {
+        urlComponents.scheme = @"https";
     }
 
     NSMutableURLRequest *mutableRequest = [request mutableCopy];
-    mutableRequest.URL = newURL;
+    mutableRequest.URL = urlComponents.URL;
     mutableRequest.HTTPBody = data;
     mutableRequest.HTTPMethod = @"POST";
 

--- a/SmartDeviceLink/SDLURLSession.m
+++ b/SmartDeviceLink/SDLURLSession.m
@@ -64,7 +64,7 @@ static float DefaultConnectionTimeout = 45.0;
 - (void)dataFromURL:(NSURL *)url completionHandler:(SDLURLConnectionRequestCompletionHandler)completionHandler {
     // Apple no longer allows HTTP URLs without a special exception as of Jan. 2017
     if ([url.scheme isEqualToString:@"http"]) {
-        url = [NSURL URLWithString:[url.absoluteString stringByReplacingOccurrencesOfString:@"http://" withString:@"https://"]];
+         url = [NSURL URLWithString:[url.absoluteString stringByReplacingCharactersInRange:NSMakeRange(0, 4) withString:@"https"]];
     }
 
     NSURLRequest *request = [NSURLRequest requestWithURL:url cachePolicy:self.cachePolicy timeoutInterval:self.connectionTimeout];
@@ -78,7 +78,7 @@ static float DefaultConnectionTimeout = 45.0;
 - (void)uploadWithURLRequest:(NSURLRequest *)request data:(NSData *)data completionHandler:(SDLURLConnectionRequestCompletionHandler)completionHandler {
     NSURL *newURL = nil;
     if ([request.URL.scheme isEqualToString:@"http"]) {
-        newURL = [NSURL URLWithString:[request.URL.absoluteString stringByReplacingOccurrencesOfString:@"http://" withString:@"https://"]];
+        newURL = [NSURL URLWithString:[request.URL.absoluteString stringByReplacingCharactersInRange:NSMakeRange(0, 4) withString:@"https"]];
     }
 
     NSMutableURLRequest *mutableRequest = [request mutableCopy];

--- a/SmartDeviceLink/SDLURLSession.m
+++ b/SmartDeviceLink/SDLURLSession.m
@@ -63,12 +63,11 @@ static float DefaultConnectionTimeout = 45.0;
 
 - (void)dataFromURL:(NSURL *)url completionHandler:(SDLURLConnectionRequestCompletionHandler)completionHandler {
     // Apple no longer allows HTTP URLs without a special exception as of Jan. 2017
-    NSURLComponents *urlComponents = [NSURLComponents componentsWithString:url.absoluteString];
-    if ([urlComponents.scheme isEqualToString:@"http"]) {
-        urlComponents.scheme = @"https";
+    if ([url.scheme isEqualToString:@"http"]) {
+        url = [NSURL URLWithString:[url.absoluteString stringByReplacingOccurrencesOfString:@"http://" withString:@"https://"]];
     }
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:urlComponents.URL cachePolicy:self.cachePolicy timeoutInterval:self.connectionTimeout];
+    NSURLRequest *request = [NSURLRequest requestWithURL:url cachePolicy:self.cachePolicy timeoutInterval:self.connectionTimeout];
 
     SDLURLRequestTask *task = [[SDLURLRequestTask alloc] initWithURLRequest:request completionHandler:completionHandler];
     task.delegate = self;
@@ -77,13 +76,13 @@ static float DefaultConnectionTimeout = 45.0;
 }
 
 - (void)uploadWithURLRequest:(NSURLRequest *)request data:(NSData *)data completionHandler:(SDLURLConnectionRequestCompletionHandler)completionHandler {
-    NSURLComponents *urlComponents = [NSURLComponents componentsWithString:request.URL.absoluteString];
-    if ([urlComponents.scheme isEqualToString:@"http"]) {
-        urlComponents.scheme = @"https";
+    NSURL *newURL = nil;
+    if ([request.URL.scheme isEqualToString:@"http"]) {
+        newURL = [NSURL URLWithString:[request.URL.absoluteString stringByReplacingOccurrencesOfString:@"http://" withString:@"https://"]];
     }
 
     NSMutableURLRequest *mutableRequest = [request mutableCopy];
-    mutableRequest.URL = urlComponents.URL;
+    mutableRequest.URL = newURL;
     mutableRequest.HTTPBody = data;
     mutableRequest.HTTPMethod = @"POST";
 

--- a/SmartDeviceLinkTests/UtilitiesSpecs/HTTP Connection/SDLURLSessionSpec.m
+++ b/SmartDeviceLinkTests/UtilitiesSpecs/HTTP Connection/SDLURLSessionSpec.m
@@ -10,36 +10,110 @@ describe(@"the url session", ^{
     __block SDLURLSession *testSession = nil;
     
     describe(@"attempting to get good data", ^{
-        context(@"uploading data", ^{
+        context(@"from an http address", ^{
+            context(@"uploading data", ^{
+                NSData *testData = [@"testData" dataUsingEncoding:NSUTF8StringEncoding];
+                NSArray *someJSONObject = @[@"one", @"two"];
+                NSData *testJSONData = [NSJSONSerialization dataWithJSONObject:someJSONObject options:0 error:nil];
+                
+                __block NSData *testReturnData = nil;
+                __block NSURLResponse *testReturnResponse = nil;
+                __block NSError *testReturnError = nil;
+                __block NSArray *testReturnJSONObject = nil;
+                
+                beforeEach(^{
+                    [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
+                        if ([request.URL.host isEqualToString:@"www.faketest.com"]) {
+                            testReturnJSONObject = [NSJSONSerialization JSONObjectWithData:request.HTTPBody options:0 error:nil];
+                            return YES;
+                        }
+                        
+                        return NO;
+                    } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
+                        return [[OHHTTPStubsResponse responseWithData:testData statusCode:200 headers:nil] requestTime:0.5 responseTime:0];
+                    }];
+                    
+                    testSession = [[SDLURLSession alloc] init];
+                    NSURLRequest *someURLRequest = [NSURLRequest requestWithURL:[NSURL URLWithString:@"https://www.faketest.com"]];
+                    
+                    [testSession uploadWithURLRequest:someURLRequest data:testJSONData completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+                        testReturnData = data;
+                        testReturnResponse = response;
+                        testReturnError = error;
+                    }];
+                });
+                
+                afterEach(^{
+                    testSession = nil;
+                    [OHHTTPStubs removeAllStubs];
+                });
+                
+                it(@"should have correct data", ^{
+                    expect(testReturnJSONObject).toEventually(equal(someJSONObject));
+                    expect(testReturnData).toEventually(equal(testData));
+                    expect(testReturnResponse).toEventuallyNot(beNil());
+                    expect(testReturnError).toEventually(beNil());
+                });
+            });
+            
+            context(@"downloading data", ^{
+                NSData *testData = [@"someData" dataUsingEncoding:NSUTF8StringEncoding];
+                
+                __block NSData *testReturnData = nil;
+                __block NSURLResponse *testReturnResponse = nil;
+                __block NSError *testReturnError = nil;
+                
+                beforeEach(^{
+                    [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
+                        return [request.URL.host isEqualToString:@"www.faketest.com"];
+                    } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
+                        return [[OHHTTPStubsResponse responseWithData:testData statusCode:200 headers:nil] requestTime:0.5 responseTime:0];
+                    }];
+                    
+                    testSession = [[SDLURLSession alloc] init];
+                    [testSession dataFromURL:[NSURL URLWithString:@"https://www.faketest.com"] completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+                        testReturnData = data;
+                        testReturnResponse = response;
+                        testReturnError = error;
+                    }];
+                });
+                
+                afterEach(^{
+                    testSession = nil;
+                    [OHHTTPStubs removeAllStubs];
+                });
+                
+                it(@"should return correct info", ^{
+                    expect(testReturnData).toEventually(equal(testData));
+                    expect(testReturnResponse).toEventuallyNot(beNil());
+                    expect(testReturnError).toEventually(beNil());
+                });
+            });
+        });
+        
+        context(@"from an http address", ^{
             NSData *testData = [@"testData" dataUsingEncoding:NSUTF8StringEncoding];
             NSArray *someJSONObject = @[@"one", @"two"];
             NSData *testJSONData = [NSJSONSerialization dataWithJSONObject:someJSONObject options:0 error:nil];
             
-            __block NSData *testReturnData = nil;
-            __block NSURLResponse *testReturnResponse = nil;
-            __block NSError *testReturnError = nil;
-            __block NSArray *testReturnJSONObject = nil;
+            __block NSString *testURLRequestComponent = nil;
             
             beforeEach(^{
                 [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
                     if ([request.URL.host isEqualToString:@"www.faketest.com"]) {
-                        testReturnJSONObject = [NSJSONSerialization JSONObjectWithData:request.HTTPBody options:0 error:nil];
+                        testURLRequestComponent = request.URL.scheme;
                         return YES;
                     }
                     
                     return NO;
                 } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
-                    return [[OHHTTPStubsResponse responseWithData:testData statusCode:200 headers:nil] requestTime:0.5 responseTime:0];
+                    return [[OHHTTPStubsResponse responseWithData:testData statusCode:200 headers:request.allHTTPHeaderFields] requestTime:0.5 responseTime:0];
                 }];
                 
                 testSession = [[SDLURLSession alloc] init];
                 NSURLRequest *someURLRequest = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://www.faketest.com"]];
                 
-                [testSession uploadWithURLRequest:someURLRequest data:testJSONData completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                    testReturnData = data;
-                    testReturnResponse = response;
-                    testReturnError = error;
-                }];
+                [testSession uploadWithURLRequest:someURLRequest data:testJSONData completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {}];
             });
             
             afterEach(^{
@@ -47,60 +121,8 @@ describe(@"the url session", ^{
                 [OHHTTPStubs removeAllStubs];
             });
             
-            it(@"should have the json object", ^{
-                expect(testReturnJSONObject).toEventually(equal(someJSONObject));
-            });
-            
-            it(@"should not return any data", ^{
-                expect(testReturnData).toEventually(equal(testData));
-            });
-            
-            it(@"should return a response", ^{
-                expect(testReturnResponse).toEventuallyNot(beNil());
-            });
-            
-            it(@"should not return an error", ^{
-                expect(testReturnError).toEventually(beNil());
-            });
-        });
-        
-        context(@"downloading data", ^{
-            NSData *testData = [@"someData" dataUsingEncoding:NSUTF8StringEncoding];
-            
-            __block NSData *testReturnData = nil;
-            __block NSURLResponse *testReturnResponse = nil;
-            __block NSError *testReturnError = nil;
-            
-            beforeEach(^{
-                [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
-                    return [request.URL.host isEqualToString:@"www.faketest.com"];
-                } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
-                    return [[OHHTTPStubsResponse responseWithData:testData statusCode:200 headers:nil] requestTime:0.5 responseTime:0];
-                }];
-                
-                testSession = [[SDLURLSession alloc] init];
-                [testSession dataFromURL:[NSURL URLWithString:@"http://www.faketest.com"] completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                    testReturnData = data;
-                    testReturnResponse = response;
-                    testReturnError = error;
-                }];
-            });
-            
-            afterEach(^{
-                testSession = nil;
-                [OHHTTPStubs removeAllStubs];
-            });
-            
-            it(@"should not return any data", ^{
-                expect(testReturnData).toEventually(equal(testData));
-            });
-            
-            it(@"should return a response", ^{
-                expect(testReturnResponse).toEventuallyNot(beNil());
-            });
-            
-            it(@"should not return an error", ^{
-                expect(testReturnError).toEventually(beNil());
+            it(@"should have called the HTTPS URL instead", ^{
+                expect(testURLRequestComponent).toEventually(match(@"https"));
             });
         });
     });
@@ -134,13 +156,7 @@ describe(@"the url session", ^{
         
         it(@"should return nil data", ^{
             expect(testReturnData).toEventually(beNil());
-        });
-        
-        it(@"should return a nil response", ^{
             expect(testReturnResponse).toEventually(beNil());
-        });
-        
-        it(@"should return an error", ^{
             expect(@(testReturnError.code)).toEventually(equal(@(someNetworkError.code)));
         });
     });
@@ -176,13 +192,7 @@ describe(@"the url session", ^{
         
         it(@"should return nil data", ^{
             expect(testReturnData).toEventually(beNil());
-        });
-        
-        it(@"should return a nil response", ^{
             expect(testReturnResponse).toEventually(beNil());
-        });
-        
-        it(@"should return an error", ^{
             expect(@(testReturnError.code)).toEventually(equal(@(kCFURLErrorCancelled)));
         });
     });


### PR DESCRIPTION
Fixes #432

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
A unit test has been included

### Summary
This PR fixes some possible bugs with HTTP -> HTTPS conversion in SDLURLSession

### Changelog
##### Bug Fixes
* If the URL contains more than one "http" in its URL, only the scheme will be modified instead of all of them.