### PR TITLE
Fixing issue relating to SDLTouchManager's single touch events not always firing.

### DIFF
--- a/SmartDeviceLink/SDLTouchManager.m
+++ b/SmartDeviceLink/SDLTouchManager.m
@@ -265,6 +265,7 @@ static NSUInteger const MaximumNumberOfTouches = 2;
     self.singleTapTimer = dispatch_create_timer(self.tapTimeThreshold, NO, ^{
         typeof(weakSelf) strongSelf = weakSelf;
         strongSelf.singleTapTouch = nil;
+        [strongSelf sdl_cancelSingleTapTimer];
         if ([strongSelf.touchEventDelegate respondsToSelector:@selector(touchManager:didReceiveSingleTapAtPoint:)]) {
             [strongSelf.touchEventDelegate touchManager:strongSelf
                              didReceiveSingleTapAtPoint:point];


### PR DESCRIPTION
Fixes #441 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Fixing issue relating to SDLTouchManager's single touch events not always firing. This was due to SDLTouchManager not clearing the timer after the first touch event.

### Changelog
##### Bug Fixes
* Fixing issue relating to SDLTouchManager's single touch events not always firing.
