### PR TITLE
Deprecation of SDLTTSChunkFactory

### DIFF
--- a/SmartDeviceLink/SDLAlert.m
+++ b/SmartDeviceLink/SDLAlert.m
@@ -48,7 +48,7 @@ static UInt16 const SDLDefaultDuration = 5000;
 }
 
 - (instancetype)initWithTTS:(NSString *)ttsText alertText1:(NSString *)alertText1 alertText2:(NSString *)alertText2 alertText3:(NSString *)alertText3 playTone:(BOOL)playTone duration:(UInt16)duration {
-    NSMutableArray* ttsChunks = [SDLTTSChunkFactory buildTTSChunksFromSimple:ttsText];
+    NSMutableArray* ttsChunks = [SDLTTSChunk textChunksFromString:ttsText];
     return [self initWithTTSChunks:ttsChunks alertText1:alertText1 alertText2:alertText2 alertText3:alertText3 playTone:playTone duration:duration softButtons:nil];
 }
 

--- a/SmartDeviceLink/SDLAlertManeuver.m
+++ b/SmartDeviceLink/SDLAlertManeuver.m
@@ -24,7 +24,7 @@
 }
 
 - (instancetype)initWithTTS:(NSString *)ttsText softButtons:(NSArray<SDLSoftButton *> *)softButtons {
-    NSMutableArray* ttsChunks = [SDLTTSChunkFactory buildTTSChunksFromSimple:ttsText];
+    NSMutableArray* ttsChunks = [SDLTTSChunk textChunksFromString:ttsText];
     return [self initWithTTSChunks:ttsChunks softButtons:softButtons];
 }
 

--- a/SmartDeviceLink/SDLPerformAudioPassThru.m
+++ b/SmartDeviceLink/SDLPerformAudioPassThru.m
@@ -32,7 +32,7 @@
         return nil;
     }
     
-    self.initialPrompt = [SDLTTSChunkFactory buildTTSChunksFromSimple:initialPrompt];
+    self.initialPrompt = [SDLTTSChunk textChunksFromString:initialPrompt];
     self.audioPassThruDisplayText1 = audioPassThruDisplayText1;
     self.audioPassThruDisplayText2 = audioPassThruDisplayText2;
     self.muteAudio = @(muteAudio);

--- a/SmartDeviceLink/SDLPerformInteraction.m
+++ b/SmartDeviceLink/SDLPerformInteraction.m
@@ -44,9 +44,9 @@ static UInt16 const SDLDefaultTimeout  = 10000;
 }
 
 - (instancetype)initWithInitialPrompt:(NSString *)initialPrompt initialText:(NSString *)initialText interactionChoiceSetIDList:(NSArray *)interactionChoiceSetIDList helpPrompt:(NSString *)helpPrompt timeoutPrompt:(NSString *)timeoutPrompt interactionMode:(SDLInteractionMode *)interactionMode timeout:(UInt16)timeout vrHelp:(NSArray *)vrHelp {
-    NSMutableArray* initialChunks = [SDLTTSChunkFactory buildTTSChunksFromSimple:initialPrompt];
-    NSMutableArray* helpChunks = [SDLTTSChunkFactory buildTTSChunksFromSimple:helpPrompt];
-    NSMutableArray* timeoutChunks = [SDLTTSChunkFactory buildTTSChunksFromSimple:timeoutPrompt];
+    NSMutableArray* initialChunks = [SDLTTSChunk textChunksFromString:initialPrompt];
+    NSMutableArray* helpChunks = [SDLTTSChunk textChunksFromString:helpPrompt];
+    NSMutableArray* timeoutChunks = [SDLTTSChunk textChunksFromString:timeoutPrompt];
     return [self initWithInitialChunks:initialChunks initialText:initialText interactionChoiceSetIDList:interactionChoiceSetIDList helpChunks:helpChunks timeoutChunks:timeoutChunks interactionMode:interactionMode timeout:timeout vrHelp:vrHelp];
 }
 

--- a/SmartDeviceLink/SDLRPCRequestFactory.m
+++ b/SmartDeviceLink/SDLRPCRequestFactory.m
@@ -314,7 +314,7 @@ static NSString *const SDLBundleShortVersionStringKey = @"CFBundleShortVersionSt
 }
 
 + (SDLPerformAudioPassThru *)buildPerformAudioPassThruWithInitialPrompt:(NSString *)initialPrompt audioPassThruDisplayText1:(NSString *)audioPassThruDisplayText1 audioPassThruDisplayText2:(NSString *)audioPassThruDisplayText2 samplingRate:(SDLSamplingRate *)samplingRate maxDuration:(NSNumber *)maxDuration bitsPerSample:(SDLBitsPerSample *)bitsPerSample audioType:(SDLAudioType *)audioType muteAudio:(NSNumber *)muteAudio correlationID:(NSNumber *)correlationID {
-    NSArray *initialChunks = [SDLTTSChunkFactory buildTTSChunksFromSimple:initialPrompt];
+    NSArray *initialChunks = [SDLTTSChunk textChunksFromString:initialPrompt];
 
     SDLPerformAudioPassThru *msg = [[SDLPerformAudioPassThru alloc] init];
     msg.initialPrompt = [initialChunks mutableCopy];
@@ -349,16 +349,16 @@ static NSString *const SDLBundleShortVersionStringKey = @"CFBundleShortVersionSt
 
 //***
 + (SDLPerformInteraction *)buildPerformInteractionWithInitialPrompt:(NSString *)initialPrompt initialText:(NSString *)initialText interactionChoiceSetIDList:(NSArray *)interactionChoiceSetIDList helpPrompt:(NSString *)helpPrompt timeoutPrompt:(NSString *)timeoutPrompt interactionMode:(SDLInteractionMode *)interactionMode timeout:(NSNumber *)timeout vrHelp:(NSArray *)vrHelp correlationID:(NSNumber *)correlationID {
-    NSArray *initialChunks = [SDLTTSChunkFactory buildTTSChunksFromSimple:initialPrompt];
-    NSArray *helpChunks = [SDLTTSChunkFactory buildTTSChunksFromSimple:helpPrompt];
-    NSArray *timeoutChunks = [SDLTTSChunkFactory buildTTSChunksFromSimple:timeoutPrompt];
+    NSArray *initialChunks = [SDLTTSChunk textChunksFromString:initialPrompt];
+    NSArray *helpChunks = [SDLTTSChunk textChunksFromString:helpPrompt];
+    NSArray *timeoutChunks = [SDLTTSChunk textChunksFromString:timeoutPrompt];
 
     return [SDLRPCRequestFactory buildPerformInteractionWithInitialChunks:initialChunks initialText:initialText interactionChoiceSetIDList:interactionChoiceSetIDList helpChunks:helpChunks timeoutChunks:timeoutChunks interactionMode:interactionMode timeout:timeout vrHelp:vrHelp correlationID:correlationID];
 }
 
 + (SDLPerformInteraction *)buildPerformInteractionWithInitialPrompt:(NSString *)initialPrompt initialText:(NSString *)initialText interactionChoiceSetID:(NSNumber *)interactionChoiceSetID vrHelp:(NSArray *)vrHelp correlationID:(NSNumber *)correlationID {
     NSArray *interactionChoiceSetIDList = [NSArray arrayWithObject:interactionChoiceSetID];
-    NSArray *initialChunks = [SDLTTSChunkFactory buildTTSChunksFromSimple:initialPrompt];
+    NSArray *initialChunks = [SDLTTSChunk textChunksFromString:initialPrompt];
 
     return [SDLRPCRequestFactory buildPerformInteractionWithInitialChunks:initialChunks initialText:initialText interactionChoiceSetIDList:interactionChoiceSetIDList helpChunks:nil timeoutChunks:nil interactionMode:SDLInteractionMode.BOTH timeout:nil vrHelp:vrHelp correlationID:correlationID];
 }
@@ -503,8 +503,8 @@ static NSString *const SDLBundleShortVersionStringKey = @"CFBundleShortVersionSt
 //***** SetGlobalProperties *****
 + (SDLSetGlobalProperties *)buildSetGlobalPropertiesWithHelpText:(NSString *)helpText timeoutText:(NSString *)timeoutText vrHelpTitle:(NSString *)vrHelpTitle vrHelp:(NSArray *)vrHelp correlationID:(NSNumber *)correlationID {
     SDLSetGlobalProperties *msg = [[SDLSetGlobalProperties alloc] init];
-    msg.helpPrompt = [SDLTTSChunkFactory buildTTSChunksFromSimple:helpText];
-    msg.timeoutPrompt = [SDLTTSChunkFactory buildTTSChunksFromSimple:timeoutText];
+    msg.helpPrompt = [SDLTTSChunk textChunksFromString:helpText];
+    msg.timeoutPrompt = [SDLTTSChunk textChunksFromString:timeoutText];
     msg.vrHelpTitle = vrHelpTitle;
     msg.vrHelp = [vrHelp mutableCopy];
     msg.correlationID = correlationID;
@@ -514,8 +514,8 @@ static NSString *const SDLBundleShortVersionStringKey = @"CFBundleShortVersionSt
 
 + (SDLSetGlobalProperties *)buildSetGlobalPropertiesWithHelpText:(NSString *)helpText timeoutText:(NSString *)timeoutText correlationID:(NSNumber *)correlationID {
     SDLSetGlobalProperties *msg = [[SDLSetGlobalProperties alloc] init];
-    msg.helpPrompt = [SDLTTSChunkFactory buildTTSChunksFromSimple:helpText];
-    msg.timeoutPrompt = [SDLTTSChunkFactory buildTTSChunksFromSimple:timeoutText];
+    msg.helpPrompt = [SDLTTSChunk textChunksFromString:helpText];
+    msg.timeoutPrompt = [SDLTTSChunk textChunksFromString:timeoutText];
     msg.correlationID = correlationID;
 
     return msg;

--- a/SmartDeviceLink/SDLSetGlobalProperties.m
+++ b/SmartDeviceLink/SDLSetGlobalProperties.m
@@ -40,8 +40,8 @@
         return nil;
     }
     
-    self.helpPrompt = [SDLTTSChunkFactory buildTTSChunksFromSimple:helpText];
-    self.timeoutPrompt = [SDLTTSChunkFactory buildTTSChunksFromSimple:timeoutText];
+    self.helpPrompt = [SDLTTSChunk textChunksFromString:helpText];
+    self.timeoutPrompt = [SDLTTSChunk textChunksFromString:timeoutText];
     self.vrHelpTitle = vrHelpTitle;
     self.vrHelp = [vrHelp mutableCopy];
     self.menuTitle = menuTitle;

--- a/SmartDeviceLink/SDLSpeak.m
+++ b/SmartDeviceLink/SDLSpeak.m
@@ -23,7 +23,7 @@
 }
 
 - (instancetype)initWithTTS:(NSString *)ttsText {
-    NSMutableArray* ttsChunks = [SDLTTSChunkFactory buildTTSChunksFromSimple:ttsText];
+    NSMutableArray* ttsChunks = [SDLTTSChunk textChunksFromString:ttsText];
     return [self initWithTTSChunks:ttsChunks];
 }
 

--- a/SmartDeviceLink/SDLTTSChunk.h
+++ b/SmartDeviceLink/SDLTTSChunk.h
@@ -54,6 +54,17 @@
 
 - (instancetype)initWithText:(NSString*)text type:(SDLSpeechCapabilities*)type;
 
++ (NSMutableArray<SDLTTSChunk *>*)textChunksFromString:(NSString*)string;
+
++ (NSMutableArray<SDLTTSChunk *>*)sapiChunksFromString:(NSString*)string;
+
++ (NSMutableArray<SDLTTSChunk *>*)lhPlusChunksFromString:(NSString*)string;
+
++ (NSMutableArray<SDLTTSChunk *>*)prerecordedChunksFromString:(NSString*)string;
+
++ (NSMutableArray<SDLTTSChunk *>*)silenceChunks;
+
+
 /**
  * @abstract Text to be spoken, or a phoneme specification, or the name of a pre-recorded sound. The contents of this field are indicated by the "type" field.
  *

--- a/SmartDeviceLink/SDLTTSChunk.m
+++ b/SmartDeviceLink/SDLTTSChunk.m
@@ -33,6 +33,34 @@
     return self;
 }
 
++ (NSMutableArray<SDLTTSChunk *>*)textChunksFromString:(NSString*)string {
+    return [self sdl_chunksFromString:string type:[SDLSpeechCapabilities TEXT]];
+}
+
++ (NSMutableArray<SDLTTSChunk *>*)sapiChunksFromString:(NSString*)string {
+    return [self sdl_chunksFromString:string type:[SDLSpeechCapabilities SAPI_PHONEMES]];
+}
+
++ (NSMutableArray<SDLTTSChunk *>*)lhPlusChunksFromString:(NSString*)string {
+    return [self sdl_chunksFromString:string type:[SDLSpeechCapabilities LHPLUS_PHONEMES]];
+}
+
++ (NSMutableArray<SDLTTSChunk *>*)prerecordedChunksFromString:(NSString*)string {
+    return [self sdl_chunksFromString:string type:[SDLSpeechCapabilities PRE_RECORDED]];
+}
+
++ (NSMutableArray<SDLTTSChunk *>*)silenceChunks {
+    return [self sdl_chunksFromString:nil type:[SDLSpeechCapabilities SILENCE]];
+}
+
++ (NSMutableArray<SDLTTSChunk *>*)sdl_chunksFromString:(NSString*)string type:(SDLSpeechCapabilities*)type {
+    if (string.length == 0) {
+        return nil;
+    }
+    
+    return [NSMutableArray arrayWithObject:[[[self class] alloc] initWithText:string type:type]];
+}
+
 - (void)setText:(NSString *)text {
     if (text != nil) {
         [store setObject:text forKey:NAMES_text];

--- a/SmartDeviceLink/SDLTTSChunkFactory.h
+++ b/SmartDeviceLink/SDLTTSChunkFactory.h
@@ -7,10 +7,10 @@
 @class SDLSpeechCapabilities;
 
 
-@interface SDLTTSChunkFactory : NSObject {
+__deprecated_msg("use SDLTTSChunk initializers instead") @interface SDLTTSChunkFactory : NSObject {
 }
 
-+ (SDLTTSChunk *)buildTTSChunkForString:(NSString *)text type:(SDLSpeechCapabilities *)type;
-+ (NSMutableArray *)buildTTSChunksFromSimple:(NSString *)simple;
++ (SDLTTSChunk *)buildTTSChunkForString:(NSString *)text type:(SDLSpeechCapabilities *)type __deprecated_msg("use SDLTTSChunk's initWithText:type: instead");
++ (NSMutableArray *)buildTTSChunksFromSimple:(NSString *)simple __deprecated_msg("use SDLTTSChunk's textChunksFromString: instead");
 
 @end

--- a/SmartDeviceLink_Example/Classes/ProxyManager.m
+++ b/SmartDeviceLink_Example/Classes/ProxyManager.m
@@ -129,7 +129,7 @@ NS_ASSUME_NONNULL_BEGIN
     config.shortAppName = @"SDL Example";
     config.appIcon = appIconArt;
     config.voiceRecognitionCommandNames = @[@"S D L Example"];
-    config.ttsName = @[[[SDLTTSChunk alloc] initWithText:config.shortAppName type:[SDLSpeechCapabilities TEXT]]];
+    config.ttsName = [SDLTTSChunk textChunksFromString:config.shortAppName];
     return config;
 }
 
@@ -183,21 +183,22 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (SDLSpeak *)appNameSpeak {
     SDLSpeak *speak = [[SDLSpeak alloc] init];
-    speak.ttsChunks = [NSMutableArray arrayWithObject:[[SDLTTSChunk alloc] initWithText:@"S D L Example App" type:[SDLSpeechCapabilities TEXT]]];
+    speak.ttsChunks = [SDLTTSChunk textChunksFromString:@"S D L Example App"];
+
     return speak;
 }
 
 + (SDLSpeak *)goodJobSpeak {
     SDLSpeak *speak = [[SDLSpeak alloc] init];
-    speak.ttsChunks = [NSMutableArray arrayWithObject:[[SDLTTSChunk alloc] initWithText:@"Good Job" type:[SDLSpeechCapabilities TEXT]]];
+    speak.ttsChunks = [SDLTTSChunk textChunksFromString:@"Good Job"];
     
     return speak;
 }
 
 + (SDLSpeak *)youMissedItSpeak {
     SDLSpeak *speak = [[SDLSpeak alloc] init];
-    speak.ttsChunks = [NSMutableArray arrayWithObject:[[SDLTTSChunk alloc] initWithText:@"You missed it" type:[SDLSpeechCapabilities TEXT]]];
-    
+    speak.ttsChunks = [SDLTTSChunk textChunksFromString:@"You missed it"];
+
     return speak;
 }
 
@@ -219,11 +220,11 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)sendPerformOnlyChoiceInteractionWithManager:(SDLManager *)manager {
     SDLPerformInteraction *performOnlyChoiceInteraction = [[SDLPerformInteraction alloc] init];
     performOnlyChoiceInteraction.initialText = @"Choose the only one! You have 5 seconds...";
-    performOnlyChoiceInteraction.initialPrompt = [NSMutableArray arrayWithObject:[[SDLTTSChunk alloc] initWithText:@"Choose it" type:[SDLSpeechCapabilities TEXT]]];
+    performOnlyChoiceInteraction.initialPrompt = [SDLTTSChunk textChunksFromString:@"Choose it"];
     performOnlyChoiceInteraction.interactionMode = [SDLInteractionMode BOTH];
     performOnlyChoiceInteraction.interactionChoiceSetIDList = [NSMutableArray arrayWithObject:@0];
-    performOnlyChoiceInteraction.helpPrompt = [NSMutableArray arrayWithObject:[[SDLTTSChunk alloc] initWithText:@"Do it" type:[SDLSpeechCapabilities TEXT]]];
-    performOnlyChoiceInteraction.timeoutPrompt = [NSMutableArray arrayWithObject:[[SDLTTSChunk alloc] initWithText:@"Too late" type:[SDLSpeechCapabilities TEXT]]];
+    performOnlyChoiceInteraction.helpPrompt = [SDLTTSChunk textChunksFromString:@"Do it"];
+    performOnlyChoiceInteraction.timeoutPrompt = [SDLTTSChunk textChunksFromString:@"Too late"];
     performOnlyChoiceInteraction.timeout = @5000;
     performOnlyChoiceInteraction.interactionLayout = [SDLLayoutMode LIST_ONLY];
     


### PR DESCRIPTION
Fixes #459 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Summary
This PR deprecates `SDLTTSChunkFactory` in favor of initializers in `SDLTTSChunk`.

### Changelog
##### Enchancements
* Deprecated `SDLTTSChunkFactory` in favor of initializers in `SDLTTSChunk`.
