### PR TITLE
Added missing initializers for waypoint initializers.

### DIFF
--- a/SmartDeviceLink/SDLSubscribeWaypointsResponse.m
+++ b/SmartDeviceLink/SDLSubscribeWaypointsResponse.m
@@ -7,7 +7,7 @@
 @implementation SDLSubscribeWaypointsResponse
 
 - (instancetype)init {
-    if (self = [super initWithName:NAMES_SubscribeVehicleData]) {
+    if (self = [super initWithName:NAMES_SubscribeWaypoints]) {
     }
     return self;
 }

--- a/SmartDeviceLink/SDLUnsubscribeWaypoints.m
+++ b/SmartDeviceLink/SDLUnsubscribeWaypoints.m
@@ -2,7 +2,15 @@
 //
 
 #import "SDLUnsubscribeWaypoints.h"
+#import "SDLNames.h"
 
 @implementation SDLUnsubscribeWaypoints
+
+- (instancetype)init {
+    if (self = [super initWithName:NAMES_UnsubscribeWaypoints]) {
+    }
+    return self;
+}
+
 
 @end

--- a/SmartDeviceLink/SDLUnsubscribeWaypointsResponse.m
+++ b/SmartDeviceLink/SDLUnsubscribeWaypointsResponse.m
@@ -3,6 +3,14 @@
 
 #import "SDLUnsubscribeWaypointsResponse.h"
 
+#import "SDLNames.h"
+
 @implementation SDLUnsubscribeWaypointsResponse
+
+- (instancetype)init {
+    if (self = [super initWithName:NAMES_UnsubscribeWaypoints]) {
+    }
+    return self;
+}
 
 @end


### PR DESCRIPTION
Fixes #465 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Adds missing initializers for `SDLUnsubscribeWaypoints` and `SDLUnsubscribeWaypointsResponse`, as well as fixes the name in the initializer for `SDLSubscribeWaypointsResponse`.

### Changelog
##### Bug Fixes
* Adds missing initializers for `SDLUnsubscribeWaypoints` and `SDLUnsubscribeWaypointsResponse`, as well as fixes the name in the initializer for `SDLSubscribeWaypointsResponse`.