### PR TITLE
Update uploading file operations to use built in cancel mechanism

### DIFF
--- a/SmartDeviceLinkTests/DevAPISpecs/SDLFileManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLFileManagerSpec.m
@@ -281,7 +281,7 @@ describe(@"SDLFileManager", ^{
                             });
                             
                             it(@"should call the completion handler with correct data", ^{
-                                expect(completionError).to(equal([NSError sdl_lifecycle_notReadyError]));
+                                expect(completionError).toEventually(equal([NSError sdl_lifecycle_notReadyError]));
                             });
                         });
                     });
@@ -404,7 +404,7 @@ describe(@"SDLFileManager", ^{
                         });
                         
                         it(@"should call the completion handler with nil error", ^{
-                            expect(completionError).to(equal([NSError sdl_lifecycle_notReadyError]));
+                            expect(completionError).toEventually(equal([NSError sdl_lifecycle_notReadyError]));
                         });
                     });
                 });


### PR DESCRIPTION
Fixes #467

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Tests all pass, and all example app functionality still works.

### Summary
This PR fixes failing tests and alters a minor amount of upload file logic for simplification.

### Changelog
##### Bug Fixes
* Update `SDLUploadFileOperation` logic for simplification
* Fix failing tests