### PR TITLE
Adding check for compressionSession nullability on teardown.

### DIFF
--- a/SmartDeviceLink/SDLStreamingMediaManager.m
+++ b/SmartDeviceLink/SDLStreamingMediaManager.m
@@ -343,8 +343,10 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark Lifecycle
 
 - (void)sdl_teardownCompressionSession {
-    VTCompressionSessionInvalidate(self.compressionSession);
-    CFRelease(self.compressionSession);
+    if (self.compressionSession != NULL) {
+        VTCompressionSessionInvalidate(self.compressionSession);
+        CFRelease(self.compressionSession);
+    }
 }
 
 


### PR DESCRIPTION
Fixes #472 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Disconnect and reconnect an mobile navigation app.

### Summary
Fixed a crash as a result of not checking for nullability of `compressionSession` in `SDLStreamingMediaManager`.

### Changelog
##### Bug Fixes
* Fixed a crash as a result of not checking for nullability of `compressionSession` in `SDLStreamingMediaManager`.

