### PR TITLE
Allow SecurityManager's AppId to be set earlier on in lifecycle

### DIFF
--- a/SmartDeviceLink/SDLProxy.m
+++ b/SmartDeviceLink/SDLProxy.m
@@ -386,6 +386,9 @@ const int POLICIES_CORRELATION_ID = 65535;
         _streamingMediaManager.displayCapabilties = registerResponse.displayCapabilities;
     }
     self.protocol.securityManager = [self securityManagerForMake:registerResponse.vehicleType.make];
+    if (self.protocol.securityManager) {
+        self.protocol.securityManager.appId = self.appId;
+    }
 
     if ([SDLGlobals globals].protocolVersion >= 4) {
         [self sendMobileHMIState];

--- a/SmartDeviceLink/SDLProxy.m
+++ b/SmartDeviceLink/SDLProxy.m
@@ -386,7 +386,8 @@ const int POLICIES_CORRELATION_ID = 65535;
         _streamingMediaManager.displayCapabilties = registerResponse.displayCapabilities;
     }
     self.protocol.securityManager = [self securityManagerForMake:registerResponse.vehicleType.make];
-    if (self.protocol.securityManager) {
+    if (self.protocol.securityManager
+        && [self.protocol.securityManager respondsToSelector:@selector(setAppId:)]) {
         self.protocol.securityManager.appId = self.appId;
     }
 

--- a/SmartDeviceLink/SDLSecurityType.h
+++ b/SmartDeviceLink/SDLSecurityType.h
@@ -12,6 +12,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol SDLSecurityType <NSObject>
 
+@property (copy, nonatomic) NSString* appId;
+
 - (void)initializeWithAppId:(NSString *)appId completionHandler:(void (^)(NSError *_Nullable error))completionHandler;
 - (void)stop;
 


### PR DESCRIPTION
Fixes #470 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
This PR does not impact any existing security managers.

### Summary
On a successful RAI, the security manager's appId is set if the selector is available.

### Changelog
##### Enchancements
* Setting security manager's appId on successful register app interface, instead of on session start.
