### PR TITLE
Added in missing response & notification dispatchers for waypoints.

### DIFF
--- a/SmartDeviceLink/SDLGetWaypoints.h
+++ b/SmartDeviceLink/SDLGetWaypoints.h
@@ -5,7 +5,8 @@
 
 @class SDLWaypointType;
 
-@interface SDLGetWaypoints : SDLRPCRequest
+
+@interface SDLGetWayPoints : SDLRPCRequest
 
 - (instancetype)initWithType:(SDLWaypointType *)type;
 
@@ -16,5 +17,10 @@
  * Required
  */
 @property (strong, nonatomic) SDLWaypointType *waypointType;
+
+@end
+
+__deprecated_msg("Use SDLGetWayPoints instead")
+@interface SDLGetWaypoints : SDLGetWayPoints
 
 @end

--- a/SmartDeviceLink/SDLGetWaypoints.m
+++ b/SmartDeviceLink/SDLGetWaypoints.m
@@ -6,7 +6,7 @@
 #import "SDLNames.h"
 #import "SDLWaypointType.h"
 
-@implementation SDLGetWaypoints
+@implementation SDLGetWayPoints
 
 - (instancetype)init {
     if (self = [super initWithName:NAMES_GetWaypoints]) {
@@ -20,9 +20,9 @@
     if (!self) {
         return nil;
     }
-
+    
     self.waypointType = type;
-
+    
     return self;
 }
 
@@ -44,3 +44,8 @@
 }
 
 @end
+
+@implementation SDLGetWaypoints
+
+@end
+

--- a/SmartDeviceLink/SDLGetWaypointsResponse.h
+++ b/SmartDeviceLink/SDLGetWaypointsResponse.h
@@ -5,7 +5,7 @@
 
 @class SDLLocationDetails;
 
-@interface SDLGetWaypointsResponse : SDLRPCResponse
+@interface SDLGetWayPointsResponse : SDLRPCResponse
 
 /**
  * @abstract Array of waypoints
@@ -15,5 +15,10 @@
  * Optional, Array size 1 - 10
  */
 @property (strong) NSArray<SDLLocationDetails *> *waypoints;
+
+@end
+
+__deprecated_msg("Use SDLGetWayPointsResponse instead")
+@interface SDLGetWaypointsResponse : SDLGetWayPointsResponse
 
 @end

--- a/SmartDeviceLink/SDLGetWaypointsResponse.m
+++ b/SmartDeviceLink/SDLGetWaypointsResponse.m
@@ -4,7 +4,7 @@
 #import "SDLGetWaypointsResponse.h"
 #import "SDLNames.h"
 
-@implementation SDLGetWaypointsResponse
+@implementation SDLGetWayPointsResponse
 
 - (instancetype)init {
     if (self = [super initWithName:NAMES_GetWaypoints]) {
@@ -25,3 +25,8 @@
 }
 
 @end
+
+@implementation SDLGetWaypointsResponse
+
+@end
+

--- a/SmartDeviceLink/SDLNotificationConstants.h
+++ b/SmartDeviceLink/SDLNotificationConstants.h
@@ -79,6 +79,7 @@ extern SDLNotificationName const SDLDidReceiveEndAudioPassThruResponse;
 extern SDLNotificationName const SDLDidReceiveGenericResponse;
 extern SDLNotificationName const SDLDidReceiveGetDTCsResponse;
 extern SDLNotificationName const SDLDidReceiveGetVehicleDataResponse;
+extern SDLNotificationName const SDLDidReceiveGetWaypointsResponse;
 extern SDLNotificationName const SDLDidReceiveListFilesResponse;
 extern SDLNotificationName const SDLDidReceivePerformAudioPassThruResponse;
 extern SDLNotificationName const SDLDidReceivePerformInteractionResponse;
@@ -98,11 +99,13 @@ extern SDLNotificationName const SDLDidReceiveSliderResponse;
 extern SDLNotificationName const SDLDidReceiveSpeakResponse;
 extern SDLNotificationName const SDLDidReceiveSubscribeButtonResponse;
 extern SDLNotificationName const SDLDidReceiveSubscribeVehicleDataResponse;
+extern SDLNotificationName const SDLDidReceiveSubscribeWaypointsResponse;
 extern SDLNotificationName const SDLDidReceiveSyncPDataResponse;
 extern SDLNotificationName const SDLDidReceiveUpdateTurnListResponse;
 extern SDLNotificationName const SDLDidReceiveUnregisterAppInterfaceResponse;
 extern SDLNotificationName const SDLDidReceiveUnsubscribeButtonResponse;
 extern SDLNotificationName const SDLDidReceiveUnsubscribeVehicleDataResponse;
+extern SDLNotificationName const SDLDidReceiveUnsubscribeWaypointsResponse;
 
 /**
  *  NSNotification names associated with specific RPC notifications.
@@ -126,6 +129,7 @@ extern SDLNotificationName const SDLDidReceiveSystemRequestNotification;
 extern SDLNotificationName const SDLDidChangeTurnByTurnStateNotification;
 extern SDLNotificationName const SDLDidReceiveTouchEventNotification;
 extern SDLNotificationName const SDLDidReceiveVehicleDataNotification;
+extern SDLNotificationName const SDLDidReceiveWaypointNotification;
 
 @interface SDLNotificationConstants : NSObject
 

--- a/SmartDeviceLink/SDLNotificationConstants.m
+++ b/SmartDeviceLink/SDLNotificationConstants.m
@@ -37,6 +37,7 @@ SDLNotificationName const SDLDidReceiveEndAudioPassThruResponse = @"com.sdl.resp
 SDLNotificationName const SDLDidReceiveGenericResponse = @"com.sdl.response.generic";
 SDLNotificationName const SDLDidReceiveGetDTCsResponse = @"com.sdl.response.getDTCs";
 SDLNotificationName const SDLDidReceiveGetVehicleDataResponse = @"com.sdl.response.getVehicleData";
+SDLNotificationName const SDLDidReceiveGetWaypointsResponse = @"com.sdl.response.getWaypoints";
 SDLNotificationName const SDLDidReceiveListFilesResponse = @"com.sdl.response.listFiles";
 SDLNotificationName const SDLDidReceivePerformAudioPassThruResponse = @"com.sdl.response.performAudioPassThru";
 SDLNotificationName const SDLDidReceivePerformInteractionResponse = @"com.sdl.response.performInteraction";
@@ -56,11 +57,13 @@ SDLNotificationName const SDLDidReceiveSliderResponse = @"com.sdl.response.slide
 SDLNotificationName const SDLDidReceiveSpeakResponse = @"com.sdl.response.speak";
 SDLNotificationName const SDLDidReceiveSubscribeButtonResponse = @"com.sdl.response.subscribeButton";
 SDLNotificationName const SDLDidReceiveSubscribeVehicleDataResponse = @"com.sdl.response.subscribeVehicleData";
+SDLNotificationName const SDLDidReceiveSubscribeWaypointsResponse = @"com.sdl.response.subscribeWaypoints";
 SDLNotificationName const SDLDidReceiveSyncPDataResponse = @"com.sdl.response.syncPData";
 SDLNotificationName const SDLDidReceiveUpdateTurnListResponse = @"com.sdl.response.updateTurnList";
 SDLNotificationName const SDLDidReceiveUnregisterAppInterfaceResponse = @"com.sdl.response.unregisterAppInterface";
 SDLNotificationName const SDLDidReceiveUnsubscribeButtonResponse = @"com.sdl.response.unsubscribeButton";
 SDLNotificationName const SDLDidReceiveUnsubscribeVehicleDataResponse = @"com.sdl.response.unsubscribeVehicleData";
+SDLNotificationName const SDLDidReceiveUnsubscribeWaypointsResponse = @"com.sdl.response.unsubscribeWaypoints";
 
 #pragma mark - RPC Notifications
 SDLNotificationName const SDLDidChangeDriverDistractionStateNotification = @"com.sdl.notification.changeDriverDistractionStateNotification";
@@ -80,6 +83,7 @@ SDLNotificationName const SDLDidReceiveSystemRequestNotification = @"com.sdl.not
 SDLNotificationName const SDLDidChangeTurnByTurnStateNotification = @"com.sdl.notification.changeTurnByTurnState";
 SDLNotificationName const SDLDidReceiveTouchEventNotification = @"com.sdl.notification.touchEvent";
 SDLNotificationName const SDLDidReceiveVehicleDataNotification = @"com.sdl.notification.vehicleData";
+SDLNotificationName const SDLDidReceiveWaypointNotification = @"com.sdl.notification.waypoint";
 
 
 @implementation SDLNotificationConstants
@@ -102,6 +106,7 @@ SDLNotificationName const SDLDidReceiveVehicleDataNotification = @"com.sdl.notif
              SDLDidReceiveGenericResponse,
              SDLDidReceiveGetDTCsResponse,
              SDLDidReceiveGetVehicleDataResponse,
+             SDLDidReceiveGetWaypointsResponse,
              SDLDidReceiveListFilesResponse,
              SDLDidReceivePerformAudioPassThruResponse,
              SDLDidReceivePerformInteractionResponse,
@@ -121,11 +126,13 @@ SDLNotificationName const SDLDidReceiveVehicleDataNotification = @"com.sdl.notif
              SDLDidReceiveSpeakResponse,
              SDLDidReceiveSubscribeButtonResponse,
              SDLDidReceiveSubscribeVehicleDataResponse,
+             SDLDidReceiveSubscribeWaypointsResponse,
              SDLDidReceiveSyncPDataResponse,
              SDLDidReceiveUpdateTurnListResponse,
              SDLDidReceiveUnregisterAppInterfaceResponse,
              SDLDidReceiveUnsubscribeButtonResponse,
-             SDLDidReceiveUnsubscribeVehicleDataResponse];
+             SDLDidReceiveUnsubscribeVehicleDataResponse,
+             SDLDidReceiveUnsubscribeWaypointsResponse];
 }
 
 + (NSArray<SDLNotificationName> *)allButtonEventNotifications {

--- a/SmartDeviceLink/SDLNotificationDispatcher.m
+++ b/SmartDeviceLink/SDLNotificationDispatcher.m
@@ -146,7 +146,7 @@ NS_ASSUME_NONNULL_BEGIN
     [self postRPCResponseNotification:SDLDidReceiveGetVehicleDataResponse response:response];
 }
 
-- (void)onGetWaypointsResponse:(SDLGetWaypointsResponse *)response {
+- (void)onGetWayPointsResponse:(SDLGetWaypointsResponse *)response {
     [self postRPCResponseNotification:SDLDidReceiveGetWaypointsResponse response:response];
 }
 
@@ -226,7 +226,7 @@ NS_ASSUME_NONNULL_BEGIN
     [self postRPCResponseNotification:SDLDidReceiveSubscribeVehicleDataResponse response:response];
 }
 
-- (void)onSubscribeWaypointsResponse:(SDLSubscribeWaypointsResponse *)response {
+- (void)onSubscribeWayPointsResponse:(SDLSubscribeWaypointsResponse *)response {
     [self postRPCResponseNotification:SDLDidReceiveSubscribeWaypointsResponse response:response];
 }
 
@@ -250,7 +250,7 @@ NS_ASSUME_NONNULL_BEGIN
     [self postRPCResponseNotification:SDLDidReceiveUnsubscribeVehicleDataResponse response:response];
 }
 
-- (void)onUnsubscribeWaypointsResponse:(SDLUnsubscribeWaypointsResponse *)response {
+- (void)onUnsubscribeWayPointsResponse:(SDLUnsubscribeWaypointsResponse *)response {
     [self postRPCResponseNotification:SDLDidReceiveUnsubscribeWaypointsResponse response:response];
 }
 
@@ -318,7 +318,7 @@ NS_ASSUME_NONNULL_BEGIN
     [self postRPCNotificationNotification:SDLDidReceiveVehicleDataNotification notification:notification];
 }
 
-- (void)onOnWaypointChange:(SDLOnWaypointChange *)notification {
+- (void)onOnWayPointChange:(SDLOnWaypointChange *)notification {
     [self postRPCNotificationNotification:SDLDidReceiveWaypointNotification notification:notification];
 }
 

--- a/SmartDeviceLink/SDLNotificationDispatcher.m
+++ b/SmartDeviceLink/SDLNotificationDispatcher.m
@@ -146,6 +146,10 @@ NS_ASSUME_NONNULL_BEGIN
     [self postRPCResponseNotification:SDLDidReceiveGetVehicleDataResponse response:response];
 }
 
+- (void)onGetWaypointsResponse:(SDLGetWaypointsResponse *)response {
+    [self postRPCResponseNotification:SDLDidReceiveGetWaypointsResponse response:response];
+}
+
 - (void)onListFilesResponse:(SDLListFilesResponse *)response {
     [self postRPCResponseNotification:SDLDidReceiveListFilesResponse response:response];
 }
@@ -222,6 +226,10 @@ NS_ASSUME_NONNULL_BEGIN
     [self postRPCResponseNotification:SDLDidReceiveSubscribeVehicleDataResponse response:response];
 }
 
+- (void)onSubscribeWaypointsResponse:(SDLSubscribeWaypointsResponse *)response {
+    [self postRPCResponseNotification:SDLDidReceiveSubscribeWaypointsResponse response:response];
+}
+
 - (void)onSyncPDataResponse:(SDLSyncPDataResponse *)response {
     [self postRPCResponseNotification:SDLDidReceiveSyncPDataResponse response:response];
 }
@@ -240,6 +248,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)onUnsubscribeVehicleDataResponse:(SDLUnsubscribeVehicleDataResponse *)response {
     [self postRPCResponseNotification:SDLDidReceiveUnsubscribeVehicleDataResponse response:response];
+}
+
+- (void)onUnsubscribeWaypointsResponse:(SDLUnsubscribeWaypointsResponse *)response {
+    [self postRPCResponseNotification:SDLDidReceiveUnsubscribeWaypointsResponse response:response];
 }
 
 - (void)onOnAppInterfaceUnregistered:(SDLOnAppInterfaceUnregistered *)notification {
@@ -304,6 +316,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)onOnVehicleData:(SDLOnVehicleData *)notification {
     [self postRPCNotificationNotification:SDLDidReceiveVehicleDataNotification notification:notification];
+}
+
+- (void)onOnWaypointChange:(SDLOnWaypointChange *)notification {
+    [self postRPCNotificationNotification:SDLDidReceiveWaypointNotification notification:notification];
 }
 
 #pragma clang diagnostic pop

--- a/SmartDeviceLink/SDLOnWaypointChange.h
+++ b/SmartDeviceLink/SDLOnWaypointChange.h
@@ -5,7 +5,7 @@
 
 @class SDLLocationDetails;
 
-@interface SDLOnWaypointChange : SDLRPCNotification
+@interface SDLOnWayPointChange : SDLRPCNotification
 
 /**
  * @abstract Location address for display purposes only.
@@ -15,3 +15,9 @@
 @property (copy, nonatomic) NSArray<SDLLocationDetails *> *waypoints;
 
 @end
+
+__deprecated_msg("Use SDLOnWayPointChange instead")
+@interface SDLOnWaypointChange : SDLOnWayPointChange
+
+@end
+

--- a/SmartDeviceLink/SDLOnWaypointChange.m
+++ b/SmartDeviceLink/SDLOnWaypointChange.m
@@ -5,7 +5,7 @@
 
 #import "SDLNames.h"
 
-@implementation SDLOnWaypointChange
+@implementation SDLOnWayPointChange
 
 - (instancetype)init {
     if (self = [super initWithName:NAMES_OnWaypointChange]) {
@@ -24,5 +24,9 @@
 - (NSArray<SDLLocationDetails *> *)waypoints {
     return parameters[NAMES_waypoints];
 }
+
+@end
+
+@implementation SDLOnWaypointChange
 
 @end

--- a/SmartDeviceLink/SDLProxyListener.h
+++ b/SmartDeviceLink/SDLProxyListener.h
@@ -96,7 +96,7 @@
 - (void)onGenericResponse:(SDLGenericResponse *)response;
 - (void)onGetDTCsResponse:(SDLGetDTCsResponse *)response;
 - (void)onGetVehicleDataResponse:(SDLGetVehicleDataResponse *)response;
-- (void)onGetWaypointsResponse:(SDLGetWaypointsResponse *)response;
+- (void)onGetWayPointsResponse:(SDLGetWaypointsResponse *)response;
 - (void)onListFilesResponse:(SDLListFilesResponse *)response;
 - (void)onReceivedLockScreenIcon:(UIImage *)icon;
 - (void)onOnAppInterfaceUnregistered:(SDLOnAppInterfaceUnregistered *)notification;
@@ -115,7 +115,7 @@
 - (void)onOnTBTClientState:(SDLOnTBTClientState *)notification;
 - (void)onOnTouchEvent:(SDLOnTouchEvent *)notification;
 - (void)onOnVehicleData:(SDLOnVehicleData *)notification;
-- (void)onOnWaypointChange:(SDLOnWaypointChange *)notification;
+- (void)onOnWayPointChange:(SDLOnWaypointChange *)notification;
 - (void)onPerformAudioPassThruResponse:(SDLPerformAudioPassThruResponse *)response;
 - (void)onPerformInteractionResponse:(SDLPerformInteractionResponse *)response;
 - (void)onPutFileResponse:(SDLPutFileResponse *)response;
@@ -134,12 +134,12 @@
 - (void)onSpeakResponse:(SDLSpeakResponse *)response;
 - (void)onSubscribeButtonResponse:(SDLSubscribeButtonResponse *)response;
 - (void)onSubscribeVehicleDataResponse:(SDLSubscribeVehicleDataResponse *)response;
-- (void)onSubscribeWaypointsResponse:(SDLSubscribeWaypointsResponse *)response;
+- (void)onSubscribeWayPointsResponse:(SDLSubscribeWaypointsResponse *)response;
 - (void)onSyncPDataResponse:(SDLSyncPDataResponse *)response;
 - (void)onUpdateTurnListResponse:(SDLUpdateTurnListResponse *)response;
 - (void)onUnregisterAppInterfaceResponse:(SDLUnregisterAppInterfaceResponse *)response;
 - (void)onUnsubscribeButtonResponse:(SDLUnsubscribeButtonResponse *)response;
 - (void)onUnsubscribeVehicleDataResponse:(SDLUnsubscribeVehicleDataResponse *)response;
-- (void)onUnsubscribeWaypointsResponse:(SDLUnsubscribeWaypointsResponse *)response;
+- (void)onUnsubscribeWayPointsResponse:(SDLUnsubscribeWaypointsResponse *)response;
 
 @end

--- a/SmartDeviceLink/SDLProxyListener.h
+++ b/SmartDeviceLink/SDLProxyListener.h
@@ -20,6 +20,7 @@
 @class SDLGenericResponse;
 @class SDLGetDTCsResponse;
 @class SDLGetVehicleDataResponse;
+@class SDLGetWaypointsResponse;
 @class SDLListFilesResponse;
 @class SDLOnAppInterfaceUnregistered;
 @class SDLOnAudioPassThru;
@@ -40,6 +41,7 @@
 @class SDLOnTBTClientState;
 @class SDLOnTouchEvent;
 @class SDLOnVehicleData;
+@class SDLOnWaypointChange;
 @class SDLPerformAudioPassThruResponse;
 @class SDLPerformInteractionResponse;
 @class SDLPutFileResponse;
@@ -58,11 +60,13 @@
 @class SDLSpeakResponse;
 @class SDLSubscribeButtonResponse;
 @class SDLSubscribeVehicleDataResponse;
+@class SDLSubscribeWaypointsResponse;
 @class SDLSyncPDataResponse;
 @class SDLUpdateTurnListResponse;
 @class SDLUnregisterAppInterfaceResponse;
 @class SDLUnsubscribeButtonResponse;
 @class SDLUnsubscribeVehicleDataResponse;
+@class SDLUnsubscribeWaypointsResponse;
 
 
 @protocol SDLProxyListener <NSObject>
@@ -92,6 +96,7 @@
 - (void)onGenericResponse:(SDLGenericResponse *)response;
 - (void)onGetDTCsResponse:(SDLGetDTCsResponse *)response;
 - (void)onGetVehicleDataResponse:(SDLGetVehicleDataResponse *)response;
+- (void)onGetWaypointsResponse:(SDLGetWaypointsResponse *)response;
 - (void)onListFilesResponse:(SDLListFilesResponse *)response;
 - (void)onReceivedLockScreenIcon:(UIImage *)icon;
 - (void)onOnAppInterfaceUnregistered:(SDLOnAppInterfaceUnregistered *)notification;
@@ -110,6 +115,7 @@
 - (void)onOnTBTClientState:(SDLOnTBTClientState *)notification;
 - (void)onOnTouchEvent:(SDLOnTouchEvent *)notification;
 - (void)onOnVehicleData:(SDLOnVehicleData *)notification;
+- (void)onOnWaypointChange:(SDLOnWaypointChange *)notification;
 - (void)onPerformAudioPassThruResponse:(SDLPerformAudioPassThruResponse *)response;
 - (void)onPerformInteractionResponse:(SDLPerformInteractionResponse *)response;
 - (void)onPutFileResponse:(SDLPutFileResponse *)response;
@@ -128,10 +134,12 @@
 - (void)onSpeakResponse:(SDLSpeakResponse *)response;
 - (void)onSubscribeButtonResponse:(SDLSubscribeButtonResponse *)response;
 - (void)onSubscribeVehicleDataResponse:(SDLSubscribeVehicleDataResponse *)response;
+- (void)onSubscribeWaypointsResponse:(SDLSubscribeWaypointsResponse *)response;
 - (void)onSyncPDataResponse:(SDLSyncPDataResponse *)response;
 - (void)onUpdateTurnListResponse:(SDLUpdateTurnListResponse *)response;
 - (void)onUnregisterAppInterfaceResponse:(SDLUnregisterAppInterfaceResponse *)response;
 - (void)onUnsubscribeButtonResponse:(SDLUnsubscribeButtonResponse *)response;
 - (void)onUnsubscribeVehicleDataResponse:(SDLUnsubscribeVehicleDataResponse *)response;
+- (void)onUnsubscribeWaypointsResponse:(SDLUnsubscribeWaypointsResponse *)response;
 
 @end

--- a/SmartDeviceLink/SDLSubscribeWaypoints.h
+++ b/SmartDeviceLink/SDLSubscribeWaypoints.h
@@ -10,7 +10,12 @@
 * @see SDLUnsubscribeWaypoints
 *
 */
-
-@interface SDLSubscribeWaypoints : SDLRPCRequest
+@interface SDLSubscribeWayPoints : SDLRPCRequest
 
 @end
+
+__deprecated_msg("Use SDLSubscribeWayPoints instead")
+@interface SDLSubscribeWaypoints : SDLSubscribeWayPoints
+
+@end
+

--- a/SmartDeviceLink/SDLSubscribeWaypoints.m
+++ b/SmartDeviceLink/SDLSubscribeWaypoints.m
@@ -4,7 +4,7 @@
 #import "SDLSubscribeWaypoints.h"
 #import "SDLNames.h"
 
-@implementation SDLSubscribeWaypoints
+@implementation SDLSubscribeWayPoints
 
 - (instancetype)init {
     if (self = [super initWithName:NAMES_SubscribeWaypoints]) {
@@ -13,3 +13,8 @@
 }
 
 @end
+
+@implementation SDLSubscribeWaypoints
+
+@end
+

--- a/SmartDeviceLink/SDLSubscribeWaypointsResponse.h
+++ b/SmartDeviceLink/SDLSubscribeWaypointsResponse.h
@@ -3,6 +3,12 @@
 
 #import "SDLRPCResponse.h"
 
-@interface SDLSubscribeWaypointsResponse : SDLRPCResponse
+@interface SDLSubscribeWayPointsResponse : SDLRPCResponse
 
 @end
+
+__deprecated_msg("Use SDLSubscribeWayPointsResponse instead")
+@interface SDLSubscribeWaypointsResponse : SDLSubscribeWayPointsResponse
+
+@end
+

--- a/SmartDeviceLink/SDLSubscribeWaypointsResponse.m
+++ b/SmartDeviceLink/SDLSubscribeWaypointsResponse.m
@@ -4,12 +4,16 @@
 #import "SDLSubscribeWaypointsResponse.h"
 #import "SDLNames.h"
 
-@implementation SDLSubscribeWaypointsResponse
+@implementation SDLSubscribeWayPointsResponse
 
 - (instancetype)init {
     if (self = [super initWithName:NAMES_SubscribeWaypoints]) {
     }
     return self;
 }
+
+@end
+
+@implementation SDLSubscribeWaypointsResponse
 
 @end

--- a/SmartDeviceLink/SDLUnsubscribeWaypoints.h
+++ b/SmartDeviceLink/SDLUnsubscribeWaypoints.h
@@ -3,6 +3,11 @@
 
 #import "SDLRPCRequest.h"
 
-@interface SDLUnsubscribeWaypoints : SDLRPCRequest
+@interface SDLUnsubscribeWayPoints : SDLRPCRequest
+
+@end
+
+__deprecated_msg("Use SDLUnsubscribeWayPoints instead")
+@interface SDLUnsubscribeWaypoints : SDLUnsubscribeWayPoints
 
 @end

--- a/SmartDeviceLink/SDLUnsubscribeWaypoints.m
+++ b/SmartDeviceLink/SDLUnsubscribeWaypoints.m
@@ -4,7 +4,7 @@
 #import "SDLUnsubscribeWaypoints.h"
 #import "SDLNames.h"
 
-@implementation SDLUnsubscribeWaypoints
+@implementation SDLUnsubscribeWayPoints
 
 - (instancetype)init {
     if (self = [super initWithName:NAMES_UnsubscribeWaypoints]) {
@@ -12,5 +12,8 @@
     return self;
 }
 
+@end
+
+@implementation SDLUnsubscribeWaypoints
 
 @end

--- a/SmartDeviceLink/SDLUnsubscribeWaypointsResponse.h
+++ b/SmartDeviceLink/SDLUnsubscribeWaypointsResponse.h
@@ -3,6 +3,11 @@
 
 #import "SDLRPCResponse.h"
 
-@interface SDLUnsubscribeWaypointsResponse : SDLRPCResponse
+@interface SDLUnsubscribeWayPointsResponse : SDLRPCResponse
+
+@end
+
+__deprecated_msg("Use SDLUnsubscribeWayPointsResponse instead")
+@interface SDLUnsubscribeWaypointsResponse : SDLUnsubscribeWayPointsResponse
 
 @end

--- a/SmartDeviceLink/SDLUnsubscribeWaypointsResponse.m
+++ b/SmartDeviceLink/SDLUnsubscribeWaypointsResponse.m
@@ -5,12 +5,16 @@
 
 #import "SDLNames.h"
 
-@implementation SDLUnsubscribeWaypointsResponse
+@implementation SDLUnsubscribeWayPointsResponse
 
 - (instancetype)init {
     if (self = [super initWithName:NAMES_UnsubscribeWaypoints]) {
     }
     return self;
 }
+
+@end
+
+@implementation SDLUnsubscribeWaypointsResponse
 
 @end

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLNotificationDispatcherSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLNotificationDispatcherSpec.m
@@ -38,6 +38,7 @@ describe(@"a notification dispatcher", ^{
         expect(@([testDispatcher respondsToSelector:@selector(onGenericResponse:)])).to(beTruthy());
         expect(@([testDispatcher respondsToSelector:@selector(onGetDTCsResponse:)])).to(beTruthy());
         expect(@([testDispatcher respondsToSelector:@selector(onGetVehicleDataResponse:)])).to(beTruthy());
+        expect(@([testDispatcher respondsToSelector:@selector(onGetWayPointsResponse:)])).to(beTruthy());
         expect(@([testDispatcher respondsToSelector:@selector(onReceivedLockScreenIcon:)])).to(beTruthy());
         expect(@([testDispatcher respondsToSelector:@selector(onOnAppInterfaceUnregistered:)])).to(beTruthy());
         expect(@([testDispatcher respondsToSelector:@selector(onOnAudioPassThru:)])).to(beTruthy());
@@ -53,6 +54,7 @@ describe(@"a notification dispatcher", ^{
         expect(@([testDispatcher respondsToSelector:@selector(onOnTBTClientState:)])).to(beTruthy());
         expect(@([testDispatcher respondsToSelector:@selector(onOnTouchEvent:)])).to(beTruthy());
         expect(@([testDispatcher respondsToSelector:@selector(onOnVehicleData:)])).to(beTruthy());
+        expect(@([testDispatcher respondsToSelector:@selector(onOnWayPointChange:)])).to(beTruthy());
         expect(@([testDispatcher respondsToSelector:@selector(onPerformAudioPassThruResponse:)])).to(beTruthy());
         expect(@([testDispatcher respondsToSelector:@selector(onPerformInteractionResponse:)])).to(beTruthy());
         expect(@([testDispatcher respondsToSelector:@selector(onPutFileResponse:)])).to(beTruthy());
@@ -71,11 +73,13 @@ describe(@"a notification dispatcher", ^{
         expect(@([testDispatcher respondsToSelector:@selector(onSpeakResponse:)])).to(beTruthy());
         expect(@([testDispatcher respondsToSelector:@selector(onSubscribeButtonResponse:)])).to(beTruthy());
         expect(@([testDispatcher respondsToSelector:@selector(onSubscribeVehicleDataResponse:)])).to(beTruthy());
+        expect(@([testDispatcher respondsToSelector:@selector(onSubscribeWayPointsResponse:)])).to(beTruthy());
         expect(@([testDispatcher respondsToSelector:@selector(onSyncPDataResponse:)])).to(beTruthy());
         expect(@([testDispatcher respondsToSelector:@selector(onUpdateTurnListResponse:)])).to(beTruthy());
         expect(@([testDispatcher respondsToSelector:@selector(onUnregisterAppInterfaceResponse:)])).to(beTruthy());
         expect(@([testDispatcher respondsToSelector:@selector(onUnsubscribeButtonResponse:)])).to(beTruthy());
         expect(@([testDispatcher respondsToSelector:@selector(onUnsubscribeVehicleDataResponse:)])).to(beTruthy());
+        expect(@([testDispatcher respondsToSelector:@selector(onUnsubscribeWayPointsResponse:)])).to(beTruthy());
     });
     
     describe(@"when told to post a notification", ^{

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnWaypointChangeSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnWaypointChangeSpec.m
@@ -17,12 +17,12 @@
 QuickSpecBegin(SDLOnWaypointChangeSpec)
 
 describe(@"Getter/Setter Tests", ^ {
-    __block SDLOnWaypointChange* testNotification = nil;
+    __block SDLOnWayPointChange* testNotification = nil;
     __block NSArray<SDLLocationDetails *>* someWaypoints = nil;
     
     describe(@"when initialized with init", ^{
         beforeEach(^{
-            testNotification = [[SDLOnWaypointChange alloc] init];
+            testNotification = [[SDLOnWayPointChange alloc] init];
         });
         
         context(@"when parameters are set correctly", ^{
@@ -71,7 +71,7 @@ describe(@"Getter/Setter Tests", ^ {
                                            NAMES_operation_name:NAMES_OnWaypointChange
                                            };
                 
-                testNotification = [[SDLOnWaypointChange alloc] initWithDictionary:[NSMutableDictionary dictionaryWithDictionary:initDict]];
+                testNotification = [[SDLOnWayPointChange alloc] initWithDictionary:[NSMutableDictionary dictionaryWithDictionary:initDict]];
             });
             
             // Since all the properties are immutable, a copy should be executed as a retain, which means they should be identical
@@ -89,7 +89,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                    }
                                            };
                 
-                testNotification = [[SDLOnWaypointChange alloc] initWithDictionary:[NSMutableDictionary dictionaryWithDictionary:initDict]];
+                testNotification = [[SDLOnWayPointChange alloc] initWithDictionary:[NSMutableDictionary dictionaryWithDictionary:initDict]];
             });
             
             it(@"should return nil for waypoints", ^{

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetWaypointsSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetWaypointsSpec.m
@@ -15,7 +15,7 @@ QuickSpecBegin(SDLGetWaypointsSpec)
 
 describe(@"Getter/Setter Tests", ^ {
     it(@"Should set and get correctly", ^ {
-        SDLGetWaypoints* testRequest = [[SDLGetWaypoints alloc] init];
+        SDLGetWayPoints* testRequest = [[SDLGetWayPoints alloc] init];
         
         testRequest.waypointType = [SDLWaypointType ALL];
         
@@ -27,13 +27,13 @@ describe(@"Getter/Setter Tests", ^ {
                                            @{NAMES_parameters:
                                                  @{NAMES_waypointType:[SDLWaypointType ALL]},
                                              NAMES_operation_name:NAMES_GetWaypoints}} mutableCopy];
-        SDLGetWaypoints* testRequest = [[SDLGetWaypoints alloc] initWithDictionary:dict];
+        SDLGetWayPoints* testRequest = [[SDLGetWayPoints alloc] initWithDictionary:dict];
         
         expect(testRequest.waypointType).to(equal([SDLWaypointType ALL]));
     });
     
     it(@"Should return nil if not set", ^ {
-        SDLGetWaypoints* testRequest = [[SDLGetWaypoints alloc] init];
+        SDLGetWayPoints* testRequest = [[SDLGetWayPoints alloc] init];
         
         expect(testRequest.waypointType).to(beNil());
     });

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetWaypointsResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetWaypointsResponseSpec.m
@@ -17,12 +17,12 @@
 QuickSpecBegin(SDLGetWaypointsResponseSpec)
 
 describe(@"Getter/Setter Tests", ^ {
-    __block SDLGetWaypointsResponse* testResponse = nil;
+    __block SDLGetWayPointsResponse* testResponse = nil;
     __block NSArray<SDLLocationDetails *>* someWaypoints = nil;
     
     describe(@"when initialized with init", ^{
         beforeEach(^{
-            testResponse = [[SDLGetWaypointsResponse alloc] init];
+            testResponse = [[SDLGetWayPointsResponse alloc] init];
         });
         
         context(@"when parameters are set correctly", ^{
@@ -70,7 +70,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                    }
                                            };
                 
-                testResponse = [[SDLGetWaypointsResponse alloc] initWithDictionary:[NSMutableDictionary dictionaryWithDictionary:initDict]];
+                testResponse = [[SDLGetWayPointsResponse alloc] initWithDictionary:[NSMutableDictionary dictionaryWithDictionary:initDict]];
             });
             
             // Since all the properties are immutable, a copy should be executed as a retain, which means they should be identical
@@ -88,7 +88,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                    }
                                            };
                 
-                testResponse = [[SDLGetWaypointsResponse alloc] initWithDictionary:[NSMutableDictionary dictionaryWithDictionary:initDict]];
+                testResponse = [[SDLGetWayPointsResponse alloc] initWithDictionary:[NSMutableDictionary dictionaryWithDictionary:initDict]];
             });
             
             it(@"should return nil for waypoints", ^{


### PR DESCRIPTION
Fixes #475 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Summary
This PR adds in missing response and notification NSNotifications for all the RPCs added in for Waypoints.

### Changelog
##### Bug Fixes
* Added in missing response and notification NSNotifications for all the RPCs added in for Waypoints.