### PR TITLE
Fixed V2 Protocol Header frameData description. 

### DIFF
--- a/SmartDeviceLink/SDLV2ProtocolHeader.m
+++ b/SmartDeviceLink/SDLV2ProtocolHeader.m
@@ -95,7 +95,7 @@ const int V2PROTOCOL_HEADERSIZE = 12;
     NSString *frameDataString = nil;
     if (self.frameType == SDLFrameType_Control) {
         if (self.frameData >= 0 && self.frameData <= 5) {
-            NSArray *controlFrameDataNames = @[@"Heartbeat", @"StartSession", @"StartSessionACK", @"StartSessionNACK", @"EndSession", @"EndSessionNACK"];
+            NSArray *controlFrameDataNames = @[@"Heartbeat", @"StartSession", @"StartSessionACK", @"StartSessionNACK", @"EndSession", @"EndSessionACK", @"EndSessionNACK"];
             frameDataString = controlFrameDataNames[self.frameData];
         } else {
             frameDataString = @"Reserved";


### PR DESCRIPTION
Fixes #479 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
This PR fixes an issue with printing the incorrect value for `EndSessionACK` in `SDLV2ProtocolHeader`'s description.

### Changelog
##### Bug Fixes
* Fixed an issue with printing the incorrect value for `EndSessionACK` in `SDLV2ProtocolHeader`'s description.
