### PR TITLE
Fixed issue around SDLPutFile's offset.

### DIFF
--- a/SmartDeviceLink/SDLUploadFileOperation.m
+++ b/SmartDeviceLink/SDLUploadFileOperation.m
@@ -141,7 +141,7 @@ NS_ASSUME_NONNULL_BEGIN
             currentOffset = mtuSize;
         } else {
             putFile.bulkData = [fileData subdataWithRange:NSMakeRange(currentOffset, [putFile.length unsignedIntegerValue])];
-            currentOffset = [putFile.length unsignedIntegerValue];
+            currentOffset += [putFile.length unsignedIntegerValue];
         }
 
         [putFiles addObject:putFile];

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLUploadFileOperationSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLUploadFileOperationSpec.m
@@ -144,15 +144,28 @@ describe(@"Upload File Operation", ^{
             NSArray<SDLPutFile *> *putFiles = testConnectionManager.receivedRequests;
             SDLPutFile *firstPutFile = putFiles.firstObject;
             
-            // First putfile
-            expect(firstPutFile.bulkData).to(equal([testFileData subdataWithRange:NSMakeRange(0, [SDLGlobals globals].maxMTUSize)]));
-            expect(firstPutFile.length).to(equal(@(testFileData.length)));
-            expect(firstPutFile.offset).to(equal(@0));
-            expect(firstPutFile.persistentFile).to(equal(@NO));
-            expect(firstPutFile.syncFileName).to(equal(testFileName));
-            
             NSUInteger numberOfPutFiles = (((testFileData.length - 1) / [SDLGlobals globals].maxMTUSize) + 1);
             expect(@(putFiles.count)).to(equal(@(numberOfPutFiles)));
+
+            // Test all PutFiles pieces for offset & length.
+            for (NSUInteger index = 0; index < numberOfPutFiles; index++) {
+                SDLPutFile *putFile = putFiles[index];
+                
+                expect(putFile.offset).to(equal(@(index * [SDLGlobals globals].maxMTUSize)));
+                expect(putFile.persistentFile).to(equal(@NO));
+                expect(putFile.syncFileName).to(equal(testFileName));
+                expect(putFile.bulkData).to(equal([testFileData subdataWithRange:NSMakeRange((index * [SDLGlobals globals].maxMTUSize), MIN(putFile.length.unsignedIntegerValue, [SDLGlobals globals].maxMTUSize))]));
+
+                // First Putfile has some differences due to informing core of the total incoming packet size.
+                if (index == 0) {
+                    expect(putFile.length).to(equal(@(testFileData.length)));
+                } else if (index == numberOfPutFiles - 1) {
+                    expect(putFile.length).to(equal(@(testFileData.length - (index * [SDLGlobals globals].maxMTUSize))));
+                } else {
+                    expect(putFile.length).to(equal(@([SDLGlobals globals].maxMTUSize)));
+                }
+            }
+            
         });
     });
 });


### PR DESCRIPTION
Fixes #495 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Unit tests within `SDLUploadFileOperationSpec.m` were expanded to test all SDLPutFiles, not just the first.

### Summary
Fixed a bug in `SDLUploadFileOperation` that caused SDLPutFiles to not be assigned the current offset.

### Changelog
##### Bug Fixes
* Fixed a bug in `SDLUploadFileOperation` that caused SDLPutFiles to not be assigned the current offset.
