### PR TITLE
Fix Sending Nil Request Causing Crash.

### DIFF
--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -367,6 +367,15 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
 - (void)sdl_sendRequest:(SDLRPCRequest *)request withResponseHandler:(nullable SDLResponseHandler)handler {
     // We will allow things to be sent in a "SDLLifeCycleStateTransportConnected" state in the private method, but block it in the public method sendRequest:withCompletionHandler: so that the lifecycle manager can complete its setup without being bothered by developer error
 
+    // If, for some reason, the request is nil we should error out.
+    if (!request) {
+        [SDLDebugTool logInfo:@"Attempting to send a nil request, request not sent."];
+        if (handler) {
+            handler(nil, nil, [NSError sdl_lifecycle_rpcErrorWithDescription:@"Nil Request" andReason:@"Request must not be nil"]);
+        }
+        return;
+    }
+    
     // Add a correlation ID to the request
     NSNumber *corrID = [self sdl_getNextCorrelationId];
     request.correlationID = corrID;

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -369,11 +369,10 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
 
     // If, for some reason, the request is nil we should error out.
     if (!request) {
-        [SDLDebugTool logInfo:@"Attempting to send a nil request, request not sent."];
-        if (handler) {
-            handler(nil, nil, [NSError sdl_lifecycle_rpcErrorWithDescription:@"Nil Request" andReason:@"Request must not be nil"]);
-        }
-        return;
+        @throw [NSException
+                exceptionWithName:NSInvalidArgumentException
+                reason:@"A Request cannot be nil."
+                userInfo:nil];
     }
     
     // Add a correlation ID to the request

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -367,12 +367,14 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
 - (void)sdl_sendRequest:(SDLRPCRequest *)request withResponseHandler:(nullable SDLResponseHandler)handler {
     // We will allow things to be sent in a "SDLLifeCycleStateTransportConnected" state in the private method, but block it in the public method sendRequest:withCompletionHandler: so that the lifecycle manager can complete its setup without being bothered by developer error
 
+    NSParameterAssert(request != nil);
+    
     // If, for some reason, the request is nil we should error out.
     if (!request) {
-        @throw [NSException
-                exceptionWithName:NSInvalidArgumentException
-                reason:@"A Request cannot be nil."
-                userInfo:nil];
+        if (handler) {
+            handler(nil, nil, [NSError sdl_lifecycle_rpcErrorWithDescription:@"Nil Request Sent" andReason:@"A nil RPC request was passed and cannot be sent."]);
+        }
+        return;
     }
     
     // Add a correlation ID to the request

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleManagerSpec.m
@@ -268,7 +268,7 @@ describe(@"a lifecycle manager", ^{
             it(@"cannot send a nil RPC", ^{
                 SDLShow *testShow = nil;
 
-                expectAction(^{ [testManager sendRequest:testShow]; }).to(raiseException().named(NSInvalidArgumentException));
+                expectAction(^{ [testManager sendRequest:testShow]; }).to(raiseException().named(NSInternalInconsistencyException));
             });
             
             describe(@"stopping the manager", ^{

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleManagerSpec.m
@@ -266,14 +266,9 @@ describe(@"a lifecycle manager", ^{
             });
             
             it(@"cannot send a nil RPC", ^{
-                __block NSError* testError = nil;
                 SDLShow *testShow = nil;
-                
-                [testManager sendRequest:testShow withResponseHandler:^(__kindof SDLRPCRequest * _Nullable request, __kindof SDLRPCResponse * _Nullable response, NSError * _Nullable error) {
-                    testError = error;
-                }];
-                
-                expect(testError).to(equal([NSError sdl_lifecycle_rpcErrorWithDescription:@"Nil Request" andReason:@"Request must not be nil"]));
+
+                expectAction(^{ [testManager sendRequest:testShow]; }).to(raiseException().named(NSInvalidArgumentException));
             });
             
             describe(@"stopping the manager", ^{

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleManagerSpec.m
@@ -265,6 +265,17 @@ describe(@"a lifecycle manager", ^{
                 OCMVerify([proxyMock sendRPC:[OCMArg isKindOfClass:[SDLShow class]]]);
             });
             
+            it(@"cannot send a nil RPC", ^{
+                __block NSError* testError = nil;
+                SDLShow *testShow = nil;
+                
+                [testManager sendRequest:testShow withResponseHandler:^(__kindof SDLRPCRequest * _Nullable request, __kindof SDLRPCResponse * _Nullable response, NSError * _Nullable error) {
+                    testError = error;
+                }];
+                
+                expect(testError).to(equal([NSError sdl_lifecycle_rpcErrorWithDescription:@"Nil Request" andReason:@"Request must not be nil"]));
+            });
+            
             describe(@"stopping the manager", ^{
                 beforeEach(^{
                     [testManager stop];


### PR DESCRIPTION
Fixes #499 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
There is a unit test that has been added to test sending a nil request in `SDLLifecycleManagerSpec` 

### Summary
Added check for sending a nil request.

### Changelog
##### Bug Fixes
* Fixed issue with sending a nil request crashes due to Invalid Exception.

### Notes
Because an app should *never* send a nil request, we throw an exception. Should we instead be just firing the response handler (if nonnull)? There would be a possibility that a developer passes a nil response handler, and in that case they would never know this error was occuring if not for a throw.