### PR TITLE
Updated Protocol Enums to Match Spec.

### DIFF
--- a/SmartDeviceLink/SDLProtocolHeader.h
+++ b/SmartDeviceLink/SDLProtocolHeader.h
@@ -5,36 +5,36 @@
 
 
 typedef NS_ENUM(UInt8, SDLFrameType) {
-    SDLFrameType_Control = 0x00,
-    SDLFrameType_Single = 0x01,
-    SDLFrameType_First = 0x02,
-    SDLFrameType_Consecutive = 0x03
+    SDLFrameTypeControl = 0x00,
+    SDLFrameTypeSingle = 0x01,
+    SDLFrameTypeFirst = 0x02,
+    SDLFrameTypeConsecutive = 0x03
 };
 
 typedef NS_ENUM(UInt8, SDLServiceType) {
-    SDLServiceType_Control = 0x00,
-    SDLServiceType_RPC = 0x07,
-    SDLServiceType_Audio = 0x0A,
-    SDLServiceType_Video = 0x0B,
-    SDLServiceType_BulkData = 0x0F
+    SDLServiceTypeControl = 0x00,
+    SDLServiceTypeRPC NS_SWIFT_NAME(rpc) = 0x07,
+    SDLServiceTypeAudio = 0x0A,
+    SDLServiceTypeVideo = 0x0B,
+    SDLServiceTypeBulkData = 0x0F
 };
 
-typedef NS_ENUM(UInt8, SDLFrameData) {
-    SDLFrameData_Heartbeat = 0x00,
-    SDLFrameData_StartSession = 0x01,
-    SDLFrameData_StartSessionACK = 0x02,
-    SDLFrameData_StartSessionNACK = 0x03,
-    SDLFrameData_EndSession = 0x04,
-    SDLFrameData_EndSessionACK = 0x05,
-    SDLFrameData_EndSessionNACK = 0x06,
-    SDLFrameData_ServiceDataACK = 0xFE,
-    SDLFrameData_HeartbeatACK = 0xFF,
+typedef NS_ENUM(UInt8, SDLFrameInfo) {
+    SDLFrameInfoHeartbeat = 0x00,
+    SDLFrameInfoStartService = 0x01,
+    SDLFrameInfoStartServiceAck = 0x02,
+    SDLFrameInfoStartServiceNack = 0x03,
+    SDLFrameInfoEndService = 0x04,
+    SDLFrameInfoEndServiceAck = 0x05,
+    SDLFrameInfoEndServiceNack = 0x06,
+    SDLFrameInfoServiceDataAck = 0xFE,
+    SDLFrameInfoHeartbeatAck = 0xFF,
     // If frameType == Single (0x01)
-    SDLFrameData_SingleFrame = 0x00,
+    SDLFrameInfoSingleFrame = 0x00,
     // If frameType == First (0x02)
-    SDLFrameData_FirstFrame = 0x00,
+    SDLFrameInfoFirstFrame = 0x00,
     // If frametype == Consecutive (0x03)
-    SDLFrameData_ConsecutiveLastFrame = 0x00
+    SDLFrameInfoConsecutiveLastFrame = 0x00
 };
 
 NS_ASSUME_NONNULL_BEGIN
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic) BOOL encrypted;
 @property (assign, nonatomic) SDLFrameType frameType;
 @property (assign, nonatomic) SDLServiceType serviceType;
-@property (assign, nonatomic) SDLFrameData frameData;
+@property (assign, nonatomic) SDLFrameInfo frameData;
 @property (assign, nonatomic) UInt8 sessionID;
 @property (assign, nonatomic) UInt32 bytesInPayload;
 

--- a/SmartDeviceLink/SDLProtocolMessage.m
+++ b/SmartDeviceLink/SDLProtocolMessage.m
@@ -52,7 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
     [description appendString:self.header.description];
 
     // If it's an RPC, provide greater detail
-    if (((self.header.serviceType == SDLServiceType_RPC) || (self.header.serviceType == SDLServiceType_BulkData)) && (self.header.frameType == SDLFrameType_Single)) {
+    if (((self.header.serviceType == SDLServiceTypeRPC) || (self.header.serviceType == SDLServiceTypeBulkData)) && (self.header.frameType == SDLFrameTypeSingle)) {
         // version of RPC Message determines how we access the info.
         if (self.header.version >= 2) {
             SDLRPCPayload *rpcPayload = [SDLRPCPayload rpcPayloadWithData:self.payload];

--- a/SmartDeviceLink/SDLProtocolMessageAssembler.m
+++ b/SmartDeviceLink/SDLProtocolMessageAssembler.m
@@ -39,12 +39,12 @@ NS_ASSUME_NONNULL_BEGIN
     // Determine which frame it is and save it.
     // Note: frames are numbered 1,2,3, ..., 0
     // Always 0 for last frame.
-    if (message.header.frameType == SDLFrameType_First) {
+    if (message.header.frameType == SDLFrameTypeFirst) {
         // If it's the first-frame, extract the meta-data
         self.expectedBytes = NSSwapBigIntToHost(((UInt32 *)message.payload.bytes)[0]);
         self.frameCount = NSSwapBigIntToHost(((UInt32 *)message.payload.bytes)[1]);
         self.parts[@"firstframe"] = message.payload;
-    } else if (message.header.frameType == SDLFrameType_Consecutive) {
+    } else if (message.header.frameType == SDLFrameTypeConsecutive) {
         // Save the frame w/ frame# as the key
         NSInteger frameNumber = message.header.frameData;
         NSNumber *frameNumberObj = @(frameNumber);
@@ -60,8 +60,8 @@ NS_ASSUME_NONNULL_BEGIN
 
         // Create the header
         SDLProtocolHeader *header = message.header.copy;
-        header.frameType = SDLFrameType_Single;
-        header.frameData = SDLFrameData_SingleFrame;
+        header.frameType = SDLFrameTypeSingle;
+        header.frameData = SDLFrameInfoSingleFrame;
 
 
         // Create the payload

--- a/SmartDeviceLink/SDLProtocolMessageDisassembler.m
+++ b/SmartDeviceLink/SDLProtocolMessageDisassembler.m
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     // Create the first message
     SDLProtocolHeader *firstFrameHeader = [incomingMessage.header copy];
-    firstFrameHeader.frameType = SDLFrameType_First;
+    firstFrameHeader.frameType = SDLFrameTypeFirst;
 
     UInt32 payloadData[2];
     payloadData[0] = CFSwapInt32HostToBig((UInt32)incomingMessage.payload.length);
@@ -57,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
         UInt8 frameNumber = (n % 255) + 1;
 
         SDLProtocolHeader *nextFrameHeader = [incomingMessage.header copy];
-        nextFrameHeader.frameType = SDLFrameType_Consecutive;
+        nextFrameHeader.frameType = SDLFrameTypeConsecutive;
         nextFrameHeader.frameData = frameNumber;
 
         NSUInteger offsetOfDataForThisFrame = headerSize + (n * numberOfDataBytesPerMessage);
@@ -71,8 +71,8 @@ NS_ASSUME_NONNULL_BEGIN
 
     // Create the last message
     SDLProtocolHeader *lastFrameHeader = [incomingMessage.header copy];
-    lastFrameHeader.frameType = SDLFrameType_Consecutive;
-    lastFrameHeader.frameData = SDLFrameData_ConsecutiveLastFrame;
+    lastFrameHeader.frameType = SDLFrameTypeConsecutive;
+    lastFrameHeader.frameData = SDLFrameInfoConsecutiveLastFrame;
 
     NSUInteger numberOfMessagesCreatedSoFar = numberOfMessagesRequired - 1;
     NSUInteger numberOfDataBytesSentSoFar = numberOfMessagesCreatedSoFar * numberOfDataBytesPerMessage;

--- a/SmartDeviceLink/SDLProtocolReceivedMessageRouter.m
+++ b/SmartDeviceLink/SDLProtocolReceivedMessageRouter.m
@@ -30,14 +30,14 @@ NS_ASSUME_NONNULL_BEGIN
     SDLFrameType frameType = message.header.frameType;
 
     switch (frameType) {
-        case SDLFrameType_Single: {
+        case SDLFrameTypeSingle: {
             [self sdl_dispatchProtocolMessage:message];
         } break;
-        case SDLFrameType_Control: {
+        case SDLFrameTypeControl: {
             [self sdl_dispatchControlMessage:message];
         } break;
-        case SDLFrameType_First: // fallthrough
-        case SDLFrameType_Consecutive: {
+        case SDLFrameTypeFirst: // fallthrough
+        case SDLFrameTypeConsecutive: {
             [self sdl_dispatchMultiPartMessage:message];
         } break;
         default: break;
@@ -52,7 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)sdl_dispatchControlMessage:(SDLProtocolMessage *)message {
     switch (message.header.frameData) {
-        case SDLFrameData_StartSessionACK: {
+        case SDLFrameInfoStartServiceAck: {
             if ([self.delegate respondsToSelector:@selector(handleProtocolStartSessionACK:sessionID:version:)]) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -66,27 +66,27 @@ NS_ASSUME_NONNULL_BEGIN
                 [self.delegate handleProtocolStartSessionACK:message.header];
             }
         } break;
-        case SDLFrameData_StartSessionNACK: {
+        case SDLFrameInfoStartServiceNack: {
             if ([self.delegate respondsToSelector:@selector(handleProtocolStartSessionNACK:)]) {
                 [self.delegate handleProtocolStartSessionNACK:message.header.serviceType];
             }
         } break;
-        case SDLFrameData_EndSessionACK: {
+        case SDLFrameInfoEndServiceAck: {
             if ([self.delegate respondsToSelector:@selector(handleProtocolEndSessionACK:)]) {
                 [self.delegate handleProtocolEndSessionACK:message.header.serviceType];
             }
         } break;
-        case SDLFrameData_EndSessionNACK: {
+        case SDLFrameInfoEndServiceNack: {
             if ([self.delegate respondsToSelector:@selector(handleProtocolStartSessionNACK:)]) {
                 [self.delegate handleProtocolEndSessionNACK:message.header.serviceType];
             }
         } break;
-        case SDLFrameData_Heartbeat: {
+        case SDLFrameInfoHeartbeat: {
             if ([self.delegate respondsToSelector:@selector(handleHeartbeatForSession:)]) {
                 [self.delegate handleHeartbeatForSession:message.header.sessionID];
             }
         } break;
-        case SDLFrameData_HeartbeatACK: {
+        case SDLFrameInfoHeartbeatAck: {
             if ([self.delegate respondsToSelector:@selector(handleHeartbeatACK)]) {
                 [self.delegate handleHeartbeatACK];
             }

--- a/SmartDeviceLink/SDLProxy.m
+++ b/SmartDeviceLink/SDLProxy.m
@@ -211,7 +211,7 @@ const int POLICIES_CORRELATION_ID = 65535;
     _isConnected = YES;
     [SDLDebugTool logInfo:@"StartSession (request)" withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
 
-    [self.protocol startServiceWithType:SDLServiceType_RPC];
+    [self.protocol startServiceWithType:SDLServiceTypeRPC];
 
     if (self.startSessionTimer == nil) {
         self.startSessionTimer = [[SDLTimer alloc] initWithDuration:startSessionTime repeat:NO];
@@ -239,7 +239,7 @@ const int POLICIES_CORRELATION_ID = 65535;
     NSString *logMessage = [NSString stringWithFormat:@"StartSession (response)\nSessionId: %d for serviceType %d", header.sessionID, header.serviceType];
     [SDLDebugTool logInfo:logMessage withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
 
-    if (header.serviceType == SDLServiceType_RPC) {
+    if (header.serviceType == SDLServiceTypeRPC) {
         [self invokeMethodOnDelegates:@selector(onProxyOpened) withObject:nil];
     }
 }

--- a/SmartDeviceLink/SDLV2ProtocolHeader.m
+++ b/SmartDeviceLink/SDLV2ProtocolHeader.m
@@ -93,16 +93,16 @@ const int V2PROTOCOL_HEADERSIZE = 12;
 
 
     NSString *frameDataString = nil;
-    if (self.frameType == SDLFrameType_Control) {
+    if (self.frameType == SDLFrameTypeControl) {
         if (self.frameData >= 0 && self.frameData <= 5) {
             NSArray *controlFrameDataNames = @[@"Heartbeat", @"StartSession", @"StartSessionACK", @"StartSessionNACK", @"EndSession", @"EndSessionACK", @"EndSessionNACK"];
             frameDataString = controlFrameDataNames[self.frameData];
         } else {
             frameDataString = @"Reserved";
         }
-    } else if (self.frameType == SDLFrameType_Single || self.frameType == SDLFrameType_First) {
+    } else if (self.frameType == SDLFrameTypeSingle || self.frameType == SDLFrameTypeFirst) {
         frameDataString = @"Reserved";
-    } else if (self.frameType == SDLFrameType_Consecutive) {
+    } else if (self.frameType == SDLFrameTypeConsecutive) {
         frameDataString = @"Frame#";
     }
 

--- a/SmartDeviceLink/SDLV2ProtocolMessage.m
+++ b/SmartDeviceLink/SDLV2ProtocolMessage.m
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 // Convert RPC payload to dictionary (for consumption by RPC layer)
 - (nullable NSDictionary<NSString *, id> *)rpcDictionary {
     // Only applicable to RPCs
-    if ((self.header.serviceType != SDLServiceType_RPC) && (self.header.serviceType != SDLServiceType_BulkData)) {
+    if ((self.header.serviceType != SDLServiceTypeRPC) && (self.header.serviceType != SDLServiceTypeBulkData)) {
         return nil;
     }
 

--- a/SmartDeviceLinkTests/ProtocolSpecs/HeaderSpecs/SDLV1ProtocolHeaderSpec.m
+++ b/SmartDeviceLinkTests/ProtocolSpecs/HeaderSpecs/SDLV1ProtocolHeaderSpec.m
@@ -21,13 +21,13 @@ beforeSuite(^ {
     testHeader = [[SDLV1ProtocolHeader alloc] init];
  
     testHeader.encrypted = YES;
-    testHeader.frameType = SDLFrameType_Control;
-    testHeader.serviceType = SDLServiceType_RPC;
-    testHeader.frameData = SDLFrameData_StartSession;
+    testHeader.frameType = SDLFrameTypeControl;
+    testHeader.serviceType = SDLServiceTypeRPC;
+    testHeader.frameData = SDLFrameInfoStartService;
     testHeader.sessionID = 0x53;
     testHeader.bytesInPayload = 0x1234;
     
-    const char testBytes[8] = {0x18 | (SDLFrameType_Control & 0xFF), SDLServiceType_RPC, SDLFrameData_StartSession, 0x53, 0x00, 0x00, 0x12, 0x34};
+    const char testBytes[8] = {0x18 | (SDLFrameTypeControl & 0xFF), SDLServiceTypeRPC, SDLFrameInfoStartService, 0x53, 0x00, 0x00, 0x12, 0x34};
     testData = [NSData dataWithBytes:testBytes length:8];
 });
     
@@ -39,9 +39,9 @@ describe(@"Getter/Setter Tests", ^ {
     
     it(@"Should set and get correctly", ^ {
         expect(@(testHeader.encrypted)).to(equal(@YES));
-        expect(@(testHeader.frameType)).to(equal(@(SDLFrameType_Control)));
-        expect(@(testHeader.serviceType)).to(equal(@(SDLServiceType_RPC)));
-        expect(@(testHeader.frameData)).to(equal(@(SDLFrameData_StartSession)));
+        expect(@(testHeader.frameType)).to(equal(@(SDLFrameTypeControl)));
+        expect(@(testHeader.serviceType)).to(equal(@(SDLServiceTypeRPC)));
+        expect(@(testHeader.frameData)).to(equal(@(SDLFrameInfoStartService)));
         expect(@(testHeader.sessionID)).to(equal(@0x53));
         expect(@(testHeader.bytesInPayload)).to(equal(@0x1234));
     });
@@ -55,9 +55,9 @@ describe(@"Copy Tests", ^ {
         expect(@(headerCopy.size)).to(equal(@8));
         
         expect(@(headerCopy.encrypted)).to(equal(@YES));
-        expect(@(headerCopy.frameType)).to(equal(@(SDLFrameType_Control)));
-        expect(@(headerCopy.serviceType)).to(equal(@(SDLServiceType_RPC)));
-        expect(@(headerCopy.frameData)).to(equal(@(SDLFrameData_StartSession)));
+        expect(@(headerCopy.frameType)).to(equal(@(SDLFrameTypeControl)));
+        expect(@(headerCopy.serviceType)).to(equal(@(SDLServiceTypeRPC)));
+        expect(@(headerCopy.frameData)).to(equal(@(SDLFrameInfoStartService)));
         expect(@(headerCopy.sessionID)).to(equal(@0x53));
         expect(@(headerCopy.bytesInPayload)).to(equal(@0x1234));
         
@@ -78,9 +78,9 @@ describe(@"RPCPayloadWithData Test", ^ {
         [constructedHeader parse:testData];
         
         expect(@(constructedHeader.encrypted)).to(equal(@YES));
-        expect(@(constructedHeader.frameType)).to(equal(@(SDLFrameType_Control)));
-        expect(@(constructedHeader.serviceType)).to(equal(@(SDLServiceType_RPC)));
-        expect(@(constructedHeader.frameData)).to(equal(@(SDLFrameData_StartSession)));
+        expect(@(constructedHeader.frameType)).to(equal(@(SDLFrameTypeControl)));
+        expect(@(constructedHeader.serviceType)).to(equal(@(SDLServiceTypeRPC)));
+        expect(@(constructedHeader.frameData)).to(equal(@(SDLFrameInfoStartService)));
         expect(@(constructedHeader.sessionID)).to(equal(@0x53));
         expect(@(constructedHeader.bytesInPayload)).to(equal(@0x1234));
     });

--- a/SmartDeviceLinkTests/ProtocolSpecs/HeaderSpecs/SDLV2ProtocolHeaderSpec.m
+++ b/SmartDeviceLinkTests/ProtocolSpecs/HeaderSpecs/SDLV2ProtocolHeaderSpec.m
@@ -21,14 +21,14 @@ beforeSuite(^ {
     testHeader = [[SDLV2ProtocolHeader alloc] init];
     
     testHeader.encrypted = YES;
-    testHeader.frameType = SDLFrameType_Control;
-    testHeader.serviceType = SDLServiceType_RPC;
-    testHeader.frameData = SDLFrameData_StartSession;
+    testHeader.frameType = SDLFrameTypeControl;
+    testHeader.serviceType = SDLServiceTypeRPC;
+    testHeader.frameData = SDLFrameInfoStartService;
     testHeader.sessionID = 0x53;
     testHeader.bytesInPayload = 0x1234;
     testHeader.messageID = 0x6DAB424F;
     
-    const char testBytes[12] = {0x28 | (SDLFrameType_Control & 0xFF), SDLServiceType_RPC, SDLFrameData_StartSession, 0x53, 0x00, 0x00, 0x12, 0x34, 0x6D, 0xAB, 0x42, 0x4F};
+    const char testBytes[12] = {0x28 | (SDLFrameTypeControl & 0xFF), SDLServiceTypeRPC, SDLFrameInfoStartService, 0x53, 0x00, 0x00, 0x12, 0x34, 0x6D, 0xAB, 0x42, 0x4F};
     testData = [NSData dataWithBytes:testBytes length:12];
 });
 
@@ -40,9 +40,9 @@ describe(@"Getter/Setter Tests", ^ {
     
     it(@"Should set and get correctly", ^ {
         expect(@(testHeader.encrypted)).to(equal(@YES));
-        expect(@(testHeader.frameType)).to(equal(@(SDLFrameType_Control)));
-        expect(@(testHeader.serviceType)).to(equal(@(SDLServiceType_RPC)));
-        expect(@(testHeader.frameData)).to(equal(@(SDLFrameData_StartSession)));
+        expect(@(testHeader.frameType)).to(equal(@(SDLFrameTypeControl)));
+        expect(@(testHeader.serviceType)).to(equal(@(SDLServiceTypeRPC)));
+        expect(@(testHeader.frameData)).to(equal(@(SDLFrameInfoStartService)));
         expect(@(testHeader.sessionID)).to(equal(@0x53));
         expect(@(testHeader.bytesInPayload)).to(equal(@0x1234));
         expect(@(testHeader.messageID)).to(equal(@0x6DAB424F));
@@ -57,9 +57,9 @@ describe(@"Copy Tests", ^ {
         expect(@(headerCopy.size)).to(equal(@12));
         
         expect(@(headerCopy.encrypted)).to(equal(@YES));
-        expect(@(headerCopy.frameType)).to(equal(@(SDLFrameType_Control)));
-        expect(@(headerCopy.serviceType)).to(equal(@(SDLServiceType_RPC)));
-        expect(@(headerCopy.frameData)).to(equal(@(SDLFrameData_StartSession)));
+        expect(@(headerCopy.frameType)).to(equal(@(SDLFrameTypeControl)));
+        expect(@(headerCopy.serviceType)).to(equal(@(SDLServiceTypeRPC)));
+        expect(@(headerCopy.frameData)).to(equal(@(SDLFrameInfoStartService)));
         expect(@(headerCopy.sessionID)).to(equal(@0x53));
         expect(@(headerCopy.bytesInPayload)).to(equal(@0x1234));
         expect(@(testHeader.messageID)).to(equal(@0x6DAB424F));
@@ -111,9 +111,9 @@ describe(@"RPCPayloadWithData Test", ^ {
         [constructedHeader parse:testData];
         
         expect(@(constructedHeader.encrypted)).to(equal(@YES));
-        expect(@(constructedHeader.frameType)).to(equal(@(SDLFrameType_Control)));
-        expect(@(constructedHeader.serviceType)).to(equal(@(SDLServiceType_RPC)));
-        expect(@(constructedHeader.frameData)).to(equal(@(SDLFrameData_StartSession)));
+        expect(@(constructedHeader.frameType)).to(equal(@(SDLFrameTypeControl)));
+        expect(@(constructedHeader.serviceType)).to(equal(@(SDLServiceTypeRPC)));
+        expect(@(constructedHeader.frameData)).to(equal(@(SDLFrameInfoStartService)));
         expect(@(constructedHeader.sessionID)).to(equal(@0x53));
         expect(@(constructedHeader.bytesInPayload)).to(equal(@0x1234));
         expect(@(testHeader.messageID)).to(equal(@0x6DAB424F));

--- a/SmartDeviceLinkTests/ProtocolSpecs/MessageSpecs/SDLProtocolMessageSpec.m
+++ b/SmartDeviceLinkTests/ProtocolSpecs/MessageSpecs/SDLProtocolMessageSpec.m
@@ -40,11 +40,11 @@ describe(@"MessageWithHeader Tests", ^ {
 
 describe(@"DetermineVersion Tests", ^ {
     it(@"Should return the correct version", ^ {
-        const char bytesV1[8] = {0x10 | SDLFrameType_First, SDLServiceType_BulkData, SDLFrameData_StartSessionACK, 0x5E, 0x00, 0x00, 0x00, 0x00};
+        const char bytesV1[8] = {0x10 | SDLFrameTypeFirst, SDLServiceTypeBulkData, SDLFrameInfoStartServiceAck, 0x5E, 0x00, 0x00, 0x00, 0x00};
         NSData* messageV1 = [NSData dataWithBytes:bytesV1 length:8];
         expect(@([SDLProtocolMessage determineVersion:messageV1])).to(equal(@1));
         
-        const char bytesV2[12] = {0x20 | SDLFrameType_First, SDLServiceType_BulkData, SDLFrameData_StartSessionACK, 0x5E, 0x00, 0x00, 0x00, 0x00, 0x44, 0x44, 0x44, 0x44};
+        const char bytesV2[12] = {0x20 | SDLFrameTypeFirst, SDLServiceTypeBulkData, SDLFrameInfoStartServiceAck, 0x5E, 0x00, 0x00, 0x00, 0x00, 0x44, 0x44, 0x44, 0x44};
         NSData* messageV2 = [NSData dataWithBytes:bytesV2 length:12];
         expect(@([SDLProtocolMessage determineVersion:messageV2])).to(equal(@2));
     });
@@ -57,7 +57,7 @@ describe(@"Data tests", ^ {
         SDLV2ProtocolHeader* testHeader = [[SDLV2ProtocolHeader alloc] init];
         
         id headerMock = OCMPartialMock(testHeader);
-        const char headerData[12] = {0x20 | SDLFrameType_First, SDLServiceType_BulkData, SDLFrameData_StartSessionACK, 0x5E, 0x0E, 0x00, 0x00, strlen("Test Data"), 0x65, 0x22, 0x41, 0x38};
+        const char headerData[12] = {0x20 | SDLFrameTypeFirst, SDLServiceTypeBulkData, SDLFrameInfoStartServiceAck, 0x5E, 0x0E, 0x00, 0x00, strlen("Test Data"), 0x65, 0x22, 0x41, 0x38};
         [[[headerMock stub] andReturn:[NSData dataWithBytes:headerData length:12]] data];
         
         testMessage.header = testHeader;

--- a/SmartDeviceLinkTests/ProtocolSpecs/MessageSpecs/SDLProtocolSpec.m
+++ b/SmartDeviceLinkTests/ProtocolSpecs/MessageSpecs/SDLProtocolSpec.m
@@ -47,12 +47,12 @@ describe(@"Send StartService Tests", ^ {
                 [invocation getArgument:&data atIndex:2];
                 NSData* dataSent = [data copy];
                 
-                const char testHeader[8] = {0x10 | SDLFrameType_Control, SDLServiceType_BulkData, SDLFrameData_StartSession, 0x00, 0x00, 0x00, 0x00, 0x00};
+                const char testHeader[8] = {0x10 | SDLFrameTypeControl, SDLServiceTypeBulkData, SDLFrameInfoStartService, 0x00, 0x00, 0x00, 0x00, 0x00};
                 expect(dataSent).to(equal([NSData dataWithBytes:testHeader length:8]));
             }] sendData:[OCMArg any]];
             testProtocol.transport = transportMock;
             
-            [testProtocol startServiceWithType:SDLServiceType_BulkData];
+            [testProtocol startServiceWithType:SDLServiceTypeBulkData];
             
             expect(@(verified)).toEventually(beTruthy());
         });
@@ -72,7 +72,7 @@ describe(@"Send EndSession Tests", ^ {
         it(@"Should send the correct data", ^ {
             SDLProtocol* testProtocol = [[SDLProtocol alloc] init];
             SDLV1ProtocolHeader *testHeader = [[SDLV1ProtocolHeader alloc] init];
-            testHeader.serviceType = SDLServiceType_RPC;
+            testHeader.serviceType = SDLServiceTypeRPC;
             testHeader.sessionID = 0x03;
             [testProtocol handleProtocolStartSessionACK:testHeader];
             
@@ -86,12 +86,12 @@ describe(@"Send EndSession Tests", ^ {
                 [invocation getArgument:&data atIndex:2];
                 NSData* dataSent = [data copy];
                 
-                const char testHeader[8] = {0x10 | SDLFrameType_Control, SDLServiceType_RPC, SDLFrameData_EndSession, 0x03, 0x00, 0x00, 0x00, 0x00};
+                const char testHeader[8] = {0x10 | SDLFrameTypeControl, SDLServiceTypeRPC, SDLFrameInfoEndService, 0x03, 0x00, 0x00, 0x00, 0x00};
                 expect(dataSent).to(equal([NSData dataWithBytes:testHeader length:8]));
             }] sendData:[OCMArg any]];
             testProtocol.transport = transportMock;
             
-            [testProtocol endServiceWithType:SDLServiceType_RPC];
+            [testProtocol endServiceWithType:SDLServiceTypeRPC];
             
             expect(@(verified)).toEventually(beTruthy());
         });
@@ -101,7 +101,7 @@ describe(@"Send EndSession Tests", ^ {
         it(@"Should send the correct data", ^ {
             SDLProtocol* testProtocol = [[SDLProtocol alloc] init];
             SDLV2ProtocolHeader *testHeader = [[SDLV2ProtocolHeader alloc] initWithVersion:2];
-            testHeader.serviceType = SDLServiceType_RPC;
+            testHeader.serviceType = SDLServiceTypeRPC;
             testHeader.sessionID = 0x61;
             [testProtocol handleProtocolStartSessionACK:testHeader];
             
@@ -115,12 +115,12 @@ describe(@"Send EndSession Tests", ^ {
                 [invocation getArgument:&data atIndex:2];
                 NSData* dataSent = [data copy];
                 
-                const char testHeader[12] = {0x20 | SDLFrameType_Control, SDLServiceType_RPC, SDLFrameData_EndSession, 0x61, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+                const char testHeader[12] = {0x20 | SDLFrameTypeControl, SDLServiceTypeRPC, SDLFrameInfoEndService, 0x61, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
                 expect(dataSent).to(equal([NSData dataWithBytes:testHeader length:12]));
             }] sendData:[OCMArg any]];
             testProtocol.transport = transportMock;
             
-            [testProtocol endServiceWithType:SDLServiceType_RPC];
+            [testProtocol endServiceWithType:SDLServiceTypeRPC];
             
             expect(@(verified)).toEventually(beTruthy());
         });
@@ -139,7 +139,7 @@ describe(@"SendRPCRequest Tests", ^ {
             
             SDLProtocol* testProtocol = [[SDLProtocol alloc] init];
             SDLV1ProtocolHeader *testHeader = [[SDLV1ProtocolHeader alloc] init];
-            testHeader.serviceType = SDLServiceType_RPC;
+            testHeader.serviceType = SDLServiceTypeRPC;
             testHeader.sessionID = 0xFF;
             [testProtocol handleProtocolStartSessionACK:testHeader];
             
@@ -156,7 +156,7 @@ describe(@"SendRPCRequest Tests", ^ {
                 NSData* jsonTestData = [NSJSONSerialization dataWithJSONObject:dictionaryV1 options:0 error:0];
                 NSUInteger dataLength = jsonTestData.length;
                 
-                const char testHeader[8] = {0x10 | SDLFrameType_Single, SDLServiceType_RPC, SDLFrameData_SingleFrame, 0xFF, (dataLength >> 24) & 0xFF, (dataLength >> 16) & 0xFF, (dataLength >> 8) & 0xFF, dataLength & 0xFF};
+                const char testHeader[8] = {0x10 | SDLFrameTypeSingle, SDLServiceTypeRPC, SDLFrameInfoSingleFrame, 0xFF, (dataLength >> 24) & 0xFF, (dataLength >> 16) & 0xFF, (dataLength >> 8) & 0xFF, dataLength & 0xFF};
                 NSMutableData* testData = [NSMutableData dataWithBytes:testHeader length:8];
                 [testData appendData:jsonTestData];
                 
@@ -179,7 +179,7 @@ describe(@"SendRPCRequest Tests", ^ {
             
             SDLProtocol* testProtocol = [[SDLProtocol alloc] init];
             SDLV2ProtocolHeader *testHeader = [[SDLV2ProtocolHeader alloc] initWithVersion:2];
-            testHeader.serviceType = SDLServiceType_RPC;
+            testHeader.serviceType = SDLServiceTypeRPC;
             testHeader.sessionID = 0x01;
             [testProtocol handleProtocolStartSessionACK:testHeader];
             
@@ -202,7 +202,7 @@ describe(@"SendRPCRequest Tests", ^ {
                 [payloadData appendData:jsonTestData];
                 [payloadData appendBytes:"COMMAND" length:strlen("COMMAND")];
                 
-                const char testHeader[12] = {0x20 | SDLFrameType_Single, SDLServiceType_BulkData, SDLFrameData_SingleFrame, 0x01, (payloadData.length >> 24) & 0xFF, (payloadData.length >> 16) & 0xFF,(payloadData.length >> 8) & 0xFF, payloadData.length & 0xFF, 0x00, 0x00, 0x00, 0x01};
+                const char testHeader[12] = {0x20 | SDLFrameTypeSingle, SDLServiceTypeBulkData, SDLFrameInfoSingleFrame, 0x01, (payloadData.length >> 24) & 0xFF, (payloadData.length >> 16) & 0xFF,(payloadData.length >> 8) & 0xFF, payloadData.length & 0xFF, 0x00, 0x00, 0x00, 0x01};
                 
                 NSMutableData* testData = [NSMutableData dataWithBytes:testHeader length:12];
                 [testData appendData:payloadData];
@@ -229,7 +229,7 @@ describe(@"HandleBytesFromTransport Tests", ^ {
 //            
 //            SDLProtocol* testProtocol = [[SDLProtocol alloc] init];
 //            SDLV1ProtocolHeader *testHeader = [[SDLV1ProtocolHeader alloc] init];
-//            testHeader.serviceType = SDLServiceType_RPC;
+//            testHeader.serviceType = SDLServiceTypeRPC;
 //            testHeader.sessionID = 0x03;
 //            [testProtocol handleProtocolStartSessionACK:testHeader];
 //            
@@ -249,14 +249,14 @@ describe(@"HandleBytesFromTransport Tests", ^ {
 //                expect(messageReceived.payload).to(equal(jsonTestData));
 //                expect(@(messageReceived.header.version)).to(equal(@1));
 //                expect(@(messageReceived.header.encrypted)).to(equal(@NO));
-//                expect(@(messageReceived.header.frameType)).to(equal(@(SDLFrameType_Single)));
+//                expect(@(messageReceived.header.frameType)).to(equal(@(SDLFrameTypeSingle)));
 //                expect(@(messageReceived.header.sessionID)).to(equal(@0xFF));
-//                expect(@(messageReceived.header.serviceType)).to(equal(@(SDLServiceType_RPC)));
-//                expect(@(messageReceived.header.frameData)).to(equal(@(SDLFrameData_SingleFrame)));
+//                expect(@(messageReceived.header.serviceType)).to(equal(@(SDLServiceTypeRPC)));
+//                expect(@(messageReceived.header.frameData)).to(equal(@(SDLFrameInfoSingleFrame)));
 //                expect(@(messageReceived.header.bytesInPayload)).to(equal(@(dataLength)));
 //            }] handleReceivedMessage:[OCMArg any]];
 //            
-//            const char testHeader2Data[8] = {0x10 | SDLFrameType_Single, SDLServiceType_RPC, SDLFrameData_SingleFrame, 0xFF, (dataLength >> 24) & 0xFF, (dataLength >> 16) & 0xFF, (dataLength >> 8) & 0xFF, dataLength & 0xFF};
+//            const char testHeader2Data[8] = {0x10 | SDLFrameTypeSingle, SDLServiceTypeRPC, SDLFrameInfoSingleFrame, 0xFF, (dataLength >> 24) & 0xFF, (dataLength >> 16) & 0xFF, (dataLength >> 8) & 0xFF, dataLength & 0xFF};
 //            NSMutableData* testData = [NSMutableData dataWithBytes:testHeader2Data length:8];
 //            [testData appendData:jsonTestData];
 //            
@@ -276,7 +276,7 @@ describe(@"HandleBytesFromTransport Tests", ^ {
 //            
 //            SDLProtocol* testProtocol = [[SDLProtocol alloc] init];
 //            SDLV2ProtocolHeader *testHeader = [[SDLV2ProtocolHeader alloc] initWithVersion:2];
-//            testHeader.serviceType = SDLServiceType_RPC;
+//            testHeader.serviceType = SDLServiceTypeRPC;
 //            testHeader.sessionID = 0xF5;
 //            [testProtocol handleProtocolStartSessionACK:testHeader];
 //            
@@ -302,17 +302,17 @@ describe(@"HandleBytesFromTransport Tests", ^ {
 //                expect(messageReceived.payload).to(equal(payloadData));
 //                expect(@(messageReceived.header.version)).to(equal(@2));
 //                expect(@(messageReceived.header.encrypted)).to(equal(@NO));
-//                expect(@(messageReceived.header.frameType)).to(equal(@(SDLFrameType_Single)));
+//                expect(@(messageReceived.header.frameType)).to(equal(@(SDLFrameTypeSingle)));
 //                expect(@(messageReceived.header.sessionID)).to(equal(@0x01));
-//                expect(@(messageReceived.header.serviceType)).to(equal(@(SDLServiceType_RPC)));
-//                expect(@(messageReceived.header.frameData)).to(equal(@(SDLFrameData_SingleFrame)));
+//                expect(@(messageReceived.header.serviceType)).to(equal(@(SDLServiceTypeRPC)));
+//                expect(@(messageReceived.header.frameData)).to(equal(@(SDLFrameInfoSingleFrame)));
 //                expect(@(messageReceived.header.bytesInPayload)).to(equal(@(payloadData.length)));
 //                expect(@(((SDLV2ProtocolHeader *)messageReceived.header).messageID)).to(equal(@1));
 //                
 //            }] handleReceivedMessage:[OCMArg any]];
 //            testProtocol.transport = routerMock;
 //            
-//            const char testHeader2Data[12] = {0x20 | SDLFrameType_Single, SDLServiceType_RPC, SDLFrameData_SingleFrame, 0x01, (payloadData.length >> 24) & 0xFF, (payloadData.length >> 16) & 0xFF,
+//            const char testHeader2Data[12] = {0x20 | SDLFrameTypeSingle, SDLServiceTypeRPC, SDLFrameInfoSingleFrame, 0x01, (payloadData.length >> 24) & 0xFF, (payloadData.length >> 16) & 0xFF,
 //                (payloadData.length >> 8) & 0xFF, payloadData.length & 0xFF, 0x00, 0x00, 0x00, 0x01};
 //            
 //            NSMutableData* testData = [NSMutableData dataWithBytes:testHeader2Data length:12];
@@ -336,9 +336,9 @@ describe(@"HandleProtocolSessionStarted Tests", ^ {
         id delegateMock = OCMProtocolMock(@protocol(SDLProtocolListener));
         
         SDLV2ProtocolHeader* testHeader = [[SDLV2ProtocolHeader alloc] init];
-        testHeader.frameType = SDLFrameType_Control;
-        testHeader.serviceType = SDLServiceType_RPC;
-        testHeader.frameData = SDLFrameData_StartSessionACK;
+        testHeader.frameType = SDLFrameTypeControl;
+        testHeader.serviceType = SDLServiceTypeRPC;
+        testHeader.frameData = SDLFrameInfoStartServiceAck;
         testHeader.sessionID = 0x93;
         testHeader.bytesInPayload = 0;
         
@@ -369,7 +369,7 @@ describe(@"OnProtocolMessageReceived Tests", ^ {
         
         SDLProtocolMessage *testMessage = [[SDLProtocolMessage alloc] init];
         SDLV2ProtocolHeader *testHeader = [[SDLV2ProtocolHeader alloc] initWithVersion:3];
-        testHeader.serviceType = SDLServiceType_RPC;
+        testHeader.serviceType = SDLServiceTypeRPC;
         testMessage.header = testHeader;
         
         id delegateMock = OCMProtocolMock(@protocol(SDLProtocolListener));

--- a/SmartDeviceLinkTests/ProtocolSpecs/MessageSpecs/SDLV2ProtocolMessageSpec.m
+++ b/SmartDeviceLinkTests/ProtocolSpecs/MessageSpecs/SDLV2ProtocolMessageSpec.m
@@ -18,7 +18,7 @@ QuickSpecBegin(SDLV2ProtocolMessageSpec)
 
 describe(@"RPCDictionary Tests", ^ {
     it(@"Should return the correct dictionary", ^ {
-        SDLServiceType serviceType = SDLServiceType_RPC;
+        SDLServiceType serviceType = SDLServiceTypeRPC;
         
         SDLV2ProtocolHeader* testHeader = [[SDLV2ProtocolHeader alloc] init];
         id headerMock = OCMPartialMock(testHeader);

--- a/SmartDeviceLinkTests/ProtocolSpecs/SDLProtocolMessageAssemblerSpec.m
+++ b/SmartDeviceLinkTests/ProtocolSpecs/SDLProtocolMessageAssemblerSpec.m
@@ -31,8 +31,8 @@ describe(@"HandleMessage Tests", ^ {
         SDLV2ProtocolHeader* testHeader = [[SDLV2ProtocolHeader alloc] init];
         
         //First frame
-        testHeader.frameType = SDLFrameType_First;
-        testHeader.serviceType = SDLServiceType_BulkData;
+        testHeader.frameType = SDLFrameTypeFirst;
+        testHeader.serviceType = SDLServiceTypeBulkData;
         testHeader.frameData = 1;
         testHeader.sessionID = 0x16;
         testHeader.bytesInPayload = 8;
@@ -58,7 +58,7 @@ describe(@"HandleMessage Tests", ^ {
         expect(@(verified)).to(beTruthy());
         verified = NO;
         
-        testMessage.header.frameType = SDLFrameType_Consecutive;
+        testMessage.header.frameType = SDLFrameTypeConsecutive;
         testMessage.header.bytesInPayload = 500;
         
         NSUInteger frameNumber = 1;
@@ -86,9 +86,9 @@ describe(@"HandleMessage Tests", ^ {
             expect(@(done)).to(equal(@YES));
             
             expect(assembledMessage.payload).to(equal(payloadData));
-            expect(@(assembledMessage.header.frameType)).to(equal(@(SDLFrameType_Single)));
-            expect(@(assembledMessage.header.serviceType)).to(equal(@(SDLServiceType_BulkData)));
-            expect(@(assembledMessage.header.frameData)).to(equal(@(SDLFrameData_SingleFrame)));
+            expect(@(assembledMessage.header.frameType)).to(equal(@(SDLFrameTypeSingle)));
+            expect(@(assembledMessage.header.serviceType)).to(equal(@(SDLServiceTypeBulkData)));
+            expect(@(assembledMessage.header.frameData)).to(equal(@(SDLFrameInfoSingleFrame)));
             expect(@(assembledMessage.header.sessionID)).to(equal(@0x16));
             expect(@(assembledMessage.header.bytesInPayload)).to(equal(@(payloadData.length)));
         }];

--- a/SmartDeviceLinkTests/ProtocolSpecs/SDLProtocolMessageDisassemblerSpec.m
+++ b/SmartDeviceLinkTests/ProtocolSpecs/SDLProtocolMessageDisassemblerSpec.m
@@ -34,9 +34,9 @@ describe(@"Disassemble Tests", ^ {
         SDLV2ProtocolMessage* testMessage = [[SDLV2ProtocolMessage alloc] init];
         SDLV2ProtocolHeader* testHeader = [[SDLV2ProtocolHeader alloc] init];
         
-        testHeader.frameType = SDLFrameType_Single;
-        testHeader.serviceType = SDLServiceType_BulkData;
-        testHeader.frameData = SDLFrameData_SingleFrame;
+        testHeader.frameType = SDLFrameTypeSingle;
+        testHeader.serviceType = SDLServiceTypeBulkData;
+        testHeader.frameData = SDLFrameInfoSingleFrame;
         testHeader.sessionID = 0x84;
         testHeader.bytesInPayload = (UInt32)payloadData.length;
         
@@ -55,9 +55,9 @@ describe(@"Disassemble Tests", ^ {
         //First frame
         expect(message.payload).to(equal([NSData dataWithBytes:firstPayload length:8]));
         
-        expect(@(message.header.frameType)).to(equal(@(SDLFrameType_First)));
-        expect(@(message.header.serviceType)).to(equal(@(SDLServiceType_BulkData)));
-        expect(@(message.header.frameData)).to(equal(@(SDLFrameData_FirstFrame)));
+        expect(@(message.header.frameType)).to(equal(@(SDLFrameTypeFirst)));
+        expect(@(message.header.serviceType)).to(equal(@(SDLServiceTypeBulkData)));
+        expect(@(message.header.frameData)).to(equal(@(SDLFrameInfoFirstFrame)));
         expect(@(message.header.sessionID)).to(equal(@0x84));
         expect(@(message.header.bytesInPayload)).to(equal(@8));
         
@@ -68,8 +68,8 @@ describe(@"Disassemble Tests", ^ {
             //Consecutive frames
             expect(message.payload).to(equal([NSData dataWithData:[payloadData subdataWithRange:NSMakeRange(offset, payloadLength)]]));
             
-            expect(@(message.header.frameType)).to(equal(@(SDLFrameType_Consecutive)));
-            expect(@(message.header.serviceType)).to(equal(@(SDLServiceType_BulkData)));
+            expect(@(message.header.frameType)).to(equal(@(SDLFrameTypeConsecutive)));
+            expect(@(message.header.serviceType)).to(equal(@(SDLServiceTypeBulkData)));
             expect(@(message.header.frameData)).to(equal(@(i)));
             expect(@(message.header.sessionID)).to(equal(@0x84));
             expect(@(message.header.bytesInPayload)).to(equal(@(payloadLength)));
@@ -84,9 +84,9 @@ describe(@"Disassemble Tests", ^ {
         //Last frame
         expect(message.payload).to(equal([NSData dataWithData:[payloadData subdataWithRange:NSMakeRange(offset, remaining)]]));
         
-        expect(@(message.header.frameType)).to(equal(@(SDLFrameType_Consecutive)));
-        expect(@(message.header.serviceType)).to(equal(@(SDLServiceType_BulkData)));
-        expect(@(message.header.frameData)).to(equal(@(SDLFrameData_ConsecutiveLastFrame)));
+        expect(@(message.header.frameType)).to(equal(@(SDLFrameTypeConsecutive)));
+        expect(@(message.header.serviceType)).to(equal(@(SDLServiceTypeBulkData)));
+        expect(@(message.header.frameData)).to(equal(@(SDLFrameInfoConsecutiveLastFrame)));
         expect(@(message.header.sessionID)).to(equal(@0x84));
         expect(@(message.header.bytesInPayload)).to(equal(@(remaining)));
     });

--- a/SmartDeviceLinkTests/ProtocolSpecs/SDLProtocolReceivedMessageRouterSpec.m
+++ b/SmartDeviceLinkTests/ProtocolSpecs/SDLProtocolReceivedMessageRouterSpec.m
@@ -25,9 +25,9 @@ describe(@"HandleReceivedMessage Tests", ^ {
             SDLV2ProtocolMessage* testMessage = [[SDLV2ProtocolMessage alloc] init];
             SDLV2ProtocolHeader* testHeader = [[SDLV2ProtocolHeader alloc] init];
             
-            testHeader.frameType = SDLFrameType_Control;
-            testHeader.serviceType = SDLServiceType_RPC;
-            testHeader.frameData = SDLFrameData_StartSessionACK;
+            testHeader.frameType = SDLFrameTypeControl;
+            testHeader.serviceType = SDLServiceTypeRPC;
+            testHeader.frameData = SDLFrameInfoStartServiceAck;
             testHeader.sessionID = 0x93;
             testHeader.bytesInPayload = 0;
             
@@ -49,9 +49,9 @@ describe(@"HandleReceivedMessage Tests", ^ {
             SDLV2ProtocolMessage* testMessage = [[SDLV2ProtocolMessage alloc] init];
             SDLV2ProtocolHeader* testHeader = [[SDLV2ProtocolHeader alloc] init];
             
-            testHeader.frameType = SDLFrameType_Single;
-            testHeader.serviceType = SDLServiceType_RPC;
-            testHeader.frameData = SDLFrameData_SingleFrame;
+            testHeader.frameType = SDLFrameTypeSingle;
+            testHeader.serviceType = SDLServiceTypeRPC;
+            testHeader.frameData = SDLFrameInfoSingleFrame;
             testHeader.sessionID = 0x07;
             testHeader.bytesInPayload = 0;
             
@@ -96,8 +96,8 @@ describe(@"HandleReceivedMessage Tests", ^ {
             SDLV2ProtocolHeader* testHeader = [[SDLV2ProtocolHeader alloc] init];
             
             //First frame
-            testHeader.frameType = SDLFrameType_First;
-            testHeader.serviceType = SDLServiceType_BulkData;
+            testHeader.frameType = SDLFrameTypeFirst;
+            testHeader.serviceType = SDLServiceTypeBulkData;
             testHeader.frameData = 1;
             testHeader.sessionID = 0x33;
             testHeader.bytesInPayload = 8;
@@ -111,7 +111,7 @@ describe(@"HandleReceivedMessage Tests", ^ {
             
             [router handleReceivedMessage:testMessage];
             
-            testMessage.header.frameType = SDLFrameType_Consecutive;
+            testMessage.header.frameType = SDLFrameTypeConsecutive;
             testMessage.header.bytesInPayload = 500;
             
             NSUInteger frameNumber = 1;
@@ -142,9 +142,9 @@ describe(@"HandleReceivedMessage Tests", ^ {
                 SDLProtocolMessage* assembledMessage = message;
                 
                 expect(assembledMessage.payload).to(equal(payloadData));
-                expect(@(assembledMessage.header.frameType)).to(equal(@(SDLFrameType_Single)));
-                expect(@(assembledMessage.header.serviceType)).to(equal(@(SDLServiceType_BulkData)));
-                expect(@(assembledMessage.header.frameData)).to(equal(@(SDLFrameData_SingleFrame)));
+                expect(@(assembledMessage.header.frameType)).to(equal(@(SDLFrameTypeSingle)));
+                expect(@(assembledMessage.header.serviceType)).to(equal(@(SDLServiceTypeBulkData)));
+                expect(@(assembledMessage.header.frameData)).to(equal(@(SDLFrameInfoSingleFrame)));
                 expect(@(assembledMessage.header.sessionID)).to(equal(@0x33));
                 expect(@(assembledMessage.header.bytesInPayload)).to(equal(@(payloadData.length)));
             }] onProtocolMessageReceived:[OCMArg any]];


### PR DESCRIPTION
Fixes #275 

This PR is **ready** for review.

### Risk
This PR makes **major** API changes.

### Testing Plan
This will use the existing unit tests, as we just renamed enum values.

### Summary
Changed names of `SDLProtocolHeader` enums to match the spec and make them easier to use in swift.

### Changelog
##### Breaking Changes
* Changed names of `SDLProtocolHeader` enums to match the spec and make them easier to use in swift.

##### Enchancements
* Changed names of `SDLProtocolHeader` enums to match the spec and make them easier to use in swift.