### PR TITLE
[SDL-0005] Immutable RPC collections

### DIFF
--- a/SmartDeviceLink-iOS.podspec
+++ b/SmartDeviceLink-iOS.podspec
@@ -12,7 +12,6 @@ s.source_files = "SmartDeviceLink/*.{h,m}"
 s.requires_arc = true
 s.resource_bundles = { 'SmartDeviceLink' => ['SmartDeviceLink/Assets/**/*', 'SmartDeviceLink/iOS 7 Assets/*'] }
 s.public_header_files = [
-'SmartDeviceLink/NSMutableDictionary+Store.h',
 'SmartDeviceLink/SmartDeviceLink.h',
 'SmartDeviceLink/SDLJingle.h',
 'SmartDeviceLink/SDLProxy.h',

--- a/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
+++ b/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
@@ -867,7 +867,7 @@
 		5DFFB9151BD7C89700DB3F04 /* SDLConnectionManagerType.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DFFB9141BD7C89700DB3F04 /* SDLConnectionManagerType.h */; };
 		DA0C46AD1DCD35080001F2A8 /* SDLNames.m in Sources */ = {isa = PBXBuildFile; fileRef = DA0C46AC1DCD35080001F2A8 /* SDLNames.m */; };
 		DA0C46AF1DCD41E30001F2A8 /* SDLMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = DA0C46AE1DCD41E30001F2A8 /* SDLMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DA318C1F1DD0F06C00C035AC /* NSMutableDictionary+Store.h in Headers */ = {isa = PBXBuildFile; fileRef = DA318C1D1DD0F06C00C035AC /* NSMutableDictionary+Store.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DA318C1F1DD0F06C00C035AC /* NSMutableDictionary+Store.h in Headers */ = {isa = PBXBuildFile; fileRef = DA318C1D1DD0F06C00C035AC /* NSMutableDictionary+Store.h */; };
 		DA318C201DD0F06C00C035AC /* NSMutableDictionary+Store.m in Sources */ = {isa = PBXBuildFile; fileRef = DA318C1E1DD0F06C00C035AC /* NSMutableDictionary+Store.m */; };
 		DA4353DF1D271FD10099B8C4 /* CGPointUtilSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = DA4353DE1D271FD10099B8C4 /* CGPointUtilSpec.m */; };
 		DA4353E31D2720A30099B8C4 /* SDLPinchGestureSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = DA4353E21D2720A30099B8C4 /* SDLPinchGestureSpec.m */; };

--- a/SmartDeviceLink/NSMutableDictionary+Store.h
+++ b/SmartDeviceLink/NSMutableDictionary+Store.h
@@ -19,8 +19,8 @@ typedef NSString* SDLEnum SDL_SWIFT_ENUM;
 - (void)sdl_setObject:(NSObject *)object forName:(SDLName)name;
 - (nullable id)sdl_objectForName:(SDLName)name;
 - (nullable id)sdl_objectForName:(SDLName)name ofClass:(Class)classType;
-- (NSMutableArray *)sdl_objectsForName:(SDLName)name ofClass:(Class)classType;
-- (NSMutableArray<SDLEnum> *)sdl_enumsForName:(SDLName)name;
+- (NSArray *)sdl_objectsForName:(SDLName)name ofClass:(Class)classType;
+- (NSArray<SDLEnum> *)sdl_enumsForName:(SDLName)name;
 
 @end
 

--- a/SmartDeviceLink/NSMutableDictionary+Store.h
+++ b/SmartDeviceLink/NSMutableDictionary+Store.h
@@ -20,7 +20,6 @@ typedef NSString* SDLEnum SDL_SWIFT_ENUM;
 - (nullable id)sdl_objectForName:(SDLName)name;
 - (nullable id)sdl_objectForName:(SDLName)name ofClass:(Class)classType;
 - (NSArray *)sdl_objectsForName:(SDLName)name ofClass:(Class)classType;
-- (NSArray<SDLEnum> *)sdl_enumsForName:(SDLName)name;
 
 @end
 

--- a/SmartDeviceLink/NSMutableDictionary+Store.m
+++ b/SmartDeviceLink/NSMutableDictionary+Store.m
@@ -33,8 +33,8 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
-- (NSMutableArray *)sdl_objectsForName:(SDLName)name ofClass:(Class)classType {
-    NSMutableArray *array = [self sdl_objectForName:name];
+- (NSArray *)sdl_objectsForName:(SDLName)name ofClass:(Class)classType {
+    NSArray *array = [self sdl_objectForName:name];
     if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:classType.class]) {
         return array;
     } else {
@@ -42,12 +42,12 @@ NS_ASSUME_NONNULL_BEGIN
         for (NSDictionary<NSString *, id> *dict in array) {
             [newList addObject:[[classType alloc] initWithDictionary:dict]];
         }
-        return newList;
+        return [NSArray arrayWithArray:newList];
     }
 }
 
-- (NSMutableArray<SDLEnum> *)sdl_enumsForName:(SDLName)name {
-    NSMutableArray<SDLEnum> *array = [self sdl_objectForName:name];
+- (NSArray<SDLEnum> *)sdl_enumsForName:(SDLName)name {
+    NSArray<SDLEnum> *array = [self sdl_objectForName:name];
     if ([array count] < 1) {
         return array;
     } else {
@@ -55,7 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
         for (SDLEnum enumString in array) {
             [newList addObject:enumString];
         }
-        return newList;
+        return [NSArray arrayWithArray:newList];
     }
 }
 

--- a/SmartDeviceLink/NSMutableDictionary+Store.m
+++ b/SmartDeviceLink/NSMutableDictionary+Store.m
@@ -35,9 +35,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSArray *)sdl_objectsForName:(SDLName)name ofClass:(Class)classType {
     NSArray *array = [self sdl_objectForName:name];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:classType.class]) {
+    if ([array count] < 1 || [array.firstObject isMemberOfClass:classType.class]) {
+        // It's an array of the actual class type, just return
         return array;
     } else {
+        // It's an array of dictionaries, make them into their class type
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];
         for (NSDictionary<NSString *, id> *dict in array) {
             [newList addObject:[[classType alloc] initWithDictionary:dict]];
@@ -47,16 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (NSArray<SDLEnum> *)sdl_enumsForName:(SDLName)name {
-    NSArray<SDLEnum> *array = [self sdl_objectForName:name];
-    if ([array count] < 1) {
-        return array;
-    } else {
-        NSMutableArray<SDLEnum> *newList = [NSMutableArray arrayWithCapacity:[array count]];
-        for (SDLEnum enumString in array) {
-            [newList addObject:enumString];
-        }
-        return [NSArray arrayWithArray:newList];
-    }
+    return [self sdl_objectForName:name];
 }
 
 

--- a/SmartDeviceLink/NSMutableDictionary+Store.m
+++ b/SmartDeviceLink/NSMutableDictionary+Store.m
@@ -44,12 +44,8 @@ NS_ASSUME_NONNULL_BEGIN
         for (NSDictionary<NSString *, id> *dict in array) {
             [newList addObject:[[classType alloc] initWithDictionary:dict]];
         }
-        return [NSArray arrayWithArray:newList];
+        return [newList copy];
     }
-}
-
-- (NSArray<SDLEnum> *)sdl_enumsForName:(SDLName)name {
-    return [self sdl_objectForName:name];
 }
 
 

--- a/SmartDeviceLink/SDLAddCommand.h
+++ b/SmartDeviceLink/SDLAddCommand.h
@@ -91,7 +91,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * Optional, Array of Strings, Max String length 99 chars, Array size 1 - 100
  */
-@property (nullable, strong, nonatomic) NSMutableArray<NSString *> *vrCommands;
+@property (nullable, strong, nonatomic) NSArray<NSString *> *vrCommands;
 
 /**
  * @abstract Image struct containing a static or dynamic icon

--- a/SmartDeviceLink/SDLAddCommand.m
+++ b/SmartDeviceLink/SDLAddCommand.m
@@ -84,11 +84,11 @@ NS_ASSUME_NONNULL_BEGIN
     return [parameters sdl_objectForName:SDLNameMenuParams ofClass:SDLMenuParams.class];
 }
 
-- (void)setVrCommands:(nullable NSMutableArray<NSString *> *)vrCommands {
+- (void)setVrCommands:(nullable NSArray<NSString *> *)vrCommands {
     [parameters sdl_setObject:vrCommands forName:SDLNameVRCommands];
 }
 
-- (nullable NSMutableArray<NSString *> *)vrCommands {
+- (nullable NSArray<NSString *> *)vrCommands {
     return [parameters sdl_objectForName:SDLNameVRCommands];
 }
 

--- a/SmartDeviceLink/SDLAlert.h
+++ b/SmartDeviceLink/SDLAlert.h
@@ -111,7 +111,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @see SDLTTSChunk
  */
-@property (nullable, strong, nonatomic) NSMutableArray<SDLTTSChunk *> *ttsChunks;
+@property (nullable, strong, nonatomic) NSArray<SDLTTSChunk *> *ttsChunks;
 
 /**
  * @abstract The duration of the displayed portion of the alert, in milliseconds.
@@ -153,7 +153,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @see SDLSoftButton
  */
-@property (nullable, strong, nonatomic) NSMutableArray<SDLSoftButton *> *softButtons;
+@property (nullable, strong, nonatomic) NSArray<SDLSoftButton *> *softButtons;
 
 @end
 

--- a/SmartDeviceLink/SDLAlert.m
+++ b/SmartDeviceLink/SDLAlert.m
@@ -44,7 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (instancetype)initWithTTS:(nullable NSString *)ttsText alertText1:(nullable NSString *)alertText1 alertText2:(nullable NSString *)alertText2 alertText3:(nullable NSString *)alertText3 playTone:(BOOL)playTone duration:(UInt16)duration {
-    NSMutableArray *ttsChunks = [SDLTTSChunk textChunksFromString:ttsText];
+    NSArray *ttsChunks = [SDLTTSChunk textChunksFromString:ttsText];
     return [self initWithTTSChunks:ttsChunks alertText1:alertText1 alertText2:alertText2 alertText3:alertText3 playTone:playTone duration:duration softButtons:nil];
 }
 
@@ -97,11 +97,11 @@ NS_ASSUME_NONNULL_BEGIN
     return [parameters sdl_objectForName:SDLNameAlertText3];
 }
 
-- (void)setTtsChunks:(nullable NSMutableArray<SDLTTSChunk *> *)ttsChunks {
+- (void)setTtsChunks:(nullable NSArray<SDLTTSChunk *> *)ttsChunks {
     [parameters sdl_setObject:ttsChunks forName:SDLNameTTSChunks];
 }
 
-- (nullable NSMutableArray<SDLTTSChunk *> *)ttsChunks {
+- (nullable NSArray<SDLTTSChunk *> *)ttsChunks {
     return [parameters sdl_objectsForName:SDLNameTTSChunks ofClass:SDLTTSChunk.class];
 }
 
@@ -129,11 +129,11 @@ NS_ASSUME_NONNULL_BEGIN
     return [parameters sdl_objectForName:SDLNameProgressIndicator];
 }
 
-- (void)setSoftButtons:(nullable NSMutableArray<SDLSoftButton *> *)softButtons {
+- (void)setSoftButtons:(nullable NSArray<SDLSoftButton *> *)softButtons {
     [parameters sdl_setObject:softButtons forName:SDLNameSoftButtons];
 }
 
-- (nullable NSMutableArray<SDLSoftButton *> *)softButtons {
+- (nullable NSArray<SDLSoftButton *> *)softButtons {
     return [parameters sdl_objectsForName:SDLNameSoftButtons ofClass:SDLSoftButton.class];
 }
 

--- a/SmartDeviceLink/SDLAlertManeuver.h
+++ b/SmartDeviceLink/SDLAlertManeuver.h
@@ -19,8 +19,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithTTS:(nullable NSString *)ttsText softButtons:(nullable NSArray<SDLSoftButton *> *)softButtons;
 - (instancetype)initWithTTSChunks:(nullable NSArray<SDLTTSChunk *> *)ttsChunks softButtons:(nullable NSArray<SDLSoftButton *> *)softButtons;
 
-@property (nullable, strong, nonatomic) NSMutableArray<SDLTTSChunk *> *ttsChunks;
-@property (nullable, strong, nonatomic) NSMutableArray<SDLSoftButton *> *softButtons;
+@property (nullable, strong, nonatomic) NSArray<SDLTTSChunk *> *ttsChunks;
+@property (nullable, strong, nonatomic) NSArray<SDLSoftButton *> *softButtons;
 
 @end
 

--- a/SmartDeviceLink/SDLAlertManeuver.m
+++ b/SmartDeviceLink/SDLAlertManeuver.m
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 
 - (instancetype)initWithTTS:(nullable NSString *)ttsText softButtons:(nullable NSArray<SDLSoftButton *> *)softButtons {
-    NSMutableArray *ttsChunks = [SDLTTSChunk textChunksFromString:ttsText];
+    NSArray *ttsChunks = [SDLTTSChunk textChunksFromString:ttsText];
     return [self initWithTTSChunks:ttsChunks softButtons:softButtons];
 }
 
@@ -37,19 +37,19 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (void)setTtsChunks:(nullable NSMutableArray<SDLTTSChunk *> *)ttsChunks {
+- (void)setTtsChunks:(nullable NSArray<SDLTTSChunk *> *)ttsChunks {
     [parameters sdl_setObject:ttsChunks forName:SDLNameTTSChunks];
 }
 
-- (nullable NSMutableArray<SDLTTSChunk *> *)ttsChunks {
+- (nullable NSArray<SDLTTSChunk *> *)ttsChunks {
     return [parameters sdl_objectsForName:SDLNameTTSChunks ofClass:SDLTTSChunk.class];
 }
 
-- (void)setSoftButtons:(nullable NSMutableArray<SDLSoftButton *> *)softButtons {
+- (void)setSoftButtons:(nullable NSArray<SDLSoftButton *> *)softButtons {
     [parameters sdl_setObject:softButtons forName:SDLNameSoftButtons];
 }
 
-- (nullable NSMutableArray<SDLSoftButton *> *)softButtons {
+- (nullable NSArray<SDLSoftButton *> *)softButtons {
     return [parameters sdl_objectsForName:SDLNameSoftButtons ofClass:SDLSoftButton.class];
 }
 

--- a/SmartDeviceLink/SDLChoice.h
+++ b/SmartDeviceLink/SDLChoice.h
@@ -36,7 +36,7 @@
  * 		</tr>
  *     <tr>
  * 			<td>vrCommands</td>
- * 			<td>NSMutableArray *</td>
+ * 			<td>NSArray *</td>
  * 			<td>An array of strings to be used as VR synonyms for this choice. If this array is provided, it must have at least one non-empty element</td>
  * 			<td>SmartDeviceLink 1.0</td>
  * 		</tr>
@@ -77,7 +77,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * Required, Array of Strings, Array length 1 - 100, Max String length 99 chars
  */
-@property (strong, nonatomic) NSMutableArray<NSString *> *vrCommands;
+@property (strong, nonatomic) NSArray<NSString *> *vrCommands;
 
 /**
  * @abstract The image of the choice

--- a/SmartDeviceLink/SDLChoice.m
+++ b/SmartDeviceLink/SDLChoice.m
@@ -54,11 +54,11 @@ NS_ASSUME_NONNULL_BEGIN
     return [store sdl_objectForName:SDLNameMenuName];
 }
 
-- (void)setVrCommands:(NSMutableArray<NSString *> *)vrCommands {
+- (void)setVrCommands:(NSArray<NSString *> *)vrCommands {
     [store sdl_setObject:vrCommands forName:SDLNameVRCommands];
 }
 
-- (NSMutableArray<NSString *> *)vrCommands {
+- (NSArray<NSString *> *)vrCommands {
     return [store sdl_objectForName:SDLNameVRCommands];
 }
 

--- a/SmartDeviceLink/SDLCreateInteractionChoiceSet.h
+++ b/SmartDeviceLink/SDLCreateInteractionChoiceSet.h
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * Required, SDLChoice, Array size 1 - 100
  */
-@property (strong, nonatomic) NSMutableArray<SDLChoice *> *choiceSet;
+@property (strong, nonatomic) NSArray<SDLChoice *> *choiceSet;
 
 @end
 

--- a/SmartDeviceLink/SDLCreateInteractionChoiceSet.m
+++ b/SmartDeviceLink/SDLCreateInteractionChoiceSet.m
@@ -37,11 +37,11 @@ NS_ASSUME_NONNULL_BEGIN
     return [parameters sdl_objectForName:SDLNameInteractionChoiceSetId];
 }
 
-- (void)setChoiceSet:(NSMutableArray<SDLChoice *> *)choiceSet {
+- (void)setChoiceSet:(NSArray<SDLChoice *> *)choiceSet {
     [parameters sdl_setObject:choiceSet forName:SDLNameChoiceSet];
 }
 
-- (NSMutableArray<SDLChoice *> *)choiceSet {
+- (NSArray<SDLChoice *> *)choiceSet {
     return [parameters sdl_objectsForName:SDLNameChoiceSet ofClass:SDLChoice.class];
 }
 

--- a/SmartDeviceLink/SDLDiagnosticMessage.h
+++ b/SmartDeviceLink/SDLDiagnosticMessage.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * Required, Array of NSNumber (Integers), Array size 1 - 65535, Integer Size 0 - 255
  */
-@property (strong, nonatomic) NSMutableArray<NSNumber<SDLInt> *> *messageData;
+@property (strong, nonatomic) NSArray<NSNumber<SDLInt> *> *messageData;
 
 @end
 

--- a/SmartDeviceLink/SDLDiagnosticMessage.m
+++ b/SmartDeviceLink/SDLDiagnosticMessage.m
@@ -46,11 +46,11 @@ NS_ASSUME_NONNULL_BEGIN
     return [parameters sdl_objectForName:SDLNameMessageLength];
 }
 
-- (void)setMessageData:(NSMutableArray<NSNumber<SDLInt> *> *)messageData {
+- (void)setMessageData:(NSArray<NSNumber<SDLInt> *> *)messageData {
     [parameters sdl_setObject:messageData forName:SDLNameMessageData];
 }
 
-- (NSMutableArray<NSNumber<SDLInt> *> *)messageData {
+- (NSArray<NSNumber<SDLInt> *> *)messageData {
     return [parameters sdl_objectForName:SDLNameMessageData];
 }
 

--- a/SmartDeviceLink/SDLDiagnosticMessageResponse.h
+++ b/SmartDeviceLink/SDLDiagnosticMessageResponse.h
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SDLDiagnosticMessageResponse : SDLRPCResponse
 
-@property (strong, nonatomic) NSMutableArray<NSNumber<SDLInt> *> *messageDataResult;
+@property (strong, nonatomic) NSArray<NSNumber<SDLInt> *> *messageDataResult;
 
 @end
 

--- a/SmartDeviceLink/SDLDiagnosticMessageResponse.m
+++ b/SmartDeviceLink/SDLDiagnosticMessageResponse.m
@@ -16,11 +16,11 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (void)setMessageDataResult:(NSMutableArray<NSNumber<SDLInt> *> *)messageDataResult {
+- (void)setMessageDataResult:(NSArray<NSNumber<SDLInt> *> *)messageDataResult {
     [parameters sdl_setObject:messageDataResult forName:SDLNameMessageDataResult];
 }
 
-- (NSMutableArray<NSNumber<SDLInt> *> *)messageDataResult {
+- (NSArray<NSNumber<SDLInt> *> *)messageDataResult {
     return [parameters objectForKey:SDLNameMessageDataResult];
 }
 

--- a/SmartDeviceLink/SDLDisplayCapabilities.h
+++ b/SmartDeviceLink/SDLDisplayCapabilities.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * Required, Array of SDLTextField, 1 - 100 objects
  */
-@property (strong, nonatomic) NSMutableArray<SDLTextField *> *textFields;
+@property (strong, nonatomic) NSArray<SDLTextField *> *textFields;
 
 /**
  * @abstract An array of SDLImageField elements
@@ -47,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * Optional, Array of SDLImageField, 1 - 100 objects
  */
-@property (nullable, strong, nonatomic) NSMutableArray<SDLImageField *> *imageFields;
+@property (nullable, strong, nonatomic) NSArray<SDLImageField *> *imageFields;
 
 /**
  * @abstract An array of SDLMediaClockFormat elements, defining the valid string formats used in specifying the contents of the media clock field
@@ -56,7 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * Required, Array of SDLMediaClockFormats, 0 - 100 objects
  */
-@property (strong, nonatomic) NSMutableArray<SDLMediaClockFormat> *mediaClockFormats;
+@property (strong, nonatomic) NSArray<SDLMediaClockFormat> *mediaClockFormats;
 
 /**
  * @abstract The display's persistent screen supports.
@@ -74,7 +74,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * Optional, Array of String, max string size 100, 0 - 100 objects
  */
-@property (nullable, strong, nonatomic) NSMutableArray<NSString *> *templatesAvailable;
+@property (nullable, strong, nonatomic) NSArray<NSString *> *templatesAvailable;
 
 /**
  * @abstract A set of all parameters related to a prescribed screen area (e.g. for video / touch input)

--- a/SmartDeviceLink/SDLDisplayCapabilities.m
+++ b/SmartDeviceLink/SDLDisplayCapabilities.m
@@ -42,7 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (NSArray<SDLMediaClockFormat> *)mediaClockFormats {
-    return [store sdl_enumsForName:SDLNameMediaClockFormats];
+    return [store sdl_objectForName:SDLNameMediaClockFormats];
 }
 
 - (void)setGraphicSupported:(NSNumber<SDLBool> *)graphicSupported {

--- a/SmartDeviceLink/SDLDisplayCapabilities.m
+++ b/SmartDeviceLink/SDLDisplayCapabilities.m
@@ -21,27 +21,27 @@ NS_ASSUME_NONNULL_BEGIN
     return [store sdl_objectForName:SDLNameDisplayType];
 }
 
-- (void)setTextFields:(NSMutableArray<SDLTextField *> *)textFields {
+- (void)setTextFields:(NSArray<SDLTextField *> *)textFields {
     [store sdl_setObject:textFields forName:SDLNameTextFields];
 }
 
-- (NSMutableArray<SDLTextField *> *)textFields {
+- (NSArray<SDLTextField *> *)textFields {
     return [store sdl_objectsForName:SDLNameTextFields ofClass:SDLTextField.class];
 }
 
-- (void)setImageFields:(nullable NSMutableArray<SDLImageField *> *)imageFields {
+- (void)setImageFields:(nullable NSArray<SDLImageField *> *)imageFields {
     [store sdl_setObject:imageFields forName:SDLNameImageFields];
 }
 
-- (nullable NSMutableArray<SDLImageField *> *)imageFields {
+- (nullable NSArray<SDLImageField *> *)imageFields {
     return [store sdl_objectsForName:SDLNameImageFields ofClass:SDLImageField.class];
 }
 
-- (void)setMediaClockFormats:(NSMutableArray<SDLMediaClockFormat> *)mediaClockFormats {
+- (void)setMediaClockFormats:(NSArray<SDLMediaClockFormat> *)mediaClockFormats {
     [store sdl_setObject:mediaClockFormats forName:SDLNameMediaClockFormats];
 }
 
-- (NSMutableArray<SDLMediaClockFormat> *)mediaClockFormats {
+- (NSArray<SDLMediaClockFormat> *)mediaClockFormats {
     return [store sdl_enumsForName:SDLNameMediaClockFormats];
 }
 
@@ -53,11 +53,11 @@ NS_ASSUME_NONNULL_BEGIN
     return [store sdl_objectForName:SDLNameGraphicSupported];
 }
 
-- (void)setTemplatesAvailable:(nullable NSMutableArray<NSString *> *)templatesAvailable {
+- (void)setTemplatesAvailable:(nullable NSArray<NSString *> *)templatesAvailable {
     [store sdl_setObject:templatesAvailable forName:SDLNameTemplatesAvailable];
 }
 
-- (nullable NSMutableArray<NSString *> *)templatesAvailable {
+- (nullable NSArray<NSString *> *)templatesAvailable {
     return [store sdl_objectForName:SDLNameTemplatesAvailable];
 }
 

--- a/SmartDeviceLink/SDLEncodedSyncPData.h
+++ b/SmartDeviceLink/SDLEncodedSyncPData.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SDLEncodedSyncPData : SDLRPCRequest
 
-@property (strong, nonatomic) NSMutableArray<NSString *> *data;
+@property (strong, nonatomic) NSArray<NSString *> *data;
 
 @end
 

--- a/SmartDeviceLink/SDLEncodedSyncPData.m
+++ b/SmartDeviceLink/SDLEncodedSyncPData.m
@@ -17,11 +17,11 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (void)setData:(NSMutableArray<NSString *> *)data {
+- (void)setData:(NSArray<NSString *> *)data {
     [parameters sdl_setObject:data forName:SDLNameData];
 }
 
-- (NSMutableArray<NSString *> *)data {
+- (NSArray<NSString *> *)data {
     return [parameters sdl_objectForName:SDLNameData];
 }
 

--- a/SmartDeviceLink/SDLGetDTCsResponse.h
+++ b/SmartDeviceLink/SDLGetDTCsResponse.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SDLGetDTCsResponse : SDLRPCResponse
 
 @property (strong, nonatomic) NSNumber<SDLInt> *ecuHeader;
-@property (strong, nonatomic) NSMutableArray<NSString *> *dtc;
+@property (strong, nonatomic) NSArray<NSString *> *dtc;
 
 @end
 

--- a/SmartDeviceLink/SDLGetDTCsResponse.m
+++ b/SmartDeviceLink/SDLGetDTCsResponse.m
@@ -25,11 +25,11 @@ NS_ASSUME_NONNULL_BEGIN
     return [parameters objectForKey:SDLNameECUHeader];
 }
 
-- (void)setDtc:(NSMutableArray<NSString *> *)dtc {
+- (void)setDtc:(NSArray<NSString *> *)dtc {
     [parameters sdl_setObject:dtc forName:SDLNameDTC];
 }
 
-- (NSMutableArray<NSString *> *)dtc {
+- (NSArray<NSString *> *)dtc {
     return [parameters objectForKey:SDLNameDTC];
 }
 

--- a/SmartDeviceLink/SDLHMIPermissions.h
+++ b/SmartDeviceLink/SDLHMIPermissions.h
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * Required, Array of SDLHMILevel, Array size 0 - 100
  */
-@property (strong, nonatomic) NSMutableArray<SDLHMILevel> *allowed;
+@property (strong, nonatomic) NSArray<SDLHMILevel> *allowed;
 
 /**
  * @abstract a set of all HMI levels that are prohibited for this given RPC
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * Required, Array of SDLHMILevel, Array size 0 - 100
  */
-@property (strong, nonatomic) NSMutableArray<SDLHMILevel> *userDisallowed;
+@property (strong, nonatomic) NSArray<SDLHMILevel> *userDisallowed;
 
 @end
 

--- a/SmartDeviceLink/SDLHMIPermissions.m
+++ b/SmartDeviceLink/SDLHMIPermissions.m
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (NSArray<SDLHMILevel> *)allowed {
-    return [store sdl_enumsForName:SDLNameAllowed];
+    return [store sdl_objectForName:SDLNameAllowed];
 }
 
 - (void)setUserDisallowed:(NSArray<SDLHMILevel> *)userDisallowed {
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (NSArray<SDLHMILevel> *)userDisallowed {
-    return [store sdl_enumsForName:SDLNameUserDisallowed];
+    return [store sdl_objectForName:SDLNameUserDisallowed];
 }
 
 @end

--- a/SmartDeviceLink/SDLHMIPermissions.m
+++ b/SmartDeviceLink/SDLHMIPermissions.m
@@ -11,19 +11,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLHMIPermissions
 
-- (void)setAllowed:(NSMutableArray<SDLHMILevel> *)allowed {
+- (void)setAllowed:(NSArray<SDLHMILevel> *)allowed {
     [store sdl_setObject:allowed forName:SDLNameAllowed];
 }
 
-- (NSMutableArray<SDLHMILevel> *)allowed {
+- (NSArray<SDLHMILevel> *)allowed {
     return [store sdl_enumsForName:SDLNameAllowed];
 }
 
-- (void)setUserDisallowed:(NSMutableArray<SDLHMILevel> *)userDisallowed {
+- (void)setUserDisallowed:(NSArray<SDLHMILevel> *)userDisallowed {
     [store sdl_setObject:userDisallowed forName:SDLNameUserDisallowed];
 }
 
-- (NSMutableArray<SDLHMILevel> *)userDisallowed {
+- (NSArray<SDLHMILevel> *)userDisallowed {
     return [store sdl_enumsForName:SDLNameUserDisallowed];
 }
 

--- a/SmartDeviceLink/SDLImageField.h
+++ b/SmartDeviceLink/SDLImageField.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SDLImageField : SDLRPCStruct
 
 @property (strong, nonatomic) SDLImageFieldName name;
-@property (strong, nonatomic) NSMutableArray<SDLFileType> *imageTypeSupported;
+@property (strong, nonatomic) NSArray<SDLFileType> *imageTypeSupported;
 @property (nullable, strong, nonatomic) SDLImageResolution *imageResolution;
 
 @end

--- a/SmartDeviceLink/SDLImageField.m
+++ b/SmartDeviceLink/SDLImageField.m
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (NSArray<SDLFileType> *)imageTypeSupported {
-    return [store sdl_enumsForName:SDLNameImageTypeSupported];
+    return [store sdl_objectForName:SDLNameImageTypeSupported];
 }
 
 - (void)setImageResolution:(nullable SDLImageResolution *)imageResolution {

--- a/SmartDeviceLink/SDLImageField.m
+++ b/SmartDeviceLink/SDLImageField.m
@@ -20,11 +20,11 @@ NS_ASSUME_NONNULL_BEGIN
     return [store sdl_objectForName:SDLNameName];
 }
 
-- (void)setImageTypeSupported:(NSMutableArray<SDLFileType> *)imageTypeSupported {
+- (void)setImageTypeSupported:(NSArray<SDLFileType> *)imageTypeSupported {
     [store sdl_setObject:imageTypeSupported forName:SDLNameImageTypeSupported];
 }
 
-- (NSMutableArray<SDLFileType> *)imageTypeSupported {
+- (NSArray<SDLFileType> *)imageTypeSupported {
     return [store sdl_enumsForName:SDLNameImageTypeSupported];
 }
 

--- a/SmartDeviceLink/SDLKeyboardProperties.h
+++ b/SmartDeviceLink/SDLKeyboardProperties.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, strong, nonatomic) SDLLanguage language;
 @property (nullable, strong, nonatomic) SDLKeyboardLayout keyboardLayout;
 @property (nullable, strong, nonatomic) SDLKeypressMode keypressMode;
-@property (nullable, strong, nonatomic) NSMutableArray<NSString *> *limitedCharacterList;
+@property (nullable, strong, nonatomic) NSArray<NSString *> *limitedCharacterList;
 @property (nullable, strong, nonatomic) NSString *autoCompleteText;
 
 @end

--- a/SmartDeviceLink/SDLKeyboardProperties.m
+++ b/SmartDeviceLink/SDLKeyboardProperties.m
@@ -49,11 +49,11 @@ NS_ASSUME_NONNULL_BEGIN
     return [store sdl_objectForName:SDLNameKeypressMode];
 }
 
-- (void)setLimitedCharacterList:(nullable NSMutableArray<NSString *> *)limitedCharacterList {
+- (void)setLimitedCharacterList:(nullable NSArray<NSString *> *)limitedCharacterList {
     [store sdl_setObject:limitedCharacterList forName:SDLNameLimitedCharacterList];
 }
 
-- (nullable NSMutableArray<NSString *> *)limitedCharacterList {
+- (nullable NSArray<NSString *> *)limitedCharacterList {
     return [store sdl_objectForName:SDLNameLimitedCharacterList];
 }
 

--- a/SmartDeviceLink/SDLListFilesResponse.h
+++ b/SmartDeviceLink/SDLListFilesResponse.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SDLListFilesResponse : SDLRPCResponse
 
-@property (nullable, strong, nonatomic) NSMutableArray<NSString *> *filenames;
+@property (nullable, strong, nonatomic) NSArray<NSString *> *filenames;
 @property (strong, nonatomic) NSNumber<SDLInt> *spaceAvailable;
 
 @end

--- a/SmartDeviceLink/SDLListFilesResponse.m
+++ b/SmartDeviceLink/SDLListFilesResponse.m
@@ -17,11 +17,11 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (void)setFilenames:(nullable NSMutableArray<NSString *> *)filenames {
+- (void)setFilenames:(nullable NSArray<NSString *> *)filenames {
     [parameters sdl_setObject:filenames forName:SDLNameFilenames];
 }
 
-- (nullable NSMutableArray<NSString *> *)filenames {
+- (nullable NSArray<NSString *> *)filenames {
     return [parameters objectForKey:SDLNameFilenames];
 }
 

--- a/SmartDeviceLink/SDLOnEncodedSyncPData.h
+++ b/SmartDeviceLink/SDLOnEncodedSyncPData.h
@@ -7,7 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SDLOnEncodedSyncPData : SDLRPCNotification
 
-@property (strong, nonatomic) NSMutableArray<NSString *> *data;
+@property (strong, nonatomic) NSArray<NSString *> *data;
 @property (nullable, strong, nonatomic) NSString *URL;
 @property (nullable, strong, nonatomic) NSNumber<SDLInt> *Timeout;
 

--- a/SmartDeviceLink/SDLOnEncodedSyncPData.m
+++ b/SmartDeviceLink/SDLOnEncodedSyncPData.m
@@ -16,11 +16,11 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (void)setData:(NSMutableArray<NSString *> *)data {
+- (void)setData:(NSArray<NSString *> *)data {
     [parameters sdl_setObject:data forName:SDLNameData];
 }
 
-- (NSMutableArray<NSString *> *)data {
+- (NSArray<NSString *> *)data {
     return [parameters sdl_objectForName:SDLNameData];
 }
 

--- a/SmartDeviceLink/SDLOnPermissionsChange.h
+++ b/SmartDeviceLink/SDLOnPermissionsChange.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @see SDLPermissionItem
  */
-@property (strong, nonatomic) NSMutableArray<SDLPermissionItem *> *permissionItem;
+@property (strong, nonatomic) NSArray<SDLPermissionItem *> *permissionItem;
 
 @end
 

--- a/SmartDeviceLink/SDLOnPermissionsChange.m
+++ b/SmartDeviceLink/SDLOnPermissionsChange.m
@@ -17,21 +17,12 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (void)setPermissionItem:(NSMutableArray<SDLPermissionItem *> *)permissionItem {
+- (void)setPermissionItem:(NSArray<SDLPermissionItem *> *)permissionItem {
     [parameters sdl_setObject:permissionItem forName:SDLNamePermissionItem];
 }
 
-- (NSMutableArray<SDLPermissionItem *> *)permissionItem {
-    NSMutableArray<SDLPermissionItem *> *array = [parameters sdl_objectForName:SDLNamePermissionItem];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLPermissionItem.class]) {
-        return array;
-    } else {
-        NSMutableArray<SDLPermissionItem *> *newList = [NSMutableArray arrayWithCapacity:[array count]];
-        for (NSDictionary<NSString *, id> *dict in array) {
-            [newList addObject:[[SDLPermissionItem alloc] initWithDictionary:(NSDictionary *)dict]];
-        }
-        return newList;
-    }
+- (NSArray<SDLPermissionItem *> *)permissionItem {
+    return [parameters sdl_objectsForName:SDLNamePermissionItem ofClass:SDLPermissionItem.class];
 }
 
 @end

--- a/SmartDeviceLink/SDLOnTouchEvent.h
+++ b/SmartDeviceLink/SDLOnTouchEvent.h
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SDLOnTouchEvent : SDLRPCNotification
 
 @property (strong, nonatomic) SDLTouchType type;
-@property (strong, nonatomic) NSMutableArray<SDLTouchEvent *> *event;
+@property (strong, nonatomic) NSArray<SDLTouchEvent *> *event;
 
 @end
 

--- a/SmartDeviceLink/SDLOnTouchEvent.m
+++ b/SmartDeviceLink/SDLOnTouchEvent.m
@@ -26,21 +26,12 @@ NS_ASSUME_NONNULL_BEGIN
     return (SDLTouchType)obj;
 }
 
-- (void)setEvent:(NSMutableArray<SDLTouchEvent *> *)event {
+- (void)setEvent:(NSArray<SDLTouchEvent *> *)event {
     [parameters sdl_setObject:event forName:SDLNameEvent];
 }
 
-- (NSMutableArray<SDLTouchEvent *> *)event {
-    NSMutableArray<SDLTouchEvent *> *array = [parameters sdl_objectForName:SDLNameEvent];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLTouchEvent.class]) {
-        return array;
-    } else {
-        NSMutableArray<SDLTouchEvent *> *newList = [NSMutableArray arrayWithCapacity:[array count]];
-        for (NSDictionary<NSString *, id> *dict in array) {
-            [newList addObject:[[SDLTouchEvent alloc] initWithDictionary:(NSDictionary *)dict]];
-        }
-        return newList;
-    }
+- (NSArray<SDLTouchEvent *> *)event {
+    return [parameters sdl_objectsForName:SDLNameEvent ofClass:SDLTouchEvent.class];
 }
 
 @end

--- a/SmartDeviceLink/SDLParameterPermissions.h
+++ b/SmartDeviceLink/SDLParameterPermissions.h
@@ -19,13 +19,13 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * Required, Array of String, max String length = 100, Array size 0 - 100
  */
-@property (strong, nonatomic) NSMutableArray<NSString *> *allowed;
+@property (strong, nonatomic) NSArray<NSString *> *allowed;
 /**
  * @abstract A set of all parameters that are prohibited for this given RPC.
  *
  * Required, Array of String, max String length = 100, Array size 0 - 100
  */
-@property (strong, nonatomic) NSMutableArray<NSString *> *userDisallowed;
+@property (strong, nonatomic) NSArray<NSString *> *userDisallowed;
 
 @end
 

--- a/SmartDeviceLink/SDLParameterPermissions.m
+++ b/SmartDeviceLink/SDLParameterPermissions.m
@@ -11,19 +11,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLParameterPermissions
 
-- (void)setAllowed:(NSMutableArray<NSString *> *)allowed {
+- (void)setAllowed:(NSArray<NSString *> *)allowed {
     [store sdl_setObject:allowed forName:SDLNameAllowed];
 }
 
-- (NSMutableArray<NSString *> *)allowed {
+- (NSArray<NSString *> *)allowed {
     return [store sdl_objectForName:SDLNameAllowed];
 }
 
-- (void)setUserDisallowed:(NSMutableArray<NSString *> *)userDisallowed {
+- (void)setUserDisallowed:(NSArray<NSString *> *)userDisallowed {
     [store sdl_setObject:userDisallowed forName:SDLNameUserDisallowed];
 }
 
-- (NSMutableArray<NSString *> *)userDisallowed {
+- (NSArray<NSString *> *)userDisallowed {
     return [store sdl_objectForName:SDLNameUserDisallowed];
 }
 

--- a/SmartDeviceLink/SDLPerformAudioPassThru.h
+++ b/SmartDeviceLink/SDLPerformAudioPassThru.h
@@ -47,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
  *            <li>Array Maxsize: 100</li>
  *            </ul>
  */
-@property (nullable, strong, nonatomic) NSMutableArray<SDLTTSChunk *> *initialPrompt;
+@property (nullable, strong, nonatomic) NSArray<SDLTTSChunk *> *initialPrompt;
 /**
  * @abstract a line of text displayed during audio capture
  * @discussion audioPassThruDisplayText1

--- a/SmartDeviceLink/SDLPerformAudioPassThru.m
+++ b/SmartDeviceLink/SDLPerformAudioPassThru.m
@@ -46,11 +46,11 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (void)setInitialPrompt:(nullable NSMutableArray<SDLTTSChunk *> *)initialPrompt {
+- (void)setInitialPrompt:(nullable NSArray<SDLTTSChunk *> *)initialPrompt {
     [parameters sdl_setObject:initialPrompt forName:SDLNameInitialPrompt];
 }
 
-- (nullable NSMutableArray<SDLTTSChunk *> *)initialPrompt {
+- (nullable NSArray<SDLTTSChunk *> *)initialPrompt {
     return [parameters sdl_objectsForName:SDLNameInitialPrompt ofClass:SDLTTSChunk.class];
 }
 

--- a/SmartDeviceLink/SDLPerformInteraction.h
+++ b/SmartDeviceLink/SDLPerformInteraction.h
@@ -57,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @abstract An array of one or more TTSChunks that, taken together, specify
  * what is to be spoken to the user at the start of an interaction
  */
-@property (nullable, strong, nonatomic) NSMutableArray<SDLTTSChunk *> *initialPrompt;
+@property (nullable, strong, nonatomic) NSArray<SDLTTSChunk *> *initialPrompt;
 /**
  * @abstract The Indicates mode that indicate how user selects interaction
  * choice. User can choose either by voice (VR_ONLY), by visual selection
@@ -68,17 +68,17 @@ NS_ASSUME_NONNULL_BEGIN
  * @abstract A Vector<Integer> value representing an Array of one or more Choice
  * Set IDs
  */
-@property (strong, nonatomic) NSMutableArray<NSNumber<SDLInt> *> *interactionChoiceSetIDList;
+@property (strong, nonatomic) NSArray<NSNumber<SDLInt> *> *interactionChoiceSetIDList;
 /**
  * @abstract A Vector<TTSChunk> which taken together, specify the help phrase to
  * be spoken when the user says "help" during the VR session
  */
-@property (nullable, strong, nonatomic) NSMutableArray<SDLTTSChunk *> *helpPrompt;
+@property (nullable, strong, nonatomic) NSArray<SDLTTSChunk *> *helpPrompt;
 /**
  * @abstract An array of TTSChunks which, taken together, specify the phrase to
  * be spoken when the listen times out during the VR session
  */
-@property (nullable, strong, nonatomic) NSMutableArray<SDLTTSChunk *> *timeoutPrompt;
+@property (nullable, strong, nonatomic) NSArray<SDLTTSChunk *> *timeoutPrompt;
 /**
  * @abstract An Integer value representing the amount of time, in milliseconds,
  * SDL will wait for the user to make a choice (VR or Menu)
@@ -89,7 +89,7 @@ NS_ASSUME_NONNULL_BEGIN
  * display on-screen during Perform Interaction
  * @since SmartDeviceLink 2.0
  */
-@property (nullable, strong, nonatomic) NSMutableArray<SDLVRHelpItem *> *vrHelp;
+@property (nullable, strong, nonatomic) NSArray<SDLVRHelpItem *> *vrHelp;
 @property (nullable, strong, nonatomic) SDLLayoutMode interactionLayout;
 
 @end

--- a/SmartDeviceLink/SDLPerformInteraction.m
+++ b/SmartDeviceLink/SDLPerformInteraction.m
@@ -51,9 +51,9 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (instancetype)initWithInitialPrompt:(nullable NSString *)initialPrompt initialText:(NSString *)initialText interactionChoiceSetIDList:(NSArray<NSNumber<SDLUInt> *> *)interactionChoiceSetIDList helpPrompt:(nullable NSString *)helpPrompt timeoutPrompt:(nullable NSString *)timeoutPrompt interactionMode:(SDLInteractionMode)interactionMode timeout:(UInt32)timeout vrHelp:(nullable NSArray<SDLVRHelpItem *> *)vrHelp {
-    NSMutableArray *initialChunks = [SDLTTSChunk textChunksFromString:initialPrompt];
-    NSMutableArray *helpChunks = [SDLTTSChunk textChunksFromString:helpPrompt];
-    NSMutableArray *timeoutChunks = [SDLTTSChunk textChunksFromString:timeoutPrompt];
+    NSArray *initialChunks = [SDLTTSChunk textChunksFromString:initialPrompt];
+    NSArray *helpChunks = [SDLTTSChunk textChunksFromString:helpPrompt];
+    NSArray *timeoutChunks = [SDLTTSChunk textChunksFromString:timeoutPrompt];
     return [self initWithInitialChunks:initialChunks initialText:initialText interactionChoiceSetIDList:interactionChoiceSetIDList helpChunks:helpChunks timeoutChunks:timeoutChunks interactionMode:interactionMode timeout:timeout vrHelp:vrHelp];
 }
 
@@ -98,11 +98,11 @@ NS_ASSUME_NONNULL_BEGIN
     return [parameters sdl_objectForName:SDLNameInitialText];
 }
 
-- (void)setInitialPrompt:(nullable NSMutableArray<SDLTTSChunk *> *)initialPrompt {
+- (void)setInitialPrompt:(nullable NSArray<SDLTTSChunk *> *)initialPrompt {
     [parameters sdl_setObject:initialPrompt forName:SDLNameInitialPrompt];
 }
 
-- (nullable NSMutableArray<SDLTTSChunk *> *)initialPrompt {
+- (nullable NSArray<SDLTTSChunk *> *)initialPrompt {
     return [parameters sdl_objectsForName:SDLNameInitialPrompt ofClass:SDLTTSChunk.class];
 }
 
@@ -114,27 +114,27 @@ NS_ASSUME_NONNULL_BEGIN
     return [parameters sdl_objectForName:SDLNameInteractionMode];
 }
 
-- (void)setInteractionChoiceSetIDList:(NSMutableArray<NSNumber<SDLInt> *> *)interactionChoiceSetIDList {
+- (void)setInteractionChoiceSetIDList:(NSArray<NSNumber<SDLInt> *> *)interactionChoiceSetIDList {
     [parameters sdl_setObject:interactionChoiceSetIDList forName:SDLNameInteractionChoiceSetIdList];
 }
 
-- (NSMutableArray<NSNumber<SDLInt> *> *)interactionChoiceSetIDList {
+- (NSArray<NSNumber<SDLInt> *> *)interactionChoiceSetIDList {
     return [parameters sdl_objectForName:SDLNameInteractionChoiceSetIdList];
 }
 
-- (void)setHelpPrompt:(nullable NSMutableArray<SDLTTSChunk *> *)helpPrompt {
+- (void)setHelpPrompt:(nullable NSArray<SDLTTSChunk *> *)helpPrompt {
     [parameters sdl_setObject:helpPrompt forName:SDLNameHelpPrompt];
 }
 
-- (nullable NSMutableArray<SDLTTSChunk *> *)helpPrompt {
+- (nullable NSArray<SDLTTSChunk *> *)helpPrompt {
     return [parameters sdl_objectsForName:SDLNameHelpPrompt ofClass:SDLTTSChunk.class];
 }
 
-- (void)setTimeoutPrompt:(nullable NSMutableArray<SDLTTSChunk *> *)timeoutPrompt {
+- (void)setTimeoutPrompt:(nullable NSArray<SDLTTSChunk *> *)timeoutPrompt {
     [parameters sdl_setObject:timeoutPrompt forName:SDLNameTimeoutPrompt];
 }
 
-- (nullable NSMutableArray<SDLTTSChunk *> *)timeoutPrompt {
+- (nullable NSArray<SDLTTSChunk *> *)timeoutPrompt {
     return [parameters sdl_objectsForName:SDLNameTimeoutPrompt ofClass:SDLTTSChunk.class];
 }
 
@@ -146,11 +146,11 @@ NS_ASSUME_NONNULL_BEGIN
     return [parameters sdl_objectForName:SDLNameTimeout];
 }
 
-- (void)setVrHelp:(nullable NSMutableArray<SDLVRHelpItem *> *)vrHelp {
+- (void)setVrHelp:(nullable NSArray<SDLVRHelpItem *> *)vrHelp {
     [parameters sdl_setObject:vrHelp forName:SDLNameVRHelp];
 }
 
-- (nullable NSMutableArray<SDLVRHelpItem *> *)vrHelp {
+- (nullable NSArray<SDLVRHelpItem *> *)vrHelp {
     return [parameters sdl_objectsForName:SDLNameVRHelp ofClass:SDLVRHelpItem.class];
 }
 

--- a/SmartDeviceLink/SDLReadDID.h
+++ b/SmartDeviceLink/SDLReadDID.h
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
  *            <li>ArrayMin:0; ArrayMax:1000</li>
  *            </ul>
  */
-@property (strong, nonatomic) NSMutableArray<NSNumber<SDLInt> *> *didLocation;
+@property (strong, nonatomic) NSArray<NSNumber<SDLInt> *> *didLocation;
 
 @end
 

--- a/SmartDeviceLink/SDLReadDID.m
+++ b/SmartDeviceLink/SDLReadDID.m
@@ -37,11 +37,11 @@ NS_ASSUME_NONNULL_BEGIN
     return [parameters sdl_objectForName:SDLNameECUName];
 }
 
-- (void)setDidLocation:(NSMutableArray<NSNumber<SDLInt> *> *)didLocation {
+- (void)setDidLocation:(NSArray<NSNumber<SDLInt> *> *)didLocation {
     [parameters sdl_setObject:didLocation forName:SDLNameDIDLocation];
 }
 
-- (NSMutableArray<NSNumber<SDLInt> *> *)didLocation {
+- (NSArray<NSNumber<SDLInt> *> *)didLocation {
     return [parameters sdl_objectForName:SDLNameDIDLocation];
 }
 

--- a/SmartDeviceLink/SDLReadDIDResponse.h
+++ b/SmartDeviceLink/SDLReadDIDResponse.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SDLReadDIDResponse : SDLRPCResponse
 
-@property (nullable, strong, nonatomic) NSMutableArray<SDLDIDResult *> *didResult;
+@property (nullable, strong, nonatomic) NSArray<SDLDIDResult *> *didResult;
 
 @end
 

--- a/SmartDeviceLink/SDLReadDIDResponse.m
+++ b/SmartDeviceLink/SDLReadDIDResponse.m
@@ -18,11 +18,11 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (void)setDidResult:(nullable NSMutableArray<SDLDIDResult *> *)didResult {
+- (void)setDidResult:(nullable NSArray<SDLDIDResult *> *)didResult {
     [parameters sdl_setObject:didResult forName:SDLNameDIDResult];
 }
 
-- (nullable NSMutableArray<SDLDIDResult *> *)didResult {
+- (nullable NSArray<SDLDIDResult *> *)didResult {
     return [parameters sdl_objectsForName:SDLNameDIDResult ofClass:SDLDIDResult.class];
 }
 

--- a/SmartDeviceLink/SDLRegisterAppInterface.h
+++ b/SmartDeviceLink/SDLRegisterAppInterface.h
@@ -130,7 +130,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @since SDL 2.0
  * @see SDLTTSChunk
  */
-@property (nullable, strong, nonatomic) NSMutableArray<SDLTTSChunk *> *ttsName;
+@property (nullable, strong, nonatomic) NSArray<SDLTTSChunk *> *ttsName;
 
 /**
  * @abstract A String representing an abbreviated version of the mobile application's name (if necessary) that will be displayed on the media screen
@@ -148,7 +148,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * Optional, Array of Strings, Array length 1 - 100, Max String length 40
  */
-@property (nullable, strong, nonatomic) NSMutableArray<NSString *> *vrSynonyms;
+@property (nullable, strong, nonatomic) NSArray<NSString *> *vrSynonyms;
 
 /**
  * @abstract Indicates if the application is a media or a non-media application.
@@ -187,7 +187,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @since SDL 2.0
  * @see SDLAppHMIType
  */
-@property (nullable, strong, nonatomic) NSMutableArray<SDLAppHMIType> *appHMIType;
+@property (nullable, strong, nonatomic) NSArray<SDLAppHMIType> *appHMIType;
 
 /**
  * @abstract ID used to uniquely identify current state of all app data that can persist through connection cycles (e.g. ignition cycles).

--- a/SmartDeviceLink/SDLRegisterAppInterface.m
+++ b/SmartDeviceLink/SDLRegisterAppInterface.m
@@ -56,7 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
     self.isMediaApplication = @(isMediaApp);
 
     if (appType != nil) {
-        self.appHMIType = [NSMutableArray arrayWithObject:appType];
+        self.appHMIType = [NSArray arrayWithObject:appType];
     }
     
     self.ngnMediaScreenAppName = shortAppName;
@@ -94,11 +94,11 @@ NS_ASSUME_NONNULL_BEGIN
     return [parameters sdl_objectForName:SDLNameAppName];
 }
 
-- (void)setTtsName:(nullable NSMutableArray<SDLTTSChunk *> *)ttsName {
+- (void)setTtsName:(nullable NSArray<SDLTTSChunk *> *)ttsName {
     [parameters sdl_setObject:ttsName forName:SDLNameTTSName];
 }
 
-- (nullable NSMutableArray<SDLTTSChunk *> *)ttsName {
+- (nullable NSArray<SDLTTSChunk *> *)ttsName {
     return [parameters sdl_objectsForName:SDLNameTTSName ofClass:SDLTTSChunk.class];
 }
 
@@ -110,11 +110,11 @@ NS_ASSUME_NONNULL_BEGIN
     return [parameters sdl_objectForName:SDLNameNGNMediaScreenAppName];
 }
 
-- (void)setVrSynonyms:(nullable NSMutableArray<NSString *> *)vrSynonyms {
+- (void)setVrSynonyms:(nullable NSArray<NSString *> *)vrSynonyms {
     [parameters sdl_setObject:vrSynonyms forName:SDLNameVRSynonyms];
 }
 
-- (nullable NSMutableArray<NSString *> *)vrSynonyms {
+- (nullable NSArray<NSString *> *)vrSynonyms {
     return [parameters sdl_objectForName:SDLNameVRSynonyms];
 }
 
@@ -142,11 +142,11 @@ NS_ASSUME_NONNULL_BEGIN
     return [parameters sdl_objectForName:SDLNameHMIDisplayLanguageDesired];
 }
 
-- (void)setAppHMIType:(nullable NSMutableArray<SDLAppHMIType> *)appHMIType {
+- (void)setAppHMIType:(nullable NSArray<SDLAppHMIType> *)appHMIType {
     [parameters sdl_setObject:appHMIType forName:SDLNameAppHMIType];
 }
 
-- (nullable NSMutableArray<SDLAppHMIType> *)appHMIType {
+- (nullable NSArray<SDLAppHMIType> *)appHMIType {
     return [parameters sdl_enumsForName:SDLNameAppHMIType];
 }
 

--- a/SmartDeviceLink/SDLRegisterAppInterface.m
+++ b/SmartDeviceLink/SDLRegisterAppInterface.m
@@ -147,7 +147,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (nullable NSArray<SDLAppHMIType> *)appHMIType {
-    return [parameters sdl_enumsForName:SDLNameAppHMIType];
+    return [parameters sdl_objectForName:SDLNameAppHMIType];
 }
 
 - (void)setHashID:(nullable NSString *)hashID {

--- a/SmartDeviceLink/SDLRegisterAppInterfaceResponse.h
+++ b/SmartDeviceLink/SDLRegisterAppInterfaceResponse.h
@@ -68,7 +68,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * Optional, Array of length 1 - 100, of SDLButtonCapabilities
  */
-@property (nullable, strong, nonatomic) NSMutableArray<SDLButtonCapabilities *> *buttonCapabilities;
+@property (nullable, strong, nonatomic) NSArray<SDLButtonCapabilities *> *buttonCapabilities;
 
 /**
  * If returned, the platform supports on-screen SoftButtons
@@ -77,7 +77,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * Optional, Array of length 1 - 100, of SDLSoftButtonCapabilities
  */
-@property (nullable, strong, nonatomic) NSMutableArray<SDLSoftButtonCapabilities *> *softButtonCapabilities;
+@property (nullable, strong, nonatomic) NSArray<SDLSoftButtonCapabilities *> *softButtonCapabilities;
 
 /**
  * If returned, the platform supports custom on-screen Presets
@@ -93,35 +93,35 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * Optional, Array of length 1 - 100, of SDLHMIZoneCapabilities
  */
-@property (nullable, strong, nonatomic) NSMutableArray<SDLHMIZoneCapabilities> *hmiZoneCapabilities;
+@property (nullable, strong, nonatomic) NSArray<SDLHMIZoneCapabilities> *hmiZoneCapabilities;
 
 /**
  * @see SDLSpeechCapabilities
  *
  * Optional, Array of length 1 - 100, of SDLSpeechCapabilities
  */
-@property (nullable, strong, nonatomic) NSMutableArray<SDLSpeechCapabilities> *speechCapabilities;
+@property (nullable, strong, nonatomic) NSArray<SDLSpeechCapabilities> *speechCapabilities;
 
 /**
  * @see SDLPrerecordedSpeech
  *
  * Optional, Array of length 1 - 100, of SDLPrerecordedSpeech
  */
-@property (nullable, strong, nonatomic) NSMutableArray<SDLPrerecordedSpeech> *prerecordedSpeech;
+@property (nullable, strong, nonatomic) NSArray<SDLPrerecordedSpeech> *prerecordedSpeech;
 
 /**
  * @see SDLVRCapabilities
  *
  * Optional, Array of length 1 - 100, of SDLVRCapabilities
  */
-@property (nullable, strong, nonatomic) NSMutableArray<SDLVRCapabilities> *vrCapabilities;
+@property (nullable, strong, nonatomic) NSArray<SDLVRCapabilities> *vrCapabilities;
 
 /**
  * @see SDLAudioPassThruCapabilities
  *
  * Optional, Array of length 1 - 100, of SDLAudioPassThruCapabilities
  */
-@property (nullable, strong, nonatomic) NSMutableArray<SDLAudioPassThruCapabilities *> *audioPassThruCapabilities;
+@property (nullable, strong, nonatomic) NSArray<SDLAudioPassThruCapabilities *> *audioPassThruCapabilities;
 
 /**
  * Specifies the vehicle's type
@@ -137,7 +137,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * Optional, Array of length 1 - 100, Integer 0 - 255
  */
-@property (nullable, strong, nonatomic) NSMutableArray<NSNumber<SDLInt> *> *supportedDiagModes;
+@property (nullable, strong, nonatomic) NSArray<NSNumber<SDLInt> *> *supportedDiagModes;
 
 /**
  * @see SDLHMICapabilities

--- a/SmartDeviceLink/SDLRegisterAppInterfaceResponse.m
+++ b/SmartDeviceLink/SDLRegisterAppInterfaceResponse.m
@@ -57,19 +57,19 @@ NS_ASSUME_NONNULL_BEGIN
     return [parameters sdl_objectForName:SDLNameDisplayCapabilities ofClass:SDLDisplayCapabilities.class];
 }
 
-- (void)setButtonCapabilities:(nullable NSMutableArray<SDLButtonCapabilities *> *)buttonCapabilities {
+- (void)setButtonCapabilities:(nullable NSArray<SDLButtonCapabilities *> *)buttonCapabilities {
     [parameters sdl_setObject:buttonCapabilities forName:SDLNameButtonCapabilities];
 }
 
-- (nullable NSMutableArray<SDLButtonCapabilities *> *)buttonCapabilities {
+- (nullable NSArray<SDLButtonCapabilities *> *)buttonCapabilities {
     return [parameters sdl_objectsForName:SDLNameButtonCapabilities ofClass:SDLButtonCapabilities.class];
 }
 
-- (void)setSoftButtonCapabilities:(nullable NSMutableArray<SDLSoftButtonCapabilities *> *)softButtonCapabilities {
+- (void)setSoftButtonCapabilities:(nullable NSArray<SDLSoftButtonCapabilities *> *)softButtonCapabilities {
     [parameters sdl_setObject:softButtonCapabilities forName:SDLNameSoftButtonCapabilities];
 }
 
-- (nullable NSMutableArray<SDLSoftButtonCapabilities *> *)softButtonCapabilities {
+- (nullable NSArray<SDLSoftButtonCapabilities *> *)softButtonCapabilities {
     return [parameters sdl_objectsForName:SDLNameSoftButtonCapabilities ofClass:SDLSoftButtonCapabilities.class];
 }
 
@@ -81,43 +81,43 @@ NS_ASSUME_NONNULL_BEGIN
     return [parameters sdl_objectForName:SDLNamePresetBankCapabilities ofClass:SDLPresetBankCapabilities.class];
 }
 
-- (void)setHmiZoneCapabilities:(nullable NSMutableArray<SDLHMIZoneCapabilities> *)hmiZoneCapabilities {
+- (void)setHmiZoneCapabilities:(nullable NSArray<SDLHMIZoneCapabilities> *)hmiZoneCapabilities {
     [parameters sdl_setObject:hmiZoneCapabilities forName:SDLNameHMIZoneCapabilities];
 }
 
-- (nullable NSMutableArray<SDLHMIZoneCapabilities> *)hmiZoneCapabilities {
+- (nullable NSArray<SDLHMIZoneCapabilities> *)hmiZoneCapabilities {
     return [parameters sdl_objectForName:SDLNameHMIZoneCapabilities];
 }
 
-- (void)setSpeechCapabilities:(nullable NSMutableArray<SDLSpeechCapabilities> *)speechCapabilities {
+- (void)setSpeechCapabilities:(nullable NSArray<SDLSpeechCapabilities> *)speechCapabilities {
     [parameters sdl_setObject:speechCapabilities forName:SDLNameSpeechCapabilities];
 }
 
-- (nullable NSMutableArray<SDLSpeechCapabilities> *)speechCapabilities {
+- (nullable NSArray<SDLSpeechCapabilities> *)speechCapabilities {
     return [parameters sdl_objectForName:SDLNameSpeechCapabilities];
 }
 
-- (void)setPrerecordedSpeech:(nullable NSMutableArray<SDLPrerecordedSpeech> *)prerecordedSpeech {
+- (void)setPrerecordedSpeech:(nullable NSArray<SDLPrerecordedSpeech> *)prerecordedSpeech {
     [parameters sdl_setObject:prerecordedSpeech forName:SDLNamePrerecordedSpeech];
 }
 
-- (nullable NSMutableArray<SDLPrerecordedSpeech> *)prerecordedSpeech {
+- (nullable NSArray<SDLPrerecordedSpeech> *)prerecordedSpeech {
     return [parameters sdl_objectForName:SDLNamePrerecordedSpeech];
 }
 
-- (void)setVrCapabilities:(nullable NSMutableArray<SDLVRCapabilities> *)vrCapabilities {
+- (void)setVrCapabilities:(nullable NSArray<SDLVRCapabilities> *)vrCapabilities {
     [parameters sdl_setObject:vrCapabilities forName:SDLNameVRCapabilities];
 }
 
-- (nullable NSMutableArray<SDLVRCapabilities> *)vrCapabilities {
+- (nullable NSArray<SDLVRCapabilities> *)vrCapabilities {
     return [parameters sdl_objectForName:SDLNameVRCapabilities];
 }
 
-- (void)setAudioPassThruCapabilities:(nullable NSMutableArray<SDLAudioPassThruCapabilities *> *)audioPassThruCapabilities {
+- (void)setAudioPassThruCapabilities:(nullable NSArray<SDLAudioPassThruCapabilities *> *)audioPassThruCapabilities {
     [parameters sdl_setObject:audioPassThruCapabilities forName:SDLNameAudioPassThruCapabilities];
 }
 
-- (nullable NSMutableArray<SDLAudioPassThruCapabilities *> *)audioPassThruCapabilities {
+- (nullable NSArray<SDLAudioPassThruCapabilities *> *)audioPassThruCapabilities {
     return [parameters sdl_objectsForName:SDLNameAudioPassThruCapabilities ofClass:SDLAudioPassThruCapabilities.class];
 }
 
@@ -129,11 +129,11 @@ NS_ASSUME_NONNULL_BEGIN
     return [parameters sdl_objectForName:SDLNameVehicleType ofClass:SDLVehicleType.class];
 }
 
-- (void)setSupportedDiagModes:(nullable NSMutableArray<NSNumber<SDLInt> *> *)supportedDiagModes {
+- (void)setSupportedDiagModes:(nullable NSArray<NSNumber<SDLInt> *> *)supportedDiagModes {
     [parameters sdl_setObject:supportedDiagModes forName:SDLNameSupportedDiagnosticModes];
 }
 
-- (nullable NSMutableArray<NSNumber<SDLInt> *> *)supportedDiagModes {
+- (nullable NSArray<NSNumber<SDLInt> *> *)supportedDiagModes {
     return [parameters sdl_objectForName:SDLNameSupportedDiagnosticModes];
 }
 

--- a/SmartDeviceLink/SDLResetGlobalProperties.h
+++ b/SmartDeviceLink/SDLResetGlobalProperties.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @abstract An array of one or more GlobalProperty enumeration elements
  * indicating which global properties to reset to their default value
  */
-@property (strong, nonatomic) NSMutableArray<SDLGlobalProperty> *properties;
+@property (strong, nonatomic) NSArray<SDLGlobalProperty> *properties;
 
 @end
 

--- a/SmartDeviceLink/SDLResetGlobalProperties.m
+++ b/SmartDeviceLink/SDLResetGlobalProperties.m
@@ -29,11 +29,11 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (void)setProperties:(NSMutableArray<SDLGlobalProperty> *)properties {
+- (void)setProperties:(NSArray<SDLGlobalProperty> *)properties {
     [parameters sdl_setObject:properties forName:SDLNameProperties];
 }
 
-- (NSMutableArray<SDLGlobalProperty> *)properties {
+- (NSArray<SDLGlobalProperty> *)properties {
     return [parameters sdl_enumsForName:SDLNameProperties];
 }
 

--- a/SmartDeviceLink/SDLResetGlobalProperties.m
+++ b/SmartDeviceLink/SDLResetGlobalProperties.m
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (NSArray<SDLGlobalProperty> *)properties {
-    return [parameters sdl_enumsForName:SDLNameProperties];
+    return [parameters sdl_objectForName:SDLNameProperties];
 }
 
 @end

--- a/SmartDeviceLink/SDLResponseDispatcher.m
+++ b/SmartDeviceLink/SDLResponseDispatcher.m
@@ -115,7 +115,7 @@ NS_ASSUME_NONNULL_BEGIN
     [self.customButtonHandlerMap removeAllObjects];
 }
 
-- (void)sdl_addToCustomButtonHandlerMap:(NSMutableArray<SDLSoftButton *> *)softButtons {
+- (void)sdl_addToCustomButtonHandlerMap:(NSArray<SDLSoftButton *> *)softButtons {
     for (SDLSoftButton *sb in softButtons) {
         if (!sb.softButtonID) {
             @throw [NSException sdl_missingIdException];

--- a/SmartDeviceLink/SDLScrollableMessage.h
+++ b/SmartDeviceLink/SDLScrollableMessage.h
@@ -48,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
  *            <p>
  *            <b>Notes: </b>Minsize=0, Maxsize=8
  */
-@property (nullable, strong, nonatomic) NSMutableArray<SDLSoftButton *> *softButtons;
+@property (nullable, strong, nonatomic) NSArray<SDLSoftButton *> *softButtons;
 
 @end
 

--- a/SmartDeviceLink/SDLScrollableMessage.m
+++ b/SmartDeviceLink/SDLScrollableMessage.m
@@ -57,11 +57,11 @@ NS_ASSUME_NONNULL_BEGIN
     return [parameters sdl_objectForName:SDLNameTimeout];
 }
 
-- (void)setSoftButtons:(nullable NSMutableArray<SDLSoftButton *> *)softButtons {
+- (void)setSoftButtons:(nullable NSArray<SDLSoftButton *> *)softButtons {
     [parameters sdl_setObject:softButtons forName:SDLNameSoftButtons];
 }
 
-- (nullable NSMutableArray<SDLSoftButton *> *)softButtons {
+- (nullable NSArray<SDLSoftButton *> *)softButtons {
     return [parameters sdl_objectsForName:SDLNameSoftButtons ofClass:SDLSoftButton.class];
 }
 

--- a/SmartDeviceLink/SDLSetDisplayLayoutResponse.h
+++ b/SmartDeviceLink/SDLSetDisplayLayoutResponse.h
@@ -19,8 +19,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SDLSetDisplayLayoutResponse : SDLRPCResponse
 
 @property (nullable, strong, nonatomic) SDLDisplayCapabilities *displayCapabilities;
-@property (nullable, strong, nonatomic) NSMutableArray<SDLButtonCapabilities *> *buttonCapabilities;
-@property (nullable, strong, nonatomic) NSMutableArray<SDLSoftButtonCapabilities *> *softButtonCapabilities;
+@property (nullable, strong, nonatomic) NSArray<SDLButtonCapabilities *> *buttonCapabilities;
+@property (nullable, strong, nonatomic) NSArray<SDLSoftButtonCapabilities *> *softButtonCapabilities;
 @property (nullable, strong, nonatomic) SDLPresetBankCapabilities *presetBankCapabilities;
 
 @end

--- a/SmartDeviceLink/SDLSetDisplayLayoutResponse.m
+++ b/SmartDeviceLink/SDLSetDisplayLayoutResponse.m
@@ -29,19 +29,19 @@ NS_ASSUME_NONNULL_BEGIN
     return [parameters sdl_objectForName:SDLNameDisplayCapabilities ofClass:SDLDisplayCapabilities.class];
 }
 
-- (void)setButtonCapabilities:(nullable NSMutableArray<SDLButtonCapabilities *> *)buttonCapabilities {
+- (void)setButtonCapabilities:(nullable NSArray<SDLButtonCapabilities *> *)buttonCapabilities {
     [parameters sdl_setObject:buttonCapabilities forName:SDLNameButtonCapabilities];
 }
 
-- (nullable NSMutableArray<SDLButtonCapabilities *> *)buttonCapabilities {
+- (nullable NSArray<SDLButtonCapabilities *> *)buttonCapabilities {
     return [parameters sdl_objectsForName:SDLNameButtonCapabilities ofClass:SDLButtonCapabilities.class];
 }
 
-- (void)setSoftButtonCapabilities:(nullable NSMutableArray<SDLSoftButtonCapabilities *> *)softButtonCapabilities {
+- (void)setSoftButtonCapabilities:(nullable NSArray<SDLSoftButtonCapabilities *> *)softButtonCapabilities {
     [parameters sdl_setObject:softButtonCapabilities forName:SDLNameSoftButtonCapabilities];
 }
 
-- (nullable NSMutableArray<SDLSoftButtonCapabilities *> *)softButtonCapabilities {
+- (nullable NSArray<SDLSoftButtonCapabilities *> *)softButtonCapabilities {
     return [parameters sdl_objectsForName:SDLNameSoftButtonCapabilities ofClass:SDLSoftButtonCapabilities.class];
 }
 

--- a/SmartDeviceLink/SDLSetGlobalProperties.h
+++ b/SmartDeviceLink/SDLSetGlobalProperties.h
@@ -42,14 +42,14 @@ NS_ASSUME_NONNULL_BEGIN
  *            <li>Only optional it timeoutPrompt has been specified</li>
  *            </ul>
  */
-@property (strong, nonatomic, nullable) NSMutableArray<SDLTTSChunk *> *helpPrompt;
+@property (strong, nonatomic, nullable) NSArray<SDLTTSChunk *> *helpPrompt;
 /**
  * @abstract A Vector<TTSChunk> for Timeout Prompt representing Array of one or
  * more TTSChunk elements specifying the help prompt used in an interaction
  * started by PTT
  *
  */
-@property (strong, nonatomic, nullable) NSMutableArray<SDLTTSChunk *> *timeoutPrompt;
+@property (strong, nonatomic, nullable) NSArray<SDLTTSChunk *> *timeoutPrompt;
 /**
  * @abstract Sets a voice recognition Help Title
  *
@@ -86,7 +86,7 @@ NS_ASSUME_NONNULL_BEGIN
  *            </ul>
  * @since SmartDeviceLink 2.0
  */
-@property (strong, nonatomic, nullable) NSMutableArray<SDLVRHelpItem *> *vrHelp;
+@property (strong, nonatomic, nullable) NSArray<SDLVRHelpItem *> *vrHelp;
 @property (strong, nonatomic, nullable) NSString *menuTitle;
 @property (strong, nonatomic, nullable) SDLImage *menuIcon;
 @property (strong, nonatomic, nullable) SDLKeyboardProperties *keyboardProperties;

--- a/SmartDeviceLink/SDLSetGlobalProperties.m
+++ b/SmartDeviceLink/SDLSetGlobalProperties.m
@@ -46,19 +46,19 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (void)setHelpPrompt:(nullable NSMutableArray<SDLTTSChunk *> *)helpPrompt {
+- (void)setHelpPrompt:(nullable NSArray<SDLTTSChunk *> *)helpPrompt {
     [parameters sdl_setObject:helpPrompt forName:SDLNameHelpPrompt];
 }
 
-- (nullable NSMutableArray<SDLTTSChunk *> *)helpPrompt {
+- (nullable NSArray<SDLTTSChunk *> *)helpPrompt {
     return [parameters sdl_objectsForName:SDLNameHelpPrompt ofClass:SDLTTSChunk.class];
 }
 
-- (void)setTimeoutPrompt:(nullable NSMutableArray<SDLTTSChunk *> *)timeoutPrompt {
+- (void)setTimeoutPrompt:(nullable NSArray<SDLTTSChunk *> *)timeoutPrompt {
     [parameters sdl_setObject:timeoutPrompt forName:SDLNameTimeoutPrompt];
 }
 
-- (nullable NSMutableArray<SDLTTSChunk *> *)timeoutPrompt {
+- (nullable NSArray<SDLTTSChunk *> *)timeoutPrompt {
     return [parameters sdl_objectsForName:SDLNameTimeoutPrompt ofClass:SDLTTSChunk.class];
 }
 
@@ -70,11 +70,11 @@ NS_ASSUME_NONNULL_BEGIN
     return [parameters sdl_objectForName:SDLNameVRHelpTitle];
 }
 
-- (void)setVrHelp:(nullable NSMutableArray<SDLVRHelpItem *> *)vrHelp {
+- (void)setVrHelp:(nullable NSArray<SDLVRHelpItem *> *)vrHelp {
     [parameters sdl_setObject:vrHelp forName:SDLNameVRHelp];
 }
 
-- (nullable NSMutableArray<SDLVRHelpItem *> *)vrHelp {
+- (nullable NSArray<SDLVRHelpItem *> *)vrHelp {
     return [parameters sdl_objectsForName:SDLNameVRHelp ofClass:SDLVRHelpItem.class];
 }
 

--- a/SmartDeviceLink/SDLShow.h
+++ b/SmartDeviceLink/SDLShow.h
@@ -215,7 +215,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @since SmartDeviceLink 2.0
  */
-@property (strong, nonatomic, nullable) NSMutableArray<SDLSoftButton *> *softButtons;
+@property (strong, nonatomic, nullable) NSArray<SDLSoftButton *> *softButtons;
 /**
  * @abstract The Custom Presets defined by the App
  *
@@ -229,7 +229,7 @@ NS_ASSUME_NONNULL_BEGIN
  *            </ul>
  * @since SmartDeviceLink 2.0
  */
-@property (strong, nonatomic, nullable) NSMutableArray<NSString *> *customPresets;
+@property (strong, nonatomic, nullable) NSArray<NSString *> *customPresets;
 
 @end
 

--- a/SmartDeviceLink/SDLShow.m
+++ b/SmartDeviceLink/SDLShow.m
@@ -132,19 +132,19 @@ NS_ASSUME_NONNULL_BEGIN
     return [parameters sdl_objectForName:SDLNameSecondaryGraphic ofClass:SDLImage.class];
 }
 
-- (void)setSoftButtons:(nullable NSMutableArray<SDLSoftButton *> *)softButtons {
+- (void)setSoftButtons:(nullable NSArray<SDLSoftButton *> *)softButtons {
     [parameters sdl_setObject:softButtons forName:SDLNameSoftButtons];
 }
 
-- (nullable NSMutableArray<SDLSoftButton *> *)softButtons {
+- (nullable NSArray<SDLSoftButton *> *)softButtons {
     return [parameters sdl_objectsForName:SDLNameSoftButtons ofClass:SDLSoftButton.class];
 }
 
-- (void)setCustomPresets:(nullable NSMutableArray<NSString *> *)customPresets {
+- (void)setCustomPresets:(nullable NSArray<NSString *> *)customPresets {
     [parameters sdl_setObject:customPresets forName:SDLNameCustomPresets];
 }
 
-- (nullable NSMutableArray<NSString *> *)customPresets {
+- (nullable NSArray<NSString *> *)customPresets {
     return [parameters sdl_objectForName:SDLNameCustomPresets];
 }
 

--- a/SmartDeviceLink/SDLShowConstantTBT.h
+++ b/SmartDeviceLink/SDLShowConstantTBT.h
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic, nullable) NSNumber<SDLFloat> *distanceToManeuver;
 @property (strong, nonatomic, nullable) NSNumber<SDLFloat> *distanceToManeuverScale;
 @property (strong, nonatomic, nullable) NSNumber<SDLBool> *maneuverComplete;
-@property (strong, nonatomic, nullable) NSMutableArray<SDLSoftButton *> *softButtons;
+@property (strong, nonatomic, nullable) NSArray<SDLSoftButton *> *softButtons;
 
 @end
 

--- a/SmartDeviceLink/SDLShowConstantTBT.m
+++ b/SmartDeviceLink/SDLShowConstantTBT.m
@@ -120,11 +120,11 @@ NS_ASSUME_NONNULL_BEGIN
     return [parameters sdl_objectForName:SDLNameManeuverComplete];
 }
 
-- (void)setSoftButtons:(nullable NSMutableArray<SDLSoftButton *> *)softButtons {
+- (void)setSoftButtons:(nullable NSArray<SDLSoftButton *> *)softButtons {
     [parameters sdl_setObject:softButtons forName:SDLNameSoftButtons];
 }
 
-- (nullable NSMutableArray<SDLSoftButton *> *)softButtons {
+- (nullable NSArray<SDLSoftButton *> *)softButtons {
     return [parameters sdl_objectsForName:SDLNameSoftButtons ofClass:SDLSoftButton.class];
 }
 

--- a/SmartDeviceLink/SDLSlider.h
+++ b/SmartDeviceLink/SDLSlider.h
@@ -56,7 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * Optional, Array of Strings, Array length 1 - 26, Max string length 500 chars
  */
-@property (strong, nonatomic, nullable) NSMutableArray<NSString *> *sliderFooter;
+@property (strong, nonatomic, nullable) NSArray<NSString *> *sliderFooter;
 
 /**
  * @abstract An App defined timeout

--- a/SmartDeviceLink/SDLSlider.m
+++ b/SmartDeviceLink/SDLSlider.m
@@ -77,11 +77,11 @@ NS_ASSUME_NONNULL_BEGIN
     return [parameters sdl_objectForName:SDLNameSliderHeader];
 }
 
-- (void)setSliderFooter:(nullable NSMutableArray<NSString *> *)sliderFooter {
+- (void)setSliderFooter:(nullable NSArray<NSString *> *)sliderFooter {
     [parameters sdl_setObject:sliderFooter forName:SDLNameSliderFooter];
 }
 
-- (nullable NSMutableArray<NSString *> *)sliderFooter {
+- (nullable NSArray<NSString *> *)sliderFooter {
     return [parameters sdl_objectForName:SDLNameSliderFooter];
 }
 

--- a/SmartDeviceLink/SDLSpeak.h
+++ b/SmartDeviceLink/SDLSpeak.h
@@ -56,7 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
  * 
  * @see SDLTTSChunk
  */
-@property (strong, nonatomic) NSMutableArray<SDLTTSChunk *> *ttsChunks;
+@property (strong, nonatomic) NSArray<SDLTTSChunk *> *ttsChunks;
 
 @end
 

--- a/SmartDeviceLink/SDLSpeak.m
+++ b/SmartDeviceLink/SDLSpeak.m
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (instancetype)initWithTTS:(NSString *)ttsText {
-    NSMutableArray *ttsChunks = [SDLTTSChunk textChunksFromString:ttsText];
+    NSArray *ttsChunks = [SDLTTSChunk textChunksFromString:ttsText];
     return [self initWithTTSChunks:ttsChunks];
 }
 
@@ -34,11 +34,11 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (void)setTtsChunks:(NSMutableArray<SDLTTSChunk *> *)ttsChunks {
+- (void)setTtsChunks:(NSArray<SDLTTSChunk *> *)ttsChunks {
     [parameters sdl_setObject:ttsChunks forName:SDLNameTTSChunks];
 }
 
-- (NSMutableArray<SDLTTSChunk *> *)ttsChunks {
+- (NSArray<SDLTTSChunk *> *)ttsChunks {
     return [parameters sdl_objectsForName:SDLNameTTSChunks ofClass:SDLTTSChunk.class];
 }
 

--- a/SmartDeviceLink/SDLTTSChunk.h
+++ b/SmartDeviceLink/SDLTTSChunk.h
@@ -43,15 +43,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithText:(NSString *)text type:(SDLSpeechCapabilities)type;
 
-+ (NSMutableArray<SDLTTSChunk *> *)textChunksFromString:(NSString *)string;
++ (NSArray<SDLTTSChunk *> *)textChunksFromString:(NSString *)string;
 
-+ (NSMutableArray<SDLTTSChunk *> *)sapiChunksFromString:(NSString *)string;
++ (NSArray<SDLTTSChunk *> *)sapiChunksFromString:(NSString *)string;
 
-+ (NSMutableArray<SDLTTSChunk *> *)lhPlusChunksFromString:(NSString *)string;
++ (NSArray<SDLTTSChunk *> *)lhPlusChunksFromString:(NSString *)string;
 
-+ (NSMutableArray<SDLTTSChunk *> *)prerecordedChunksFromString:(NSString *)string;
++ (NSArray<SDLTTSChunk *> *)prerecordedChunksFromString:(NSString *)string;
 
-+ (NSMutableArray<SDLTTSChunk *> *)silenceChunks;
++ (NSArray<SDLTTSChunk *> *)silenceChunks;
 
 
 /**

--- a/SmartDeviceLink/SDLTTSChunk.m
+++ b/SmartDeviceLink/SDLTTSChunk.m
@@ -22,32 +22,32 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-+ (NSMutableArray<SDLTTSChunk *> *)textChunksFromString:(NSString *)string {
++ (NSArray<SDLTTSChunk *> *)textChunksFromString:(NSString *)string {
     return [self sdl_chunksFromString:string type:SDLSpeechCapabilitiesText];
 }
 
-+ (NSMutableArray<SDLTTSChunk *> *)sapiChunksFromString:(NSString *)string {
++ (NSArray<SDLTTSChunk *> *)sapiChunksFromString:(NSString *)string {
     return [self sdl_chunksFromString:string type:SDLSpeechCapabilitiesSAPIPhonemes];
 }
 
-+ (NSMutableArray<SDLTTSChunk *> *)lhPlusChunksFromString:(NSString *)string {
++ (NSArray<SDLTTSChunk *> *)lhPlusChunksFromString:(NSString *)string {
     return [self sdl_chunksFromString:string type:SDLSpeechCapabilitiesLHPlusPhonemes];
 }
 
-+ (NSMutableArray<SDLTTSChunk *> *)prerecordedChunksFromString:(NSString *)string {
++ (NSArray<SDLTTSChunk *> *)prerecordedChunksFromString:(NSString *)string {
     return [self sdl_chunksFromString:string type:SDLSpeechCapabilitiesPrerecorded];
 }
 
-+ (NSMutableArray<SDLTTSChunk *> *)silenceChunks {
++ (NSArray<SDLTTSChunk *> *)silenceChunks {
     return [self sdl_chunksFromString:nil type:SDLSpeechCapabilitiesSilence];
 }
 
-+ (nullable NSMutableArray<SDLTTSChunk *> *)sdl_chunksFromString:(nullable NSString *)string type:(SDLSpeechCapabilities)type {
++ (nullable NSArray<SDLTTSChunk *> *)sdl_chunksFromString:(nullable NSString *)string type:(SDLSpeechCapabilities)type {
     if (string.length == 0) {
         return nil;
     }
 
-    return [NSMutableArray arrayWithObject:[[[self class] alloc] initWithText:string type:type]];
+    return [NSArray arrayWithObject:[[[self class] alloc] initWithText:string type:type]];
 }
 
 - (void)setText:(NSString *)text {

--- a/SmartDeviceLink/SDLTouchEvent.h
+++ b/SmartDeviceLink/SDLTouchEvent.h
@@ -30,12 +30,12 @@ NS_ASSUME_NONNULL_BEGIN
  
  Mandatory, array size 1-1000, contains <NSNumber> size 0-5000000000
  */
-@property (strong, nonatomic) NSMutableArray<NSNumber<SDLInt> *> *timeStamp;
+@property (strong, nonatomic) NSArray<NSNumber<SDLInt> *> *timeStamp;
 
 /**
  *  Mandatory, array size 1-1000, contains SDLTouchCoord
  */
-@property (strong, nonatomic) NSMutableArray<SDLTouchCoord *> *coord;
+@property (strong, nonatomic) NSArray<SDLTouchCoord *> *coord;
 
 @end
 

--- a/SmartDeviceLink/SDLTouchEvent.m
+++ b/SmartDeviceLink/SDLTouchEvent.m
@@ -20,19 +20,19 @@ NS_ASSUME_NONNULL_BEGIN
     return [store sdl_objectForName:SDLNameId];
 }
 
-- (void)setTimeStamp:(NSMutableArray<NSNumber<SDLInt> *> *)timeStamp {
+- (void)setTimeStamp:(NSArray<NSNumber<SDLInt> *> *)timeStamp {
     [store sdl_setObject:timeStamp forName:SDLNameTimestamp];
 }
 
-- (NSMutableArray<NSNumber<SDLInt> *> *)timeStamp {
+- (NSArray<NSNumber<SDLInt> *> *)timeStamp {
     return [store sdl_objectForName:SDLNameTimestamp];
 }
 
-- (void)setCoord:(NSMutableArray<SDLTouchCoord *> *)coord {
+- (void)setCoord:(NSArray<SDLTouchCoord *> *)coord {
     [store sdl_setObject:coord forName:SDLNameCoordinate];
 }
 
-- (NSMutableArray<SDLTouchCoord *> *)coord {
+- (NSArray<SDLTouchCoord *> *)coord {
     return [store sdl_objectsForName:SDLNameCoordinate ofClass:SDLTouchCoord.class];
 }
 

--- a/SmartDeviceLink/SDLUpdateTurnList.h
+++ b/SmartDeviceLink/SDLUpdateTurnList.h
@@ -22,12 +22,12 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Optional, SDLTurn, 1 - 100 entries
  */
-@property (strong, nonatomic, nullable) NSMutableArray<SDLTurn *> *turnList;
+@property (strong, nonatomic, nullable) NSArray<SDLTurn *> *turnList;
 
 /**
  *  Required, SDLSoftButton, 0 - 1 Entries
  */
-@property (strong, nonatomic, nullable) NSMutableArray<SDLSoftButton *> *softButtons;
+@property (strong, nonatomic, nullable) NSArray<SDLSoftButton *> *softButtons;
 
 @end
 

--- a/SmartDeviceLink/SDLUpdateTurnList.m
+++ b/SmartDeviceLink/SDLUpdateTurnList.m
@@ -31,19 +31,19 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (void)setTurnList:(nullable NSMutableArray<SDLTurn *> *)turnList {
+- (void)setTurnList:(nullable NSArray<SDLTurn *> *)turnList {
     [parameters sdl_setObject:turnList forName:SDLNameTurnList];
 }
 
-- (nullable NSMutableArray<SDLTurn *> *)turnList {
+- (nullable NSArray<SDLTurn *> *)turnList {
     return [parameters sdl_objectsForName:SDLNameTurnList ofClass:SDLTurn.class];
 }
 
-- (void)setSoftButtons:(nullable NSMutableArray<SDLSoftButton *> *)softButtons {
+- (void)setSoftButtons:(nullable NSArray<SDLSoftButton *> *)softButtons {
     [parameters sdl_setObject:softButtons forName:SDLNameSoftButtons];
 }
 
-- (nullable NSMutableArray<SDLSoftButton *> *)softButtons {
+- (nullable NSArray<SDLSoftButton *> *)softButtons {
     return [parameters sdl_objectsForName:SDLNameSoftButtons ofClass:SDLSoftButton.class];
 }
 

--- a/SmartDeviceLink/SmartDeviceLink.h
+++ b/SmartDeviceLink/SmartDeviceLink.h
@@ -306,7 +306,6 @@ FOUNDATION_EXPORT const unsigned char SmartDeviceLinkVersionString[];
 #import "SDLPermissionManager.h"
 
 // Utilities
-#import "NSMutableDictionary+Store.h"
 #import "NSNumber+NumberType.h"
 #import "SDLErrorConstants.h"
 #import "SDLNotificationConstants.h"

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLFileManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLFileManagerSpec.m
@@ -94,7 +94,7 @@ describe(@"SDLFileManager", ^{
                 testListFilesResponse = [[SDLListFilesResponse alloc] init];
                 testListFilesResponse.success = @YES;
                 testListFilesResponse.spaceAvailable = @(initialSpaceAvailable);
-                testListFilesResponse.filenames = [NSMutableArray arrayWithArray:[testInitialFileNames allObjects]];
+                testListFilesResponse.filenames = [NSArray arrayWithArray:[testInitialFileNames allObjects]];
                 
                 [testConnectionManager respondToLastRequestWithResponse:testListFilesResponse];
             });

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLListFilesOperationSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLListFilesOperationSpec.m
@@ -45,11 +45,11 @@ describe(@"List Files Operation", ^{
         context(@"when a good response comes back", ^{
             __block SDLListFilesResponse *goodResponse = nil;
             __block NSNumber *responseSpaceAvailable = nil;
-            __block NSMutableArray<NSString *> *responseFileNames = nil;
+            __block NSArray<NSString *> *responseFileNames = nil;
             
             beforeEach(^{
                 responseSpaceAvailable = @(11212512);
-                responseFileNames = [NSMutableArray arrayWithArray:@[@"test1", @"test2"]];
+                responseFileNames = [NSArray arrayWithArray:@[@"test1", @"test2"]];
                 
                 goodResponse = [[SDLListFilesResponse alloc] init];
                 goodResponse.success = @YES;
@@ -76,14 +76,14 @@ describe(@"List Files Operation", ^{
         context(@"when a bad response comes back", ^{
             __block SDLListFilesResponse *badResponse = nil;
             __block NSNumber *responseSpaceAvailable = nil;
-            __block NSMutableArray<NSString *> *responseFileNames = nil;
+            __block NSArray<NSString *> *responseFileNames = nil;
             
             __block NSString *responseErrorDescription = nil;
             __block NSString *responseErrorReason = nil;
             
             beforeEach(^{
                 responseSpaceAvailable = @(0);
-                responseFileNames = [NSMutableArray arrayWithArray:@[]];
+                responseFileNames = [NSArray arrayWithArray:@[]];
                 
                 responseErrorDescription = @"some description";
                 responseErrorReason = @"some reason";

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLListFilesOperationSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLListFilesOperationSpec.m
@@ -49,7 +49,7 @@ describe(@"List Files Operation", ^{
             
             beforeEach(^{
                 responseSpaceAvailable = @(11212512);
-                responseFileNames = [NSArray arrayWithArray:@[@"test1", @"test2"]];
+                responseFileNames = @[@"test1", @"test2"];
                 
                 goodResponse = [[SDLListFilesResponse alloc] init];
                 goodResponse.success = @YES;
@@ -83,7 +83,7 @@ describe(@"List Files Operation", ^{
             
             beforeEach(^{
                 responseSpaceAvailable = @(0);
-                responseFileNames = [NSArray arrayWithArray:@[]];
+                responseFileNames = @[];
                 
                 responseErrorDescription = @"some description";
                 responseErrorReason = @"some reason";

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLPermissionsManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLPermissionsManagerSpec.m
@@ -55,18 +55,18 @@ describe(@"SDLPermissionsManager", ^{
         
         // Permission states
         testHMIPermissionsAllAllowed = [[SDLHMIPermissions alloc] init];
-        testHMIPermissionsAllAllowed.allowed = [NSMutableArray arrayWithArray:@[SDLHMILevelBackground, SDLHMILevelFull, SDLHMILevelLimited, SDLHMILevelNone]];
+        testHMIPermissionsAllAllowed.allowed = [NSArray arrayWithArray:@[SDLHMILevelBackground, SDLHMILevelFull, SDLHMILevelLimited, SDLHMILevelNone]];
         
         testHMIPermissionsAllDisallowed = [[SDLHMIPermissions alloc] init];
-        testHMIPermissionsAllDisallowed.userDisallowed = [NSMutableArray arrayWithArray:@[SDLHMILevelBackground, SDLHMILevelFull, SDLHMILevelLimited, SDLHMILevelNone]];
+        testHMIPermissionsAllDisallowed.userDisallowed = [NSArray arrayWithArray:@[SDLHMILevelBackground, SDLHMILevelFull, SDLHMILevelLimited, SDLHMILevelNone]];
         
         testHMIPermissionsFullLimitedAllowed = [[SDLHMIPermissions alloc] init];
-        testHMIPermissionsFullLimitedAllowed.allowed = [NSMutableArray arrayWithArray:@[SDLHMILevelFull, SDLHMILevelLimited]];
-        testHMIPermissionsFullLimitedAllowed.userDisallowed = [NSMutableArray arrayWithArray:@[SDLHMILevelBackground, SDLHMILevelNone]];
+        testHMIPermissionsFullLimitedAllowed.allowed = [NSArray arrayWithArray:@[SDLHMILevelFull, SDLHMILevelLimited]];
+        testHMIPermissionsFullLimitedAllowed.userDisallowed = [NSArray arrayWithArray:@[SDLHMILevelBackground, SDLHMILevelNone]];
         
         testHMIPermissionsFullLimitedBackgroundAllowed = [[SDLHMIPermissions alloc] init];
-        testHMIPermissionsFullLimitedBackgroundAllowed.allowed = [NSMutableArray arrayWithArray:@[SDLHMILevelFull, SDLHMILevelLimited, SDLHMILevelBackground]];
-        testHMIPermissionsFullLimitedBackgroundAllowed.userDisallowed = [NSMutableArray arrayWithArray:@[SDLHMILevelNone]];
+        testHMIPermissionsFullLimitedBackgroundAllowed.allowed = [NSArray arrayWithArray:@[SDLHMILevelFull, SDLHMILevelLimited, SDLHMILevelBackground]];
+        testHMIPermissionsFullLimitedBackgroundAllowed.userDisallowed = [NSArray arrayWithArray:@[SDLHMILevelNone]];
         
         // Assemble Permissions
         SDLParameterPermissions *testParameterPermissions = [[SDLParameterPermissions alloc] init];
@@ -103,7 +103,7 @@ describe(@"SDLPermissionsManager", ^{
         
         // Create OnPermissionsChange object
         testPermissionsChange = [[SDLOnPermissionsChange alloc] init];
-        testPermissionsChange.permissionItem = [NSMutableArray arrayWithArray:@[testPermissionAllAllowed, testPermissionAllDisallowed, testPermissionFullLimitedAllowed, testPermissionFullLimitedBackgroundAllowed]];
+        testPermissionsChange.permissionItem = [NSArray arrayWithArray:@[testPermissionAllAllowed, testPermissionAllDisallowed, testPermissionFullLimitedAllowed, testPermissionFullLimitedBackgroundAllowed]];
         
         // Permission Notifications
         testPermissionsNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidChangePermissionsNotification object:nil rpcNotification:testPermissionsChange];
@@ -367,15 +367,15 @@ describe(@"SDLPermissionsManager", ^{
             
             __block SDLOnPermissionsChange *testPermissionChangeUpdate = nil;
             __block SDLPermissionItem *testPermissionUpdated = nil;
-            __block NSMutableArray<NSDictionary<SDLPermissionRPCName,NSNumber<SDLBool> *> *> *changeDicts = nil;
-            __block NSMutableArray<NSNumber<SDLUInt> *> *testStatuses = nil;
+            __block NSArray<NSDictionary<SDLPermissionRPCName,NSNumber<SDLBool> *> *> *changeDicts = nil;
+            __block NSArray<NSNumber<SDLUInt> *> *testStatuses = nil;
             
             context(@"to match an ANY observer", ^{
                 beforeEach(^{
                     // Reset vars
                     numberOfTimesObserverCalled = 0;
-                    changeDicts = [NSMutableArray array];
-                    testStatuses = [NSMutableArray array];
+                    changeDicts = [NSArray array];
+                    testStatuses = [NSArray array];
                     
                     // Post the notification before setting the observer to make sure data is already present
                     // HMI Full & Limited allowed, hmi level LIMITED
@@ -391,8 +391,8 @@ describe(@"SDLPermissionsManager", ^{
                     // Create a permission update disallowing our current HMI level for the observed permission
                     SDLParameterPermissions *testParameterPermissions = [[SDLParameterPermissions alloc] init];
                     SDLHMIPermissions *testHMIPermissionsUpdated = [[SDLHMIPermissions alloc] init];
-                    testHMIPermissionsUpdated.allowed = [NSMutableArray arrayWithArray:@[SDLHMILevelBackground, SDLHMILevelFull]];
-                    testHMIPermissionsUpdated.userDisallowed = [NSMutableArray arrayWithArray:@[SDLHMILevelLimited, SDLHMILevelNone]];
+                    testHMIPermissionsUpdated.allowed = [NSArray arrayWithArray:@[SDLHMILevelBackground, SDLHMILevelFull]];
+                    testHMIPermissionsUpdated.userDisallowed = [NSArray arrayWithArray:@[SDLHMILevelLimited, SDLHMILevelNone]];
                     
                     testPermissionUpdated = [[SDLPermissionItem alloc] init];
                     testPermissionUpdated.rpcName = testRPCNameAllAllowed;
@@ -400,7 +400,7 @@ describe(@"SDLPermissionsManager", ^{
                     testPermissionUpdated.parameterPermissions = testParameterPermissions;
                     
                     testPermissionChangeUpdate = [[SDLOnPermissionsChange alloc] init];
-                    testPermissionChangeUpdate.permissionItem = [NSMutableArray arrayWithObject:testPermissionUpdated];
+                    testPermissionChangeUpdate.permissionItem = [NSArray arrayWithObject:testPermissionUpdated];
                     
                     // Send the permission update
                     NSNotification *updatedNotification = [NSNotification notificationWithName:SDLDidChangePermissionsNotification object:nil userInfo:@{SDLNotificationUserInfoObject: testPermissionChangeUpdate}];
@@ -438,8 +438,8 @@ describe(@"SDLPermissionsManager", ^{
                 beforeEach(^{
                     // Reset vars
                     numberOfTimesObserverCalled = 0;
-                    changeDicts = [NSMutableArray array];
-                    testStatuses = [NSMutableArray array];
+                    changeDicts = [NSArray array];
+                    testStatuses = [NSArray array];
                     
                     // Post the notification before setting the observer to make sure data is already present
                     // HMI Full & Limited allowed, hmi level BACKGROUND
@@ -459,8 +459,8 @@ describe(@"SDLPermissionsManager", ^{
                         // Create a permission update allowing our current HMI level for the observed permission
                         SDLParameterPermissions *testParameterPermissions = [[SDLParameterPermissions alloc] init];
                         SDLHMIPermissions *testHMIPermissionsUpdated = [[SDLHMIPermissions alloc] init];
-                        testHMIPermissionsUpdated.allowed = [NSMutableArray arrayWithArray:@[SDLHMILevelLimited, SDLHMILevelNone, SDLHMILevelBackground, SDLHMILevelFull]];
-                        testHMIPermissionsUpdated.userDisallowed = [NSMutableArray arrayWithArray:@[]];
+                        testHMIPermissionsUpdated.allowed = [NSArray arrayWithArray:@[SDLHMILevelLimited, SDLHMILevelNone, SDLHMILevelBackground, SDLHMILevelFull]];
+                        testHMIPermissionsUpdated.userDisallowed = [NSArray arrayWithArray:@[]];
                         
                         testPermissionUpdated = [[SDLPermissionItem alloc] init];
                         testPermissionUpdated.rpcName = testRPCNameAllDisallowed;
@@ -468,7 +468,7 @@ describe(@"SDLPermissionsManager", ^{
                         testPermissionUpdated.parameterPermissions = testParameterPermissions;
                         
                         testPermissionChangeUpdate = [[SDLOnPermissionsChange alloc] init];
-                        testPermissionChangeUpdate.permissionItem = [NSMutableArray arrayWithObject:testPermissionUpdated];
+                        testPermissionChangeUpdate.permissionItem = [NSArray arrayWithObject:testPermissionUpdated];
                         
                         // Send the permission update
                         NSNotification *updatedNotification = [NSNotification notificationWithName:SDLDidChangePermissionsNotification object:nil userInfo:@{SDLNotificationUserInfoObject: testPermissionChangeUpdate}];
@@ -502,8 +502,8 @@ describe(@"SDLPermissionsManager", ^{
                         // Create a permission update disallowing our current HMI level for the observed permission
                         SDLParameterPermissions *testParameterPermissions = [[SDLParameterPermissions alloc] init];
                         SDLHMIPermissions *testHMIPermissionsUpdated = [[SDLHMIPermissions alloc] init];
-                        testHMIPermissionsUpdated.allowed = [NSMutableArray arrayWithArray:@[]];
-                        testHMIPermissionsUpdated.userDisallowed = [NSMutableArray arrayWithArray:@[SDLHMILevelBackground, SDLHMILevelFull, SDLHMILevelLimited, SDLHMILevelNone]];
+                        testHMIPermissionsUpdated.allowed = [NSArray arrayWithArray:@[]];
+                        testHMIPermissionsUpdated.userDisallowed = [NSArray arrayWithArray:@[SDLHMILevelBackground, SDLHMILevelFull, SDLHMILevelLimited, SDLHMILevelNone]];
                         
                         testPermissionUpdated = [[SDLPermissionItem alloc] init];
                         testPermissionUpdated.rpcName = testRPCNameAllAllowed;
@@ -511,7 +511,7 @@ describe(@"SDLPermissionsManager", ^{
                         testPermissionUpdated.parameterPermissions = testParameterPermissions;
                         
                         testPermissionChangeUpdate = [[SDLOnPermissionsChange alloc] init];
-                        testPermissionChangeUpdate.permissionItem = [NSMutableArray arrayWithObject:testPermissionUpdated];
+                        testPermissionChangeUpdate.permissionItem = [NSArray arrayWithObject:testPermissionUpdated];
                         
                         // Send the permission update
                         NSNotification *updatedNotification = [NSNotification notificationWithName:SDLDidChangePermissionsNotification object:nil userInfo:@{SDLNotificationUserInfoObject: testPermissionChangeUpdate}];
@@ -544,8 +544,8 @@ describe(@"SDLPermissionsManager", ^{
                 beforeEach(^{
                     // Reset vars
                     numberOfTimesObserverCalled = 0;
-                    changeDicts = [NSMutableArray array];
-                    testStatuses = [NSMutableArray array];
+                    changeDicts = [NSArray array];
+                    testStatuses = [NSArray array];
                     
                     // Post the notification before setting the observer to make sure data is already present
                     // HMI Full & Limited allowed, hmi level BACKGROUND
@@ -565,8 +565,8 @@ describe(@"SDLPermissionsManager", ^{
                         // Create a permission update disallowing our current HMI level for the observed permission
                         SDLParameterPermissions *testParameterPermissions = [[SDLParameterPermissions alloc] init];
                         SDLHMIPermissions *testHMIPermissionsUpdated = [[SDLHMIPermissions alloc] init];
-                        testHMIPermissionsUpdated.allowed = [NSMutableArray arrayWithArray:@[]];
-                        testHMIPermissionsUpdated.userDisallowed = [NSMutableArray arrayWithArray:@[SDLHMILevelBackground, SDLHMILevelFull, SDLHMILevelLimited, SDLHMILevelNone]];
+                        testHMIPermissionsUpdated.allowed = [NSArray arrayWithArray:@[]];
+                        testHMIPermissionsUpdated.userDisallowed = [NSArray arrayWithArray:@[SDLHMILevelBackground, SDLHMILevelFull, SDLHMILevelLimited, SDLHMILevelNone]];
                         
                         testPermissionUpdated = [[SDLPermissionItem alloc] init];
                         testPermissionUpdated.rpcName = testRPCNameAllAllowed;
@@ -574,7 +574,7 @@ describe(@"SDLPermissionsManager", ^{
                         testPermissionUpdated.parameterPermissions = testParameterPermissions;
                         
                         testPermissionChangeUpdate = [[SDLOnPermissionsChange alloc] init];
-                        testPermissionChangeUpdate.permissionItem = [NSMutableArray arrayWithObject:testPermissionUpdated];
+                        testPermissionChangeUpdate.permissionItem = [NSArray arrayWithObject:testPermissionUpdated];
                         
                         // Send the permission update
                         NSNotification *updatedNotification = [NSNotification notificationWithName:SDLDidChangePermissionsNotification object:nil userInfo:@{SDLNotificationUserInfoObject: testPermissionChangeUpdate}];
@@ -599,8 +599,8 @@ describe(@"SDLPermissionsManager", ^{
                         // Create a permission update disallowing our current HMI level for the observed permission
                         SDLParameterPermissions *testParameterPermissions = [[SDLParameterPermissions alloc] init];
                         SDLHMIPermissions *testHMIPermissionsUpdated = [[SDLHMIPermissions alloc] init];
-                        testHMIPermissionsUpdated.allowed = [NSMutableArray arrayWithArray:@[SDLHMILevelLimited, SDLHMILevelBackground]];
-                        testHMIPermissionsUpdated.userDisallowed = [NSMutableArray arrayWithArray:@[SDLHMILevelFull, SDLHMILevelNone]];
+                        testHMIPermissionsUpdated.allowed = [NSArray arrayWithArray:@[SDLHMILevelLimited, SDLHMILevelBackground]];
+                        testHMIPermissionsUpdated.userDisallowed = [NSArray arrayWithArray:@[SDLHMILevelFull, SDLHMILevelNone]];
                         
                         testPermissionUpdated = [[SDLPermissionItem alloc] init];
                         testPermissionUpdated.rpcName = testRPCNameAllAllowed;
@@ -608,7 +608,7 @@ describe(@"SDLPermissionsManager", ^{
                         testPermissionUpdated.parameterPermissions = testParameterPermissions;
                         
                         testPermissionChangeUpdate = [[SDLOnPermissionsChange alloc] init];
-                        testPermissionChangeUpdate.permissionItem = [NSMutableArray arrayWithObject:testPermissionUpdated];
+                        testPermissionChangeUpdate.permissionItem = [NSArray arrayWithObject:testPermissionUpdated];
                         
                         // Send the permission update
                         NSNotification *updatedNotification = [NSNotification notificationWithName:SDLDidChangePermissionsNotification object:nil userInfo:@{SDLNotificationUserInfoObject: testPermissionChangeUpdate}];
@@ -625,15 +625,15 @@ describe(@"SDLPermissionsManager", ^{
         
         context(@"updating an observer with a new HMI level", ^{
             __block NSInteger numberOfTimesObserverCalled = 0;
-            __block NSMutableArray<NSDictionary<SDLPermissionRPCName,NSNumber<SDLBool> *> *> *changeDicts = nil;
-            __block NSMutableArray<NSNumber<SDLUInt> *> *testStatuses = nil;
+            __block NSArray<NSDictionary<SDLPermissionRPCName,NSNumber<SDLBool> *> *> *changeDicts = nil;
+            __block NSArray<NSNumber<SDLUInt> *> *testStatuses = nil;
             
             context(@"to match an ANY observer", ^{
                 beforeEach(^{
                     // Reset vars
                     numberOfTimesObserverCalled = 0;
-                    changeDicts = [NSMutableArray array];
-                    testStatuses = [NSMutableArray array];
+                    changeDicts = [NSArray array];
+                    testStatuses = [NSArray array];
                     
                     // Post the notification before setting the observer to make sure data is already present
                     // HMI Full & Limited allowed, hmi level BACKGROUND
@@ -680,8 +680,8 @@ describe(@"SDLPermissionsManager", ^{
                 beforeEach(^{
                     // Reset vars
                     numberOfTimesObserverCalled = 0;
-                    changeDicts = [NSMutableArray array];
-                    testStatuses = [NSMutableArray array];
+                    changeDicts = [NSArray array];
+                    testStatuses = [NSArray array];
                     
                     // Post the notification before setting the observer to make sure data is already present
                     // HMI Full & Limited allowed, hmi level BACKGROUND
@@ -749,8 +749,8 @@ describe(@"SDLPermissionsManager", ^{
                 beforeEach(^{
                     // Reset vars
                     numberOfTimesObserverCalled = 0;
-                    changeDicts = [NSMutableArray array];
-                    testStatuses = [NSMutableArray array];
+                    changeDicts = [NSArray array];
+                    testStatuses = [NSArray array];
                     
                     // Post the notification before setting the observer to make sure data is already present
                     // HMI Full & Limited allowed, hmi level BACKGROUND

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLPermissionsManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLPermissionsManagerSpec.m
@@ -55,18 +55,18 @@ describe(@"SDLPermissionsManager", ^{
         
         // Permission states
         testHMIPermissionsAllAllowed = [[SDLHMIPermissions alloc] init];
-        testHMIPermissionsAllAllowed.allowed = [NSArray arrayWithArray:@[SDLHMILevelBackground, SDLHMILevelFull, SDLHMILevelLimited, SDLHMILevelNone]];
+        testHMIPermissionsAllAllowed.allowed = @[SDLHMILevelBackground, SDLHMILevelFull, SDLHMILevelLimited, SDLHMILevelNone];
         
         testHMIPermissionsAllDisallowed = [[SDLHMIPermissions alloc] init];
-        testHMIPermissionsAllDisallowed.userDisallowed = [NSArray arrayWithArray:@[SDLHMILevelBackground, SDLHMILevelFull, SDLHMILevelLimited, SDLHMILevelNone]];
+        testHMIPermissionsAllDisallowed.userDisallowed = @[SDLHMILevelBackground, SDLHMILevelFull, SDLHMILevelLimited, SDLHMILevelNone];
         
         testHMIPermissionsFullLimitedAllowed = [[SDLHMIPermissions alloc] init];
-        testHMIPermissionsFullLimitedAllowed.allowed = [NSArray arrayWithArray:@[SDLHMILevelFull, SDLHMILevelLimited]];
-        testHMIPermissionsFullLimitedAllowed.userDisallowed = [NSArray arrayWithArray:@[SDLHMILevelBackground, SDLHMILevelNone]];
+        testHMIPermissionsFullLimitedAllowed.allowed = @[SDLHMILevelFull, SDLHMILevelLimited];
+        testHMIPermissionsFullLimitedAllowed.userDisallowed = @[SDLHMILevelBackground, SDLHMILevelNone];
         
         testHMIPermissionsFullLimitedBackgroundAllowed = [[SDLHMIPermissions alloc] init];
-        testHMIPermissionsFullLimitedBackgroundAllowed.allowed = [NSArray arrayWithArray:@[SDLHMILevelFull, SDLHMILevelLimited, SDLHMILevelBackground]];
-        testHMIPermissionsFullLimitedBackgroundAllowed.userDisallowed = [NSArray arrayWithArray:@[SDLHMILevelNone]];
+        testHMIPermissionsFullLimitedBackgroundAllowed.allowed = @[SDLHMILevelFull, SDLHMILevelLimited, SDLHMILevelBackground];
+        testHMIPermissionsFullLimitedBackgroundAllowed.userDisallowed = @[SDLHMILevelNone];
         
         // Assemble Permissions
         SDLParameterPermissions *testParameterPermissions = [[SDLParameterPermissions alloc] init];
@@ -103,7 +103,7 @@ describe(@"SDLPermissionsManager", ^{
         
         // Create OnPermissionsChange object
         testPermissionsChange = [[SDLOnPermissionsChange alloc] init];
-        testPermissionsChange.permissionItem = [NSArray arrayWithArray:@[testPermissionAllAllowed, testPermissionAllDisallowed, testPermissionFullLimitedAllowed, testPermissionFullLimitedBackgroundAllowed]];
+        testPermissionsChange.permissionItem = @[testPermissionAllAllowed, testPermissionAllDisallowed, testPermissionFullLimitedAllowed, testPermissionFullLimitedBackgroundAllowed];
         
         // Permission Notifications
         testPermissionsNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidChangePermissionsNotification object:nil rpcNotification:testPermissionsChange];
@@ -367,15 +367,15 @@ describe(@"SDLPermissionsManager", ^{
             
             __block SDLOnPermissionsChange *testPermissionChangeUpdate = nil;
             __block SDLPermissionItem *testPermissionUpdated = nil;
-            __block NSArray<NSDictionary<SDLPermissionRPCName,NSNumber<SDLBool> *> *> *changeDicts = nil;
-            __block NSArray<NSNumber<SDLUInt> *> *testStatuses = nil;
+            __block NSMutableArray<NSDictionary<SDLPermissionRPCName,NSNumber<SDLBool> *> *> *changeDicts = nil;
+            __block NSMutableArray<NSNumber<SDLUInt> *> *testStatuses = nil;
             
             context(@"to match an ANY observer", ^{
                 beforeEach(^{
                     // Reset vars
                     numberOfTimesObserverCalled = 0;
-                    changeDicts = [NSArray array];
-                    testStatuses = [NSArray array];
+                    changeDicts = [NSMutableArray array];
+                    testStatuses = [NSMutableArray array];
                     
                     // Post the notification before setting the observer to make sure data is already present
                     // HMI Full & Limited allowed, hmi level LIMITED
@@ -391,8 +391,8 @@ describe(@"SDLPermissionsManager", ^{
                     // Create a permission update disallowing our current HMI level for the observed permission
                     SDLParameterPermissions *testParameterPermissions = [[SDLParameterPermissions alloc] init];
                     SDLHMIPermissions *testHMIPermissionsUpdated = [[SDLHMIPermissions alloc] init];
-                    testHMIPermissionsUpdated.allowed = [NSArray arrayWithArray:@[SDLHMILevelBackground, SDLHMILevelFull]];
-                    testHMIPermissionsUpdated.userDisallowed = [NSArray arrayWithArray:@[SDLHMILevelLimited, SDLHMILevelNone]];
+                    testHMIPermissionsUpdated.allowed = @[SDLHMILevelBackground, SDLHMILevelFull];
+                    testHMIPermissionsUpdated.userDisallowed = @[SDLHMILevelLimited, SDLHMILevelNone];
                     
                     testPermissionUpdated = [[SDLPermissionItem alloc] init];
                     testPermissionUpdated.rpcName = testRPCNameAllAllowed;
@@ -438,8 +438,8 @@ describe(@"SDLPermissionsManager", ^{
                 beforeEach(^{
                     // Reset vars
                     numberOfTimesObserverCalled = 0;
-                    changeDicts = [NSArray array];
-                    testStatuses = [NSArray array];
+                    changeDicts = [NSMutableArray array];
+                    testStatuses = [NSMutableArray array];
                     
                     // Post the notification before setting the observer to make sure data is already present
                     // HMI Full & Limited allowed, hmi level BACKGROUND
@@ -459,8 +459,8 @@ describe(@"SDLPermissionsManager", ^{
                         // Create a permission update allowing our current HMI level for the observed permission
                         SDLParameterPermissions *testParameterPermissions = [[SDLParameterPermissions alloc] init];
                         SDLHMIPermissions *testHMIPermissionsUpdated = [[SDLHMIPermissions alloc] init];
-                        testHMIPermissionsUpdated.allowed = [NSArray arrayWithArray:@[SDLHMILevelLimited, SDLHMILevelNone, SDLHMILevelBackground, SDLHMILevelFull]];
-                        testHMIPermissionsUpdated.userDisallowed = [NSArray arrayWithArray:@[]];
+                        testHMIPermissionsUpdated.allowed = @[SDLHMILevelLimited, SDLHMILevelNone, SDLHMILevelBackground, SDLHMILevelFull];
+                        testHMIPermissionsUpdated.userDisallowed = @[];
                         
                         testPermissionUpdated = [[SDLPermissionItem alloc] init];
                         testPermissionUpdated.rpcName = testRPCNameAllDisallowed;
@@ -502,8 +502,8 @@ describe(@"SDLPermissionsManager", ^{
                         // Create a permission update disallowing our current HMI level for the observed permission
                         SDLParameterPermissions *testParameterPermissions = [[SDLParameterPermissions alloc] init];
                         SDLHMIPermissions *testHMIPermissionsUpdated = [[SDLHMIPermissions alloc] init];
-                        testHMIPermissionsUpdated.allowed = [NSArray arrayWithArray:@[]];
-                        testHMIPermissionsUpdated.userDisallowed = [NSArray arrayWithArray:@[SDLHMILevelBackground, SDLHMILevelFull, SDLHMILevelLimited, SDLHMILevelNone]];
+                        testHMIPermissionsUpdated.allowed = @[];
+                        testHMIPermissionsUpdated.userDisallowed = @[SDLHMILevelBackground, SDLHMILevelFull, SDLHMILevelLimited, SDLHMILevelNone];
                         
                         testPermissionUpdated = [[SDLPermissionItem alloc] init];
                         testPermissionUpdated.rpcName = testRPCNameAllAllowed;
@@ -544,8 +544,8 @@ describe(@"SDLPermissionsManager", ^{
                 beforeEach(^{
                     // Reset vars
                     numberOfTimesObserverCalled = 0;
-                    changeDicts = [NSArray array];
-                    testStatuses = [NSArray array];
+                    changeDicts = [NSMutableArray array];
+                    testStatuses = [NSMutableArray array];
                     
                     // Post the notification before setting the observer to make sure data is already present
                     // HMI Full & Limited allowed, hmi level BACKGROUND
@@ -565,8 +565,8 @@ describe(@"SDLPermissionsManager", ^{
                         // Create a permission update disallowing our current HMI level for the observed permission
                         SDLParameterPermissions *testParameterPermissions = [[SDLParameterPermissions alloc] init];
                         SDLHMIPermissions *testHMIPermissionsUpdated = [[SDLHMIPermissions alloc] init];
-                        testHMIPermissionsUpdated.allowed = [NSArray arrayWithArray:@[]];
-                        testHMIPermissionsUpdated.userDisallowed = [NSArray arrayWithArray:@[SDLHMILevelBackground, SDLHMILevelFull, SDLHMILevelLimited, SDLHMILevelNone]];
+                        testHMIPermissionsUpdated.allowed = @[];
+                        testHMIPermissionsUpdated.userDisallowed = @[SDLHMILevelBackground, SDLHMILevelFull, SDLHMILevelLimited, SDLHMILevelNone];
                         
                         testPermissionUpdated = [[SDLPermissionItem alloc] init];
                         testPermissionUpdated.rpcName = testRPCNameAllAllowed;
@@ -599,8 +599,8 @@ describe(@"SDLPermissionsManager", ^{
                         // Create a permission update disallowing our current HMI level for the observed permission
                         SDLParameterPermissions *testParameterPermissions = [[SDLParameterPermissions alloc] init];
                         SDLHMIPermissions *testHMIPermissionsUpdated = [[SDLHMIPermissions alloc] init];
-                        testHMIPermissionsUpdated.allowed = [NSArray arrayWithArray:@[SDLHMILevelLimited, SDLHMILevelBackground]];
-                        testHMIPermissionsUpdated.userDisallowed = [NSArray arrayWithArray:@[SDLHMILevelFull, SDLHMILevelNone]];
+                        testHMIPermissionsUpdated.allowed = @[SDLHMILevelLimited, SDLHMILevelBackground];
+                        testHMIPermissionsUpdated.userDisallowed = @[SDLHMILevelFull, SDLHMILevelNone];
                         
                         testPermissionUpdated = [[SDLPermissionItem alloc] init];
                         testPermissionUpdated.rpcName = testRPCNameAllAllowed;
@@ -625,15 +625,15 @@ describe(@"SDLPermissionsManager", ^{
         
         context(@"updating an observer with a new HMI level", ^{
             __block NSInteger numberOfTimesObserverCalled = 0;
-            __block NSArray<NSDictionary<SDLPermissionRPCName,NSNumber<SDLBool> *> *> *changeDicts = nil;
-            __block NSArray<NSNumber<SDLUInt> *> *testStatuses = nil;
+            __block NSMutableArray<NSDictionary<SDLPermissionRPCName,NSNumber<SDLBool> *> *> *changeDicts = nil;
+            __block NSMutableArray<NSNumber<SDLUInt> *> *testStatuses = nil;
             
             context(@"to match an ANY observer", ^{
                 beforeEach(^{
                     // Reset vars
                     numberOfTimesObserverCalled = 0;
-                    changeDicts = [NSArray array];
-                    testStatuses = [NSArray array];
+                    changeDicts = [NSMutableArray array];
+                    testStatuses = [NSMutableArray array];
                     
                     // Post the notification before setting the observer to make sure data is already present
                     // HMI Full & Limited allowed, hmi level BACKGROUND
@@ -680,8 +680,8 @@ describe(@"SDLPermissionsManager", ^{
                 beforeEach(^{
                     // Reset vars
                     numberOfTimesObserverCalled = 0;
-                    changeDicts = [NSArray array];
-                    testStatuses = [NSArray array];
+                    changeDicts = [NSMutableArray array];
+                    testStatuses = [NSMutableArray array];
                     
                     // Post the notification before setting the observer to make sure data is already present
                     // HMI Full & Limited allowed, hmi level BACKGROUND
@@ -749,8 +749,8 @@ describe(@"SDLPermissionsManager", ^{
                 beforeEach(^{
                     // Reset vars
                     numberOfTimesObserverCalled = 0;
-                    changeDicts = [NSArray array];
-                    testStatuses = [NSArray array];
+                    changeDicts = [NSMutableArray array];
+                    testStatuses = [NSMutableArray array];
                     
                     // Post the notification before setting the observer to make sure data is already present
                     // HMI Full & Limited allowed, hmi level BACKGROUND

--- a/SmartDeviceLinkTests/UtilitiesSpecs/Touches/SDLPinchGestureSpec.m
+++ b/SmartDeviceLinkTests/UtilitiesSpecs/Touches/SDLPinchGestureSpec.m
@@ -46,8 +46,8 @@ describe(@"SDLPinchGesture Tests", ^{
             
             SDLTouchEvent* firstTouchEvent = [[SDLTouchEvent alloc] init];
             firstTouchEvent.touchEventId = @0;
-            firstTouchEvent.coord = [NSMutableArray arrayWithObject:firstCoord];
-            firstTouchEvent.timeStamp = [NSMutableArray arrayWithObject:@(timeStamp)];
+            firstTouchEvent.coord = [NSArray arrayWithObject:firstCoord];
+            firstTouchEvent.timeStamp = [NSArray arrayWithObject:@(timeStamp)];
             
             SDLTouch* firstTouch = [[SDLTouch alloc] initWithTouchEvent:firstTouchEvent];
             
@@ -57,8 +57,8 @@ describe(@"SDLPinchGesture Tests", ^{
             
             SDLTouchEvent* secondTouchEvent = [[SDLTouchEvent alloc] init];
             secondTouchEvent.touchEventId = @1;
-            secondTouchEvent.coord = [NSMutableArray arrayWithObject:secondCoord];
-            secondTouchEvent.timeStamp = [NSMutableArray arrayWithObject:@(secondTimeStamp)];
+            secondTouchEvent.coord = [NSArray arrayWithObject:secondCoord];
+            secondTouchEvent.timeStamp = [NSArray arrayWithObject:@(secondTimeStamp)];
             
             SDLTouch* secondTouch = [[SDLTouch alloc] initWithTouchEvent:secondTouchEvent];
 
@@ -103,8 +103,8 @@ describe(@"SDLPinchGesture Tests", ^{
             
             SDLTouchEvent* firstTouchEvent = [[SDLTouchEvent alloc] init];
             firstTouchEvent.touchEventId = @0;
-            firstTouchEvent.coord = [NSMutableArray arrayWithObject:firstCoord];
-            firstTouchEvent.timeStamp = [NSMutableArray arrayWithObject:@(timeStamp)];
+            firstTouchEvent.coord = [NSArray arrayWithObject:firstCoord];
+            firstTouchEvent.timeStamp = [NSArray arrayWithObject:@(timeStamp)];
             
             SDLTouch* firstTouch = [[SDLTouch alloc] initWithTouchEvent:firstTouchEvent];
             
@@ -114,8 +114,8 @@ describe(@"SDLPinchGesture Tests", ^{
             
             SDLTouchEvent* secondTouchEvent = [[SDLTouchEvent alloc] init];
             secondTouchEvent.touchEventId = @1;
-            secondTouchEvent.coord = [NSMutableArray arrayWithObject:secondCoord];
-            secondTouchEvent.timeStamp = [NSMutableArray arrayWithObject:@(secondTimeStamp)];
+            secondTouchEvent.coord = [NSArray arrayWithObject:secondCoord];
+            secondTouchEvent.timeStamp = [NSArray arrayWithObject:@(secondTimeStamp)];
             
             SDLTouch* secondTouch = [[SDLTouch alloc] initWithTouchEvent:secondTouchEvent];
             
@@ -128,13 +128,13 @@ describe(@"SDLPinchGesture Tests", ^{
             
             SDLTouchEvent* newFirstTouchEvent = [[SDLTouchEvent alloc] init];
             newFirstTouchEvent.touchEventId = @0;
-            newFirstTouchEvent.coord = [NSMutableArray arrayWithObject:newCoord];
-            newFirstTouchEvent.timeStamp = [NSMutableArray arrayWithObject:@(newTimeStamp)];
+            newFirstTouchEvent.coord = [NSArray arrayWithObject:newCoord];
+            newFirstTouchEvent.timeStamp = [NSArray arrayWithObject:@(newTimeStamp)];
 
             SDLTouchEvent* newSecondTouchEvent = [[SDLTouchEvent alloc] init];
             newSecondTouchEvent.touchEventId = @1;
-            newSecondTouchEvent.coord = [NSMutableArray arrayWithObject:newCoord];
-            newSecondTouchEvent.timeStamp = [NSMutableArray arrayWithObject:@(newTimeStamp)];
+            newSecondTouchEvent.coord = [NSArray arrayWithObject:newCoord];
+            newSecondTouchEvent.timeStamp = [NSArray arrayWithObject:@(newTimeStamp)];
 
             newFirstTouch = [[SDLTouch alloc] initWithTouchEvent:newFirstTouchEvent];
             newSecondTouch = [[SDLTouch alloc] initWithTouchEvent:newSecondTouchEvent];

--- a/SmartDeviceLinkTests/UtilitiesSpecs/Touches/SDLTouchManagerSpec.m
+++ b/SmartDeviceLinkTests/UtilitiesSpecs/Touches/SDLTouchManagerSpec.m
@@ -177,16 +177,16 @@ describe(@"SDLTouchManager Tests", ^{
                 
                 SDLTouchEvent* touchEvent = [[SDLTouchEvent alloc] init];
                 touchEvent.touchEventId = @0;
-                touchEvent.coord = [NSMutableArray arrayWithObject:firstTouchCoord];
-                touchEvent.timeStamp = [NSMutableArray arrayWithObject:@(firstTouchTimeStamp)];
+                touchEvent.coord = [NSArray arrayWithObject:firstTouchCoord];
+                touchEvent.timeStamp = [NSArray arrayWithObject:@(firstTouchTimeStamp)];
                 
                 firstOnTouchEventStart = [[SDLOnTouchEvent alloc] init];
                 firstOnTouchEventStart.type = SDLTouchTypeBegin;
-                firstOnTouchEventStart.event = [NSMutableArray arrayWithObject:touchEvent];
+                firstOnTouchEventStart.event = [NSArray arrayWithObject:touchEvent];
                 
                 firstOnTouchEventEnd = [[SDLOnTouchEvent alloc] init];
                 firstOnTouchEventEnd.type = SDLTouchTypeEnd;
-                firstOnTouchEventEnd.event = [NSMutableArray arrayWithObject:touchEvent];
+                firstOnTouchEventEnd.event = [NSArray arrayWithObject:touchEvent];
             });
             
             describe(@"when receiving a single tap", ^{
@@ -237,7 +237,7 @@ describe(@"SDLTouchManager Tests", ^{
                     secondTouchEvent = [[SDLTouchEvent alloc] init];
                     secondTouchEvent.touchEventId = @0;
                     NSUInteger secondTouchTimeStamp = firstTouchTimeStamp + (touchManager.tapTimeThreshold - 0.1) * 1000;
-                    secondTouchEvent.timeStamp = [NSMutableArray arrayWithObject:@(secondTouchTimeStamp)];
+                    secondTouchEvent.timeStamp = [NSArray arrayWithObject:@(secondTouchTimeStamp)];
                 });
                 
                 context(@"near the same point", ^{
@@ -246,11 +246,11 @@ describe(@"SDLTouchManager Tests", ^{
                         touchCoord.x = @(firstTouchCoord.x.floatValue + touchManager.tapDistanceThreshold);
                         touchCoord.y = @(firstTouchCoord.y.floatValue + touchManager.tapDistanceThreshold);
                         
-                        secondTouchEvent.coord = [NSMutableArray arrayWithObject:touchCoord];
+                        secondTouchEvent.coord = [NSArray arrayWithObject:touchCoord];
                         
-                        secondOnTouchEventStart.event = [NSMutableArray arrayWithObject:secondTouchEvent];
+                        secondOnTouchEventStart.event = [NSArray arrayWithObject:secondTouchEvent];
                         
-                        secondOnTouchEventEnd.event = [NSMutableArray arrayWithObject:secondTouchEvent];
+                        secondOnTouchEventEnd.event = [NSArray arrayWithObject:secondTouchEvent];
                         
                         averagePoint = CGPointMake((firstTouchCoord.x.floatValue + touchCoord.x.floatValue) / 2.0f,
                                                    (firstTouchCoord.y.floatValue + touchCoord.y.floatValue) / 2.0f);
@@ -291,11 +291,11 @@ describe(@"SDLTouchManager Tests", ^{
                         touchCoord.x = @(firstTouchCoord.x.floatValue + touchManager.tapDistanceThreshold + 1);
                         touchCoord.y = @(firstTouchCoord.y.floatValue + touchManager.tapDistanceThreshold + 1);
                         
-                        secondTouchEvent.coord = [NSMutableArray arrayWithObject:touchCoord];
+                        secondTouchEvent.coord = [NSArray arrayWithObject:touchCoord];
                         
-                        secondOnTouchEventStart.event = [NSMutableArray arrayWithObject:secondTouchEvent];
+                        secondOnTouchEventStart.event = [NSArray arrayWithObject:secondTouchEvent];
                         
-                        secondOnTouchEventEnd.event = [NSMutableArray arrayWithObject:secondTouchEvent];
+                        secondOnTouchEventEnd.event = [NSArray arrayWithObject:secondTouchEvent];
                     });
                     
                     it(@"should should not issue delegate callbacks", ^{
@@ -343,11 +343,11 @@ describe(@"SDLTouchManager Tests", ^{
                 NSUInteger panStartTimeStamp = ([[NSDate date] timeIntervalSince1970] * 1000) + movementTimeThresholdOffset;
                 
                 SDLTouchEvent* panStartTouchEvent = [[SDLTouchEvent alloc] init];
-                panStartTouchEvent.coord = [NSMutableArray arrayWithObject:panStartTouchCoord];
-                panStartTouchEvent.timeStamp = [NSMutableArray arrayWithObject:@(panStartTimeStamp)];
+                panStartTouchEvent.coord = [NSArray arrayWithObject:panStartTouchCoord];
+                panStartTouchEvent.timeStamp = [NSArray arrayWithObject:@(panStartTimeStamp)];
                 
                 panStartOnTouchEvent = [[SDLOnTouchEvent alloc] init];
-                panStartOnTouchEvent.event = [NSMutableArray arrayWithObject:panStartTouchEvent];
+                panStartOnTouchEvent.event = [NSArray arrayWithObject:panStartTouchEvent];
                 panStartOnTouchEvent.type = SDLTouchTypeBegin;
                 
                 // Finger Move
@@ -360,11 +360,11 @@ describe(@"SDLTouchManager Tests", ^{
                 NSUInteger panMoveTimeStamp = panStartTimeStamp + movementTimeThresholdOffset;
                 
                 SDLTouchEvent* panMoveTouchEvent = [[SDLTouchEvent alloc] init];
-                panMoveTouchEvent.coord = [NSMutableArray arrayWithObject:panMoveTouchCoord];
-                panMoveTouchEvent.timeStamp = [NSMutableArray arrayWithObject:@(panMoveTimeStamp)];
+                panMoveTouchEvent.coord = [NSArray arrayWithObject:panMoveTouchCoord];
+                panMoveTouchEvent.timeStamp = [NSArray arrayWithObject:@(panMoveTimeStamp)];
                 
                 panMoveOnTouchEvent = [[SDLOnTouchEvent alloc] init];
-                panMoveOnTouchEvent.event = [NSMutableArray arrayWithObject:panMoveTouchEvent];
+                panMoveOnTouchEvent.event = [NSArray arrayWithObject:panMoveTouchEvent];
                 panMoveOnTouchEvent.type = SDLTouchTypeMove;
                 
                 // Finger Move
@@ -377,11 +377,11 @@ describe(@"SDLTouchManager Tests", ^{
                 NSUInteger panSecondMoveTimeStamp = panMoveTimeStamp + movementTimeThresholdOffset;
                 
                 SDLTouchEvent* panSecondMoveTouchEvent = [[SDLTouchEvent alloc] init];
-                panSecondMoveTouchEvent.coord = [NSMutableArray arrayWithObject:panSecondMoveTouchCoord];
-                panSecondMoveTouchEvent.timeStamp = [NSMutableArray arrayWithObject:@(panSecondMoveTimeStamp)];
+                panSecondMoveTouchEvent.coord = [NSArray arrayWithObject:panSecondMoveTouchCoord];
+                panSecondMoveTouchEvent.timeStamp = [NSArray arrayWithObject:@(panSecondMoveTimeStamp)];
                 
                 panSecondMoveOnTouchEvent = [[SDLOnTouchEvent alloc] init];
-                panSecondMoveOnTouchEvent.event = [NSMutableArray arrayWithObject:panSecondMoveTouchEvent];
+                panSecondMoveOnTouchEvent.event = [NSArray arrayWithObject:panSecondMoveTouchEvent];
                 panSecondMoveOnTouchEvent.type = SDLTouchTypeMove;
                 
                 // Finger End
@@ -394,11 +394,11 @@ describe(@"SDLTouchManager Tests", ^{
                 NSUInteger panEndTimeStamp = panSecondMoveTimeStamp + movementTimeThresholdOffset;
                 
                 SDLTouchEvent* panEndTouchEvent = [[SDLTouchEvent alloc] init];
-                panEndTouchEvent.coord = [NSMutableArray arrayWithObject:panEndTouchCoord];
-                panEndTouchEvent.timeStamp = [NSMutableArray arrayWithObject:@(panEndTimeStamp)];
+                panEndTouchEvent.coord = [NSArray arrayWithObject:panEndTouchCoord];
+                panEndTouchEvent.timeStamp = [NSArray arrayWithObject:@(panEndTimeStamp)];
                 
                 panEndOnTouchEvent = [[SDLOnTouchEvent alloc] init];
-                panEndOnTouchEvent.event = [NSMutableArray arrayWithObject:panEndTouchEvent];
+                panEndOnTouchEvent.event = [NSArray arrayWithObject:panEndTouchEvent];
                 panEndOnTouchEvent.type = SDLTouchTypeEnd;
             });
             
@@ -479,11 +479,11 @@ describe(@"SDLTouchManager Tests", ^{
                 NSUInteger firstFingerTimeStamp = [[NSDate date] timeIntervalSince1970] * 1000;
                 
                 SDLTouchEvent* firstFingerTouchEvent = [[SDLTouchEvent alloc] init];
-                firstFingerTouchEvent.coord = [NSMutableArray arrayWithObject:firstFingerTouchCoord];
-                firstFingerTouchEvent.timeStamp = [NSMutableArray arrayWithObject:@(firstFingerTimeStamp)];
+                firstFingerTouchEvent.coord = [NSArray arrayWithObject:firstFingerTouchCoord];
+                firstFingerTouchEvent.timeStamp = [NSArray arrayWithObject:@(firstFingerTimeStamp)];
                 
                 pinchStartFirstFingerOnTouchEvent = [[SDLOnTouchEvent alloc] init];
-                pinchStartFirstFingerOnTouchEvent.event = [NSMutableArray arrayWithObject:firstFingerTouchEvent];
+                pinchStartFirstFingerOnTouchEvent.event = [NSArray arrayWithObject:firstFingerTouchEvent];
                 pinchStartFirstFingerOnTouchEvent.type = SDLTouchTypeBegin;
                 
                 // Second finger touch down
@@ -495,11 +495,11 @@ describe(@"SDLTouchManager Tests", ^{
                 
                 SDLTouchEvent* secondFingerTouchEvent = [[SDLTouchEvent alloc] init];
                 secondFingerTouchEvent.touchEventId = @1;
-                secondFingerTouchEvent.coord = [NSMutableArray arrayWithObject:secondFingerTouchCoord];
-                secondFingerTouchEvent.timeStamp = [NSMutableArray arrayWithObject:@(secondFingerTimeStamp)];
+                secondFingerTouchEvent.coord = [NSArray arrayWithObject:secondFingerTouchCoord];
+                secondFingerTouchEvent.timeStamp = [NSArray arrayWithObject:@(secondFingerTimeStamp)];
                 
                 pinchStartSecondFingerOnTouchEvent = [[SDLOnTouchEvent alloc] init];
-                pinchStartSecondFingerOnTouchEvent.event = [NSMutableArray arrayWithObject:secondFingerTouchEvent];
+                pinchStartSecondFingerOnTouchEvent.event = [NSArray arrayWithObject:secondFingerTouchEvent];
                 pinchStartSecondFingerOnTouchEvent.type = SDLTouchTypeBegin;
                 
                 pinchStartCenter = CGPointMake((firstFingerTouchCoord.x.floatValue + secondFingerTouchCoord.x.floatValue) / 2.0f,
@@ -517,11 +517,11 @@ describe(@"SDLTouchManager Tests", ^{
                 
                 SDLTouchEvent* secondFingerMoveTouchEvent = [[SDLTouchEvent alloc] init];
                 secondFingerMoveTouchEvent.touchEventId = @1;
-                secondFingerMoveTouchEvent.coord = [NSMutableArray arrayWithObject:secondFingerMoveTouchCoord];
-                secondFingerMoveTouchEvent.timeStamp = [NSMutableArray arrayWithObject:@(secondFingerMoveTimeStamp)];
+                secondFingerMoveTouchEvent.coord = [NSArray arrayWithObject:secondFingerMoveTouchCoord];
+                secondFingerMoveTouchEvent.timeStamp = [NSArray arrayWithObject:@(secondFingerMoveTimeStamp)];
                 
                 pinchMoveSecondFingerOnTouchEvent = [[SDLOnTouchEvent alloc] init];
-                pinchMoveSecondFingerOnTouchEvent.event = [NSMutableArray arrayWithObject:secondFingerMoveTouchEvent];
+                pinchMoveSecondFingerOnTouchEvent.event = [NSArray arrayWithObject:secondFingerMoveTouchEvent];
                 pinchMoveSecondFingerOnTouchEvent.type = SDLTouchTypeMove;
                 
                 pinchMoveCenter = CGPointMake((firstFingerTouchCoord.x.floatValue + secondFingerMoveTouchCoord.x.floatValue) / 2.0f,
@@ -539,11 +539,11 @@ describe(@"SDLTouchManager Tests", ^{
                 
                 SDLTouchEvent* secondFingerEndTouchEvent = [[SDLTouchEvent alloc] init];
                 secondFingerEndTouchEvent.touchEventId = @1;
-                secondFingerEndTouchEvent.coord = [NSMutableArray arrayWithObject:secondFingerEndTouchCoord];
-                secondFingerEndTouchEvent.timeStamp = [NSMutableArray arrayWithObject:@(secondFingerEndTimeStamp)];
+                secondFingerEndTouchEvent.coord = [NSArray arrayWithObject:secondFingerEndTouchCoord];
+                secondFingerEndTouchEvent.timeStamp = [NSArray arrayWithObject:@(secondFingerEndTimeStamp)];
                 
                 pinchEndSecondFingerOnTouchEvent = [[SDLOnTouchEvent alloc] init];
-                pinchEndSecondFingerOnTouchEvent.event = [NSMutableArray arrayWithObject:secondFingerEndTouchEvent];
+                pinchEndSecondFingerOnTouchEvent.event = [NSArray arrayWithObject:secondFingerEndTouchEvent];
                 pinchEndSecondFingerOnTouchEvent.type = SDLTouchTypeEnd;
                 
                 pinchEndCenter = CGPointMake((firstFingerTouchCoord.x.floatValue + secondFingerEndTouchCoord.x.floatValue) / 2.0f,

--- a/SmartDeviceLinkTests/UtilitiesSpecs/Touches/SDLTouchSpec.m
+++ b/SmartDeviceLinkTests/UtilitiesSpecs/Touches/SDLTouchSpec.m
@@ -48,8 +48,8 @@ describe(@"SDLTouch Tests", ^{
             
             SDLTouchEvent* touchEvent = [[SDLTouchEvent alloc] init];
             touchEvent.touchEventId = @0;
-            touchEvent.coord = [NSMutableArray arrayWithObject:coord];
-            touchEvent.timeStamp = [NSMutableArray arrayWithObject:@(timeStamp)];
+            touchEvent.coord = [NSArray arrayWithObject:coord];
+            touchEvent.timeStamp = [NSArray arrayWithObject:@(timeStamp)];
             
             touch = [[SDLTouch alloc] initWithTouchEvent:touchEvent];
         });
@@ -81,8 +81,8 @@ describe(@"SDLTouch Tests", ^{
             
             SDLTouchEvent* touchEvent = [[SDLTouchEvent alloc] init];
             touchEvent.touchEventId = @1;
-            touchEvent.coord = [NSMutableArray arrayWithObject:coord];
-            touchEvent.timeStamp = [NSMutableArray arrayWithObject:@(timeStamp)];
+            touchEvent.coord = [NSArray arrayWithObject:coord];
+            touchEvent.timeStamp = [NSArray arrayWithObject:@(timeStamp)];
             
             touch = [[SDLTouch alloc] initWithTouchEvent:touchEvent];
         });

--- a/SmartDeviceLink_Example/Classes/ProxyManager.m
+++ b/SmartDeviceLink_Example/Classes/ProxyManager.m
@@ -176,7 +176,7 @@ NS_ASSUME_NONNULL_BEGIN
     commandMenuParams.menuName = commandName;
     
     SDLAddCommand *speakNameCommand = [[SDLAddCommand alloc] init];
-    speakNameCommand.vrCommands = [NSMutableArray arrayWithObject:commandName];
+    speakNameCommand.vrCommands = @[commandName];
     speakNameCommand.menuParams = commandMenuParams;
     speakNameCommand.cmdID = @0;
     
@@ -194,7 +194,7 @@ NS_ASSUME_NONNULL_BEGIN
     commandMenuParams.menuName = commandName;
     
     SDLAddCommand *performInteractionCommand = [[SDLAddCommand alloc] init];
-    performInteractionCommand.vrCommands = [NSMutableArray arrayWithObject:commandName];
+    performInteractionCommand.vrCommands = @[commandName];
     performInteractionCommand.menuParams = commandMenuParams;
     performInteractionCommand.cmdID = @1;
     
@@ -236,9 +236,9 @@ NS_ASSUME_NONNULL_BEGIN
     SDLChoice *theOnlyChoice = [[SDLChoice alloc] init];
     theOnlyChoice.choiceID = @0;
     theOnlyChoice.menuName = theOnlyChoiceName;
-    theOnlyChoice.vrCommands = [NSMutableArray arrayWithObject:theOnlyChoiceName];
+    theOnlyChoice.vrCommands = @[theOnlyChoiceName];
     
-    createInteractionSet.choiceSet = [NSMutableArray arrayWithArray:@[theOnlyChoice]];
+    createInteractionSet.choiceSet = @[theOnlyChoice];
     
     return createInteractionSet;
 }
@@ -248,7 +248,7 @@ NS_ASSUME_NONNULL_BEGIN
     performOnlyChoiceInteraction.initialText = @"Choose the only one! You have 5 seconds...";
     performOnlyChoiceInteraction.initialPrompt = [SDLTTSChunk textChunksFromString:@"Choose it"];
     performOnlyChoiceInteraction.interactionMode = SDLInteractionModeBoth;
-    performOnlyChoiceInteraction.interactionChoiceSetIDList = [NSMutableArray arrayWithObject:@0];
+    performOnlyChoiceInteraction.interactionChoiceSetIDList = @[@0];
     performOnlyChoiceInteraction.helpPrompt = [SDLTTSChunk textChunksFromString:@"Do it"];
     performOnlyChoiceInteraction.timeoutPrompt = [SDLTTSChunk textChunksFromString:@"Too late"];
     performOnlyChoiceInteraction.timeout = @5000;


### PR DESCRIPTION
Fixes #507

This PR is **ready** for review.

### Risk
This PR makes **major** API changes.

### Testing Plan
All tests continue to pass.

### Summary
This PR changes RPC properties that are currently `NSMutableArray`s to be `NSArray`s instead, and updates breaking code. Note that passing a mutable array to an immutable array parameter is still valid, therefore, some code will not break for end users. However, assigning an immutable array to a mutable variable is an error, and so some code will break.

### Changelog
##### Breaking Changes
* RPC parameters previously marked `NSMutableArray` are now `NSArray` instead.
