### PR TITLE
Updated `stop` method of SDLManager to actually stop.

### DIFF
--- a/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
+++ b/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
@@ -4292,6 +4292,7 @@
 				TargetAttributes = {
 					5D4019AE1A76EC350006B0C2 = {
 						CreatedOnToolsVersion = 6.1.1;
+						DevelopmentTeam = ACNGAAM3M7;
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
 								enabled = 1;
@@ -5167,6 +5168,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = ACNGAAM3M7;
 				INFOPLIST_FILE = "$(SRCROOT)/SmartDeviceLink_Example/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -5180,6 +5182,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = ACNGAAM3M7;
 				INFOPLIST_FILE = "$(SRCROOT)/SmartDeviceLink_Example/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
+++ b/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
@@ -4292,7 +4292,6 @@
 				TargetAttributes = {
 					5D4019AE1A76EC350006B0C2 = {
 						CreatedOnToolsVersion = 6.1.1;
-						DevelopmentTeam = ACNGAAM3M7;
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
 								enabled = 1;
@@ -5168,7 +5167,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = ACNGAAM3M7;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/SmartDeviceLink_Example/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -5182,7 +5181,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = ACNGAAM3M7;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/SmartDeviceLink_Example/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/SmartDeviceLink/SDLLifecycleManager.h
+++ b/SmartDeviceLink/SDLLifecycleManager.h
@@ -36,7 +36,6 @@
 NS_ASSUME_NONNULL_BEGIN
 
 typedef NSString SDLLifecycleState;
-extern SDLLifecycleState *const SDLLifecycleStateReconnecting;
 extern SDLLifecycleState *const SDLLifecycleStateStopped;
 extern SDLLifecycleState *const SDLLifecycleStateStarted;
 extern SDLLifecycleState *const SDLLifecycleStateConnected;

--- a/SmartDeviceLink/SDLLifecycleManager.h
+++ b/SmartDeviceLink/SDLLifecycleManager.h
@@ -36,6 +36,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 typedef NSString SDLLifecycleState;
+extern SDLLifecycleState *const SDLLifecycleStateReconnecting;
 extern SDLLifecycleState *const SDLLifecycleStateDisconnected;
 extern SDLLifecycleState *const SDLLifecycleStateTransportConnected;
 extern SDLLifecycleState *const SDLLifecycleStateRegistered;

--- a/SmartDeviceLink/SDLLifecycleManager.h
+++ b/SmartDeviceLink/SDLLifecycleManager.h
@@ -38,6 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 typedef NSString SDLLifecycleState;
 extern SDLLifecycleState *const SDLLifecycleStateStopped;
 extern SDLLifecycleState *const SDLLifecycleStateStarted;
+extern SDLLifecycleState *const SDLLifecycleStateReconnecting;
 extern SDLLifecycleState *const SDLLifecycleStateConnected;
 extern SDLLifecycleState *const SDLLifecycleStateRegistered;
 extern SDLLifecycleState *const SDLLifecycleStateSettingUpManagers;

--- a/SmartDeviceLink/SDLLifecycleManager.h
+++ b/SmartDeviceLink/SDLLifecycleManager.h
@@ -37,8 +37,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef NSString SDLLifecycleState;
 extern SDLLifecycleState *const SDLLifecycleStateReconnecting;
-extern SDLLifecycleState *const SDLLifecycleStateDisconnected;
-extern SDLLifecycleState *const SDLLifecycleStateTransportConnected;
+extern SDLLifecycleState *const SDLLifecycleStateStopped;
+extern SDLLifecycleState *const SDLLifecycleStateStarted;
+extern SDLLifecycleState *const SDLLifecycleStateConnected;
 extern SDLLifecycleState *const SDLLifecycleStateRegistered;
 extern SDLLifecycleState *const SDLLifecycleStateSettingUpManagers;
 extern SDLLifecycleState *const SDLLifecycleStatePostManagerProcessing;

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -442,7 +442,7 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
 
 - (void)transportDidDisconnect {
     if (self.lifecycleState == SDLLifecycleStateUnregistering || self.lifecycleState == SDLLifecycleStateStopped) {
-        [self.lifecycleStateMachine transitionToState:SDLLifecycleStateStopped];;
+        [self.lifecycleStateMachine transitionToState:SDLLifecycleStateStopped];
     } else {
         [self.lifecycleStateMachine transitionToState:SDLLifecycleStateReconnecting];
     }

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -186,11 +186,12 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
 
     // Due to a race condition internally with EAStream, we cannot immediately attempt to restart the proxy, as we will randomly crash.
     // Apple Bug ID #30059457
+    __weak typeof(self) weakSelf = self;
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        [self.delegate managerDidDisconnect];
+        [weakSelf.delegate managerDidDisconnect];
 
         if (shouldRestart) {
-            [self.lifecycleStateMachine transitionToState:SDLLifecycleStateStarted];
+            [weakSelf.lifecycleStateMachine transitionToState:SDLLifecycleStateStarted];
         }
     });
 }

--- a/SmartDeviceLink/SDLManager.h
+++ b/SmartDeviceLink/SDLManager.h
@@ -93,6 +93,8 @@ typedef void (^SDLManagerReadyBlock)(BOOL success, NSError *_Nullable error);
 
 /**
  *  Stop the manager, it will disconnect if needed and no longer look for a connection. You probably don't need to call this method ever.
+ *  
+ *  If you do call this method, you must wait for SDLManagerDelegate's managerDidDisconnect callback to call startWithReadyHandler:.
  */
 - (void)stop;
 

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleManagerSpec.m
@@ -82,7 +82,7 @@ describe(@"a lifecycle manager", ^{
     it(@"should initialize properties", ^{
         expect(testManager.configuration).to(equal(testConfig));
         expect(testManager.delegate).to(equal(managerDelegateMock)); // TODO: Broken on OCMock 3.3.1 & Swift 3 Quick / Nimble
-        expect(testManager.lifecycleState).to(match(SDLLifecycleStateDisconnected));
+        expect(testManager.lifecycleState).to(match(SDLLifecycleStateStopped));
         expect(@(testManager.lastCorrelationId)).to(equal(@0));
         expect(testManager.fileManager).toNot(beNil());
         expect(testManager.permissionManager).toNot(beNil());
@@ -151,7 +151,8 @@ describe(@"a lifecycle manager", ^{
         });
         
         it(@"should do nothing", ^{
-            expect(testManager.lifecycleState).to(match(SDLLifecycleStateDisconnected));
+            expect(testManager.lifecycleState).to(match(SDLLifecycleStateStopped));
+            expect(testManager.lifecycleState).toEventuallyNot(match(SDLLifecycleStateStarted));
         });
     });
     
@@ -162,7 +163,7 @@ describe(@"a lifecycle manager", ^{
         
         it(@"should initialize the proxy property", ^{
             expect(testManager.proxy).toNot(beNil());
-            expect(testManager.lifecycleState).to(match(SDLLifecycleStateDisconnected));
+            expect(testManager.lifecycleState).to(match(SDLLifecycleStateStarted));
         });
         
         describe(@"after receiving a connect notification", ^{
@@ -176,7 +177,7 @@ describe(@"a lifecycle manager", ^{
             
             it(@"should send a register app interface request and be in the connected state", ^{
                 OCMVerifyAllWithDelay(proxyMock, 0.5);
-                expect(testManager.lifecycleState).to(match(SDLLifecycleStateTransportConnected));
+                expect(testManager.lifecycleState).to(match(SDLLifecycleStateConnected));
             });
             
             itBehavesLike(@"unable to send an RPC", ^{ return @{ @"manager": testManager }; });
@@ -187,8 +188,8 @@ describe(@"a lifecycle manager", ^{
                     [NSThread sleepForTimeInterval:0.1];
                 });
                 
-                it(@"should be in the disconnect state", ^{
-                    expect(testManager.lifecycleState).to(match(SDLLifecycleStateDisconnected));
+                it(@"should be in the started state", ^{
+                    expect(testManager.lifecycleState).to(match(SDLLifecycleStateStarted));
                 });
             });
             
@@ -197,15 +198,15 @@ describe(@"a lifecycle manager", ^{
                     [testManager stop];
                 });
                 
-                it(@"should simply disconnect", ^{
-                    expect(testManager.lifecycleState).to(match(SDLLifecycleStateDisconnected));
+                it(@"should simply stop", ^{
+                    expect(testManager.lifecycleState).to(match(SDLLifecycleStateStopped));
                 });
             });
         });
         
         describe(@"in the connected state", ^{
             beforeEach(^{
-                [testManager.lifecycleStateMachine setToState:SDLLifecycleStateTransportConnected];
+                [testManager.lifecycleStateMachine setToState:SDLLifecycleStateConnected];
             });
             
             describe(@"after receiving a register app interface response", ^{
@@ -237,8 +238,8 @@ describe(@"a lifecycle manager", ^{
                     [testManager.notificationDispatcher postNotificationName:SDLTransportDidDisconnect infoObject:nil];
                 });
                 
-                it(@"should enter the disconnect state", ^{
-                    expect(testManager.lifecycleState).toEventually(match(SDLLifecycleStateDisconnected));
+                it(@"should enter the started state", ^{
+                    expect(testManager.lifecycleState).toEventually(match(SDLLifecycleStateStarted));
                 });
             });
             
@@ -247,8 +248,8 @@ describe(@"a lifecycle manager", ^{
                     [testManager stop];
                 });
                 
-                it(@"should enter the disconnect state", ^{
-                    expect(testManager.lifecycleState).to(match(SDLLifecycleStateDisconnected));
+                it(@"should enter the stopped state", ^{
+                    expect(testManager.lifecycleState).to(match(SDLLifecycleStateStopped));
                 });
             });
         });
@@ -292,8 +293,8 @@ describe(@"a lifecycle manager", ^{
                         [testManager.notificationDispatcher postRPCResponseNotification:SDLDidReceiveUnregisterAppInterfaceResponse response:testUnregisterResponse];
                     });
                     
-                    it(@"should disconnect", ^{
-                        expect(testManager.lifecycleState).toEventually(match(SDLLifecycleStateDisconnected));
+                    it(@"should stop", ^{
+                        expect(testManager.lifecycleState).toEventually(match(SDLLifecycleStateStopped));
                     });
                 });
             });

--- a/SmartDeviceLink_Example/Base.lproj/ConnectionIAPTableViewController.storyboard
+++ b/SmartDeviceLink_Example/Base.lproj/ConnectionIAPTableViewController.storyboard
@@ -1,8 +1,13 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="J12-ul-Tx1">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="J12-ul-Tx1">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--ConnectionIAP Table View Controller-->
@@ -10,22 +15,24 @@
             <objects>
                 <tableViewController id="J12-ul-Tx1" customClass="ConnectionIAPTableViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" id="MzB-GZ-Ook">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" red="0.93725490196078431" green="0.93725490196078431" blue="0.95686274509803926" alpha="1" colorSpace="calibratedRGB"/>
+                        <color key="backgroundColor" red="0.93725490196078431" green="0.93725490196078431" blue="0.95686274509803926" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <sections>
                             <tableViewSection id="Qz3-D9-j37">
                                 <cells>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="2sd-U1-9xV">
+                                        <rect key="frame" x="0.0" y="35" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="2sd-U1-9xV" id="EhZ-2E-WQ5">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rjq-vZ-OjB">
-                                                    <rect key="frame" x="0.0" y="0.0" width="600" height="44"/>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rjq-vZ-OjB">
+                                                    <rect key="frame" x="8" y="0.0" width="359" height="44"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="23"/>
                                                     <state key="normal" title="Connect">
-                                                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                                        <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     </state>
                                                     <connections>
                                                         <action selector="connectButtonWasPressed:" destination="J12-ul-Tx1" eventType="touchUpInside" id="95T-fc-kXs"/>
@@ -35,8 +42,8 @@
                                             <constraints>
                                                 <constraint firstItem="rjq-vZ-OjB" firstAttribute="top" secondItem="EhZ-2E-WQ5" secondAttribute="top" id="8GY-v0-41a"/>
                                                 <constraint firstAttribute="bottom" secondItem="rjq-vZ-OjB" secondAttribute="bottom" id="FKB-JG-o5G"/>
-                                                <constraint firstAttribute="trailingMargin" secondItem="rjq-vZ-OjB" secondAttribute="trailing" constant="-8" id="ISQ-6b-S34"/>
-                                                <constraint firstItem="rjq-vZ-OjB" firstAttribute="leading" secondItem="EhZ-2E-WQ5" secondAttribute="leadingMargin" constant="-8" id="PiJ-h3-NOR"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="rjq-vZ-OjB" secondAttribute="trailing" id="ISQ-6b-S34"/>
+                                                <constraint firstItem="rjq-vZ-OjB" firstAttribute="leading" secondItem="EhZ-2E-WQ5" secondAttribute="leadingMargin" id="PiJ-h3-NOR"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>

--- a/SmartDeviceLink_Example/Base.lproj/ConnectionTCPTableViewController.storyboard
+++ b/SmartDeviceLink_Example/Base.lproj/ConnectionTCPTableViewController.storyboard
@@ -1,31 +1,35 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="l5Q-ZP-1BO">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="l5Q-ZP-1BO">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--ConnectionTCP Table View Controller-->
         <scene sceneID="geJ-kX-PTm">
             <objects>
                 <tableViewController id="l5Q-ZP-1BO" customClass="ConnectionTCPTableViewController" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" showsSelectionImmediatelyOnTouchBegin="NO" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" id="7ZH-AV-Zyf">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" id="7ZH-AV-Zyf">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" red="0.93725490196078431" green="0.93725490196078431" blue="0.95686274509803926" alpha="1" colorSpace="calibratedRGB"/>
+                        <color key="backgroundColor" red="0.93725490196078431" green="0.93725490196078431" blue="0.95686274509803926" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <sections>
                             <tableViewSection headerTitle="TCP Server" id="bF6-yi-Ial">
                                 <cells>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="pbJ-oz-jNt">
-                                        <rect key="frame" x="0.0" y="50" width="600" height="44"/>
+                                        <rect key="frame" x="0.0" y="56" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="pbJ-oz-jNt" id="B7X-yY-lwJ">
-                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="IP Address" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="xqM-s4-9RV">
-                                                    <rect key="frame" x="8" y="0.0" width="584" height="44"/>
+                                                    <rect key="frame" x="8" y="0.0" width="359" height="44"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="44" id="5Pw-mh-x83"/>
                                                     </constraints>
@@ -41,14 +45,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="C5b-fS-v3d">
-                                        <rect key="frame" x="0.0" y="94" width="600" height="44"/>
+                                        <rect key="frame" x="0.0" y="100" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="C5b-fS-v3d" id="ZD4-xA-og5">
-                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Port" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="hsI-ld-8xY">
-                                                    <rect key="frame" x="8" y="0.0" width="584" height="44"/>
+                                                    <rect key="frame" x="8" y="0.0" width="359" height="44"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="44" id="FpG-5e-MHT"/>
                                                     </constraints>
@@ -68,17 +72,17 @@
                             <tableViewSection headerTitle="" id="rgl-Lm-uDH">
                                 <cells>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="ybX-Eh-Hbx">
-                                        <rect key="frame" x="0.0" y="158" width="600" height="44"/>
+                                        <rect key="frame" x="0.0" y="164" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="ybX-Eh-Hbx" id="uI9-fK-205">
-                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="tailTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="t37-4W-6F4">
-                                                    <rect key="frame" x="0.0" y="0.0" width="600" height="43"/>
+                                                    <rect key="frame" x="8" y="0.0" width="359" height="43"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="23"/>
                                                     <state key="normal" title="Connect">
-                                                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                                        <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     </state>
                                                     <connections>
                                                         <action selector="connectButtonWasPressed:" destination="l5Q-ZP-1BO" eventType="touchUpInside" id="tgb-10-M4m"/>
@@ -87,9 +91,9 @@
                                             </subviews>
                                             <constraints>
                                                 <constraint firstItem="t37-4W-6F4" firstAttribute="top" secondItem="uI9-fK-205" secondAttribute="top" id="IfU-4k-EXx"/>
-                                                <constraint firstItem="t37-4W-6F4" firstAttribute="leading" secondItem="uI9-fK-205" secondAttribute="leadingMargin" constant="-8" id="cc3-uk-9fL"/>
+                                                <constraint firstItem="t37-4W-6F4" firstAttribute="leading" secondItem="uI9-fK-205" secondAttribute="leadingMargin" id="cc3-uk-9fL"/>
                                                 <constraint firstAttribute="bottom" secondItem="t37-4W-6F4" secondAttribute="bottom" id="hnD-4g-xvT"/>
-                                                <constraint firstAttribute="trailingMargin" secondItem="t37-4W-6F4" secondAttribute="trailing" constant="-8" id="j4p-fi-0LP"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="t37-4W-6F4" secondAttribute="trailing" id="j4p-fi-0LP"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>

--- a/SmartDeviceLink_Example/Classes/ConnectionIAPTableViewController.m
+++ b/SmartDeviceLink_Example/Classes/ConnectionIAPTableViewController.m
@@ -73,7 +73,7 @@
 - (void)proxyManagerDidChangeState:(ProxyState)newState {
     UIColor* newColor = nil;
     NSString* newTitle = nil;
-    
+
     switch (newState) {
         case ProxyStateStopped: {
             newColor = [UIColor redColor];
@@ -89,11 +89,11 @@
         } break;
         default: break;
     }
-    
-    if (newColor && newTitle) {
+
+    if (newColor || newTitle) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            self.connectTableViewCell.backgroundColor = newColor;
-            self.connectButton.titleLabel.text = newTitle;
+            [self.connectTableViewCell setBackgroundColor:newColor];
+            [self.connectButton setTitle:newTitle forState:UIControlStateNormal];
         });
     }
 }

--- a/SmartDeviceLink_Example/Classes/ConnectionTCPTableViewController.m
+++ b/SmartDeviceLink_Example/Classes/ConnectionTCPTableViewController.m
@@ -122,10 +122,10 @@
         default: break;
     }
     
-    if (newColor && newTitle) {
+    if (newColor || newTitle) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            self.connectTableViewCell.backgroundColor = newColor;
-            self.connectButton.titleLabel.text = newTitle;
+            [self.connectTableViewCell setBackgroundColor:newColor];
+            [self.connectButton setTitle:newTitle forState:UIControlStateNormal];
         });
     }
 }

--- a/SmartDeviceLink_Example/Classes/ProxyManager.m
+++ b/SmartDeviceLink_Example/Classes/ProxyManager.m
@@ -15,7 +15,7 @@ NSString *const SDLAppId = @"9999";
 NSString *const PointingSoftButtonArtworkName = @"PointingSoftButtonIcon";
 NSString *const MainGraphicArtworkName = @"MainArtwork";
 
-BOOL const ShouldRestartOnDisconnect = YES;
+BOOL const ShouldRestartOnDisconnect = NO;
 
 typedef NS_ENUM(NSUInteger, SDLHMIFirstState) {
     SDLHMIFirstStateNone,
@@ -110,6 +110,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)reset {
+    [self sdlex_updateProxyState:ProxyStateStopped];
     [self.sdlManager stop];
 }
 

--- a/SmartDeviceLink_Example/Classes/ProxyManager.m
+++ b/SmartDeviceLink_Example/Classes/ProxyManager.m
@@ -91,7 +91,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)startManager {
     __weak typeof (self) weakSelf = self;
     [self.sdlManager startWithReadyHandler:^(BOOL success, NSError * _Nullable error) {
-        if (!success) {
+        if (!weakSelf.sdlManager.registerResponse.success.boolValue) {
             NSLog(@"SDL errored starting up: %@", error);
             [weakSelf sdlex_updateProxyState:ProxyStateStopped];
         } else {
@@ -108,6 +108,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)reset {
     [self.sdlManager stop];
+    [self startManager];
 }
 
 - (void)showInitialData {

--- a/SmartDeviceLink_Example/Classes/ProxyManager.m
+++ b/SmartDeviceLink_Example/Classes/ProxyManager.m
@@ -93,14 +93,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)startManager {
     __weak typeof (self) weakSelf = self;
     [self.sdlManager startWithReadyHandler:^(BOOL success, NSError * _Nullable error) {
-        if (!weakSelf.sdlManager.registerResponse.success.boolValue) {
+        if (!success) {
             NSLog(@"SDL errored starting up: %@", error);
             [weakSelf sdlex_updateProxyState:ProxyStateStopped];
-        } else {
-            [weakSelf sdlex_updateProxyState:ProxyStateConnected];
+            return;
         }
+        
+        [weakSelf sdlex_updateProxyState:ProxyStateConnected];
 
-        [self setupPermissionsCallbacks];
+        [weakSelf setupPermissionsCallbacks];
         
         if ([weakSelf.sdlManager.hmiLevel isEqualToEnum:[SDLHMILevel FULL]]) {
             [weakSelf showInitialData];

--- a/SmartDeviceLink_Example/Classes/ProxyManager.m
+++ b/SmartDeviceLink_Example/Classes/ProxyManager.m
@@ -15,6 +15,8 @@ NSString *const SDLAppId = @"9999";
 NSString *const PointingSoftButtonArtworkName = @"PointingSoftButtonIcon";
 NSString *const MainGraphicArtworkName = @"MainArtwork";
 
+BOOL const ShouldRestartOnDisconnect = YES;
+
 typedef NS_ENUM(NSUInteger, SDLHMIFirstState) {
     SDLHMIFirstStateNone,
     SDLHMIFirstStateNonNone,
@@ -108,7 +110,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)reset {
     [self.sdlManager stop];
-    [self startManager];
 }
 
 - (void)showInitialData {
@@ -355,6 +356,9 @@ NS_ASSUME_NONNULL_BEGIN
     self.firstTimeState = SDLHMIFirstStateNone;
     self.initialShowState = SDLHMIInitialShowStateNone;
     _state = ProxyStateStopped;
+    if (ShouldRestartOnDisconnect) {
+        [self startManager];
+    }
 }
 
 - (void)hmiLevel:(SDLHMILevel *)oldLevel didChangeToLevel:(SDLHMILevel *)newLevel {


### PR DESCRIPTION
#Fixes #509 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
You can test this by calling `stop` in your project. The proxy will now no longer attempt to re-register.

### Summary
Added an additional stage in the lifecycle manager to fix a bug around calling `stop` which wouldn't actually stop the proxy and remain stopped, but instead would restart the proxy.

### Changelog
##### Bug Fixes
* Fixed a bug within `SDLLifecycleManager`'s `stop` method that caused to proxy to stay stopped.