### PR TITLE
Fixed SDLDebugTool deleting log file after proxy restart

### DIFF
--- a/SmartDeviceLink/SDLDebugTool.m
+++ b/SmartDeviceLink/SDLDebugTool.m
@@ -185,6 +185,10 @@
 }
 
 - (void)sdl_enableDebugToLogFile {
+    if (self.debugToLogFile) {
+        return;
+    }
+    
     [SDLDebugTool logInfo:@"Enabling Log File" withType:SDLDebugType_Debug];
 
     self.debugToLogFile = YES;

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -87,6 +87,9 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
     _configuration = configuration;
     _delegate = delegate;
 
+    // Logging
+    [self.class sdl_updateLoggingWithFlags:self.configuration.lifecycleConfig.logFlags];
+
     // Private properties
     _lifecycleStateMachine = [[SDLStateMachine alloc] initWithTarget:self initialState:SDLLifecycleStateStopped states:[self.class sdl_stateTransitionDictionary]];
     _lastCorrelationId = 0;
@@ -98,9 +101,6 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
     _fileManager = [[SDLFileManager alloc] initWithConnectionManager:self];
     _permissionManager = [[SDLPermissionManager alloc] init];
     _lockScreenManager = [[SDLLockScreenManager alloc] initWithConfiguration:_configuration.lockScreenConfig notificationDispatcher:_notificationDispatcher presenter:[[SDLLockScreenPresenter alloc] init]];
-
-    // Logging
-    [self.class sdl_updateLoggingWithFlags:self.configuration.lifecycleConfig.logFlags];
 
     // Notifications
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(transportDidConnect) name:SDLTransportDidConnect object:_notificationDispatcher];

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -65,7 +65,6 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
 
 // Private properties
 @property (copy, nonatomic) SDLManagerReadyBlock readyHandler;
-@property (assign, nonatomic) SDLLogOutput currentLogging;
 
 @end
 
@@ -94,13 +93,16 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
     _notificationDispatcher = [[SDLNotificationDispatcher alloc] init];
     _responseDispatcher = [[SDLResponseDispatcher alloc] initWithNotificationDispatcher:_notificationDispatcher];
     _registerResponse = nil;
-    _currentLogging = SDLLogOutputNone;
 
     // Managers
     _fileManager = [[SDLFileManager alloc] initWithConnectionManager:self];
     _permissionManager = [[SDLPermissionManager alloc] init];
     _lockScreenManager = [[SDLLockScreenManager alloc] initWithConfiguration:_configuration.lockScreenConfig notificationDispatcher:_notificationDispatcher presenter:[[SDLLockScreenPresenter alloc] init]];
 
+    // Logging
+    [self.class sdl_updateLoggingWithFlags:self.configuration.lifecycleConfig.logFlags];
+
+    // Notifications
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(transportDidConnect) name:SDLTransportDidConnect object:_notificationDispatcher];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(transportDidDisconnect) name:SDLTransportDidDisconnect object:_notificationDispatcher];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(hmiStatusDidChange:) name:SDLDidChangeHMIStatusNotification object:_notificationDispatcher];
@@ -152,9 +154,6 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
 }
 
 - (void)didEnterStateStarted {
-    // Set up our logging capabilities based on the config
-    [self.class sdl_updateLoggingWithFlags:self.configuration.lifecycleConfig.logFlags];
-    
     // Start up the internal proxy object
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -413,13 +412,7 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
     return YES;
 }
 
-- (void)sdl_updateLoggingWithFlags:(SDLLogOutput)logFlags {
-    if (_currentLogging == logFlags) {
-        return;
-    }
-    
-    _currentLogging = logFlags;
-    
++ (void)sdl_updateLoggingWithFlags:(SDLLogOutput)logFlags {
     if (logFlags == SDLLogOutputNone) {
         [SDLDebugTool disable];
         return;

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -63,6 +63,7 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
 
 // Private properties
 @property (copy, nonatomic) SDLManagerReadyBlock readyHandler;
+@property (assign, nonatomic) SDLLogOutput currentLogging;
 
 @end
 
@@ -91,6 +92,7 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
     _notificationDispatcher = [[SDLNotificationDispatcher alloc] init];
     _responseDispatcher = [[SDLResponseDispatcher alloc] initWithNotificationDispatcher:_notificationDispatcher];
     _registerResponse = nil;
+    _currentLogging = SDLLogOutputNone;
 
     // Managers
     _fileManager = [[SDLFileManager alloc] initWithConnectionManager:self];
@@ -387,8 +389,17 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
     return YES;
 }
 
-    + (void)sdl_updateLoggingWithFlags : (SDLLogOutput)logFlags {
-    [SDLDebugTool disable];
+- (void)sdl_updateLoggingWithFlags:(SDLLogOutput)logFlags {
+    if (_currentLogging == logFlags) {
+        return;
+    }
+    
+    _currentLogging = logFlags;
+    
+    if (logFlags == SDLLogOutputNone) {
+        [SDLDebugTool disable];
+        return;
+    }
 
     if ((logFlags & SDLLogOutputConsole) == SDLLogOutputConsole) {
         [SDLDebugTool enable];


### PR DESCRIPTION
Fixes #512 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
This PR fixes an issue with `SDLDebugTool` writing over the log file if the proxy is recycled, instead of appending to it.

### Changelog
##### Bug Fixes
* This PR fixes an issue with `SDLDebugTool` writing over the log file if the proxy is recycled, instead of appending to it.