### PR TITLE
Sending HMI Level Change delegate only when actually different

### DIFF
--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -466,7 +466,9 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
         return;
     }
 
-    [self.delegate hmiLevel:oldHMILevel didChangeToLevel:self.hmiLevel];
+    if (![oldHMILevel isEqualToEnum:self.hmiLevel]) {
+        [self.delegate hmiLevel:oldHMILevel didChangeToLevel:self.hmiLevel];
+    }
 }
 
 - (void)remoteHardwareDidUnregister:(SDLRPCNotificationNotification *)notification {


### PR DESCRIPTION
Fixes #516 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Unable to find successful testing plan

### Summary
Added in a check to only send the `hmiLevel:didChangeToLevel:` when there is a difference.

### Changelog
##### Bug Fixes
* Added in a check to only send the `hmiLevel:didChangeToLevel:` when there is a difference.
