### PR TITLE
Fix issue around releasing already released Compression Session

### DIFF
--- a/SmartDeviceLink/SDLStreamingMediaManager.m
+++ b/SmartDeviceLink/SDLStreamingMediaManager.m
@@ -377,6 +377,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (self.compressionSession != NULL) {
         VTCompressionSessionInvalidate(self.compressionSession);
         CFRelease(self.compressionSession);
+        self.compressionSession = NULL;
     }
 }
 


### PR DESCRIPTION
Fixes #518 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
This can be tested by passing in unsupported video encoder settings.

### Summary
This PR fixes an issue with over-releasing the video compression session when providing bad encoder settings.

### Changelog
##### Bug Fixes
* Fixed an issue with over-releasing the video compression session when providing bad encoder settings.
