### PR TITLE
Fixed issue with throwing instead of returning nil in SDLProxy's streamingMediaManager

### DIFF
--- a/SmartDeviceLink/SDLProxy.m
+++ b/SmartDeviceLink/SDLProxy.m
@@ -182,7 +182,7 @@ const int POLICIES_CORRELATION_ID = 65535;
 - (SDLStreamingMediaManager *)streamingMediaManager {
     if (_streamingMediaManager == nil) {
         if (self.displayCapabilities == nil) {
-            @throw [NSException exceptionWithName:NSInvalidArgumentException reason:@"SDLStreamingMediaManager must be accessed only after a successful RegisterAppInterfaceResponse" userInfo:nil];
+            return nil;
         }
         _streamingMediaManager = [[SDLStreamingMediaManager alloc] initWithProtocol:self.protocol displayCapabilities:self.displayCapabilities];
         [self.protocol.protocolDelegateTable addObject:_streamingMediaManager];


### PR DESCRIPTION
Fixes #520 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
You can test this by starting the manager, while not connected, and attempting to access `SDLStreamingMediaManager` via `SDLManager`.

### Summary
Fixed issue with throwing instead of returning nil when accessing uninitialized object. 

### Changelog
##### Bug Fixes
* Fixed issue with throwing instead of returning nil when accessing uninitialized object.
