### PR TITLE
Update structs to support being copied

### DIFF
--- a/SmartDeviceLink/SDLAddCommand.m
+++ b/SmartDeviceLink/SDLAddCommand.m
@@ -100,6 +100,13 @@ NS_ASSUME_NONNULL_BEGIN
     return [parameters sdl_objectForName:SDLNameCommandIcon ofClass:SDLImage.class];
 }
 
+-(id)copyWithZone:(nullable NSZone *)zone {
+    SDLAddCommand *newCommand = [super copyWithZone:zone];
+    newCommand->_handler = self.handler;
+
+    return newCommand;
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLRPCStruct.h
+++ b/SmartDeviceLink/SDLRPCStruct.h
@@ -8,7 +8,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SDLRPCStruct : NSObject {
+@interface SDLRPCStruct : NSObject <NSCopying> {
     NSMutableDictionary<NSString *, id> *store;
 }
 

--- a/SmartDeviceLink/SDLRPCStruct.m
+++ b/SmartDeviceLink/SDLRPCStruct.m
@@ -75,6 +75,13 @@ NS_ASSUME_NONNULL_BEGIN
     return ret;
 }
 
+-(id)copyWithZone:(nullable NSZone *)zone {
+    SDLRPCStruct *newStruct = [[[self class] allocWithZone:zone] init];
+    newStruct->store = [self->store copy];
+
+    return newStruct;
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLSoftButton.m
+++ b/SmartDeviceLink/SDLSoftButton.m
@@ -87,6 +87,13 @@ NS_ASSUME_NONNULL_BEGIN
     return [store sdl_objectForName:SDLNameSystemAction];
 }
 
+-(id)copyWithZone:(nullable NSZone *)zone {
+    SDLSoftButton *newButton = [super copyWithZone:zone];
+    newButton->_handler = self.handler;
+
+    return newButton;
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLSubscribeButton.m
+++ b/SmartDeviceLink/SDLSubscribeButton.m
@@ -48,6 +48,13 @@ NS_ASSUME_NONNULL_BEGIN
     return [parameters sdl_objectForName:SDLNameButtonName];
 }
 
+-(id)copyWithZone:(nullable NSZone *)zone {
+    SDLSubscribeButton *newButton = [super copyWithZone:zone];
+    newButton->_handler = self.handler;
+
+    return newButton;
+}
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Fixes #523 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
n/a

### Summary
This PR merely adds the ability for RPCs to be copied. They remain not copied within any RPC class.

### Changelog
##### Enchancements
* RPCs may now be copied instead passed by reference if desired.
