### PR TITLE
Fix lock screen showing when HMI is backgrounded

### DIFF
--- a/SmartDeviceLink/SDLLockScreenStatusManager.m
+++ b/SmartDeviceLink/SDLLockScreenStatusManager.m
@@ -71,10 +71,17 @@
         return [SDLLockScreenStatus OFF];
     } else if ([self.hmiLevel isEqualToEnum:[SDLHMILevel BACKGROUND]]) {
         // App is in the background on the car
-        // The lockscreen depends entirely on if the user selected the app
         if (self.userSelected) {
-            return [SDLLockScreenStatus REQUIRED];
+            // It was user selected
+            if (self.haveDriverDistractionStatus && !self.driverDistracted) {
+                // We have the distraction status, and the driver is not distracted
+                return [SDLLockScreenStatus OPTIONAL];
+            } else {
+                // We don't have the distraction status, and/or the driver is distracted
+                return [SDLLockScreenStatus REQUIRED];
+            }
         } else {
+            // It wasn't user selected
             return [SDLLockScreenStatus OFF];
         }
     } else if ([self.hmiLevel isEqualToEnum:[SDLHMILevel FULL]] || [self.hmiLevel isEqualToEnum:[SDLHMILevel LIMITED]]) {

--- a/SmartDeviceLinkTests/ProxySpecs/SDLLockScreenStatusManagerSpec.m
+++ b/SmartDeviceLinkTests/ProxySpecs/SDLLockScreenStatusManagerSpec.m
@@ -122,9 +122,31 @@ describe(@"the lockscreen status manager", ^{
                 beforeEach(^{
                     lockScreenManager.userSelected = YES;
                 });
-                
-                it(@"should return lock screen required", ^{
-                    expect(lockScreenManager.lockScreenStatus).to(equal([SDLLockScreenStatus REQUIRED]));
+
+                context(@"if we do not set the driver distraction state", ^{
+                    it(@"should return lock screen required", ^{
+                        expect(lockScreenManager.lockScreenStatus).to(equal([SDLLockScreenStatus REQUIRED]));
+                    });
+                });
+
+                context(@"if we set the driver distraction state to false", ^{
+                    beforeEach(^{
+                        lockScreenManager.driverDistracted = NO;
+                    });
+
+                    it(@"should return lock screen optional", ^{
+                        expect(lockScreenManager.lockScreenStatus).to(equal([SDLLockScreenStatus OPTIONAL]));
+                    });
+                });
+
+                context(@"if we set the driver distraction state to true", ^{
+                    beforeEach(^{
+                        lockScreenManager.driverDistracted = YES;
+                    });
+
+                    it(@"should return lock screen required", ^{
+                        expect(lockScreenManager.lockScreenStatus).to(equal([SDLLockScreenStatus REQUIRED]));
+                    });
                 });
             });
             


### PR DESCRIPTION
Fixes #539

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Unit tests are included.

### Summary
This fixes a bug in which the lock screen will sometimes appear when it ought not.

### Changelog
##### Bug Fixes
* Update `SDLLockScreenStatusManager` to use OPTIONAL status in the background when appropriate.