### PR TITLE
Fix issue with disconnecting while streaming video.

### DIFF
--- a/SmartDeviceLink/SDLStreamingMediaManager.m
+++ b/SmartDeviceLink/SDLStreamingMediaManager.m
@@ -384,13 +384,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark Callbacks
 
-void sdl_videoEncoderOutputCallback(void *outputCallbackRefCon, void *sourceFrameRefCon, OSStatus status, VTEncodeInfoFlags infoFlags, CMSampleBufferRef sampleBuffer) {
+void sdl_videoEncoderOutputCallback(void * CM_NULLABLE outputCallbackRefCon, void * CM_NULLABLE sourceFrameRefCon, OSStatus status, VTEncodeInfoFlags infoFlags, CM_NULLABLE CMSampleBufferRef sampleBuffer) {
     // If there was an error in the encoding, drop the frame
     if (status != noErr) {
         [SDLDebugTool logFormat:@"Error encoding video, err=%lld", (int64_t)status];
         return;
     }
 
+    if (outputCallbackRefCon == NULL || sourceFrameRefCon == NULL || sampleBuffer == NULL) {
+        return;
+    }
+    
     SDLStreamingMediaManager *mediaManager = (__bridge SDLStreamingMediaManager *)sourceFrameRefCon;
     NSData *elementaryStreamData = [mediaManager.class sdl_encodeElementaryStreamWithSampleBuffer:sampleBuffer];
 


### PR DESCRIPTION
Fixes #529 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
This issue is being confirmed as fixed by @clu42

### Summary
This PR adds in some checks around the nullability of callback values from the video encoder.

### Changelog
##### Bug Fixes
* Added in nullability checks into video encoder callback.
