### PR TITLE
Improve description of state machine exception throw

### DIFF
--- a/SmartDeviceLink/SDLStateMachine.m
+++ b/SmartDeviceLink/SDLStateMachine.m
@@ -62,9 +62,11 @@ SDLStateMachineTransitionFormat const SDLStateMachineTransitionFormatDidEnter = 
     }
 
     if (![self sdl_canState:self.currentState transitionToState:state]) {
+        NSString *classString = NSStringFromClass([self.target class]);
+        NSString *reasonMessage = [NSString stringWithFormat:@"Invalid state machine transition of %@ occurred from %@ to %@", classString, self.currentState, state];
         @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                       reason:@"Invalid state machine transition occurred"
-                                     userInfo:@{SDLStateMachineExceptionInfoKeyTargetClass: NSStringFromClass([self.target class]),
+                                       reason:reasonMessage
+                                     userInfo:@{SDLStateMachineExceptionInfoKeyTargetClass: classString,
                                                 SDLStateMachineExceptionInfoKeyFromState: self.currentState,
                                                 SDLStateMachineExceptionInfoKeyToClass: state}];
     }

--- a/SmartDeviceLink/SDLStateMachine.m
+++ b/SmartDeviceLink/SDLStateMachine.m
@@ -62,11 +62,11 @@ SDLStateMachineTransitionFormat const SDLStateMachineTransitionFormatDidEnter = 
     }
 
     if (![self sdl_canState:self.currentState transitionToState:state]) {
-        NSString *classString = NSStringFromClass([self.target class]);
-        NSString *reasonMessage = [NSString stringWithFormat:@"Invalid state machine transition of %@ occurred from %@ to %@", classString, self.currentState, state];
+        NSString *targetClassString = NSStringFromClass([self.target class]);
+        NSString *reasonMessage = [NSString stringWithFormat:@"Invalid state machine %@ transition of target %@ occurred from %@ to %@", NSStringFromClass(self.class), targetClassString, self.currentState, state];
         @throw [NSException exceptionWithName:NSInternalInconsistencyException
                                        reason:reasonMessage
-                                     userInfo:@{SDLStateMachineExceptionInfoKeyTargetClass: classString,
+                                     userInfo:@{SDLStateMachineExceptionInfoKeyTargetClass: targetClassString,
                                                 SDLStateMachineExceptionInfoKeyFromState: self.currentState,
                                                 SDLStateMachineExceptionInfoKeyToClass: state}];
     }

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLStateMachineSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLStateMachineSpec.m
@@ -121,11 +121,14 @@ describe(@"A state machine", ^{
             });
             
             it(@"should throw an exception trying to transition incorrectly and nothing should be called", ^{
+                NSString *stateMachineClassString = NSStringFromClass(testStateMachine.class);
+                NSString *targetClassString = NSStringFromClass(testTarget.class);
+                
                 // Side effects, but I can't think of any other way around it.
                 expectAction(^{
                     [testStateMachine transitionToState:thirdState];
-                }).to(raiseException().named(NSInternalInconsistencyException));
-                
+                }).to(raiseException().named(NSInternalInconsistencyException).reason([NSString stringWithFormat:@"Invalid state machine %@ transition of target %@ occurred from %@ to %@", stateMachineClassString, targetClassString, initialState, thirdState]).userInfo(@{@"fromState": initialState, @"toState": thirdState, @"targetClass": targetClassString}));
+                    
                 expect(@([testStateMachine isCurrentState:initialState])).to(equal(@YES));
                 expect(@([testStateMachine isCurrentState:thirdState])).to(equal(@NO));
                 expect(@(willLeaveNotificationCalled)).to(equal(@NO));
@@ -140,5 +143,7 @@ describe(@"A state machine", ^{
         });
     });
 });
+
+// Invalid state machine transition of TestStateMachineTarget occurred from Initial to Third
 
 QuickSpecEnd


### PR DESCRIPTION
Fixes #543 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
This PR adds in a more descriptive reason message for invalid state machine transition.

### Changelog
##### Enchancements
* Improved description when throwing an error for invalid state machine transition.