### PR TITLE
Fix crash when trying to start and already started SDLManager

### DIFF
--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -112,6 +112,11 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
 }
 
 - (void)startWithReadyHandler:(SDLManagerReadyBlock)readyHandler {
+    if (![self.lifecycleStateMachine isCurrentState:SDLLifecycleStateStopped]) {
+        [SDLDebugTool logFormat:@"Warning: SDL has already been started, this attempt will be ignored."];
+        return;
+    }
+    
     self.readyHandler = [readyHandler copy];
 
     [self.lifecycleStateMachine transitionToState:SDLLifecycleStateStarted];


### PR DESCRIPTION
Fixes #549 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
You can test this change by replacing code to `ProxyManager.m`'s `startManager` function:

```objc
- (void)startManager {
    __weak typeof (self) weakSelf = self;
    [self.sdlManager startWithReadyHandler:^(BOOL success, NSError * _Nullable error) {
        if (!success) {
            NSLog(@"SDL errored starting up: %@", error);
            [weakSelf sdlex_updateProxyState:ProxyStateStopped];
            return;
        }
        
        [weakSelf sdlex_updateProxyState:ProxyStateConnected];

        [weakSelf setupPermissionsCallbacks];
        
        if ([weakSelf.sdlManager.hmiLevel isEqualToEnum:[SDLHMILevel FULL]]) {
            [weakSelf showInitialData];
        }
        
        // This will cause a crash
        [weakSelf.sdlManager startWithReadyHandler:^(BOOL success, NSError * _Nullable error) {
            
        }];
    }];
}
```

### Summary
Fix issue with trying to start and already started `SDLManager`. 

### Changelog
##### Bug Fixes
* Fix issue with trying to start and already started `SDLManager`.