### PR TITLE
Improve notification handling

### DIFF
--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -401,16 +401,7 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
     return @(++self.lastCorrelationId);
 }
 
-+ (BOOL)sdl_checkNotification:(NSNotification *)notification containsKindOfClass:(Class)class {
-    NSAssert([notification.userInfo[SDLNotificationUserInfoObject] isKindOfClass:class], @"A notification was sent with an unanticipated object");
-    if (![notification.userInfo[SDLNotificationUserInfoObject] isKindOfClass:class]) {
-        return NO;
-    }
-
-    return YES;
-}
-
-+ (void)sdl_updateLoggingWithFlags : (SDLLogOutput)logFlags {
++ (void)sdl_updateLoggingWithFlags:(SDLLogOutput)logFlags {
     if (logFlags == SDLLogOutputNone) {
         [SDLDebugTool disable];
         return;
@@ -443,7 +434,7 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
 }
 
 - (void)hmiStatusDidChange:(SDLRPCNotificationNotification *)notification {
-    if (![self.class sdl_checkNotification:notification containsKindOfClass:[SDLOnHMIStatus class]]) {
+    if (![notification isNotificationKindOfClass:[SDLOnHMIStatus class]]) {
         return;
     }
 
@@ -461,7 +452,7 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
 }
 
 - (void)remoteHardwareDidUnregister:(SDLRPCNotificationNotification *)notification {
-    if (![self.class sdl_checkNotification:notification containsKindOfClass:[SDLOnAppInterfaceUnregistered class]]) {
+    if (![notification isNotificationKindOfClass:[SDLOnAppInterfaceUnregistered class]]) {
         return;
     }
 

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -434,7 +434,7 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
 }
 
 - (void)hmiStatusDidChange:(SDLRPCNotificationNotification *)notification {
-    if (![notification isNotificationKindOfClass:[SDLOnHMIStatus class]]) {
+    if (![notification isNotificationMemberOfClass:[SDLOnHMIStatus class]]) {
         return;
     }
 
@@ -452,7 +452,7 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
 }
 
 - (void)remoteHardwareDidUnregister:(SDLRPCNotificationNotification *)notification {
-    if (![notification isNotificationKindOfClass:[SDLOnAppInterfaceUnregistered class]]) {
+    if (![notification isNotificationMemberOfClass:[SDLOnAppInterfaceUnregistered class]]) {
         return;
     }
 

--- a/SmartDeviceLink/SDLLockScreenManager.m
+++ b/SmartDeviceLink/SDLLockScreenManager.m
@@ -91,7 +91,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Notification Selectors
 
 - (void)sdl_lockScreenStatusDidChange:(SDLRPCNotificationNotification *)notification {
-    if (![notification isNotificationKindOfClass:[SDLOnLockScreenStatus class]]) {
+    if (![notification isNotificationMemberOfClass:[SDLOnLockScreenStatus class]]) {
         return;
     }
 

--- a/SmartDeviceLink/SDLLockScreenManager.m
+++ b/SmartDeviceLink/SDLLockScreenManager.m
@@ -91,8 +91,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Notification Selectors
 
 - (void)sdl_lockScreenStatusDidChange:(SDLRPCNotificationNotification *)notification {
-    NSAssert([notification.notification isKindOfClass:[SDLOnLockScreenStatus class]], @"A notification was sent with an unanticipated object");
-    if (![notification.notification isKindOfClass:[SDLOnLockScreenStatus class]]) {
+    if (![notification isNotificationKindOfClass:[SDLOnLockScreenStatus class]]) {
         return;
     }
 

--- a/SmartDeviceLink/SDLPermissionManager.m
+++ b/SmartDeviceLink/SDLPermissionManager.m
@@ -175,7 +175,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - SDL Notification Observers
 
 - (void)sdl_permissionsDidChange:(SDLRPCNotificationNotification *)notification {
-    if (![notification isNotificationKindOfClass:[SDLOnPermissionsChange class]]) {
+    if (![notification isNotificationMemberOfClass:[SDLOnPermissionsChange class]]) {
         return;
     }
 
@@ -218,7 +218,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)sdl_hmiLevelDidChange:(SDLRPCNotificationNotification *)notification {
-    if (![notification isNotificationKindOfClass:[SDLOnHMIStatus class]]) {
+    if (![notification isNotificationMemberOfClass:[SDLOnHMIStatus class]]) {
         return;
     }
 

--- a/SmartDeviceLink/SDLPermissionManager.m
+++ b/SmartDeviceLink/SDLPermissionManager.m
@@ -174,13 +174,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - SDL Notification Observers
 
-- (void)sdl_permissionsDidChange:(NSNotification *)notification {
-    NSAssert([notification.userInfo[SDLNotificationUserInfoObject] isKindOfClass:[SDLOnPermissionsChange class]], @"A notification was sent with an unanticipated object");
-    if (![notification.userInfo[SDLNotificationUserInfoObject] isKindOfClass:[SDLOnPermissionsChange class]]) {
+- (void)sdl_permissionsDidChange:(SDLRPCNotificationNotification *)notification {
+    if (![notification isNotificationKindOfClass:[SDLOnPermissionsChange class]]) {
         return;
     }
 
-    SDLOnPermissionsChange *onPermissionChange = notification.userInfo[SDLNotificationUserInfoObject];
+    SDLOnPermissionsChange *onPermissionChange = notification.notification;
     NSArray<SDLPermissionItem *> *newPermissionItems = [onPermissionChange.permissionItem copy];
     NSArray<SDLPermissionFilter *> *currentFilters = [self.filters copy];
 
@@ -219,12 +218,11 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)sdl_hmiLevelDidChange:(SDLRPCNotificationNotification *)notification {
-    NSAssert([notification.notification isKindOfClass:[SDLOnHMIStatus class]], @"A notification was sent with an unanticipated object");
-    if (![notification.notification isKindOfClass:[SDLOnHMIStatus class]]) {
+    if (![notification isNotificationKindOfClass:[SDLOnHMIStatus class]]) {
         return;
     }
 
-    SDLOnHMIStatus *hmiStatus = notification.userInfo[SDLNotificationUserInfoObject];
+    SDLOnHMIStatus *hmiStatus = notification.notification;
 
     SDLHMILevel oldHMILevel = [self.currentHMILevel copy];
     self.currentHMILevel = hmiStatus.hmiLevel;

--- a/SmartDeviceLink/SDLRPCNotificationNotification.h
+++ b/SmartDeviceLink/SDLRPCNotificationNotification.h
@@ -20,12 +20,19 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithName:(NSString *)name object:(nullable id)object rpcNotification:(__kindof SDLRPCNotification *)notification;
 
 /**
- *
- *  Returns whether or not the containing notification is a kind of class.
+ *  Returns whether or not the containing notification is equal to a class, not including subclasses.
  *
  *  @param aClass the class your are questioning
  */
+- (BOOL)isNotificationMemberOfClass:(Class)aClass;
+
+/**
+ *  Returns whether or not the containing notification is a kind of class, including subclasses.
+ *
+ *  @param aClass the class you are questioning
+ */
 - (BOOL)isNotificationKindOfClass:(Class)aClass;
+
 
 @end
 

--- a/SmartDeviceLink/SDLRPCNotificationNotification.h
+++ b/SmartDeviceLink/SDLRPCNotificationNotification.h
@@ -19,6 +19,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithName:(NSString *)name object:(nullable id)object rpcNotification:(__kindof SDLRPCNotification *)notification;
 
+/**
+ *
+ *  Returns whether or not the containing notification is a kind of class.
+ *
+ *  @param aClass the class your are questioning
+ */
+- (BOOL)isNotificationKindOfClass:(Class)aClass;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLRPCNotificationNotification.h
+++ b/SmartDeviceLink/SDLRPCNotificationNotification.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Returns whether or not the containing notification is equal to a class, not including subclasses.
  *
- *  @param aClass the class your are questioning
+ *  @param aClass the class you are questioning
  */
 - (BOOL)isNotificationMemberOfClass:(Class)aClass;
 

--- a/SmartDeviceLink/SDLRPCNotificationNotification.m
+++ b/SmartDeviceLink/SDLRPCNotificationNotification.m
@@ -31,6 +31,11 @@ NS_ASSUME_NONNULL_BEGIN
     return _userInfo[SDLNotificationUserInfoObject];
 }
 
+- (BOOL)isNotificationMemberOfClass:(Class)aClass {
+    NSAssert([self.notification isMemberOfClass:aClass], @"A notification was sent with an unanticipated object");
+    return [self.notification isMemberOfClass:aClass];
+}
+
 - (BOOL)isNotificationKindOfClass:(Class)aClass {
     NSAssert([self.notification isKindOfClass:aClass], @"A notification was sent with an unanticipated object");
     return [self.notification isKindOfClass:aClass];

--- a/SmartDeviceLink/SDLRPCNotificationNotification.m
+++ b/SmartDeviceLink/SDLRPCNotificationNotification.m
@@ -31,6 +31,11 @@ NS_ASSUME_NONNULL_BEGIN
     return _userInfo[SDLNotificationUserInfoObject];
 }
 
+- (BOOL)isNotificationKindOfClass:(Class)aClass {
+    NSAssert([self.notification isKindOfClass:aClass], @"A notification was sent with an unanticipated object");
+    return [self.notification isKindOfClass:aClass];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLRPCResponseNotification.h
+++ b/SmartDeviceLink/SDLRPCResponseNotification.h
@@ -20,10 +20,16 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithName:(NSString *)name object:(nullable id)object rpcResponse:(__kindof SDLRPCResponse *)response;
 
 /**
- *
- *  Returns whether or not the containing response is a kind of class.
+ *  Returns whether or not the containing response is equal to a class, not including subclasses.
  *
  *  @param aClass the class your are questioning
+ */
+- (BOOL)isResponseMemberOfClass:(Class)aClass;
+
+/**
+ *  Returns whether or not the containing response is a kind of class, including subclasses.
+ *
+ *  @param aClass the class you are questioning
  */
 - (BOOL)isResponseKindOfClass:(Class)aClass;
 

--- a/SmartDeviceLink/SDLRPCResponseNotification.h
+++ b/SmartDeviceLink/SDLRPCResponseNotification.h
@@ -19,6 +19,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithName:(NSString *)name object:(nullable id)object rpcResponse:(__kindof SDLRPCResponse *)response;
 
+/**
+ *
+ *  Returns whether or not the containing response is a kind of class.
+ *
+ *  @param aClass the class your are questioning
+ */
+- (BOOL)isResponseKindOfClass:(Class)aClass;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLRPCResponseNotification.h
+++ b/SmartDeviceLink/SDLRPCResponseNotification.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Returns whether or not the containing response is equal to a class, not including subclasses.
  *
- *  @param aClass the class your are questioning
+ *  @param aClass the class you are questioning
  */
 - (BOOL)isResponseMemberOfClass:(Class)aClass;
 

--- a/SmartDeviceLink/SDLRPCResponseNotification.m
+++ b/SmartDeviceLink/SDLRPCResponseNotification.m
@@ -30,4 +30,9 @@
     return _userInfo[SDLNotificationUserInfoObject];
 }
 
+- (BOOL)isResponseKindOfClass:(Class)aClass {
+    NSAssert([self.response isKindOfClass:aClass], @"A notification was sent with an unanticipated object");
+    return [self.response isKindOfClass:aClass];
+}
+
 @end

--- a/SmartDeviceLink/SDLRPCResponseNotification.m
+++ b/SmartDeviceLink/SDLRPCResponseNotification.m
@@ -11,6 +11,7 @@
 #import "SDLNotificationConstants.h"
 #import "SDLRPCResponse.h"
 
+NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLRPCResponseNotification
 
@@ -30,9 +31,16 @@
     return _userInfo[SDLNotificationUserInfoObject];
 }
 
+- (BOOL)isResponseMemberOfClass:(Class)aClass {
+    NSAssert([self.response isMemberOfClass:aClass], @"A notification was sent with an unanticipated object");
+    return [self.response isMemberOfClass:aClass];
+}
+
 - (BOOL)isResponseKindOfClass:(Class)aClass {
     NSAssert([self.response isKindOfClass:aClass], @"A notification was sent with an unanticipated object");
     return [self.response isKindOfClass:aClass];
 }
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLResponseDispatcher.m
+++ b/SmartDeviceLink/SDLResponseDispatcher.m
@@ -18,8 +18,10 @@
 #import "SDLOnButtonEvent.h"
 #import "SDLOnButtonPress.h"
 #import "SDLOnCommand.h"
-#import "SDLRPCResponse.h"
 #import "SDLResult.h"
+#import "SDLRPCResponse.h"
+#import "SDLRPCNotificationNotification.h"
+#import "SDLRPCResponseNotification.h"
 #import "SDLScrollableMessage.h"
 #import "SDLShow.h"
 #import "SDLSoftButton.h"
@@ -130,13 +132,12 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Notification Handler
 
 // Called by notifications
-- (void)sdl_runHandlersForResponse:(NSNotification *)notification {
-    NSAssert([notification.userInfo[SDLNotificationUserInfoObject] isKindOfClass:[SDLRPCResponse class]], @"A notification was sent with an unanticipated object");
-    if (![notification.userInfo[SDLNotificationUserInfoObject] isKindOfClass:[SDLRPCResponse class]]) {
+- (void)sdl_runHandlersForResponse:(SDLRPCResponseNotification *)notification {
+    if (![notification isResponseKindOfClass:[SDLRPCResponse class]]) {
         return;
     }
 
-    __kindof SDLRPCResponse *response = notification.userInfo[SDLNotificationUserInfoObject];
+    __kindof SDLRPCResponse *response = notification.response;
 
     NSError *error = nil;
     if (![response.success boolValue]) {
@@ -173,8 +174,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark Command
 
-- (void)sdl_runHandlerForCommand:(NSNotification *)notification {
-    SDLOnCommand *onCommandNotification = notification.userInfo[SDLNotificationUserInfoObject];
+- (void)sdl_runHandlerForCommand:(SDLRPCNotificationNotification *)notification {
+    SDLOnCommand *onCommandNotification = notification.notification;
     SDLRPCNotificationHandler handler = nil;
 
     handler = self.commandHandlerMap[onCommandNotification.cmdID];
@@ -185,8 +186,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark Button
 
-- (void)sdl_runHandlerForButton:(NSNotification *)notification {
-    __kindof SDLRPCNotification *rpcNotification = notification.userInfo[SDLNotificationUserInfoObject];
+- (void)sdl_runHandlerForButton:(SDLRPCNotificationNotification *)notification {
+    __kindof SDLRPCNotification *rpcNotification = notification.notification;
 
     SDLRPCNotificationHandler handler = nil;
     SDLButtonName name = nil;

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLPermissionsManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLPermissionsManagerSpec.m
@@ -403,7 +403,7 @@ describe(@"SDLPermissionsManager", ^{
                     testPermissionChangeUpdate.permissionItem = [NSArray arrayWithObject:testPermissionUpdated];
                     
                     // Send the permission update
-                    NSNotification *updatedNotification = [NSNotification notificationWithName:SDLDidChangePermissionsNotification object:nil userInfo:@{SDLNotificationUserInfoObject: testPermissionChangeUpdate}];
+                    SDLRPCNotificationNotification *updatedNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidChangePermissionsNotification object:nil rpcNotification:testPermissionChangeUpdate];
                     [[NSNotificationCenter defaultCenter] postNotification:updatedNotification];
                 });
                 
@@ -471,7 +471,7 @@ describe(@"SDLPermissionsManager", ^{
                         testPermissionChangeUpdate.permissionItem = [NSArray arrayWithObject:testPermissionUpdated];
                         
                         // Send the permission update
-                        NSNotification *updatedNotification = [NSNotification notificationWithName:SDLDidChangePermissionsNotification object:nil userInfo:@{SDLNotificationUserInfoObject: testPermissionChangeUpdate}];
+                        SDLRPCNotificationNotification *updatedNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidChangePermissionsNotification object:nil rpcNotification:testPermissionChangeUpdate];
                         [[NSNotificationCenter defaultCenter] postNotification:updatedNotification];
                     });
                     
@@ -514,7 +514,7 @@ describe(@"SDLPermissionsManager", ^{
                         testPermissionChangeUpdate.permissionItem = [NSArray arrayWithObject:testPermissionUpdated];
                         
                         // Send the permission update
-                        NSNotification *updatedNotification = [NSNotification notificationWithName:SDLDidChangePermissionsNotification object:nil userInfo:@{SDLNotificationUserInfoObject: testPermissionChangeUpdate}];
+                        SDLRPCNotificationNotification *updatedNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidChangePermissionsNotification object:nil rpcNotification:testPermissionChangeUpdate];
                         [[NSNotificationCenter defaultCenter] postNotification:updatedNotification];
                     });
                     
@@ -577,7 +577,7 @@ describe(@"SDLPermissionsManager", ^{
                         testPermissionChangeUpdate.permissionItem = [NSArray arrayWithObject:testPermissionUpdated];
                         
                         // Send the permission update
-                        NSNotification *updatedNotification = [NSNotification notificationWithName:SDLDidChangePermissionsNotification object:nil userInfo:@{SDLNotificationUserInfoObject: testPermissionChangeUpdate}];
+                        SDLRPCNotificationNotification *updatedNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidChangePermissionsNotification object:nil rpcNotification:testPermissionChangeUpdate];
                         [[NSNotificationCenter defaultCenter] postNotification:updatedNotification];
                     });
                     
@@ -611,7 +611,7 @@ describe(@"SDLPermissionsManager", ^{
                         testPermissionChangeUpdate.permissionItem = [NSArray arrayWithObject:testPermissionUpdated];
                         
                         // Send the permission update
-                        NSNotification *updatedNotification = [NSNotification notificationWithName:SDLDidChangePermissionsNotification object:nil userInfo:@{SDLNotificationUserInfoObject: testPermissionChangeUpdate}];
+                        SDLRPCNotificationNotification *updatedNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidChangePermissionsNotification object:nil rpcNotification:testPermissionChangeUpdate];
                         [[NSNotificationCenter defaultCenter] postNotification:updatedNotification];
                     });
                     

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLResponseDispatcherSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLResponseDispatcherSpec.m
@@ -13,6 +13,8 @@
 #import "SDLReadDID.h"
 #import "SDLReadDIDResponse.h"
 #import "SDLResponseDispatcher.h"
+#import "SDLRPCNotificationNotification.h"
+#import "SDLRPCResponseNotification.h"
 #import "SDLScrollableMessage.h"
 #import "SDLShow.h"
 #import "SDLSoftButton.h"
@@ -98,7 +100,8 @@ describe(@"a response dispatcher", ^{
                 testResponse = [[SDLReadDIDResponse alloc] init];
                 testResponse.correlationID = testCorrelationId;
                 
-                [[NSNotificationCenter defaultCenter] postNotificationName:SDLDidReceiveReadDIDResponse object:nil userInfo:@{ SDLNotificationUserInfoObject: testResponse }];
+                SDLRPCResponseNotification *responseNotification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveReadDIDResponse object:nil rpcResponse:testResponse];
+                [[NSNotificationCenter defaultCenter] postNotification:responseNotification];
             });
             
             it(@"should run the handler", ^{
@@ -150,8 +153,11 @@ describe(@"a response dispatcher", ^{
                         testButtonPress.customButtonID = testSoftButton1.softButtonID;
                         testButtonPress.buttonName = SDLButtonNameCustomButton;
                         
-                        [[NSNotificationCenter defaultCenter] postNotificationName:SDLDidReceiveButtonEventNotification object:nil userInfo:@{ SDLNotificationUserInfoObject: testButtonEvent }];
-                        [[NSNotificationCenter defaultCenter] postNotificationName:SDLDidReceiveButtonPressNotification object:nil userInfo:@{ SDLNotificationUserInfoObject: testButtonPress }];
+                        SDLRPCNotificationNotification *buttonEventNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidReceiveButtonEventNotification object:nil rpcNotification:testButtonEvent];
+                        SDLRPCNotificationNotification *buttonPressNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidReceiveButtonPressNotification object:nil rpcNotification:testButtonPress];
+                        
+                        [[NSNotificationCenter defaultCenter] postNotification:buttonEventNotification];
+                        [[NSNotificationCenter defaultCenter] postNotification:buttonPressNotification];
                     });
                     
                     it(@"should run the handler for each", ^{
@@ -167,8 +173,11 @@ describe(@"a response dispatcher", ^{
                         testButtonPress = [[SDLOnButtonPress alloc] init];
                         testButtonPress.buttonName = SDLButtonNameOk;
                         
-                        [[NSNotificationCenter defaultCenter] postNotificationName:SDLDidReceiveButtonEventNotification object:nil userInfo:@{ SDLNotificationUserInfoObject: testButtonEvent }];
-                        [[NSNotificationCenter defaultCenter] postNotificationName:SDLDidReceiveButtonPressNotification object:nil userInfo:@{ SDLNotificationUserInfoObject: testButtonPress }];
+                        SDLRPCNotificationNotification *buttonEventNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidReceiveButtonEventNotification object:nil rpcNotification:testButtonEvent];
+                        SDLRPCNotificationNotification *buttonPressNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidReceiveButtonPressNotification object:nil rpcNotification:testButtonPress];
+                        
+                        [[NSNotificationCenter defaultCenter] postNotification:buttonEventNotification];
+                        [[NSNotificationCenter defaultCenter] postNotification:buttonPressNotification];
                     });
                     
                     it(@"should not run the handler", ^{
@@ -261,7 +270,9 @@ describe(@"a response dispatcher", ^{
                         testOnCommand = [[SDLOnCommand alloc] init];
                         testOnCommand.cmdID = @(testCommandId);
                         
-                        [[NSNotificationCenter defaultCenter] postNotificationName:SDLDidReceiveCommandNotification object:nil userInfo:@{ SDLNotificationUserInfoObject: testOnCommand }];
+                        SDLRPCNotificationNotification *commandNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidReceiveCommandNotification object:nil rpcNotification:testOnCommand];
+                        
+                        [[NSNotificationCenter defaultCenter] postNotification:commandNotification];
                     });
                     
                     it(@"should run the handler for each", ^{
@@ -274,7 +285,9 @@ describe(@"a response dispatcher", ^{
                         testOnCommand = [[SDLOnCommand alloc] init];
                         testOnCommand.cmdID = @999;
                         
-                        [[NSNotificationCenter defaultCenter] postNotificationName:SDLDidReceiveCommandNotification object:nil userInfo:@{ SDLNotificationUserInfoObject: testOnCommand }];
+                        SDLRPCNotificationNotification *commandNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidReceiveCommandNotification object:nil rpcNotification:testOnCommand];
+                        
+                        [[NSNotificationCenter defaultCenter] postNotification:commandNotification];
                     });
                     
                     it(@"should not run the handler", ^{
@@ -303,7 +316,9 @@ describe(@"a response dispatcher", ^{
                     testDeleteResponse.correlationID = testDeleteCommandCorrelationId;
                     testDeleteResponse.success = @YES;
                     
-                    [[NSNotificationCenter defaultCenter] postNotificationName:SDLDidReceiveDeleteCommandResponse object:nil userInfo:@{ SDLNotificationUserInfoObject: testDeleteResponse }];
+                    SDLRPCResponseNotification *deleteCommandNotification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveDeleteCommandResponse object:nil rpcResponse:testDeleteResponse];
+                    
+                    [[NSNotificationCenter defaultCenter] postNotification:deleteCommandNotification];
                 });
                 
                 it(@"should have removed all the handlers", ^{
@@ -378,8 +393,11 @@ describe(@"a response dispatcher", ^{
                         testButtonPress = [[SDLOnButtonPress alloc] init];
                         testButtonPress.buttonName = testButtonName;
                         
-                        [[NSNotificationCenter defaultCenter] postNotificationName:SDLDidReceiveButtonEventNotification object:nil userInfo:@{ SDLNotificationUserInfoObject: testButtonEvent }];
-                        [[NSNotificationCenter defaultCenter] postNotificationName:SDLDidReceiveButtonPressNotification object:nil userInfo:@{ SDLNotificationUserInfoObject: testButtonPress }];
+                        SDLRPCNotificationNotification *buttonEventNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidReceiveButtonEventNotification object:nil rpcNotification:testButtonEvent];
+                        SDLRPCNotificationNotification *buttonPressNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidReceiveButtonPressNotification object:nil rpcNotification:testButtonPress];
+                        
+                        [[NSNotificationCenter defaultCenter] postNotification:buttonEventNotification];
+                        [[NSNotificationCenter defaultCenter] postNotification:buttonPressNotification];
                     });
                     
                     it(@"should run the handler for each", ^{
@@ -395,8 +413,11 @@ describe(@"a response dispatcher", ^{
                         testButtonPress = [[SDLOnButtonPress alloc] init];
                         testButtonPress.buttonName = SDLButtonNamePreset0;
                         
-                        [[NSNotificationCenter defaultCenter] postNotificationName:SDLDidReceiveButtonEventNotification object:nil userInfo:@{ SDLNotificationUserInfoObject: testButtonEvent }];
-                        [[NSNotificationCenter defaultCenter] postNotificationName:SDLDidReceiveButtonPressNotification object:nil userInfo:@{ SDLNotificationUserInfoObject: testButtonPress }];
+                        SDLRPCNotificationNotification *buttonEventNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidReceiveButtonEventNotification object:nil rpcNotification:testButtonEvent];
+                        SDLRPCNotificationNotification *buttonPressNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidReceiveButtonPressNotification object:nil rpcNotification:testButtonPress];
+                        
+                        [[NSNotificationCenter defaultCenter] postNotification:buttonEventNotification];
+                        [[NSNotificationCenter defaultCenter] postNotification:buttonPressNotification];
                     });
                     
                     it(@"should not run the handler", ^{
@@ -425,7 +446,8 @@ describe(@"a response dispatcher", ^{
                     testUnsubscribeResponse.correlationID = testUnsubscribeCorrelationId;
                     testUnsubscribeResponse.success = @YES;
                     
-                    [[NSNotificationCenter defaultCenter] postNotificationName:SDLDidReceiveUnsubscribeButtonResponse object:nil userInfo:@{ SDLNotificationUserInfoObject: testUnsubscribeResponse }];
+                    SDLRPCResponseNotification *unsubscribeNotification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveUnsubscribeButtonResponse object:nil rpcResponse:testUnsubscribeResponse];
+                    [[NSNotificationCenter defaultCenter] postNotification:unsubscribeNotification];
                 });
                 
                 it(@"should have removed all the handlers", ^{
@@ -490,8 +512,11 @@ describe(@"a response dispatcher", ^{
                         testButtonPress.buttonName = SDLButtonNameCustomButton;
                         testButtonPress.customButtonID = testSoftButton1.softButtonID;
                         
-                        [[NSNotificationCenter defaultCenter] postNotificationName:SDLDidReceiveButtonEventNotification object:nil userInfo:@{ SDLNotificationUserInfoObject: testButtonEvent }];
-                        [[NSNotificationCenter defaultCenter] postNotificationName:SDLDidReceiveButtonPressNotification object:nil userInfo:@{ SDLNotificationUserInfoObject: testButtonPress }];
+                        SDLRPCNotificationNotification *buttonEventNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidReceiveButtonEventNotification object:nil rpcNotification:testButtonEvent];
+                        SDLRPCNotificationNotification *buttonPressNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidReceiveButtonPressNotification object:nil rpcNotification:testButtonPress];
+                        
+                        [[NSNotificationCenter defaultCenter] postNotification:buttonEventNotification];
+                        [[NSNotificationCenter defaultCenter] postNotification:buttonPressNotification];
                     });
                     
                     it(@"should run the handler for each", ^{
@@ -506,9 +531,12 @@ describe(@"a response dispatcher", ^{
                         
                         testButtonPress = [[SDLOnButtonPress alloc] init];
                         testButtonPress.buttonName = SDLButtonNameOk;
+                    
+                        SDLRPCNotificationNotification *buttonEventNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidReceiveButtonEventNotification object:nil rpcNotification:testButtonEvent];
+                        SDLRPCNotificationNotification *buttonPressNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidReceiveButtonPressNotification object:nil rpcNotification:testButtonPress];
                         
-                        [[NSNotificationCenter defaultCenter] postNotificationName:SDLDidReceiveButtonEventNotification object:nil userInfo:@{ SDLNotificationUserInfoObject: testButtonEvent }];
-                        [[NSNotificationCenter defaultCenter] postNotificationName:SDLDidReceiveButtonPressNotification object:nil userInfo:@{ SDLNotificationUserInfoObject: testButtonPress }];
+                        [[NSNotificationCenter defaultCenter] postNotification:buttonEventNotification];
+                        [[NSNotificationCenter defaultCenter] postNotification:buttonPressNotification];
                     });
                     
                     it(@"should not run the handler", ^{
@@ -595,8 +623,11 @@ describe(@"a response dispatcher", ^{
                         testButtonPress.buttonName = SDLButtonNameCustomButton;
                         testButtonPress.customButtonID = testSoftButton1.softButtonID;
                         
-                        [[NSNotificationCenter defaultCenter] postNotificationName:SDLDidReceiveButtonEventNotification object:nil userInfo:@{ SDLNotificationUserInfoObject: testButtonEvent }];
-                        [[NSNotificationCenter defaultCenter] postNotificationName:SDLDidReceiveButtonPressNotification object:nil userInfo:@{ SDLNotificationUserInfoObject: testButtonPress }];
+                        SDLRPCNotificationNotification *buttonEventNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidReceiveButtonEventNotification object:nil rpcNotification:testButtonEvent];
+                        SDLRPCNotificationNotification *buttonPressNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidReceiveButtonPressNotification object:nil rpcNotification:testButtonPress];
+                        
+                        [[NSNotificationCenter defaultCenter] postNotification:buttonEventNotification];
+                        [[NSNotificationCenter defaultCenter] postNotification:buttonPressNotification];
                     });
                     
                     it(@"should run the handler for each", ^{
@@ -612,8 +643,11 @@ describe(@"a response dispatcher", ^{
                         testButtonPress = [[SDLOnButtonPress alloc] init];
                         testButtonPress.buttonName = SDLButtonNameOk;
                         
-                        [[NSNotificationCenter defaultCenter] postNotificationName:SDLDidReceiveButtonEventNotification object:nil userInfo:@{ SDLNotificationUserInfoObject: testButtonEvent }];
-                        [[NSNotificationCenter defaultCenter] postNotificationName:SDLDidReceiveButtonPressNotification object:nil userInfo:@{ SDLNotificationUserInfoObject: testButtonPress }];
+                        SDLRPCNotificationNotification *buttonEventNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidReceiveButtonEventNotification object:nil rpcNotification:testButtonEvent];
+                        SDLRPCNotificationNotification *buttonPressNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidReceiveButtonPressNotification object:nil rpcNotification:testButtonPress];
+                        
+                        [[NSNotificationCenter defaultCenter] postNotification:buttonEventNotification];
+                        [[NSNotificationCenter defaultCenter] postNotification:buttonPressNotification];
                     });
                     
                     it(@"should not run the handler", ^{


### PR DESCRIPTION
Fixes #553 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Summary
This PR adds a new convenience methods onto `SDLRPCNotificationNotification`:

```objc
- (BOOL)isNotificationKindOfClass:(Class)aClass;
- (BOOL)isNotificationMemberOfClass:(Class)aClass;
```

and `SDLRPCResponseNotification`:

```objc
- (BOOL)isResponseKindOfClass:(Class)aClass;
- (BOOL)isResponseMemberOfClass:(Class)aClass;
``` 

that allow use to easily check notifications internally, as well as externally for developers on an incoming notification.

Spec tests have also been updated to send the correct SDL `NSNotification` subclasses.

### Changelog
##### Enhancements
* Added convenience methods for checking notification object's classes.