### PR TITLE
[Example App] Fixed issue with incorrectly setting state on manager disconnect

### DIFF
--- a/SmartDeviceLink_Example/Classes/ProxyManager.m
+++ b/SmartDeviceLink_Example/Classes/ProxyManager.m
@@ -357,7 +357,7 @@ NS_ASSUME_NONNULL_BEGIN
     // Reset our state
     self.firstTimeState = SDLHMIFirstStateNone;
     self.initialShowState = SDLHMIInitialShowStateNone;
-    _state = ProxyStateStopped;
+    [self sdlex_updateProxyState:ProxyStateStopped];
     if (ShouldRestartOnDisconnect) {
         [self startManager];
     }


### PR DESCRIPTION
Fixes #560 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Cause the ProxyManager to enter `managerDidDisconnect`.

### Summary
Fixed an issue with ProxyManager not correctly setting its state, so the UI will not update on disconnect.

### Changelog
##### Bug Fixes
* Fixed an issue with ProxyManager not correctly setting its state, so the UI will not update on disconnect.