### PR TITLE
Prevent infinite loops in send block while by checking ostream state.

### DIFF
--- a/SmartDeviceLink/SDLIAPSession.h
+++ b/SmartDeviceLink/SDLIAPSession.h
@@ -10,7 +10,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef void (^SessionCompletionHandler)(BOOL success);
+typedef BOOL (^SessionSendHandler)(NSError **error);
 
 @interface SDLIAPSession : NSObject
 
@@ -25,6 +25,7 @@ typedef void (^SessionCompletionHandler)(BOOL success);
 
 - (BOOL)start;
 - (void)stop;
+- (void)sendData:(SessionSendHandler)sender;
 
 @end
 

--- a/SmartDeviceLink/SDLIAPSession.m
+++ b/SmartDeviceLink/SDLIAPSession.m
@@ -7,13 +7,20 @@
 #import "SDLStreamDelegate.h"
 #import "SDLTimer.h"
 
-NS_ASSUME_NONNULL_BEGIN
+#define IO_STREAMTHREAD_NAME            @ "com.smartdevicelink.iostream"
+#define STREAM_THREAD_WAIT_SECS         1.0
+#define STREAM_THREAD_WAIT_WRITE_SECS   5.0
 
 @interface SDLIAPSession ()
 
 @property (assign, nonatomic) BOOL isInputStreamOpen;
 @property (assign, nonatomic) BOOL isOutputStreamOpen;
-
+@property (assign, nonatomic) BOOL isDataSession;
+@property (nonatomic, copy) SessionSendHandler sendBlock;
+@property (nonatomic, strong) NSThread *ioStreamThread;
+@property (nonatomic, assign) BOOL isSendStarted;
+@property (nonatomic, strong) dispatch_semaphore_t canceledSema;
+@property (nonatomic, strong) dispatch_semaphore_t sendCompleteSema;
 @end
 
 
@@ -24,6 +31,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithAccessory:(EAAccessory *)accessory forProtocol:(NSString *)protocol {
     NSString *logMessage = [NSString stringWithFormat:@"SDLIAPSession initWithAccessory:%@ forProtocol:%@", accessory, protocol];
     [SDLDebugTool logInfo:logMessage];
+    
+    if ([protocol isEqualToString:@"com.smartdevicelink.prot0"]){
+        _isDataSession = NO;
+    }
+    else{
+        _isDataSession = YES;
+    }
 
     self = [super init];
     if (self) {
@@ -31,6 +45,9 @@ NS_ASSUME_NONNULL_BEGIN
         _protocol = protocol;
         _isInputStreamOpen = NO;
         _isOutputStreamOpen = NO;
+        _canceledSema = dispatch_semaphore_create(0);
+        _sendCompleteSema = dispatch_semaphore_create(0);
+        _sendBlock = nil;
     }
     return self;
 }
@@ -51,9 +68,17 @@ NS_ASSUME_NONNULL_BEGIN
 
         strongSelf.streamDelegate.streamErrorHandler = [self streamErroredHandler];
         strongSelf.streamDelegate.streamOpenHandler = [self streamOpenedHandler];
-
-        [strongSelf startStream:weakSelf.easession.outputStream];
-        [strongSelf startStream:weakSelf.easession.inputStream];
+        if (!self.isDataSession){
+            [strongSelf startStream:weakSelf.easession.outputStream];
+            [strongSelf startStream:weakSelf.easession.inputStream];
+        }
+        else{
+            strongSelf.streamDelegate.streamHasSpaceHandler = [self streamHasSpaceHandler];
+            // Start I/O event loop processing events in iAP channel
+            _ioStreamThread = [[NSThread alloc] initWithTarget:self selector:@selector(accessoryEventLoop) object:nil];
+            [_ioStreamThread setName:IO_STREAMTHREAD_NAME];
+            [_ioStreamThread start];
+        }
 
         return YES;
 
@@ -64,9 +89,118 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)stop {
-    [self stopStream:self.easession.outputStream];
-    [self stopStream:self.easession.inputStream];
+
+    if (!self.isDataSession){
+        [self stopStream:self.easession.outputStream];
+        [self stopStream:self.easession.inputStream];
+    }
+    else{
+        [self.ioStreamThread cancel];
+        
+        long lWait = dispatch_semaphore_wait(self.canceledSema, dispatch_time(DISPATCH_TIME_NOW, STREAM_THREAD_WAIT_SECS * NSEC_PER_SEC));
+        if (lWait == 0){
+            [SDLDebugTool logInfo:@"Stream thread canceled"];
+        }
+        else{
+           [SDLDebugTool logInfo:@"Error: failed to cancel stream thread"];
+        }
+        self.ioStreamThread = nil;
+        self.isDataSession = NO;
+    }
     self.easession = nil;
+}
+
+- (void)sendData:(SessionSendHandler)sender{
+    @synchronized (self) {
+        self.sendBlock = sender;
+        self.isSendStarted = NO;
+    }
+    long lWait = dispatch_semaphore_wait(self.sendCompleteSema, dispatch_time(DISPATCH_TIME_NOW, STREAM_THREAD_WAIT_WRITE_SECS * NSEC_PER_SEC));
+    if (lWait != 0){
+        NSLog(@"ERROR! Failed to write data!!!");
+    }
+}
+
+- (void)accessoryEventLoop {
+    BOOL sendStarted;
+    SessionSendHandler sendBlock;
+    
+  @autoreleasepool {
+    NSAssert(self.easession, @"_session must be assigned before calling");
+    
+    if (!self.easession) {
+      return;
+    }
+    
+    // Open I/O streams of the iAP session
+    NSInputStream *inStream = [self.easession inputStream];
+    [inStream setDelegate:self.streamDelegate];
+    [inStream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+    [inStream open];
+    
+    NSOutputStream *outStream = [self.easession outputStream];
+    [outStream setDelegate:self.streamDelegate];
+    [outStream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+    [outStream open];
+    
+    [SDLDebugTool logInfo:@"starting the event loop for accessory"];
+    do {
+      @autoreleasepool {
+          @synchronized (self) {
+              sendBlock = self.sendBlock;
+              sendStarted = self.isSendStarted;
+          }
+          
+          if (sendBlock != nil &&!sendStarted && outStream.hasSpaceAvailable){
+              NSError *err = nil;
+              BOOL sendComplete = sendBlock(&err);
+              
+              
+              if (err != nil){
+                  [SDLDebugTool logFormat:@"Output stream error %@", err];
+              }
+              else{
+                  if (sendComplete){
+                      @synchronized (self) {
+                          self.sendBlock = nil;
+                      }
+                      dispatch_semaphore_signal(self.sendCompleteSema);
+                  }
+                  else{
+                      @synchronized (self) {
+                          self.isSendStarted = YES;
+                      }
+                  }
+              }
+          }
+        
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
+                                 beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.25f]];
+      }
+    } while (self.accessory != nil &&
+             self.accessory.connected &&
+             ![NSThread currentThread].cancelled);
+    
+    NSLog(@"closing accessory session");
+    
+    // Close I/O streams of the iAP session
+    [self closeSession];
+    _accessory = nil;
+      dispatch_semaphore_signal(self.canceledSema);
+  }
+}
+
+// Must be called on accessoryEventLoop.
+- (void)closeSession {
+  if (self.easession) {
+    NSLog(@"Close EASession: %tu", self.easession.accessory.connectionID);
+    NSInputStream *inStream = [self.easession inputStream];
+    NSOutputStream *outStream = [self.easession outputStream];
+    
+    [self stopStream:inStream];
+    [self stopStream:outStream];
+    self.easession = nil;
+  }
 }
 
 
@@ -91,7 +225,7 @@ NS_ASSUME_NONNULL_BEGIN
         [stream close];
     }
 
-    [stream removeFromRunLoop:[NSRunLoop mainRunLoop] forMode:NSDefaultRunLoopMode];
+    [stream removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
     [stream setDelegate:nil];
 
     NSUInteger status2 = stream.streamStatus;
@@ -139,6 +273,51 @@ NS_ASSUME_NONNULL_BEGIN
     };
 }
 
+- (SDLStreamHasSpaceHandler)streamHasSpaceHandler {
+    __weak typeof(self) weakSelf = self;
+    
+    return ^(NSStream *stream) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        
+        if (strongSelf.isDataSession){
+            SessionSendHandler sendCompletion;
+            @synchronized (strongSelf) {
+                sendCompletion = strongSelf.sendBlock;
+            }
+            
+            if (sendCompletion != nil){
+                NSError *err = nil;
+                BOOL sendComplete = sendCompletion(&err);
+                if (err != nil){
+                    NSLog(@"ERROR!!! Output stream reported %@", err);
+                }
+                else{
+                    if (sendComplete){
+                        @synchronized (strongSelf) {
+                            strongSelf.sendBlock = nil;
+                        }
+                        dispatch_semaphore_signal(strongSelf.sendCompleteSema);
+                    }
+                }
+            }
+        }
+    };
+}
+
+#pragma mark - Lifecycle Destruction
+
+- (void)dealloc {
+    self.delegate = nil;
+    self.accessory = nil;
+    self.protocol = nil;
+    self.streamDelegate = nil;
+    self.easession = nil;
+    self.ioStreamThread =  nil;
+    self.canceledSema = nil;
+    self.sendBlock = nil;
+    self.sendCompleteSema = nil;
+    [SDLDebugTool logInfo:@"SDLIAPSession Dealloc"];
+}
+
 @end
 
-NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLIAPTransport.m
+++ b/SmartDeviceLink/SDLIAPTransport.m
@@ -272,8 +272,9 @@ int const streamOpenTimeoutSeconds = 2;
         NSOutputStream *ostream = self.session.easession.outputStream;
         NSMutableData *remainder = data.mutableCopy;
 
-        while (remainder.length != 0) {
-            if (ostream.streamStatus == NSStreamStatusOpen && ostream.hasSpaceAvailable) {
+        while (ostream.streamStatus == NSStreamStatusOpen &&
+               remainder.length != 0) {
+            if (ostream.hasSpaceAvailable){
                 NSInteger bytesWritten = [ostream write:remainder.bytes maxLength:remainder.length];
 
                 if (bytesWritten == -1) {


### PR DESCRIPTION
Fixes #522 

This PR is ready for review.

### Risk
This PR makes no API changes.

### Testing Plan
This change *could* be tested by using a mock NSOutputStream injected into the SDLIAPTransport class. However, I tested it with a number of pre-production head units supporting the MFi protocol over BT and USB.

### Summary
This PR addresses very specifically a logic bug in the SDLIAPTransport.m sendData method. Because the NSOutputStream uses polled writes, it places the sendData while loop on a serial dispatch queue to prevent the main thread from blocking. There is a deeper flaw in this design as I've summarized in issue 522, specifically that the output stream is scheduled on the main thread but written to from the thread backing the dispatch queue, violating Apple's guideline for scheduling and accessing streams from the same thread. 

The fact that multiple send blocks can be enqueued on the dispatch queue while the stream is closed on the main thread creates a race condition. As soon as the stream closes, the NSMutableData remainder can no longer be consumed and the length will never reach zero. We have observed a number of SDL app crashes that are actually iOS force quitting the app due to the hung dispatch queue thread. It is easiest to reproduce the crash by backgrounding the app and performing a number of connect/disconnect cycles from the head unit over BT or USB.

The fix for the send block hang is to check the output stream state and exit the block as soon as it is no longer open.

### Changelog
##### Breaking Changes
None

##### Enhancements
None

##### Bug Fixes
Partial fix for issue 522.

### Tasks Remaining:
More PRs to come to transition from polled to scheduled writes.
