### PR TITLE
Fix issue around premature stream close resulting in hangs in iAP transmit queue

### DIFF
--- a/SmartDeviceLink/SDLIAPTransport.m
+++ b/SmartDeviceLink/SDLIAPTransport.m
@@ -272,8 +272,9 @@ int const streamOpenTimeoutSeconds = 2;
         NSOutputStream *ostream = self.session.easession.outputStream;
         NSMutableData *remainder = data.mutableCopy;
 
-        while (remainder.length != 0) {
-            if (ostream.streamStatus == NSStreamStatusOpen && ostream.hasSpaceAvailable) {
+        while (ostream.streamStatus == NSStreamStatusOpen &&
+               remainder.length != 0) {
+            if (ostream.hasSpaceAvailable){
                 NSInteger bytesWritten = [ostream write:remainder.bytes maxLength:remainder.length];
 
                 if (bytesWritten == -1) {

--- a/SmartDeviceLink/SDLIAPTransport.m
+++ b/SmartDeviceLink/SDLIAPTransport.m
@@ -272,8 +272,7 @@ int const streamOpenTimeoutSeconds = 2;
         NSOutputStream *ostream = self.session.easession.outputStream;
         NSMutableData *remainder = data.mutableCopy;
 
-        while (ostream.streamStatus == NSStreamStatusOpen &&
-               remainder.length != 0) {
+        while (ostream.streamStatus == NSStreamStatusOpen && remainder.length != 0) {
             if (ostream.hasSpaceAvailable){
                 NSInteger bytesWritten = [ostream write:remainder.bytes maxLength:remainder.length];
 


### PR DESCRIPTION
Fixes #522

This PR is **ready** for review.

### Risk

This PR makes **no** API changes. However, it affects every send over the IAP transport, so risk is moderate.

### Testing Plan

Testing has been performed using test apps against several pre-production head units running SDLCore.

### Summary
Fixes a hang due to stream close on main thread while loop runs on IAP transmit queue

### Changelog

##### Bug Fixes
* Fixes hangs in the IAP transmit queue when the output stream closes on the main thread before all data in the current send block has been transmitted.
