### PR TITLE
Updating Data Session I/O to be in compliance with Apple guidelines

### DIFF
--- a/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
+++ b/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
@@ -859,6 +859,8 @@
 		5DE5ABB71B0E38C90067BB02 /* SDLSystemRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D61FBD21A84238B00846EE7 /* SDLSystemRequest.h */; };
 		5DE5ABB81B0E38C90067BB02 /* SDLSystemRequestResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D61FBD41A84238B00846EE7 /* SDLSystemRequestResponse.h */; };
 		5DFFB9151BD7C89700DB3F04 /* SDLConnectionManagerType.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DFFB9141BD7C89700DB3F04 /* SDLConnectionManagerType.h */; };
+		974053E11E6DEB1300CC1567 /* SDLMutableDataQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 974053DF1E6DEB1300CC1567 /* SDLMutableDataQueue.h */; };
+		974053E21E6DEB1300CC1567 /* SDLMutableDataQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = 974053E01E6DEB1300CC1567 /* SDLMutableDataQueue.m */; };
 		DA0C46AD1DCD35080001F2A8 /* SDLNames.m in Sources */ = {isa = PBXBuildFile; fileRef = DA0C46AC1DCD35080001F2A8 /* SDLNames.m */; };
 		DA0C46AF1DCD41E30001F2A8 /* SDLMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = DA0C46AE1DCD41E30001F2A8 /* SDLMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA318C1F1DD0F06C00C035AC /* NSMutableDictionary+Store.h in Headers */ = {isa = PBXBuildFile; fileRef = DA318C1D1DD0F06C00C035AC /* NSMutableDictionary+Store.h */; };
@@ -1863,6 +1865,8 @@
 		5DEE55BF1B8509CB004F0D0F /* SDLURLRequestTaskSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SDLURLRequestTaskSpec.m; path = "UtilitiesSpecs/HTTP Connection/SDLURLRequestTaskSpec.m"; sourceTree = "<group>"; };
 		5DF2BB9C1B94E38A00CE5994 /* SDLURLSessionSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SDLURLSessionSpec.m; path = "UtilitiesSpecs/HTTP Connection/SDLURLSessionSpec.m"; sourceTree = "<group>"; };
 		5DFFB9141BD7C89700DB3F04 /* SDLConnectionManagerType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDLConnectionManagerType.h; sourceTree = "<group>"; };
+		974053DF1E6DEB1300CC1567 /* SDLMutableDataQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDLMutableDataQueue.h; sourceTree = "<group>"; };
+		974053E01E6DEB1300CC1567 /* SDLMutableDataQueue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLMutableDataQueue.m; sourceTree = "<group>"; };
 		DA0C46AC1DCD35080001F2A8 /* SDLNames.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLNames.m; sourceTree = "<group>"; };
 		DA0C46AE1DCD41E30001F2A8 /* SDLMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDLMacros.h; sourceTree = "<group>"; };
 		DA318C1D1DD0F06C00C035AC /* NSMutableDictionary+Store.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMutableDictionary+Store.h"; sourceTree = "<group>"; };
@@ -3011,6 +3015,8 @@
 		5D5934F61A85189500687FB9 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				974053DF1E6DEB1300CC1567 /* SDLMutableDataQueue.h */,
+				974053E01E6DEB1300CC1567 /* SDLMutableDataQueue.m */,
 				DAC5724C1D0FE3B60004288B /* Touches */,
 				E9C32B831AB20B2900F283AF /* @categories */,
 				5D5934F91A851A8000687FB9 /* Prioritized Objects */,
@@ -3820,6 +3826,7 @@
 				5D61FD931A84238C00846EE7 /* SDLShowConstantTBTResponse.h in Headers */,
 				5D61FCCB1A84238C00846EE7 /* SDLIgnitionStatus.h in Headers */,
 				5D61FCB71A84238C00846EE7 /* SDLGetVehicleDataResponse.h in Headers */,
+				974053E11E6DEB1300CC1567 /* SDLMutableDataQueue.h in Headers */,
 				5D61FDA91A84238C00846EE7 /* SDLSpeechCapabilities.h in Headers */,
 				5D61FCE01A84238C00846EE7 /* SDLKeyboardEvent.h in Headers */,
 				5D3E48751D6F3B330000BFEF /* SDLAsynchronousOperation.h in Headers */,
@@ -4504,6 +4511,7 @@
 				5D61FC6C1A84238C00846EE7 /* SDLCreateInteractionChoiceSet.m in Sources */,
 				5D61FD081A84238C00846EE7 /* SDLOnCommand.m in Sources */,
 				5D53C46E1B7A99B9003526EA /* SDLStreamingMediaManager.m in Sources */,
+				974053E21E6DEB1300CC1567 /* SDLMutableDataQueue.m in Sources */,
 				5D61FD6A1A84238C00846EE7 /* SDLRPCMessage.m in Sources */,
 				5D61FDA21A84238C00846EE7 /* SDLSoftButtonCapabilities.m in Sources */,
 				5D8204321BD001C700D0A41B /* SDLArtwork.m in Sources */,

--- a/SmartDeviceLink/SDLIAPSession.h
+++ b/SmartDeviceLink/SDLIAPSession.h
@@ -10,8 +10,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef void (^SessionCompletionHandler)(BOOL success);
-
 @interface SDLIAPSession : NSObject
 
 @property (nullable, strong, nonatomic) EAAccessory *accessory;

--- a/SmartDeviceLink/SDLIAPSession.h
+++ b/SmartDeviceLink/SDLIAPSession.h
@@ -10,7 +10,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef void (^SessionCompletionHandler)(BOOL success);
+@class SDLStreamDelegate;
 
 @interface SDLIAPSession : NSObject
 
@@ -25,6 +25,7 @@ typedef void (^SessionCompletionHandler)(BOOL success);
 
 - (BOOL)start;
 - (void)stop;
+- (void)sendData:(NSData *)data;
 
 @end
 

--- a/SmartDeviceLink/SDLIAPSession.h
+++ b/SmartDeviceLink/SDLIAPSession.h
@@ -10,7 +10,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class SDLStreamDelegate;
+typedef void (^SessionCompletionHandler)(BOOL success);
 
 @interface SDLIAPSession : NSObject
 

--- a/SmartDeviceLink/SDLIAPSession.m
+++ b/SmartDeviceLink/SDLIAPSession.m
@@ -6,13 +6,20 @@
 #import "SDLDebugTool.h"
 #import "SDLStreamDelegate.h"
 #import "SDLTimer.h"
+#import "SDLMutableDataQueue.h"
 
 NS_ASSUME_NONNULL_BEGIN
+#define IO_STREAMTHREAD_NAME            @ "com.smartdevicelink.iostream"
+#define STREAM_THREAD_WAIT_SECS         1.0
 
 @interface SDLIAPSession ()
 
 @property (assign, nonatomic) BOOL isInputStreamOpen;
 @property (assign, nonatomic) BOOL isOutputStreamOpen;
+@property (assign, nonatomic) BOOL isDataSession;
+@property (nonatomic, strong) NSThread *ioStreamThread;
+@property (nonatomic, strong) SDLMutableDataQueue *sendDataQueue;
+@property (nonatomic, strong) dispatch_semaphore_t canceledSema;
 
 @end
 
@@ -27,10 +34,18 @@ NS_ASSUME_NONNULL_BEGIN
 
     self = [super init];
     if (self) {
+        if ([protocol isEqualToString:@"com.smartdevicelink.prot0"]){
+            _isDataSession = NO;
+        }
+        else{
+            _isDataSession = YES;
+        }
         _accessory = accessory;
         _protocol = protocol;
         _isInputStreamOpen = NO;
         _isOutputStreamOpen = NO;
+        _canceledSema = dispatch_semaphore_create(0);
+        _sendDataQueue = [[SDLMutableDataQueue alloc] init];
     }
     return self;
 }
@@ -51,9 +66,17 @@ NS_ASSUME_NONNULL_BEGIN
 
         strongSelf.streamDelegate.streamErrorHandler = [self streamErroredHandler];
         strongSelf.streamDelegate.streamOpenHandler = [self streamOpenedHandler];
-
-        [strongSelf startStream:weakSelf.easession.outputStream];
-        [strongSelf startStream:weakSelf.easession.inputStream];
+        if (!self.isDataSession){
+            [strongSelf startStream:weakSelf.easession.outputStream];
+            [strongSelf startStream:weakSelf.easession.inputStream];
+        }
+        else{
+            strongSelf.streamDelegate.streamHasSpaceHandler = [self streamHasSpaceHandler];
+            // Start I/O event loop processing events in iAP channel
+            self.ioStreamThread = [[NSThread alloc] initWithTarget:self selector:@selector(sdl_accessoryEventLoop) object:nil];
+            [self.ioStreamThread setName:IO_STREAMTHREAD_NAME];
+            [self.ioStreamThread start];
+        }
 
         return YES;
 
@@ -64,9 +87,128 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)stop {
-    [self stopStream:self.easession.outputStream];
-    [self stopStream:self.easession.inputStream];
+
+    if (!self.isDataSession){
+        [self stopStream:self.easession.outputStream];
+        [self stopStream:self.easession.inputStream];
+    }
+    else{
+        [self.ioStreamThread cancel];
+        
+        long lWait = dispatch_semaphore_wait(self.canceledSema, dispatch_time(DISPATCH_TIME_NOW, STREAM_THREAD_WAIT_SECS * NSEC_PER_SEC));
+        if (lWait == 0){
+            [SDLDebugTool logInfo:@"Stream thread canceled"];
+        }
+        else{
+           [SDLDebugTool logInfo:@"Error: failed to cancel stream thread"];
+        }
+        self.ioStreamThread = nil;
+        self.isDataSession = NO;
+    }
     self.easession = nil;
+}
+
+- (void)sendData:(NSData *)data{
+    // Enqueue the data for transmission on the IO thread
+    [self.sendDataQueue enqueue:data.mutableCopy];
+}
+
+- (BOOL)sdl_dequeueAndWriteToOutputStream:(NSError **)error{
+    NSOutputStream *ostream = self.easession.outputStream;
+    NSMutableData *remainder = [self.sendDataQueue front];
+    BOOL allDataWritten = NO;
+    
+    if (remainder != nil && ostream.streamStatus == NSStreamStatusOpen){
+        NSInteger bytesRemaining = remainder.length;
+        NSInteger bytesWritten = [ostream write:remainder.bytes maxLength:bytesRemaining];
+        if (bytesWritten < 0){
+            *error = ostream.streamError;
+        }
+        else{
+            if (bytesWritten == bytesRemaining){
+                // Remove the data from the queue
+                [self.sendDataQueue pop];
+                allDataWritten = YES;
+            }
+            else{
+                // Cleave the sent bytes from the data, the remainder will sit at the head of the queue
+                [remainder replaceBytesInRange:NSMakeRange(0, bytesWritten) withBytes:NULL length:0];
+            }
+        }
+    }
+    
+    return allDataWritten;
+}
+
+- (void)sdl_handleOutputStreamWriteError:(NSError *)error{
+    NSString *errString = [NSString stringWithFormat:@"Output stream error: %@", error];
+    [SDLDebugTool logInfo:errString];
+    // REVIEW: We should look at the domain and the code as a tuple and decide
+    // how to handle the error based on both values. For now, if the stream
+    // is closed, we will flush the send queue and leave it as-is otherwise
+    // so that temporary error conditions can be dealt with by retrying
+    if (self.easession == nil ||
+        self.easession.outputStream == nil ||
+        self.easession.outputStream.streamStatus != NSStreamStatusOpen){
+        [self.sendDataQueue flush];
+    }
+}
+
+- (void)sdl_accessoryEventLoop {
+    
+  @autoreleasepool {
+    NSAssert(self.easession, @"_session must be assigned before calling");
+    
+    if (!self.easession) {
+      return;
+    }
+    
+    // Open I/O streams of the iAP session
+    NSInputStream *inStream = [self.easession inputStream];
+    [inStream setDelegate:self.streamDelegate];
+    [inStream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+    [inStream open];
+    
+    NSOutputStream *outStream = [self.easession outputStream];
+    [outStream setDelegate:self.streamDelegate];
+    [outStream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+    [outStream open];
+    
+    [SDLDebugTool logInfo:@"starting the event loop for accessory"];
+    do {
+        if (self.sendDataQueue.count > 0 && !self.sendDataQueue.frontDequeued){
+            NSError *sendErr = nil;
+            if (![self sdl_dequeueAndWriteToOutputStream:&sendErr] && sendErr != nil){
+                [self sdl_handleOutputStreamWriteError:sendErr];
+            }
+        }
+        
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
+                                 beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.25f]];
+    } while (self.accessory != nil &&
+             self.accessory.connected &&
+             ![NSThread currentThread].cancelled);
+    
+    NSLog(@"closing accessory session");
+    
+    // Close I/O streams of the iAP session
+    [self sdl_closeSession];
+    _accessory = nil;
+      dispatch_semaphore_signal(self.canceledSema);
+  }
+}
+
+// Must be called on accessoryEventLoop.
+- (void)sdl_closeSession {
+  if (self.easession) {
+    NSLog(@"Close EASession: %tu", self.easession.accessory.connectionID);
+    NSInputStream *inStream = [self.easession inputStream];
+    NSOutputStream *outStream = [self.easession outputStream];
+    
+    [self stopStream:inStream];
+    [self stopStream:outStream];
+    self.easession = nil;
+  }
 }
 
 
@@ -91,7 +233,7 @@ NS_ASSUME_NONNULL_BEGIN
         [stream close];
     }
 
-    [stream removeFromRunLoop:[NSRunLoop mainRunLoop] forMode:NSDefaultRunLoopMode];
+    [stream removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
     [stream setDelegate:nil];
 
     NSUInteger status2 = stream.streamStatus;
@@ -137,6 +279,37 @@ NS_ASSUME_NONNULL_BEGIN
         [SDLDebugTool logInfo:@"Stream Error"];
         [strongSelf.delegate onSessionStreamsEnded:strongSelf];
     };
+}
+
+- (SDLStreamHasSpaceHandler)streamHasSpaceHandler {
+    __weak typeof(self) weakSelf = self;
+    
+    return ^(NSStream *stream) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        
+        if (strongSelf.isDataSession){
+            NSError *sendErr = nil;
+            
+            if (![strongSelf sdl_dequeueAndWriteToOutputStream:&sendErr] && sendErr != nil){
+                [strongSelf sdl_handleOutputStreamWriteError:sendErr];
+            }
+        }
+    };
+}
+
+#pragma mark - Lifecycle Destruction
+
+- (void)dealloc {
+    [self.sendDataQueue flush];
+    self.sendDataQueue = nil;
+    self.delegate = nil;
+    self.accessory = nil;
+    self.protocol = nil;
+    self.streamDelegate = nil;
+    self.easession = nil;
+    self.ioStreamThread =  nil;
+    self.canceledSema = nil;
+    [SDLDebugTool logInfo:@"SDLIAPSession Dealloc"];
 }
 
 @end

--- a/SmartDeviceLink/SDLIAPTransport.m
+++ b/SmartDeviceLink/SDLIAPTransport.m
@@ -268,23 +268,9 @@ int const streamOpenTimeoutSeconds = 2;
 #pragma mark - Data Transmission
 
 - (void)sendData:(NSData *)data {
-    dispatch_async(_transmit_queue, ^{
-        NSOutputStream *ostream = self.session.easession.outputStream;
-        NSMutableData *remainder = data.mutableCopy;
-
-        while (remainder.length != 0) {
-            if (ostream.streamStatus == NSStreamStatusOpen && ostream.hasSpaceAvailable) {
-                NSInteger bytesWritten = [ostream write:remainder.bytes maxLength:remainder.length];
-
-                if (bytesWritten == -1) {
-                    [SDLDebugTool logInfo:[NSString stringWithFormat:@"Error: %@", [ostream streamError]] withType:SDLDebugType_Transport_iAP toOutput:SDLDebugOutput_All];
-                    break;
-                }
-
-                [remainder replaceBytesInRange:NSMakeRange(0, bytesWritten) withBytes:NULL length:0];
-            }
-        }
-    });
+    if (self.session != nil && self.session.accessory.connected){
+        [self.session sendData:data];
+    }
 }
 
 

--- a/SmartDeviceLink/SDLIAPTransport.m
+++ b/SmartDeviceLink/SDLIAPTransport.m
@@ -268,7 +268,7 @@ int const streamOpenTimeoutSeconds = 2;
 #pragma mark - Data Transmission
 
 - (void)sendData:(NSData *)data {
-    if (self.session != nil && self.session.accessory.connected){
+    if (self.session != nil && self.session.accessory.connected) {
         [self.session sendData:data];
     }
 }

--- a/SmartDeviceLink/SDLMutableDataQueue.h
+++ b/SmartDeviceLink/SDLMutableDataQueue.h
@@ -12,8 +12,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-- (instancetype)init;
-
 // frontBuffer returns the NSMutableData * buffer at the front of the queue,
 // but does not remove it -- modeled after the STL C++ queue front method
 - (NSMutableData *)frontBuffer;
@@ -32,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 // Since data can be dequeued from the front multiple times, use this
 // flag to track whether it has been dequeued once
-@property(nonatomic, assign, readonly) BOOL frontDequeued;
+@property(nonatomic, assign, readonly, getter=isFrontBufferDequeued) BOOL frontDequeued;
 
 NS_ASSUME_NONNULL_END
 

--- a/SmartDeviceLink/SDLMutableDataQueue.h
+++ b/SmartDeviceLink/SDLMutableDataQueue.h
@@ -10,18 +10,20 @@
 
 @interface SDLMutableDataQueue : NSObject
 
+NS_ASSUME_NONNULL_BEGIN
+
 - (instancetype)init;
 
-// front returns the NSMutableData * buffer at the front of the queue,
+// frontBuffer returns the NSMutableData * buffer at the front of the queue,
 // but does not remove it -- modeled after the STL C++ queue front method
-- (NSMutableData *)front;
+- (NSMutableData *)frontBuffer;
 
-// pop removes the buffer at the head of the queue -- modeled after the
+// popBuffer removes the buffer at the head of the queue -- modeled after the
 // STL C++ queue pop method
-- (void)pop;
+- (void)popBuffer;
 
 // Enqueues a new NSMutableData * buffer at the back of the queue
-- (void)enqueue:(NSMutableData *)data;
+- (void)enqueueBuffer:(NSMutableData *)data;
 
 // Empty the queue
 - (void)flush;
@@ -31,5 +33,7 @@
 // Since data can be dequeued from the front multiple times, use this
 // flag to track whether it has been dequeued once
 @property(nonatomic, assign, readonly) BOOL frontDequeued;
+
+NS_ASSUME_NONNULL_END
 
 @end

--- a/SmartDeviceLink/SDLMutableDataQueue.h
+++ b/SmartDeviceLink/SDLMutableDataQueue.h
@@ -1,0 +1,35 @@
+//
+//  SDLMutableDataQueue.h
+//  
+//
+//  Created by David Switzer on 3/2/17.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@interface SDLMutableDataQueue : NSObject
+
+- (instancetype)init;
+
+// front returns the NSMutableData * buffer at the front of the queue,
+// but does not remove it -- modeled after the STL C++ queue front method
+- (NSMutableData *)front;
+
+// pop removes the buffer at the head of the queue -- modeled after the
+// STL C++ queue pop method
+- (void)pop;
+
+// Enqueues a new NSMutableData * buffer at the back of the queue
+- (void)enqueue:(NSMutableData *)data;
+
+// Empty the queue
+- (void)flush;
+
+@property(nonatomic, assign, readonly) NSUInteger count;
+
+// Since data can be dequeued from the front multiple times, use this
+// flag to track whether it has been dequeued once
+@property(nonatomic, assign, readonly) BOOL frontDequeued;
+
+@end

--- a/SmartDeviceLink/SDLMutableDataQueue.m
+++ b/SmartDeviceLink/SDLMutableDataQueue.m
@@ -19,27 +19,29 @@
 
 - (instancetype)init{
     self = [super init];
-    if (self != nil) {
-        self.elements = [[NSMutableArray alloc] init];
+    if (!self) {
+        return nil;
     }
+    
+    self.elements = [[NSMutableArray alloc] init];
     
     return self;
 }
 
-- (void)enqueue:(NSMutableData *)data{
+- (void)enqueueBuffer:(NSMutableData *)data{
     @synchronized (self) {
         [self.elements addObject:data];
         self.frontDequeued = NO;
     }
 }
 
-- (NSMutableData *)front{
+- (NSMutableData *)frontBuffer{
     NSMutableData *dataAtFront = nil;
     
     @synchronized (self) {
-        if (self.elements.count > 0) {
+        if (self.elements.count) {
             // The front of the queue is always at index 0
-            dataAtFront = [self.elements objectAtIndex:0];
+            dataAtFront = self.elements[0];
             self.frontDequeued = YES;
         }
     }
@@ -47,7 +49,7 @@
     return dataAtFront;
 }
 
-- (void)pop{
+- (void)popBuffer{
     @synchronized (self) {
         [self.elements removeObjectAtIndex:0];
     }
@@ -63,10 +65,6 @@
     @synchronized (self) {
         return self.elements.count;
     }
-}
-
-- (void)dealloc{
-    self.elements = nil;
 }
 
 @end

--- a/SmartDeviceLink/SDLMutableDataQueue.m
+++ b/SmartDeviceLink/SDLMutableDataQueue.m
@@ -67,4 +67,9 @@
     }
 }
 
+- (void)dealloc{
+    [self flush];
+    self.elements = nil;
+}
+
 @end

--- a/SmartDeviceLink/SDLMutableDataQueue.m
+++ b/SmartDeviceLink/SDLMutableDataQueue.m
@@ -8,8 +8,6 @@
 
 #import "SDLMutableDataQueue.h"
 
-foo;
-
 @interface SDLMutableDataQueue()
 
 @property(nonatomic, strong) NSMutableArray *elements;
@@ -21,7 +19,7 @@ foo;
 
 - (instancetype)init{
     self = [super init];
-    if (self != nil){
+    if (self != nil) {
         self.elements = [[NSMutableArray alloc] init];
     }
     
@@ -39,7 +37,7 @@ foo;
     NSMutableData *dataAtFront = nil;
     
     @synchronized (self) {
-        if (self.elements.count > 0){
+        if (self.elements.count > 0) {
             // The front of the queue is always at index 0
             dataAtFront = [self.elements objectAtIndex:0];
             self.frontDequeued = YES;

--- a/SmartDeviceLink/SDLMutableDataQueue.m
+++ b/SmartDeviceLink/SDLMutableDataQueue.m
@@ -1,0 +1,74 @@
+//
+//  SDLMutableDataQueue.m
+//  
+//
+//  Created by David Switzer on 3/2/17.
+//
+//
+
+#import "SDLMutableDataQueue.h"
+
+foo;
+
+@interface SDLMutableDataQueue()
+
+@property(nonatomic, strong) NSMutableArray *elements;
+@property(nonatomic, assign, readwrite) BOOL frontDequeued;
+
+@end
+
+@implementation SDLMutableDataQueue
+
+- (instancetype)init{
+    self = [super init];
+    if (self != nil){
+        self.elements = [[NSMutableArray alloc] init];
+    }
+    
+    return self;
+}
+
+- (void)enqueue:(NSMutableData *)data{
+    @synchronized (self) {
+        [self.elements addObject:data];
+        self.frontDequeued = NO;
+    }
+}
+
+- (NSMutableData *)front{
+    NSMutableData *dataAtFront = nil;
+    
+    @synchronized (self) {
+        if (self.elements.count > 0){
+            // The front of the queue is always at index 0
+            dataAtFront = [self.elements objectAtIndex:0];
+            self.frontDequeued = YES;
+        }
+    }
+    
+    return dataAtFront;
+}
+
+- (void)pop{
+    @synchronized (self) {
+        [self.elements removeObjectAtIndex:0];
+    }
+}
+
+- (void)flush{
+    @synchronized (self) {
+        [self.elements removeAllObjects];
+    }
+}
+
+- (NSUInteger)count{
+    @synchronized (self) {
+        return self.elements.count;
+    }
+}
+
+- (void)dealloc{
+    self.elements = nil;
+}
+
+@end


### PR DESCRIPTION
Fixes #522

This PR is ready for review.

### Risk
This PR makes no API changes.

### Testing Plan
We will perform manual and automated testing with a number of internal SDL test apps and prototype headunit hardware, covering validation and verification of correct RPC and a variety of cold and warm connect/disconnect scenarios over BT and USB.

### Summary
This PR moves all IAP transport reads and writes for the active data session to a background thread. Send buffers are enqueued from the IAPTransport sendData method to an internal FIFO managed by the IAPSession instance. They are dequeued and consumed by the background thread using an initial stream write to consume as much of the buffer as possible, and by scheduled writes using the delegate space available callback to consume the remainder as space is available, thereby minimizing CPU utilization and preserving battery life when the iOS device is unplugged. For plugged scenarios, battery charging should be faster due to the minimized CPU utilization.

### Changelog
##### Breaking Changes
* No API breaking changes.

##### Enhancements
* Data session I/O is now in full compliance with Apple guidelines.

##### Bug Fixes
* All session output stream API calls are made on the scheduled thread, scheduled thread is no longer the main thread and polling is no longer used to minimize CPU impact.

### Tasks Remaining:
Requesting SDL iOS team feedback so any implementation issues are addressed before a full internal test pass.
