### PR TITLE
Added more descriptive error for registering successfully with warning

### DIFF
--- a/SmartDeviceLink/SDLError.h
+++ b/SmartDeviceLink/SDLError.h
@@ -30,6 +30,7 @@ extern SDLErrorDomain *const SDLErrorDomainFileManager;
 + (NSError *)sdl_lifecycle_unknownRemoteErrorWithDescription:(NSString *)description andReason:(NSString *)reason;
 + (NSError *)sdl_lifecycle_managersFailedToStart;
 + (NSError *)sdl_lifecycle_startedWithBadResult:(SDLResult)result info:(NSString *)info;
++ (NSError *)sdl_lifecycle_startedWithWarning:(SDLResult)result info:(NSString *)info;
 + (NSError *)sdl_lifecycle_failedWithBadResult:(SDLResult)result info:(NSString *)info;
 
 #pragma mark SDLFileManager

--- a/SmartDeviceLink/SDLError.m
+++ b/SmartDeviceLink/SDLError.m
@@ -81,6 +81,16 @@ SDLErrorDomain *const SDLErrorDomainFileManager = @"com.sdl.filemanager.error";
                            userInfo:userInfo];
 }
 
++ (NSError *)sdl_lifecycle_startedWithWarning:(SDLResult)result info:(NSString *)info {
+    NSDictionary<NSString *, NSString *> *userInfo = @{
+                                                       NSLocalizedDescriptionKey: NSLocalizedString(result, nil),
+                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(info, nil)
+                                                       };
+    return [NSError errorWithDomain:SDLErrorDomainLifecycleManager
+                               code:SDLManagerErrorRegistrationSuccessWithWarning
+                           userInfo:userInfo];
+}
+
 + (NSError *)sdl_lifecycle_failedWithBadResult:(SDLResult)result info:(NSString *)info {
     NSDictionary<NSString *, NSString *> *userInfo = @{
         NSLocalizedDescriptionKey: NSLocalizedString(result, nil),

--- a/SmartDeviceLink/SDLErrorConstants.h
+++ b/SmartDeviceLink/SDLErrorConstants.h
@@ -36,6 +36,10 @@ typedef NS_ENUM(NSInteger, SDLManagerError) {
      *  Registering with the remote system failed.
      */
     SDLManagerErrorRegistrationFailed = -6,
+    /**
+     *  Registering with the remote system was successful, but had a warning.
+     */
+    SDLManagerErrorRegistrationSuccessWithWarning = -7
 };
 
 /**

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -282,7 +282,7 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
 
     // If the resultCode isn't success, we got a warning. Errors were handled in `didEnterStateConnected`.
     if (![registerResult isEqualToString:SDLResultSuccess]) {
-        startError = [NSError sdl_lifecycle_startedWithBadResult:registerResult info:registerInfo];
+        startError = [NSError sdl_lifecycle_startedWithWarning:registerResult info:registerInfo];
     }
 
     // If we got to this point, we succeeded, send the error if there was a warning.


### PR DESCRIPTION
Fixes #511 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Summary
This PR adds in a more descriptive error code for handling successful registrations with warnings, instead of returning back `SDLManagerErrorRegistrationFailed`, which is not correct.

### Changelog
##### Enhancements
* Added more descriptive error code for handling successful registrations with warnings.
