### PR TITLE
SDLManagerDelegate support AudioStreamingState and SystemContext

### DIFF
--- a/SmartDeviceLink/SDLLifecycleManager.h
+++ b/SmartDeviceLink/SDLLifecycleManager.h
@@ -9,8 +9,10 @@
 #import "SDLNotificationConstants.h"
 #import <Foundation/Foundation.h>
 
+#import "SDLAudioStreamingState.h"
 #import "SDLHMILevel.h"
 #import "SDLLanguage.h"
+#import "SDLSystemContext.h"
 
 @class SDLConfiguration;
 @class SDLFileManager;
@@ -73,6 +75,8 @@ typedef void (^SDLManagerReadyBlock)(BOOL success, NSError *_Nullable error);
 @property (assign, nonatomic) UInt16 lastCorrelationId;
 @property (copy, nonatomic, readonly) SDLLifecycleState *lifecycleState;
 @property (copy, nonatomic, nullable) SDLHMILevel hmiLevel;
+@property (copy, nonatomic, nullable) SDLAudioStreamingState audioStreamingState;
+@property (copy, nonatomic, nullable) SDLSystemContext systemContext;
 @property (strong, nonatomic, nullable) SDLRegisterAppInterfaceResponse *registerResponse;
 
 

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -186,7 +186,13 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
     self.registerResponse = nil;
     self.lastCorrelationId = 0;
     self.hmiLevel = nil;
-
+    
+    // New Start
+    self.audioStreamingState = nil;
+    self.systemContext = nil;
+    // New End
+    
+    
     [SDLDebugTool logInfo:@"Stopping Proxy"];
     self.proxy = nil;
 
@@ -450,13 +456,29 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
     SDLOnHMIStatus *hmiStatusNotification = notification.notification;
     SDLHMILevel oldHMILevel = self.hmiLevel;
     self.hmiLevel = hmiStatusNotification.hmiLevel;
-
+    
+    SDLAudioStreamingState oldStreamingState = self.audioStreamingState;
+    self.audioStreamingState = hmiStatusNotification.audioStreamingState;
+    
+    SDLSystemContext oldSystemContext = self.systemContext;
+    self.systemContext = hmiStatusNotification.systemContext;
+    
     if (![self.lifecycleStateMachine isCurrentState:SDLLifecycleStateReady]) {
         return;
     }
 
     if (![oldHMILevel isEqualToString:self.hmiLevel]) {
         [self.delegate hmiLevel:oldHMILevel didChangeToLevel:self.hmiLevel];
+    }
+        
+    if (![oldStreamingState isEqualToString:self.audioStreamingState]
+        && [self.delegate respondsToSelector:@selector(audioStreamingState:didChangeToState:)]) {
+        [self.delegate audioStreamingState:oldStreamingState didChangeToState:self.audioStreamingState];
+    }
+    
+    if (![oldSystemContext isEqualToString:self.systemContext]
+        && [self.delegate respondsToSelector:@selector(systemContext:didChangeToContext:)]) {
+        [self.delegate systemContext:oldSystemContext didChangeToContext:self.systemContext];
     }
 }
 

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -186,12 +186,8 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
     self.registerResponse = nil;
     self.lastCorrelationId = 0;
     self.hmiLevel = nil;
-    
-    // New Start
     self.audioStreamingState = nil;
     self.systemContext = nil;
-    // New End
-    
     
     [SDLDebugTool logInfo:@"Stopping Proxy"];
     self.proxy = nil;

--- a/SmartDeviceLink/SDLManager.h
+++ b/SmartDeviceLink/SDLManager.h
@@ -2,8 +2,10 @@
 
 #import "SDLNotificationConstants.h"
 
+#import "SDLAudioStreamingState.h"
 #import "SDLHMILevel.h"
 #import "SDLLanguage.h"
+#import "SDLSystemContext.h"
 
 @class SDLConfiguration;
 @class SDLFileManager;
@@ -37,6 +39,16 @@ typedef void (^SDLManagerReadyBlock)(BOOL success, NSError *_Nullable error);
  *  The current HMI level of the running app.
  */
 @property (copy, nonatomic, readonly) SDLHMILevel hmiLevel;
+
+/**
+ *  The current audio streaming state of the running app.
+ */
+@property (copy, nonatomic, readonly) SDLAudioStreamingState audioStreamingState;
+
+/**
+ *  The current system context of the running app.
+ */
+@property (copy, nonatomic, readonly) SDLSystemContext systemContext;
 
 /**
  *  The file manager to be used by the running app.

--- a/SmartDeviceLink/SDLManagerDelegate.h
+++ b/SmartDeviceLink/SDLManagerDelegate.h
@@ -8,7 +8,9 @@
 
 #import <Foundation/Foundation.h>
 
+#import "SDLAudioStreamingState.h"
 #import "SDLHMILevel.h"
+#import "SDLSystemContext.h"
 
 
 NS_ASSUME_NONNULL_BEGIN
@@ -27,6 +29,23 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param newLevel The current level.
  */
 - (void)hmiLevel:(SDLHMILevel)oldLevel didChangeToLevel:(SDLHMILevel)newLevel;
+
+@optional
+/**
+ *  Called when the audio streaming state of this application changes on the remote system. This refers to when streaming audio is audible to the user.
+ *
+ *  @param oldState The previous state which has now been left.
+ *  @param newState The current state.
+ */
+- (void)audioStreamingState:(nullable SDLAudioStreamingState)oldState didChangeToState:(SDLAudioStreamingState)newState;
+
+/**
+ *  Called when the system context of this application changes on the remote system. This refers to whether or not a user-initiated interaction is in progress, and if so, what it is.
+ *
+ *  @param oldContext The previous context which has now been left.
+ *  @param newContext The current context.
+ */
+- (void)systemContext:(nullable SDLSystemContext)oldContext didChangeToContext:(SDLSystemContext)newContext;
 
 
 @end

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleManagerSpec.m
@@ -367,7 +367,63 @@ describe(@"a lifecycle manager", ^{
                     });
                 });
             });
-        });
+            
+            describe(@"receiving an audio state change", ^{
+                __block SDLOnHMIStatus *testHMIStatus = nil;
+                __block SDLAudioStreamingState testAudioStreamingState = nil;
+                __block SDLAudioStreamingState oldAudioStreamingState = nil;
+                
+                beforeEach(^{
+                    oldAudioStreamingState = testManager.audioStreamingState;
+                    testHMIStatus = [[SDLOnHMIStatus alloc] init];
+                });
+                
+                context(@"a not audible audio state", ^{
+                    beforeEach(^{
+                        testAudioStreamingState = SDLAudioStreamingStateNotAudible;
+                        testHMIStatus.audioStreamingState = testAudioStreamingState;
+                        
+                        [testManager.notificationDispatcher postRPCNotificationNotification:SDLDidChangeHMIStatusNotification notification:testHMIStatus];
+                    });
+                    
+                    it(@"should set the audio state", ^{
+                        expect(testManager.audioStreamingState).toEventually(equal(testAudioStreamingState));
+                    });
+                    
+                    it(@"should call the delegate", ^{
+                        OCMVerify([managerDelegateMock audioStreamingState:oldAudioStreamingState didChangeToState:testAudioStreamingState]);
+                    });
+                });
+            });
+            
+            describe(@"receiving a system context change", ^{
+                __block SDLOnHMIStatus *testHMIStatus = nil;
+                __block SDLSystemContext testSystemContext = nil;
+                __block SDLSystemContext oldSystemContext = nil;
+                
+                beforeEach(^{
+                    oldSystemContext = testManager.systemContext;
+                    testHMIStatus = [[SDLOnHMIStatus alloc] init];
+                });
+                
+                context(@"a alert system context state", ^{
+                    beforeEach(^{
+                        testSystemContext = SDLSystemContextAlert;
+                        testHMIStatus.systemContext = testSystemContext;
+                        
+                        [testManager.notificationDispatcher postRPCNotificationNotification:SDLDidChangeHMIStatusNotification notification:testHMIStatus];
+                    });
+                    
+                    it(@"should set the system context", ^{
+                        expect(testManager.systemContext).toEventually(equal(testSystemContext));
+                    });
+                    
+                    it(@"should call the delegate", ^{
+                        OCMVerify([managerDelegateMock systemContext:oldSystemContext didChangeToContext:testSystemContext]);
+                    });
+                });
+            });
+         });
     });
 });
 


### PR DESCRIPTION
Fixes #569 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Unit tests were written for these changes.

### Summary
This PR implements [SDL-0032](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0032-on-hmi-status-state-changes.md).

> This proposal is to add in support to inform developers of additional state changes with `onHMIStatus`. Currently, [SDLManagerDelegate](https://github.com/smartdevicelink/sdl_ios/blob/master/SmartDeviceLink/SDLManagerDelegate.h) only supports `SDLHMIStatus` changes, and is missing callbacks for `SDLAudioStreamingState` as well as `SDLSystemContext`.


### Changelog
##### Enhancements
* Added in support for system context and audio streaming state change delegate callbacks.