### PR TITLE
Added convenience isEqualToEnum function.

### DIFF
--- a/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
+++ b/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
@@ -867,6 +867,7 @@
 		DA4353E91D2721680099B8C4 /* DispatchTimerSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = DA4353E61D2721680099B8C4 /* DispatchTimerSpec.m */; };
 		DA4353EA1D2721680099B8C4 /* SDLTouchManagerSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = DA4353E71D2721680099B8C4 /* SDLTouchManagerSpec.m */; };
 		DA4353EB1D2721680099B8C4 /* SDLTouchSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = DA4353E81D2721680099B8C4 /* SDLTouchSpec.m */; };
+		DA4F47961E771AA100FC809E /* SDLEnum.m in Sources */ = {isa = PBXBuildFile; fileRef = DA4F47951E771AA100FC809E /* SDLEnum.m */; };
 		DA96C0661D4D4F730022F520 /* SDLAppInfoSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = DA96C0651D4D4F730022F520 /* SDLAppInfoSpec.m */; };
 		DA9F7E631DCBFAC800ACAE48 /* SDLDateTime.h in Headers */ = {isa = PBXBuildFile; fileRef = DA9F7E611DCBFAC800ACAE48 /* SDLDateTime.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA9F7E641DCBFAC800ACAE48 /* SDLDateTime.m in Sources */ = {isa = PBXBuildFile; fileRef = DA9F7E621DCBFAC800ACAE48 /* SDLDateTime.m */; };
@@ -1870,6 +1871,7 @@
 		DA4353E61D2721680099B8C4 /* DispatchTimerSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = DispatchTimerSpec.m; path = UtilitiesSpecs/Touches/DispatchTimerSpec.m; sourceTree = "<group>"; };
 		DA4353E71D2721680099B8C4 /* SDLTouchManagerSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SDLTouchManagerSpec.m; path = UtilitiesSpecs/Touches/SDLTouchManagerSpec.m; sourceTree = "<group>"; };
 		DA4353E81D2721680099B8C4 /* SDLTouchSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SDLTouchSpec.m; path = UtilitiesSpecs/Touches/SDLTouchSpec.m; sourceTree = "<group>"; };
+		DA4F47951E771AA100FC809E /* SDLEnum.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLEnum.m; sourceTree = "<group>"; };
 		DA7515981D95FAA000F29323 /* lock_arrow_down_black.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = lock_arrow_down_black.png; sourceTree = "<group>"; };
 		DA7515991D95FAA000F29323 /* lock_arrow_down_black@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "lock_arrow_down_black@2x.png"; sourceTree = "<group>"; };
 		DA75159A1D95FAA000F29323 /* lock_arrow_down_black@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "lock_arrow_down_black@3x.png"; sourceTree = "<group>"; };
@@ -3101,6 +3103,7 @@
 			isa = PBXGroup;
 			children = (
 				5D61FABA1A84238A00846EE7 /* SDLEnum.h */,
+				DA4F47951E771AA100FC809E /* SDLEnum.m */,
 				5DB92D301AC9C8BA00C15BB0 /* SDLRPCStruct.h */,
 				5DB92D311AC9C8BA00C15BB0 /* SDLRPCStruct.m */,
 				5D61FB7C1A84238B00846EE7 /* SDLRPCMessage.h */,
@@ -4446,6 +4449,7 @@
 				5D1665C51CF8CA2700CC4CA1 /* SDLListFilesOperation.m in Sources */,
 				5D61FE021A84238C00846EE7 /* SDLVehicleDataNotificationStatus.m in Sources */,
 				5D61FDD81A84238C00846EE7 /* SDLTouchType.m in Sources */,
+				DA4F47961E771AA100FC809E /* SDLEnum.m in Sources */,
 				5D61FDD61A84238C00846EE7 /* SDLTouchEventCapabilities.m in Sources */,
 				5DA102A51D4122C700C15826 /* NSMutableDictionary+SafeRemove.m in Sources */,
 				5D61FCF11A84238C00846EE7 /* SDLLockScreenStatusManager.m in Sources */,

--- a/SmartDeviceLink/SDLEnum.h
+++ b/SmartDeviceLink/SDLEnum.h
@@ -5,4 +5,14 @@
 #import <Foundation/Foundation.h>
 #import "SDLMacros.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 typedef NSString* SDLEnum SDL_SWIFT_ENUM;
+
+@interface NSString (Enum)
+
+- (BOOL)isEqualToEnum:(SDLEnum)enumObj;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLEnum.h
+++ b/SmartDeviceLink/SDLEnum.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef NSString* SDLEnum SDL_SWIFT_ENUM;
 
-@interface NSString (Enum)
+@interface NSString (SDLEnum)
 
 - (BOOL)isEqualToEnum:(SDLEnum)enumObj;
 

--- a/SmartDeviceLink/SDLEnum.m
+++ b/SmartDeviceLink/SDLEnum.m
@@ -1,0 +1,21 @@
+//
+//  SDLEnum.m
+//  SmartDeviceLink-iOS
+//
+//  Created by Muller, Alexander (A.) on 3/13/17.
+//  Copyright © 2017 smartdevicelink. All rights reserved.
+//
+
+#import "SDLEnum.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation NSString (Enum)
+
+- (BOOL)isEqualToEnum:(SDLEnum)enumObj {
+    return [self isEqualToString:enumObj];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLEnum.m
+++ b/SmartDeviceLink/SDLEnum.m
@@ -10,7 +10,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@implementation NSString (Enum)
+@implementation NSString (SDLEnum)
 
 - (BOOL)isEqualToEnum:(SDLEnum)enumObj {
     return [self isEqualToString:enumObj];

--- a/SmartDeviceLink/SDLLifecycleConfiguration.m
+++ b/SmartDeviceLink/SDLLifecycleConfiguration.m
@@ -72,7 +72,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark Computed Properties
 
 - (BOOL)isMedia {
-    if ([self.appType isEqualToString:SDLAppHMITypeMedia]) {
+    if ([self.appType isEqualToEnum:SDLAppHMITypeMedia]) {
         return YES;
     }
 

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -283,7 +283,7 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
     NSError *startError = nil;
 
     // If the resultCode isn't success, we got a warning. Errors were handled in `didEnterStateConnected`.
-    if (![registerResult isEqualToString:SDLResultSuccess]) {
+    if (![registerResult isEqualToEnum:SDLResultSuccess]) {
         startError = [NSError sdl_lifecycle_startedWithWarning:registerResult info:registerInfo];
     }
 
@@ -454,16 +454,16 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
         return;
     }
 
-    if (![oldHMILevel isEqualToString:self.hmiLevel]) {
+    if (![oldHMILevel isEqualToEnum:self.hmiLevel]) {
         [self.delegate hmiLevel:oldHMILevel didChangeToLevel:self.hmiLevel];
     }
         
-    if (![oldStreamingState isEqualToString:self.audioStreamingState]
+    if (![oldStreamingState isEqualToEnum:self.audioStreamingState]
         && [self.delegate respondsToSelector:@selector(audioStreamingState:didChangeToState:)]) {
         [self.delegate audioStreamingState:oldStreamingState didChangeToState:self.audioStreamingState];
     }
     
-    if (![oldSystemContext isEqualToString:self.systemContext]
+    if (![oldSystemContext isEqualToEnum:self.systemContext]
         && [self.delegate respondsToSelector:@selector(systemContext:didChangeToContext:)]) {
         [self.delegate systemContext:oldSystemContext didChangeToContext:self.systemContext];
     }

--- a/SmartDeviceLink/SDLLockScreenManager.m
+++ b/SmartDeviceLink/SDLLockScreenManager.m
@@ -128,17 +128,17 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     // Present the VC depending on the lock screen status
-    if ([self.lastLockNotification.lockScreenStatus isEqualToString:SDLLockScreenStatusRequired]) {
+    if ([self.lastLockNotification.lockScreenStatus isEqualToEnum:SDLLockScreenStatusRequired]) {
         if (!self.presenter.presented && self.canPresent) {
             [self.presenter present];
         }
-    } else if ([self.lastLockNotification.lockScreenStatus isEqualToString:SDLLockScreenStatusOptional]) {
+    } else if ([self.lastLockNotification.lockScreenStatus isEqualToEnum:SDLLockScreenStatusOptional]) {
         if (self.config.showInOptionalState && !self.presenter.presented && self.canPresent) {
             [self.presenter present];
         } else if (self.presenter.presented) {
             [self.presenter dismiss];
         }
-    } else if ([self.lastLockNotification.lockScreenStatus isEqualToString:SDLLockScreenStatusOff]) {
+    } else if ([self.lastLockNotification.lockScreenStatus isEqualToEnum:SDLLockScreenStatusOff]) {
         if (self.presenter.presented) {
             [self.presenter dismiss];
         }

--- a/SmartDeviceLink/SDLLockScreenStatusManager.m
+++ b/SmartDeviceLink/SDLLockScreenStatusManager.m
@@ -45,9 +45,9 @@ NS_ASSUME_NONNULL_BEGIN
         _hmiLevel = hmiLevel;
     }
 
-    if ([hmiLevel isEqualToString:SDLHMILevelFull] || [hmiLevel isEqualToString:SDLHMILevelLimited]) {
+    if ([hmiLevel isEqualToEnum:SDLHMILevelFull] || [hmiLevel isEqualToEnum:SDLHMILevelLimited]) {
         self.userSelected = YES;
-    } else if ([hmiLevel isEqualToString:SDLHMILevelNone]) {
+    } else if ([hmiLevel isEqualToEnum:SDLHMILevelNone]) {
         self.userSelected = NO;
     }
 }
@@ -66,10 +66,10 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (SDLLockScreenStatus)lockScreenStatus {
-    if (self.hmiLevel == nil || [self.hmiLevel isEqualToString:SDLHMILevelNone]) {
+    if (self.hmiLevel == nil || [self.hmiLevel isEqualToEnum:SDLHMILevelNone]) {
         // App is not active on the car
         return SDLLockScreenStatusOff;
-    } else if ([self.hmiLevel isEqualToString:SDLHMILevelBackground]) {
+    } else if ([self.hmiLevel isEqualToEnum:SDLHMILevelBackground]) {
         // App is in the background on the car
         if (self.userSelected) {
             // It was user selected
@@ -83,7 +83,7 @@ NS_ASSUME_NONNULL_BEGIN
         } else {
             return SDLLockScreenStatusOff;
         }
-    } else if ([self.hmiLevel isEqualToString:SDLHMILevelFull] || [self.hmiLevel isEqualToString:SDLHMILevelLimited]) {
+    } else if ([self.hmiLevel isEqualToEnum:SDLHMILevelFull] || [self.hmiLevel isEqualToEnum:SDLHMILevelLimited]) {
         // App is in the foreground on the car in some manner
         if (self.haveDriverDistractionStatus && !self.driverDistracted) {
             // We have the distraction status, and the driver is not distracted

--- a/SmartDeviceLink/SDLProxy.m
+++ b/SmartDeviceLink/SDLProxy.m
@@ -403,13 +403,13 @@ static float DefaultConnectionTimeout = 45.0;
     SDLRequestType requestType = systemRequest.requestType;
 
     // Handle the various OnSystemRequest types
-    if ([requestType isEqualToString:SDLRequestTypeProprietary]) {
+    if ([requestType isEqualToEnum:SDLRequestTypeProprietary]) {
         [self handleSystemRequestProprietary:systemRequest];
-    } else if ([requestType isEqualToString:SDLRequestTypeLockScreenIconURL]) {
+    } else if ([requestType isEqualToEnum:SDLRequestTypeLockScreenIconURL]) {
         [self handleSystemRequestLockScreenIconURL:systemRequest];
-    } else if ([requestType isEqualToString:SDLRequestTypeHTTP]) {
+    } else if ([requestType isEqualToEnum:SDLRequestTypeHTTP]) {
         [self sdl_handleSystemRequestHTTP:systemRequest];
-    } else if ([requestType isEqualToString:SDLRequestTypeLaunchApp]) {
+    } else if ([requestType isEqualToEnum:SDLRequestTypeLaunchApp]) {
         [self sdl_handleSystemRequestLaunchApp:systemRequest];
     }
 }
@@ -587,7 +587,7 @@ static float DefaultConnectionTimeout = 45.0;
         return nil;
     }
 
-    if (![fileType isEqualToString:SDLFileTypeJSON]) {
+    if (![fileType isEqualToEnum:SDLFileTypeJSON]) {
         [SDLDebugTool logInfo:@"OnSystemRequest (notification) failure: file type is not JSON" withType:SDLDebugType_RPC toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
         return nil;
     }

--- a/SmartDeviceLink/SDLResponseDispatcher.m
+++ b/SmartDeviceLink/SDLResponseDispatcher.m
@@ -200,7 +200,7 @@ NS_ASSUME_NONNULL_BEGIN
         customID = ((SDLOnButtonPress *)rpcNotification).customButtonID;
     }
 
-    if ([name isEqualToString:SDLButtonNameCustomButton]) {
+    if ([name isEqualToEnum:SDLButtonNameCustomButton]) {
         handler = self.customButtonHandlerMap[customID];
     } else {
         handler = self.buttonHandlerMap[name];

--- a/SmartDeviceLink/SDLTouchManager.m
+++ b/SmartDeviceLink/SDLTouchManager.m
@@ -118,11 +118,11 @@ static NSUInteger const MaximumNumberOfTouches = 2;
         return;
     }
 
-    if ([notification.type isEqualToString:SDLTouchTypeBegin]) {
+    if ([notification.type isEqualToEnum:SDLTouchTypeBegin]) {
         [self sdl_handleTouchBegan:touch];
-    } else if ([notification.type isEqualToString:SDLTouchTypeMove]) {
+    } else if ([notification.type isEqualToEnum:SDLTouchTypeMove]) {
         [self sdl_handleTouchMoved:touch];
-    } else if ([notification.type isEqualToString:SDLTouchTypeEnd]) {
+    } else if ([notification.type isEqualToEnum:SDLTouchTypeEnd]) {
         [self sdl_handleTouchEnded:touch];
     }
 }

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleConfigurationSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleConfigurationSpec.m
@@ -29,10 +29,10 @@ describe(@"a lifecycle configuration", ^{
             expect(@(testConfig.tcpDebugMode)).to(beFalsy());
             expect(testConfig.tcpDebugIPAddress).to(match(@"192.168.0.1"));
             expect(@(testConfig.tcpDebugPort)).to(equal(@12345));
-            expect(@([testConfig.appType isEqualToString:SDLAppHMITypeDefault])).to(equal(@YES));
+            expect(@([testConfig.appType isEqualToEnum:SDLAppHMITypeDefault])).to(equal(@YES));
             expect(@(testConfig.isMedia)).to(beFalsy());
-            expect(@([testConfig.language isEqualToString:SDLLanguageEnUs])).to(equal(@YES));
-            expect(@([[testConfig.languagesSupported firstObject] isEqualToString:SDLLanguageEnUs])).to(equal(@YES));
+            expect(@([testConfig.language isEqualToEnum:SDLLanguageEnUs])).to(equal(@YES));
+            expect(@([[testConfig.languagesSupported firstObject] isEqualToEnum:SDLLanguageEnUs])).to(equal(@YES));
             expect(testConfig.shortAppName).to(beNil());
             expect(testConfig.ttsName).to(beNil());
             expect(testConfig.voiceRecognitionCommandNames).to(beNil());
@@ -72,9 +72,9 @@ describe(@"a lifecycle configuration", ^{
                 expect(@(testConfig.tcpDebugMode)).to(beFalsy());
                 expect(testConfig.tcpDebugIPAddress).to(match(@"192.168.0.1"));
                 expect(@(testConfig.tcpDebugPort)).to(equal(@12345));
-                expect(@([testConfig.appType isEqualToString:SDLAppHMITypeMedia])).to(equal(@YES));
+                expect(@([testConfig.appType isEqualToEnum:SDLAppHMITypeMedia])).to(equal(@YES));
                 expect(@(testConfig.isMedia)).to(beTruthy());
-                expect(@([testConfig.language isEqualToString:SDLLanguageArSa])).to(equal(@YES));
+                expect(@([testConfig.language isEqualToEnum:SDLLanguageArSa])).to(equal(@YES));
                 expect(testConfig.languagesSupported).to(haveCount(@3));
                 expect(testConfig.shortAppName).to(match(someShortAppName));
                 expect(testConfig.ttsName).to(contain(someTTSChunk));
@@ -107,8 +107,8 @@ describe(@"a lifecycle configuration", ^{
             expect(@(testConfig.tcpDebugMode)).to(beTruthy());
             expect(testConfig.tcpDebugIPAddress).to(match(someIPAddress));
             expect(@(testConfig.tcpDebugPort)).to(equal(@(somePort)));
-            expect(@([testConfig.appType isEqualToString:SDLAppHMITypeDefault])).to(equal(@YES));
-            expect(@([testConfig.language isEqualToString:SDLLanguageEnUs])).to(equal(@YES));
+            expect(@([testConfig.appType isEqualToEnum:SDLAppHMITypeDefault])).to(equal(@YES));
+            expect(@([testConfig.language isEqualToEnum:SDLLanguageEnUs])).to(equal(@YES));
             expect(@([[testConfig.languagesSupported firstObject] isEqualToString:SDLLanguageEnUs])).to(equal(@YES));
             expect(testConfig.shortAppName).to(beNil());
             expect(testConfig.ttsName).to(beNil());
@@ -148,9 +148,9 @@ describe(@"a lifecycle configuration", ^{
                 expect(@(testConfig.tcpDebugMode)).to(beTruthy());
                 expect(testConfig.tcpDebugIPAddress).to(match(someIPAddress));
                 expect(@(testConfig.tcpDebugPort)).to(equal(@(somePort)));
-                expect(@([testConfig.appType isEqualToString:SDLAppHMITypeMedia])).to(equal(@YES));
+                expect(@([testConfig.appType isEqualToEnum:SDLAppHMITypeMedia])).to(equal(@YES));
                 expect(@(testConfig.isMedia)).to(beTruthy());
-                expect(@([testConfig.language isEqualToString:SDLLanguageArSa])).to(equal(@YES));
+                expect(@([testConfig.language isEqualToEnum:SDLLanguageArSa])).to(equal(@YES));
                 expect(testConfig.languagesSupported).to(haveCount(@3));
                 expect(testConfig.shortAppName).to(match(someShortAppName));
                 expect(testConfig.ttsName).to(contain(someTTSChunk));

--- a/SmartDeviceLink_Example/Classes/ProxyManager.m
+++ b/SmartDeviceLink_Example/Classes/ProxyManager.m
@@ -103,7 +103,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         [weakSelf setupPermissionsCallbacks];
         
-        if ([weakSelf.sdlManager.hmiLevel isEqualToString:SDLHMILevelFull]) {
+        if ([weakSelf.sdlManager.hmiLevel isEqualToEnum:SDLHMILevelFull]) {
             [weakSelf showInitialData];
         }
     }];
@@ -115,7 +115,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)showInitialData {
-    if ((self.initialShowState != SDLHMIInitialShowStateDataAvailable) || ![self.sdlManager.hmiLevel isEqualToString:SDLHMILevelFull]) {
+    if ((self.initialShowState != SDLHMIInitialShowStateDataAvailable) || ![self.sdlManager.hmiLevel isEqualToEnum:SDLHMILevelFull]) {
         return;
     }
     
@@ -366,7 +366,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)hmiLevel:(SDLHMILevel)oldLevel didChangeToLevel:(SDLHMILevel)newLevel {
-    if (![newLevel isEqualToString:SDLHMILevelNone] && (self.firstTimeState == SDLHMIFirstStateNone)) {
+    if (![newLevel isEqualToEnum:SDLHMILevelNone] && (self.firstTimeState == SDLHMIFirstStateNone)) {
         // This is our first time in a non-NONE state
         self.firstTimeState = SDLHMIFirstStateNonNone;
         
@@ -374,12 +374,12 @@ NS_ASSUME_NONNULL_BEGIN
         [self prepareRemoteSystem];
     }
     
-    if ([newLevel isEqualToString:SDLHMILevelFull] && (self.firstTimeState != SDLHMIFirstStateFull)) {
+    if ([newLevel isEqualToEnum:SDLHMILevelFull] && (self.firstTimeState != SDLHMIFirstStateFull)) {
         // This is our first time in a FULL state
         self.firstTimeState = SDLHMIFirstStateFull;
     }
     
-    if ([newLevel isEqualToString:SDLHMILevelFull]) {
+    if ([newLevel isEqualToEnum:SDLHMILevelFull]) {
         // We're always going to try to show the initial state, because if we've already shown it, it won't be shown, and we need to guard against some possible weird states
         [self showInitialData];
     }


### PR DESCRIPTION
Fixes #577 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
This PR adds back in `isEqualToEnum` function back for `SDLEnum`s, to help ease 5.0 adoption.

### Changelog
##### Bug Fixes
* Re-added `isEqualToEnum:` for enum equality checking.
