### PR TITLE
Setting nil appType should set it to default value.

### DIFF
--- a/SmartDeviceLink/SDLLifecycleConfiguration.m
+++ b/SmartDeviceLink/SDLLifecycleConfiguration.m
@@ -92,6 +92,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setAppType:(nullable SDLAppHMIType *)appType {
     if (appType == nil) {
         _appType = [SDLAppHMIType DEFAULT];
+        return;
     }
 
     _appType = appType;


### PR DESCRIPTION
Fixes #579 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
You can test this by setting the `SDLLifecycleConfiguration`'s `appType` property to `nil` in the example app.

### Summary
Fixed an issue with setting `appType` to `nil` not setting it to it's default value in `SDLLifecycleConfiguration`.

### Changelog
##### Bug Fixes
* Fixed an issue with setting `appType` to `nil` not setting it to it's default value in `SDLLifecycleConfiguration`.
