### PR TITLE
Update array getters to check for NSNull and return an empty array

### DIFF
--- a/SmartDeviceLink/SDLAlert.m
+++ b/SmartDeviceLink/SDLAlert.m
@@ -123,7 +123,9 @@ static UInt16 const SDLDefaultDuration = 5000;
 
 - (NSMutableArray *)ttsChunks {
     NSMutableArray *array = [parameters objectForKey:NAMES_ttsChunks];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLTTSChunk.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLTTSChunk.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];
@@ -180,7 +182,9 @@ static UInt16 const SDLDefaultDuration = 5000;
 
 - (NSMutableArray *)softButtons {
     NSMutableArray *array = [parameters objectForKey:NAMES_softButtons];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLSoftButton.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLSoftButton.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];

--- a/SmartDeviceLink/SDLAlertManeuver.m
+++ b/SmartDeviceLink/SDLAlertManeuver.m
@@ -50,7 +50,9 @@
 
 - (NSMutableArray *)ttsChunks {
     NSMutableArray *array = [parameters objectForKey:NAMES_ttsChunks];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLTTSChunk.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLTTSChunk.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];
@@ -71,7 +73,9 @@
 
 - (NSMutableArray *)softButtons {
     NSMutableArray *array = [parameters objectForKey:NAMES_softButtons];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLSoftButton.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLSoftButton.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];

--- a/SmartDeviceLink/SDLCreateInteractionChoiceSet.m
+++ b/SmartDeviceLink/SDLCreateInteractionChoiceSet.m
@@ -54,7 +54,9 @@
 
 - (NSMutableArray *)choiceSet {
     NSMutableArray *array = [parameters objectForKey:NAMES_choiceSet];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLChoice.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLChoice.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];

--- a/SmartDeviceLink/SDLDisplayCapabilities.m
+++ b/SmartDeviceLink/SDLDisplayCapabilities.m
@@ -52,7 +52,9 @@
 
 - (NSMutableArray *)textFields {
     NSMutableArray *array = [store objectForKey:NAMES_textFields];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLTextField.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLTextField.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];
@@ -73,7 +75,9 @@
 
 - (NSMutableArray *)imageFields {
     NSMutableArray *array = [store objectForKey:NAMES_imageFields];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLImageField.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLImageField.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];
@@ -94,7 +98,9 @@
 
 - (NSMutableArray *)mediaClockFormats {
     NSMutableArray *array = [store objectForKey:NAMES_mediaClockFormats];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLMediaClockFormat.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLMediaClockFormat.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];

--- a/SmartDeviceLink/SDLGetWaypointsResponse.m
+++ b/SmartDeviceLink/SDLGetWaypointsResponse.m
@@ -24,7 +24,9 @@
 
 - (NSArray<SDLLocationDetails *> *)waypoints {
     NSMutableArray *array = [parameters objectForKey:NAMES_waypoints];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLLocationDetails.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLLocationDetails.class]) {
         return [array copy];
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];

--- a/SmartDeviceLink/SDLHMIPermissions.m
+++ b/SmartDeviceLink/SDLHMIPermissions.m
@@ -31,7 +31,9 @@
 
 - (NSMutableArray *)allowed {
     NSMutableArray *array = [store objectForKey:NAMES_allowed];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLHMILevel.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLHMILevel.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];
@@ -52,7 +54,9 @@
 
 - (NSMutableArray *)userDisallowed {
     NSMutableArray *array = [store objectForKey:NAMES_userDisallowed];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLHMILevel.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLHMILevel.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];

--- a/SmartDeviceLink/SDLImageField.m
+++ b/SmartDeviceLink/SDLImageField.m
@@ -50,7 +50,9 @@
 
 - (NSMutableArray *)imageTypeSupported {
     NSMutableArray *array = [store objectForKey:NAMES_imageTypeSupported];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLFileType.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLFileType.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];

--- a/SmartDeviceLink/SDLOnPermissionsChange.m
+++ b/SmartDeviceLink/SDLOnPermissionsChange.m
@@ -31,7 +31,9 @@
 
 - (NSMutableArray *)permissionItem {
     NSMutableArray *array = [parameters objectForKey:NAMES_permissionItem];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLPermissionItem.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLPermissionItem.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];

--- a/SmartDeviceLink/SDLOnTouchEvent.m
+++ b/SmartDeviceLink/SDLOnTouchEvent.m
@@ -49,7 +49,9 @@
 
 - (NSMutableArray *)event {
     NSMutableArray *array = [parameters objectForKey:NAMES_event];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLTouchEvent.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLTouchEvent.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];

--- a/SmartDeviceLink/SDLOnWaypointChange.m
+++ b/SmartDeviceLink/SDLOnWaypointChange.m
@@ -24,7 +24,9 @@
 
 - (NSArray<SDLLocationDetails *> *)waypoints {
     NSMutableArray *array = [parameters objectForKey:NAMES_waypoints];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLLocationDetails.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLLocationDetails.class]) {
         return [array copy];
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];

--- a/SmartDeviceLink/SDLPerformAudioPassThru.m
+++ b/SmartDeviceLink/SDLPerformAudioPassThru.m
@@ -64,7 +64,9 @@
 
 - (NSMutableArray *)initialPrompt {
     NSMutableArray *array = [parameters objectForKey:NAMES_initialPrompt];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLTTSChunk.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLTTSChunk.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];

--- a/SmartDeviceLink/SDLPerformInteraction.m
+++ b/SmartDeviceLink/SDLPerformInteraction.m
@@ -105,7 +105,9 @@ static UInt16 const SDLDefaultTimeout = 10000;
 
 - (NSMutableArray *)initialPrompt {
     NSMutableArray *array = [parameters objectForKey:NAMES_initialPrompt];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLTTSChunk.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLTTSChunk.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];
@@ -155,7 +157,9 @@ static UInt16 const SDLDefaultTimeout = 10000;
 
 - (NSMutableArray *)helpPrompt {
     NSMutableArray *array = [parameters objectForKey:NAMES_helpPrompt];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLTTSChunk.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLTTSChunk.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];
@@ -176,7 +180,9 @@ static UInt16 const SDLDefaultTimeout = 10000;
 
 - (NSMutableArray *)timeoutPrompt {
     NSMutableArray *array = [parameters objectForKey:NAMES_timeoutPrompt];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLTTSChunk.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLTTSChunk.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];
@@ -209,7 +215,9 @@ static UInt16 const SDLDefaultTimeout = 10000;
 
 - (NSMutableArray *)vrHelp {
     NSMutableArray *array = [parameters objectForKey:NAMES_vrHelp];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLVRHelpItem.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLVRHelpItem.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];

--- a/SmartDeviceLink/SDLReadDIDResponse.m
+++ b/SmartDeviceLink/SDLReadDIDResponse.m
@@ -31,7 +31,9 @@
 
 - (NSMutableArray *)didResult {
     NSMutableArray *array = [parameters objectForKey:NAMES_didResult];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLDIDResult.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLDIDResult.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];

--- a/SmartDeviceLink/SDLRegisterAppInterface.m
+++ b/SmartDeviceLink/SDLRegisterAppInterface.m
@@ -107,7 +107,9 @@
 
 - (NSMutableArray *)ttsName {
     NSMutableArray *array = [parameters objectForKey:NAMES_ttsName];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLTTSChunk.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLTTSChunk.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];
@@ -198,7 +200,9 @@
 
 - (NSMutableArray *)appHMIType {
     NSMutableArray *array = [parameters objectForKey:NAMES_appHMIType];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLAppHMIType.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLAppHMIType.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];

--- a/SmartDeviceLink/SDLRegisterAppInterfaceResponse.m
+++ b/SmartDeviceLink/SDLRegisterAppInterfaceResponse.m
@@ -112,7 +112,9 @@
 
 - (NSMutableArray *)buttonCapabilities {
     NSMutableArray *array = [parameters objectForKey:NAMES_buttonCapabilities];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLButtonCapabilities.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLButtonCapabilities.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];
@@ -133,7 +135,9 @@
 
 - (NSMutableArray *)softButtonCapabilities {
     NSMutableArray *array = [parameters objectForKey:NAMES_softButtonCapabilities];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLSoftButtonCapabilities.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLSoftButtonCapabilities.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];
@@ -171,7 +175,9 @@
 
 - (NSMutableArray *)hmiZoneCapabilities {
     NSMutableArray *array = [parameters objectForKey:NAMES_hmiZoneCapabilities];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLHMIZoneCapabilities.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLHMIZoneCapabilities.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];
@@ -192,7 +198,9 @@
 
 - (NSMutableArray *)speechCapabilities {
     NSMutableArray *array = [parameters objectForKey:NAMES_speechCapabilities];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLSpeechCapabilities.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLSpeechCapabilities.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];
@@ -213,7 +221,9 @@
 
 - (NSMutableArray *)prerecordedSpeech {
     NSMutableArray *array = [parameters objectForKey:NAMES_prerecordedSpeech];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLPrerecordedSpeech.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLPrerecordedSpeech.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];
@@ -234,7 +244,9 @@
 
 - (NSMutableArray *)vrCapabilities {
     NSMutableArray *array = [parameters objectForKey:NAMES_vrCapabilities];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLVRCapabilities.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLVRCapabilities.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];
@@ -255,7 +267,9 @@
 
 - (NSMutableArray *)audioPassThruCapabilities {
     NSMutableArray *array = [parameters objectForKey:NAMES_audioPassThruCapabilities];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLAudioPassThruCapabilities.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLAudioPassThruCapabilities.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];

--- a/SmartDeviceLink/SDLResetGlobalProperties.m
+++ b/SmartDeviceLink/SDLResetGlobalProperties.m
@@ -42,7 +42,9 @@
 
 - (NSMutableArray *)properties {
     NSMutableArray *array = [parameters objectForKey:NAMES_properties];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLGlobalProperty.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLGlobalProperty.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];

--- a/SmartDeviceLink/SDLScrollableMessage.m
+++ b/SmartDeviceLink/SDLScrollableMessage.m
@@ -78,7 +78,9 @@
 
 - (NSMutableArray *)softButtons {
     NSMutableArray *array = [parameters objectForKey:NAMES_softButtons];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLSoftButton.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLSoftButton.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];

--- a/SmartDeviceLink/SDLSetDisplayLayoutResponse.m
+++ b/SmartDeviceLink/SDLSetDisplayLayoutResponse.m
@@ -52,7 +52,9 @@
 
 - (NSMutableArray *)buttonCapabilities {
     NSMutableArray *array = [parameters objectForKey:NAMES_buttonCapabilities];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLButtonCapabilities.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLButtonCapabilities.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];
@@ -73,7 +75,9 @@
 
 - (NSMutableArray *)softButtonCapabilities {
     NSMutableArray *array = [parameters objectForKey:NAMES_softButtonCapabilities];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLSoftButtonCapabilities.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLSoftButtonCapabilities.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];

--- a/SmartDeviceLink/SDLSetGlobalProperties.m
+++ b/SmartDeviceLink/SDLSetGlobalProperties.m
@@ -62,7 +62,9 @@
 
 - (NSMutableArray *)helpPrompt {
     NSMutableArray *array = [parameters objectForKey:NAMES_helpPrompt];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLTTSChunk.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLTTSChunk.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];
@@ -83,7 +85,9 @@
 
 - (NSMutableArray *)timeoutPrompt {
     NSMutableArray *array = [parameters objectForKey:NAMES_timeoutPrompt];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLTTSChunk.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLTTSChunk.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];
@@ -116,7 +120,9 @@
 
 - (NSMutableArray *)vrHelp {
     NSMutableArray *array = [parameters objectForKey:NAMES_vrHelp];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLVRHelpItem.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLVRHelpItem.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];

--- a/SmartDeviceLink/SDLShow.m
+++ b/SmartDeviceLink/SDLShow.m
@@ -202,7 +202,9 @@
 
 - (NSMutableArray *)softButtons {
     NSMutableArray *array = [parameters objectForKey:NAMES_softButtons];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLSoftButton.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLSoftButton.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];

--- a/SmartDeviceLink/SDLShowConstantTBT.m
+++ b/SmartDeviceLink/SDLShowConstantTBT.m
@@ -184,7 +184,9 @@
 
 - (NSMutableArray *)softButtons {
     NSMutableArray *array = [parameters objectForKey:NAMES_softButtons];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLSoftButton.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLSoftButton.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];

--- a/SmartDeviceLink/SDLSpeak.m
+++ b/SmartDeviceLink/SDLSpeak.m
@@ -48,7 +48,9 @@
 
 - (NSMutableArray *)ttsChunks {
     NSMutableArray *array = [parameters objectForKey:NAMES_ttsChunks];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLTTSChunk.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLTTSChunk.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];

--- a/SmartDeviceLink/SDLTouchEvent.m
+++ b/SmartDeviceLink/SDLTouchEvent.m
@@ -55,7 +55,9 @@
 
 - (NSMutableArray *)coord {
     NSMutableArray *array = [store objectForKey:NAMES_c];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLTouchCoord.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLTouchCoord.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];

--- a/SmartDeviceLink/SDLUpdateTurnList.m
+++ b/SmartDeviceLink/SDLUpdateTurnList.m
@@ -44,7 +44,9 @@
 
 - (NSMutableArray *)turnList {
     NSMutableArray *array = [parameters objectForKey:NAMES_turnList];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLTurn.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLTurn.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];
@@ -65,7 +67,9 @@
 
 - (NSMutableArray *)softButtons {
     NSMutableArray *array = [parameters objectForKey:NAMES_softButtons];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLSoftButton.class]) {
+    if ([array isEqual:[NSNull null]]) {
+        return [NSMutableArray array];
+    } else if (array.count < 1 || [array.firstObject isKindOfClass:SDLSoftButton.class]) {
         return array;
     } else {
         NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLAlertSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLAlertSpec.m
@@ -64,6 +64,23 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testRequest.progressIndicator).to(equal(@NO));
         expect(testRequest.softButtons).to(equal([@[button] mutableCopy]));
     });
+
+    it(@"Should handle NSNull", ^{
+        NSMutableDictionary* dict = [@{NAMES_request:
+                                           @{NAMES_parameters:
+                                                 @{NAMES_alertText1:@"alert#1",
+                                                   NAMES_alertText2:@"alert#2",
+                                                   NAMES_alertText3:@"alert#3",
+                                                   NAMES_ttsChunks:[@[tts] mutableCopy],
+                                                   NAMES_duration:@4357,
+                                                   NAMES_playTone:@YES,
+                                                   NAMES_progressIndicator:@NO,
+                                                   NAMES_softButtons:[NSNull null]},
+                                             NAMES_operation_name:NAMES_Alert}} mutableCopy];
+        SDLAlert* testRequest = [[SDLAlert alloc] initWithDictionary:dict];
+
+        expect(testRequest.softButtons).to(beEmpty());
+    });
     
     it(@"Should return nil if not set", ^ {
         SDLAlert* testRequest = [[SDLAlert alloc] init];


### PR DESCRIPTION
Fixes #557 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
I have added some unit tests that check `NSNull` arrays.

### Summary
This PR changes RPC array parameters to return an empty array if the array happens to be `NSNull` which *should* never happen, but appears to be happening in production somewhere.

### Changelog
##### Bug Fixes
* This PR changes RPC array parameters to return an empty array if the array happens to be `NSNull` which *should* never happen, but appears to be happening in production somewhere.