### PR TITLE
IAP transport read/writes on background thread

### DIFF
--- a/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
+++ b/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
@@ -885,6 +885,8 @@
 		5DEE55C01B8509CB004F0D0F /* SDLURLRequestTaskSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DEE55BF1B8509CB004F0D0F /* SDLURLRequestTaskSpec.m */; };
 		5DF2BB9D1B94E38A00CE5994 /* SDLURLSessionSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DF2BB9C1B94E38A00CE5994 /* SDLURLSessionSpec.m */; };
 		5DFFB9151BD7C89700DB3F04 /* SDLConnectionManagerType.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DFFB9141BD7C89700DB3F04 /* SDLConnectionManagerType.h */; };
+		97E26DEC1E807AD70074A3C7 /* SDLMutableDataQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 97E26DEA1E807AD70074A3C7 /* SDLMutableDataQueue.h */; };
+		97E26DED1E807AD70074A3C7 /* SDLMutableDataQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = 97E26DEB1E807AD70074A3C7 /* SDLMutableDataQueue.m */; };
 		DA4353DF1D271FD10099B8C4 /* CGPointUtilSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = DA4353DE1D271FD10099B8C4 /* CGPointUtilSpec.m */; };
 		DA4353E31D2720A30099B8C4 /* SDLPinchGestureSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = DA4353E21D2720A30099B8C4 /* SDLPinchGestureSpec.m */; };
 		DA4353E91D2721680099B8C4 /* DispatchTimerSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = DA4353E61D2721680099B8C4 /* DispatchTimerSpec.m */; };
@@ -1924,6 +1926,8 @@
 		5DEE55BF1B8509CB004F0D0F /* SDLURLRequestTaskSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SDLURLRequestTaskSpec.m; path = "UtilitiesSpecs/HTTP Connection/SDLURLRequestTaskSpec.m"; sourceTree = "<group>"; };
 		5DF2BB9C1B94E38A00CE5994 /* SDLURLSessionSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SDLURLSessionSpec.m; path = "UtilitiesSpecs/HTTP Connection/SDLURLSessionSpec.m"; sourceTree = "<group>"; };
 		5DFFB9141BD7C89700DB3F04 /* SDLConnectionManagerType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDLConnectionManagerType.h; sourceTree = "<group>"; };
+		97E26DEA1E807AD70074A3C7 /* SDLMutableDataQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDLMutableDataQueue.h; sourceTree = "<group>"; };
+		97E26DEB1E807AD70074A3C7 /* SDLMutableDataQueue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLMutableDataQueue.m; sourceTree = "<group>"; };
 		DA4353DE1D271FD10099B8C4 /* CGPointUtilSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CGPointUtilSpec.m; path = UtilitiesSpecs/Touches/CGPointUtilSpec.m; sourceTree = "<group>"; };
 		DA4353E21D2720A30099B8C4 /* SDLPinchGestureSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SDLPinchGestureSpec.m; path = UtilitiesSpecs/Touches/SDLPinchGestureSpec.m; sourceTree = "<group>"; };
 		DA4353E61D2721680099B8C4 /* DispatchTimerSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = DispatchTimerSpec.m; path = UtilitiesSpecs/Touches/DispatchTimerSpec.m; sourceTree = "<group>"; };
@@ -3091,6 +3095,8 @@
 		5D5934F61A85189500687FB9 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				97E26DEA1E807AD70074A3C7 /* SDLMutableDataQueue.h */,
+				97E26DEB1E807AD70074A3C7 /* SDLMutableDataQueue.m */,
 				DAC5724C1D0FE3B60004288B /* Touches */,
 				5DCC199D1B8221D2004FFAD9 /* HTTP Connection */,
 				E9C32B831AB20B2900F283AF /* @categories */,
@@ -4201,6 +4207,7 @@
 				5D61FD4A1A84238C00846EE7 /* SDLProtocolMessageAssembler.h in Headers */,
 				5D61FD4C1A84238C00846EE7 /* SDLProtocolMessageDisassembler.h in Headers */,
 				5D61FD4E1A84238C00846EE7 /* SDLProtocolReceivedMessageRouter.h in Headers */,
+				97E26DEC1E807AD70074A3C7 /* SDLMutableDataQueue.h in Headers */,
 				5D61FDF71A84238C00846EE7 /* SDLV1ProtocolMessage.h in Headers */,
 				5D61FDFB1A84238C00846EE7 /* SDLV2ProtocolMessage.h in Headers */,
 				5D7F87EB1CE3C1A1002DD7C4 /* SDLDeleteFileOperation.h in Headers */,
@@ -4668,6 +4675,7 @@
 				5D61FD7A1A84238C00846EE7 /* SDLScreenParams.m in Sources */,
 				5D61FC831A84238C00846EE7 /* SDLDeviceInfo.m in Sources */,
 				5D7F87EC1CE3C1A1002DD7C4 /* SDLDeleteFileOperation.m in Sources */,
+				97E26DED1E807AD70074A3C7 /* SDLMutableDataQueue.m in Sources */,
 				5D61FD641A84238C00846EE7 /* SDLResetGlobalProperties.m in Sources */,
 				5D60088B1BE3ED540094A505 /* SDLStateMachine.m in Sources */,
 				5D61FD181A84238C00846EE7 /* SDLOnPermissionsChange.m in Sources */,

--- a/SmartDeviceLink/SDLIAPSession.h
+++ b/SmartDeviceLink/SDLIAPSession.h
@@ -23,5 +23,5 @@ typedef void (^SessionCompletionHandler)(BOOL success);
 
 - (BOOL)start;
 - (void)stop;
-
+- (void)sendData:(NSData *)data;
 @end

--- a/SmartDeviceLink/SDLIAPSession.h
+++ b/SmartDeviceLink/SDLIAPSession.h
@@ -17,6 +17,7 @@ typedef void (^SessionCompletionHandler)(BOOL success);
 @property (strong, atomic) EASession *easession;
 @property (weak) id<SDLIAPSessionDelegate> delegate;
 @property (strong, atomic) SDLStreamDelegate *streamDelegate;
+@property (assign, readonly, getter=isStopped) BOOL stopped;
 
 - (instancetype)initWithAccessory:(EAAccessory *)accessory
                       forProtocol:(NSString *)protocol;

--- a/SmartDeviceLink/SDLIAPSession.m
+++ b/SmartDeviceLink/SDLIAPSession.m
@@ -200,6 +200,7 @@ NSTimeInterval const streamThreadWaitSecs = 1.0;
 
 - (void)startStream:(NSStream *)stream {
     stream.delegate = self.streamDelegate;
+    NSAssert((self.isDataSession && [[NSThread currentThread] isEqual:self.ioStreamThread]) || [NSThread isMainThread], @"startStream is being called on the wrong thread!!!");
     [stream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
     [stream open];
 }
@@ -210,6 +211,8 @@ NSTimeInterval const streamThreadWaitSecs = 1.0;
 
     // When you disconect the cable you get a stream end event and come here but stream is already in closed state.
     // Still need to remove from run loop.
+    
+    NSAssert((self.isDataSession && [[NSThread currentThread] isEqual:self.ioStreamThread]) || [NSThread isMainThread], @"startStream is being called on the wrong thread!!!");
 
     NSUInteger status1 = stream.streamStatus;
     if (status1 != NSStreamStatusNotOpen &&
@@ -283,18 +286,6 @@ NSTimeInterval const streamThreadWaitSecs = 1.0;
             [strongSelf sdl_handleOutputStreamWriteError:sendErr];
         }
     };
-}
-
-#pragma mark - Lifecycle Destruction
-
-- (void)dealloc {
-    self.sendDataQueue = nil;
-    self.delegate = nil;
-    self.accessory = nil;
-    self.protocol = nil;
-    self.streamDelegate = nil;
-    self.easession = nil;
-    [SDLDebugTool logInfo:@"SDLIAPSession Dealloc"];
 }
 
 @end

--- a/SmartDeviceLink/SDLIAPSession.m
+++ b/SmartDeviceLink/SDLIAPSession.m
@@ -212,7 +212,7 @@ NSTimeInterval const streamThreadWaitSecs = 1.0;
     // When you disconect the cable you get a stream end event and come here but stream is already in closed state.
     // Still need to remove from run loop.
     
-    NSAssert((self.isDataSession && [[NSThread currentThread] isEqual:self.ioStreamThread]) || [NSThread isMainThread], @"startStream is being called on the wrong thread!!!");
+    NSAssert((self.isDataSession && [[NSThread currentThread] isEqual:self.ioStreamThread]) || [NSThread isMainThread], @"stopStream is being called on the wrong thread!!!");
 
     NSUInteger status1 = stream.streamStatus;
     if (status1 != NSStreamStatusNotOpen &&

--- a/SmartDeviceLink/SDLIAPSession.m
+++ b/SmartDeviceLink/SDLIAPSession.m
@@ -6,12 +6,19 @@
 #import "SDLDebugTool.h"
 #import "SDLStreamDelegate.h"
 #import "SDLTimer.h"
+#import "SDLMutableDataQueue.h"
 
+NSString *const ioStreamThreadName  = @ "com.smartdevicelink.iostream";
+NSTimeInterval const streamThreadWaitSecs = 1.0;
 
 @interface SDLIAPSession ()
 
 @property (assign) BOOL isInputStreamOpen;
 @property (assign) BOOL isOutputStreamOpen;
+@property (assign, nonatomic) BOOL isDataSession;
+@property (nonatomic, strong, nullable) NSThread *ioStreamThread;
+@property (nonatomic, strong, nullable) SDLMutableDataQueue *sendDataQueue;
+@property (nonatomic, strong, nullable) dispatch_semaphore_t canceledSemaphore;
 
 @end
 
@@ -27,8 +34,11 @@
     self = [super init];
     if (self) {
         _delegate = nil;
+        _isDataSession = [protocol isEqualToString:@"com.smartdevicelink.prot0"] ? NO : YES;
         _accessory = accessory;
         _protocol = protocol;
+        _canceledSemaphore = dispatch_semaphore_create(0);
+        _sendDataQueue = [[SDLMutableDataQueue alloc] init];
         _streamDelegate = nil;
         _easession = nil;
         _isInputStreamOpen = NO;
@@ -43,19 +53,26 @@
 - (BOOL)start {
     __weak typeof(self) weakSelf = self;
 
-    NSString *logMessage = [NSString stringWithFormat:@"Opening EASession withAccessory:%@ forProtocol:%@", _accessory.name, _protocol];
+    NSString *logMessage = [NSString stringWithFormat:@"Opening EASession withAccessory:%@ forProtocol:%@", self.accessory.name, self.protocol];
     [SDLDebugTool logInfo:logMessage];
 
-    if ((self.easession = [[EASession alloc] initWithAccessory:_accessory forProtocol:_protocol])) {
+    if ((self.easession = [[EASession alloc] initWithAccessory:self.accessory forProtocol:self.protocol])) {
         __strong typeof(self) strongSelf = weakSelf;
 
         [SDLDebugTool logInfo:@"Created Session Object"];
 
         strongSelf.streamDelegate.streamErrorHandler = [self streamErroredHandler];
         strongSelf.streamDelegate.streamOpenHandler = [self streamOpenedHandler];
-
-        [strongSelf startStream:weakSelf.easession.outputStream];
-        [strongSelf startStream:weakSelf.easession.inputStream];
+        if (!self.isDataSession) {
+            [self startStream:self.easession.outputStream];
+            [self startStream:self.easession.inputStream];
+        } else {
+            self.streamDelegate.streamHasSpaceHandler = [self streamHasSpaceHandler];
+            // Start I/O event loop processing events in iAP channel
+            self.ioStreamThread = [[NSThread alloc] initWithTarget:self selector:@selector(sdl_accessoryEventLoop) object:nil];
+            [self.ioStreamThread setName:ioStreamThreadName];
+            [self.ioStreamThread start];
+        }
 
         return YES;
 
@@ -66,9 +83,109 @@
 }
 
 - (void)stop {
-    [self stopStream:self.easession.outputStream];
-    [self stopStream:self.easession.inputStream];
+
+    if (!self.isDataSession) {
+        [self stopStream:self.easession.outputStream];
+        [self stopStream:self.easession.inputStream];
+    } else {
+        [self.ioStreamThread cancel];
+        
+        long lWait = dispatch_semaphore_wait(self.canceledSemaphore, dispatch_time(DISPATCH_TIME_NOW, streamThreadWaitSecs * NSEC_PER_SEC));
+        if (lWait == 0) {
+            [SDLDebugTool logInfo:@"Stream thread canceled"];
+        } else{
+           [SDLDebugTool logInfo:@"Error: failed to cancel stream thread"];
+        }
+        self.ioStreamThread = nil;
+        self.isDataSession = NO;
+    }
     self.easession = nil;
+}
+
+- (void)sendData:(NSData *)data {
+    // Enqueue the data for transmission on the IO thread
+    [self.sendDataQueue enqueueBuffer:data.mutableCopy];
+}
+
+- (BOOL)sdl_dequeueAndWriteToOutputStream:(NSError **)error {
+    NSOutputStream *ostream = self.easession.outputStream;
+    NSMutableData *remainder = [self.sendDataQueue frontBuffer];
+    BOOL allDataWritten = NO;
+    
+    if (error != nil && remainder != nil && ostream.streamStatus == NSStreamStatusOpen) {
+        NSInteger bytesRemaining = remainder.length;
+        NSInteger bytesWritten = [ostream write:remainder.bytes maxLength:bytesRemaining];
+        if (bytesWritten < 0) {
+            *error = ostream.streamError;
+        } else if (bytesWritten == bytesRemaining) {
+                // Remove the data from the queue
+                [self.sendDataQueue popBuffer];
+                allDataWritten = YES;
+            } else {
+                // Cleave the sent bytes from the data, the remainder will sit at the head of the queue
+                [remainder replaceBytesInRange:NSMakeRange(0, bytesWritten) withBytes:NULL length:0];
+            }
+    }
+
+    return allDataWritten;
+}
+
+- (void)sdl_handleOutputStreamWriteError:(NSError *)error {
+    NSString *errString = [NSString stringWithFormat:@"Output stream error: %@", error];
+    [SDLDebugTool logInfo:errString];
+    // REVIEW: We should look at the domain and the code as a tuple and decide
+    // how to handle the error based on both values. For now, if the stream
+    // is closed, we will flush the send queue and leave it as-is otherwise
+    // so that temporary error conditions can be dealt with by retrying
+    if (self.easession == nil ||
+        self.easession.outputStream == nil ||
+        self.easession.outputStream.streamStatus != NSStreamStatusOpen) {
+        [self.sendDataQueue flush];
+    }
+}
+
+- (void)sdl_accessoryEventLoop {
+    @autoreleasepool {
+        NSAssert(self.easession, @"_session must be assigned before calling");
+
+        if (!self.easession) {
+          return;
+        }
+        
+        [self startStream:self.easession.inputStream];
+        [self startStream:self.easession.outputStream];
+
+        [SDLDebugTool logInfo:@"starting the event loop for accessory"];
+        do {
+            if (self.sendDataQueue.count > 0 && !self.sendDataQueue.frontDequeued) {
+                NSError *sendErr = nil;
+                if (![self sdl_dequeueAndWriteToOutputStream:&sendErr] && sendErr != nil) {
+                    [self sdl_handleOutputStreamWriteError:sendErr];
+                }
+            }
+            
+            [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
+                                     beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.25f]];
+        } while (![NSThread currentThread].cancelled);
+
+        NSLog(@"closing accessory session");
+
+        // Close I/O streams of the iAP session
+        [self sdl_closeSession];
+        dispatch_semaphore_signal(self.canceledSemaphore);
+    }
+}
+
+// Must be called on accessoryEventLoop.
+- (void)sdl_closeSession {
+  if (self.easession) {
+    NSLog(@"Close EASession: %tu", self.easession.accessory.connectionID);
+    NSInputStream *inStream = [self.easession inputStream];
+    NSOutputStream *outStream = [self.easession outputStream];
+    
+    [self stopStream:inStream];
+    [self stopStream:outStream];
+  }
 }
 
 
@@ -76,7 +193,7 @@
 
 - (void)startStream:(NSStream *)stream {
     stream.delegate = self.streamDelegate;
-    [stream scheduleInRunLoop:[NSRunLoop mainRunLoop] forMode:NSDefaultRunLoopMode];
+    [stream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
     [stream open];
 }
 
@@ -93,7 +210,7 @@
         [stream close];
     }
 
-    [stream removeFromRunLoop:[NSRunLoop mainRunLoop] forMode:NSDefaultRunLoopMode];
+    [stream removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
     [stream setDelegate:nil];
 
     NSUInteger status2 = stream.streamStatus;
@@ -141,10 +258,26 @@
     };
 }
 
+- (SDLStreamHasSpaceHandler)streamHasSpaceHandler {
+    __weak typeof(self) weakSelf = self;
+    
+    return ^(NSStream *stream) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        
+        if (strongSelf.isDataSession) {
+            NSError *sendErr = nil;
+            
+            if (![strongSelf sdl_dequeueAndWriteToOutputStream:&sendErr] && sendErr != nil) {
+                [strongSelf sdl_handleOutputStreamWriteError:sendErr];
+            }
+        }
+    };
+}
 
 #pragma mark - Lifecycle Destruction
 
 - (void)dealloc {
+    self.sendDataQueue = nil;
     self.delegate = nil;
     self.accessory = nil;
     self.protocol = nil;

--- a/SmartDeviceLink/SDLIAPTransport.m
+++ b/SmartDeviceLink/SDLIAPTransport.m
@@ -172,6 +172,9 @@ int const streamOpenTimeoutSeconds = 2;
         // We should be attempting to connect
         self.retryCounter++;
         EAAccessory *sdlAccessory = accessory;
+        // If we are being called from sdl_connectAccessory, the EAAccessoryDidConnectNotification
+        // will contain the SDL accessory to connect to and we can connect without searching the
+        // accessory manager's connected accessory list. Otherwise, we fall through to a search.
         if (sdlAccessory != nil && [self sdl_connectAccessory:sdlAccessory]){
             // Connection underway, exit
             return;
@@ -414,6 +417,8 @@ int const streamOpenTimeoutSeconds = 2;
 
         uint8_t buf[[SDLGlobals globals].maxMTUSize];
         while (istream.streamStatus == NSStreamStatusOpen && istream.hasBytesAvailable) {
+            // It is necessary to check the stream status and whether there are bytes available because the dataStreamHasBytesHandler is executed on the IO thread and the accessory disconnect notification arrives on the main thread, causing data to be passed to the delegate while the main thread is tearing down the transport.
+            
             NSInteger bytesRead = [istream read:buf maxLength:[SDLGlobals globals].maxMTUSize];
             NSData *dataIn = [NSData dataWithBytes:buf length:bytesRead];
 

--- a/SmartDeviceLink/SDLIAPTransport.m
+++ b/SmartDeviceLink/SDLIAPTransport.m
@@ -152,7 +152,7 @@ int const streamOpenTimeoutSeconds = 2;
 
 #pragma mark - Creating Session Streams
 
-- (BOOL)sdl_tryConnectAccessory:(EAAccessory *)accessory {
+- (BOOL)sdl_connectAccessory:(EAAccessory *)accessory {
     BOOL connecting = NO;
     
     if ([accessory supportsProtocol:controlProtocolString]) {
@@ -172,7 +172,7 @@ int const streamOpenTimeoutSeconds = 2;
         // We should be attempting to connect
         self.retryCounter++;
         EAAccessory *sdlAccessory = accessory;
-        if (sdlAccessory != nil && [self sdl_tryConnectAccessory:sdlAccessory]){
+        if (sdlAccessory != nil && [self sdl_connectAccessory:sdlAccessory]){
             // Connection underway, exit
             return;
         }

--- a/SmartDeviceLink/SDLIAPTransport.m
+++ b/SmartDeviceLink/SDLIAPTransport.m
@@ -106,7 +106,7 @@ int const streamOpenTimeoutSeconds = 2;
     if (accessory.connectionID != self.session.accessory.connectionID) {
          [SDLDebugTool logInfo:@"Accessory connection ID mismatch!!!" withType:SDLDebugType_Transport_iAP toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
     }
-    if ([accessory.name isEqualToString:self.session.accessory.name]){
+    if ([accessory.serialNumber isEqualToString:self.session.accessory.serialNumber]){
         self.sessionSetupInProgress = NO;
         [self disconnect];
         [self.delegate onTransportDisconnected];

--- a/SmartDeviceLink/SDLIAPTransport.m
+++ b/SmartDeviceLink/SDLIAPTransport.m
@@ -172,9 +172,7 @@ int const streamOpenTimeoutSeconds = 2;
         // We should be attempting to connect
         self.retryCounter++;
         EAAccessory *sdlAccessory = accessory;
-        // If we are being called from sdl_connectAccessory, the EAAccessoryDidConnectNotification
-        // will contain the SDL accessory to connect to and we can connect without searching the
-        // accessory manager's connected accessory list. Otherwise, we fall through to a search.
+        // If we are being called from sdl_connectAccessory, the EAAccessoryDidConnectNotification will contain the SDL accessory to connect to and we can connect without searching the accessory manager's connected accessory list. Otherwise, we fall through to a search.
         if (sdlAccessory != nil && [self sdl_connectAccessory:sdlAccessory]){
             // Connection underway, exit
             return;

--- a/SmartDeviceLink/SDLIAPTransport.m
+++ b/SmartDeviceLink/SDLIAPTransport.m
@@ -100,7 +100,6 @@ int const streamOpenTimeoutSeconds = 2;
 
 - (void)sdl_accessoryDisconnected:(NSNotification *)notification {
     [SDLDebugTool logInfo:@"Accessory Disconnected Event" withType:SDLDebugType_Transport_iAP toOutput:SDLDebugOutput_All toGroup:self.debugConsoleGroupName];
-    [self sdl_stopEventListening];
 
     // Only check for the data session, the control session is handled separately
     EAAccessory *accessory = [notification.userInfo objectForKey:EAAccessoryKey];

--- a/SmartDeviceLink/SDLMutableDataQueue.h
+++ b/SmartDeviceLink/SDLMutableDataQueue.h
@@ -1,0 +1,38 @@
+//
+//  SDLMutableDataQueue.h
+//  
+//
+//  Created by David Switzer on 3/2/17.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@interface SDLMutableDataQueue : NSObject
+
+NS_ASSUME_NONNULL_BEGIN
+
+// frontBuffer returns the NSMutableData * buffer at the front of the queue,
+// but does not remove it -- modeled after the STL C++ queue front method
+- (NSMutableData *)frontBuffer;
+
+// popBuffer removes the buffer at the head of the queue -- modeled after the
+// STL C++ queue pop method
+- (void)popBuffer;
+
+// Enqueues a new NSMutableData * buffer at the back of the queue
+- (void)enqueueBuffer:(NSMutableData *)data;
+
+// Empty the queue
+- (void)flush;
+
+@property(nonatomic, assign, readonly) NSUInteger count;
+
+// Since data can be dequeued from the front multiple times, use this
+// flag to track whether it has been dequeued once
+@property(nonatomic, assign, readonly, getter=isFrontBufferDequeued) BOOL frontDequeued;
+
+NS_ASSUME_NONNULL_END
+
+
+@end

--- a/SmartDeviceLink/SDLMutableDataQueue.h
+++ b/SmartDeviceLink/SDLMutableDataQueue.h
@@ -8,28 +8,50 @@
 
 #import <Foundation/Foundation.h>
 
+/**
+ This queue class is used by the IAP data session to provide safe, async writing of RPC messages to the connected SDL compliant accessory. It uses NSMutableData objects because the NSOutputStream has a variable amount of space available based on iOS and accessory buffering. We want to be able to pop the buffer at the head multiiple times and consume as many bytes as there are available in the stream.
+ */
+
 @interface SDLMutableDataQueue : NSObject
 
 NS_ASSUME_NONNULL_BEGIN
 
-// frontBuffer returns the NSMutableData * buffer at the front of the queue,
-// but does not remove it -- modeled after the STL C++ queue front method
-- (NSMutableData *)frontBuffer;
+/**
+ frontBuffer returns the NSMutableData * buffer at the front of the queue, but does not remove it - modeled after the STL C++ queue front method
 
-// popBuffer removes the buffer at the head of the queue -- modeled after the
-// STL C++ queue pop method
+ @return NSMutableData containing the buffer at the head of the queue or nil if
+ the queue is empty
+ */
+- (NSMutableData  * _Nullable)frontBuffer;
+
+
+/**
+ popBuffer removes the buffer at the head of the queue -- modeled after the
+ STL C++ queue pop method. Use to remove the buffer once all of the data has
+ been consumed or the data is no longer valid/needed.
+ */
 - (void)popBuffer;
 
-// Enqueues a new NSMutableData * buffer at the back of the queue
+/**
+ Enqueues a new buffer at the back of the queue
+
+ @param data NSMutableData containing the buffer to enqueue
+ */
 - (void)enqueueBuffer:(NSMutableData *)data;
 
-// Empty the queue
-- (void)flush;
+/**
+ Empty the queue
+ */
+- (void)removeAllObjects;
 
+/**
+ Gets the number of buffers currently enqueued
+ */
 @property(nonatomic, assign, readonly) NSUInteger count;
 
-// Since data can be dequeued from the front multiple times, use this
-// flag to track whether it has been dequeued once
+/**
+ A flag indicating whether the buffer at the head of the queue has been dequeued at least once.
+ */
 @property(nonatomic, assign, readonly, getter=isFrontBufferDequeued) BOOL frontDequeued;
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLMutableDataQueue.m
+++ b/SmartDeviceLink/SDLMutableDataQueue.m
@@ -23,7 +23,7 @@
         return nil;
     }
     
-    self.elements = [[NSMutableArray alloc] init];
+    _elements = [NSMutableArray array];
     
     return self;
 }
@@ -35,7 +35,7 @@
     }
 }
 
-- (NSMutableData *)frontBuffer {
+- (NSMutableData  * _Nullable )frontBuffer {
     NSMutableData *dataAtFront = nil;
     
     @synchronized (self) {
@@ -55,7 +55,7 @@
     }
 }
 
-- (void)flush {
+- (void)removeAllObjects {
     @synchronized (self) {
         [self.elements removeAllObjects];
     }
@@ -68,7 +68,7 @@
 }
 
 - (void)dealloc {
-    [self flush];
+    [self removeAllObjects];
     self.elements = nil;
 }
 

--- a/SmartDeviceLink/SDLMutableDataQueue.m
+++ b/SmartDeviceLink/SDLMutableDataQueue.m
@@ -31,9 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)enqueueBuffer:(NSMutableData *)data {
-    // Since this method is being called from the main thread and the dequeue methods
-    // are being called from the data session stream thread, we need to put critical
-    // sections around the queue members. Use the @synchronized object level lock to do this.
+    // Since this method is being called from the main thread and the dequeue methods are being called from the data session stream thread, we need to put critical sections around the queue members. Use the @synchronized object level lock to do this.
     @synchronized (self) {
         [self.elements addObject:data];
         self.frontDequeued = NO;

--- a/SmartDeviceLink/SDLMutableDataQueue.m
+++ b/SmartDeviceLink/SDLMutableDataQueue.m
@@ -67,9 +67,4 @@
     }
 }
 
-- (void)dealloc {
-    [self removeAllObjects];
-    self.elements = nil;
-}
-
 @end

--- a/SmartDeviceLink/SDLMutableDataQueue.m
+++ b/SmartDeviceLink/SDLMutableDataQueue.m
@@ -8,6 +8,8 @@
 
 #import "SDLMutableDataQueue.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface SDLMutableDataQueue()
 
 @property(nonatomic, strong) NSMutableArray *elements;
@@ -66,5 +68,7 @@
         return self.elements.count;
     }
 }
+
+NS_ASSUME_NONNULL_END
 
 @end

--- a/SmartDeviceLink/SDLMutableDataQueue.m
+++ b/SmartDeviceLink/SDLMutableDataQueue.m
@@ -1,0 +1,75 @@
+//
+//  SDLMutableDataQueue.m
+//  
+//
+//  Created by David Switzer on 3/2/17.
+//
+//
+
+#import "SDLMutableDataQueue.h"
+
+@interface SDLMutableDataQueue()
+
+@property(nonatomic, strong) NSMutableArray *elements;
+@property(nonatomic, assign, readwrite) BOOL frontDequeued;
+
+@end
+
+@implementation SDLMutableDataQueue
+
+- (instancetype)init {
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+    
+    self.elements = [[NSMutableArray alloc] init];
+    
+    return self;
+}
+
+- (void)enqueueBuffer:(NSMutableData *)data {
+    @synchronized (self) {
+        [self.elements addObject:data];
+        self.frontDequeued = NO;
+    }
+}
+
+- (NSMutableData *)frontBuffer {
+    NSMutableData *dataAtFront = nil;
+    
+    @synchronized (self) {
+        if (self.elements.count) {
+            // The front of the queue is always at index 0
+            dataAtFront = self.elements[0];
+            self.frontDequeued = YES;
+        }
+    }
+    
+    return dataAtFront;
+}
+
+- (void)popBuffer {
+    @synchronized (self) {
+        [self.elements removeObjectAtIndex:0];
+    }
+}
+
+- (void)flush {
+    @synchronized (self) {
+        [self.elements removeAllObjects];
+    }
+}
+
+- (NSUInteger)count {
+    @synchronized (self) {
+        return self.elements.count;
+    }
+}
+
+- (void)dealloc {
+    [self flush];
+    self.elements = nil;
+}
+
+@end

--- a/SmartDeviceLink/SDLMutableDataQueue.m
+++ b/SmartDeviceLink/SDLMutableDataQueue.m
@@ -31,6 +31,9 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)enqueueBuffer:(NSMutableData *)data {
+    // Since this method is being called from the main thread and the dequeue methods
+    // are being called from the data session stream thread, we need to put critical
+    // sections around the queue members. Use the @synchronized object level lock to do this.
     @synchronized (self) {
         [self.elements addObject:data];
         self.frontDequeued = NO;

--- a/SmartDeviceLink/SDLProxy.m
+++ b/SmartDeviceLink/SDLProxy.m
@@ -88,7 +88,6 @@ const int POLICIES_CORRELATION_ID = 65535;
         [self.transport connect];
 
         [SDLDebugTool logInfo:@"SDLProxy initWithTransport"];
-        [[EAAccessoryManager sharedAccessoryManager] registerForLocalNotifications];
     }
 
     return self;
@@ -99,7 +98,6 @@ const int POLICIES_CORRELATION_ID = 65535;
         _alreadyDestructed = YES;
 
         [[NSNotificationCenter defaultCenter] removeObserver:self];
-        [[EAAccessoryManager sharedAccessoryManager] unregisterForLocalNotifications];
 
         [[SDLURLSession defaultSession] cancelAllTasks];
 


### PR DESCRIPTION
Fixes #522, #424 

This PR is ready for review.

### Risk
This PR makes no API changes.

### Testing Plan
We performed manual testing with a number of internal SDL test apps and prototype headunit hardware, covering validation and verification of correct RPC and a variety of cold and warm connect/disconnect scenarios over BT and USB. We are adding automated testing to perform longhaul characterization of MTTF.

### Summary
This PR moves all IAP transport reads and writes for the active data session to a background thread. Send buffers are enqueued from the IAPTransport sendData method to an internal FIFO managed by the IAPSession instance. They are dequeued and consumed by the background thread using an initial stream write to consume as much of the buffer as possible, and by scheduled writes using the delegate space available callback to consume the remainder as space is available, thereby minimizing CPU utilization and preserving battery life when the iOS device is unplugged. For plugged scenarios, battery charging should be faster due to the minimized CPU utilization.

In addition, race conditions caused by sending events to deallocating proxy objects have been fixed. Crashes and hangs due to these race conditions should now be reduced to rare occurrences.

### Changelog
##### Breaking Changes
* No API breaking changes.

##### Enhancements
* Data session I/O is now in full compliance with Apple guidelines.

##### Bug Fixes
* All session output stream API calls are made on the scheduled thread, scheduled thread is no longer the main thread and polling is no longer used to minimize CPU impact.

### Tasks Remaining:
Additional PRs for remaining sources of crashes and hangs in SDLIAPTransport will be created along with supporting issues.
