### PR TITLE
Fix reconnection attempts unable to be stopped

### DIFF
--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -148,7 +148,7 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
     return @{
         SDLLifecycleStateStopped: @[SDLLifecycleStateStarted],
         SDLLifecycleStateStarted : @[SDLLifecycleStateConnected, SDLLifecycleStateStopped, SDLLifecycleStateReconnecting],
-        SDLLifecycleStateReconnecting: @[SDLLifecycleStateStarted],
+        SDLLifecycleStateReconnecting: @[SDLLifecycleStateStarted, SDLLifecycleStateStopped],
         SDLLifecycleStateConnected: @[SDLLifecycleStateStopped, SDLLifecycleStateReconnecting, SDLLifecycleStateRegistered],
         SDLLifecycleStateRegistered: @[SDLLifecycleStateStopped, SDLLifecycleStateReconnecting, SDLLifecycleStateSettingUpManagers],
         SDLLifecycleStateSettingUpManagers: @[SDLLifecycleStateStopped, SDLLifecycleStateReconnecting, SDLLifecycleStatePostManagerProcessing],


### PR DESCRIPTION
Fixes #590 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
n/a

### Summary
Fixes an issue where if `stop` is called while the app is attempting to reconnect, a crash will occur.

### Changelog
##### Bug Fixes
* Fixes an issue where if `stop` is called while the app is attempting to reconnect, a crash will occur.