### PR TITLE
Fix CocoaPods resource bundle usage

### DIFF
--- a/SmartDeviceLink/NSBundle+SDLBundle.m
+++ b/SmartDeviceLink/NSBundle+SDLBundle.m
@@ -22,7 +22,15 @@ NS_ASSUME_NONNULL_BEGIN
         sdlBundle = [NSBundle bundleWithURL:sdlBundleURL];
     }
     if (sdlBundle == nil) {
-        sdlBundle = [NSBundle bundleForClass:[SDLManager class]];
+        NSBundle *frameworkBundle = [NSBundle bundleForClass:[SDLManager class]];
+
+        // HAX: Cocoapods will have the bundle as an inner bundle that we need to unpack...because reasons. Otherwise it's just the bundle we need
+        NSURL *innerBundleURL = [frameworkBundle URLForResource:@"SmartDeviceLink" withExtension:@"bundle"];
+        if (innerBundleURL) {
+            sdlBundle = [NSBundle bundleWithURL:innerBundleURL];
+        } else {
+            sdlBundle = frameworkBundle;
+        }
     }
     if (sdlBundle == nil) {
         @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"SDL WARNING: The 'SmartDeviceLink.bundle' resources bundle was not found. If you are using cocoapods, try dragging the bundle from the SmartDeviceLink-iOS pod 'products' directory into your resources build phase. If this does not work, please go to the SDL slack at slack.smartdevicelink.com and explain your issue. You may disable the lockscreen in configuration to prevent this failure, for now." userInfo:nil];


### PR DESCRIPTION
Fixes #601

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
This has been tested with both a manually imported framework file and a CocoaPods test app.

### Summary
This PR fixes finding the SmartDeviceLink resource bundle when the library is imported via CocoaPods.

### Changelog
##### Bug Fixes
* Fixes finding the SmartDeviceLink resource bundle when the library is imported via CocoaPods.
* If you are currently using CocoaPods, you should remove the manually imported CocoaPods SmartDeviceLink resource bundle if you had previously done so.