### PR TITLE
Fixed clearing of upload queue

### DIFF
--- a/SmartDeviceLink/SDLFileManager.m
+++ b/SmartDeviceLink/SDLFileManager.m
@@ -136,7 +136,7 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
     }
 }
 
-- (void)willEnterStateShutdown {
+- (void)didEnterStateShutdown {
     [self.transactionQueue cancelAllOperations];
     [self.mutableRemoteFileNames removeAllObjects];
     [self.class sdl_clearTemporaryFileDirectory];

--- a/SmartDeviceLink/SDLResponseDispatcher.m
+++ b/SmartDeviceLink/SDLResponseDispatcher.m
@@ -108,6 +108,10 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)clear {
+    for (SDLRPCCorrelationId *key in self.rpcResponseHandlerMap) {
+            SDLResponseHandler f = self.rpcResponseHandlerMap[key];
+            f(self.rpcRequestDictionary[key], nil, [NSError sdl_lifecycle_notConnectedError]);
+        }
     [self.rpcRequestDictionary removeAllObjects];
     [self.rpcResponseHandlerMap removeAllObjects];
     [self.commandHandlerMap removeAllObjects];

--- a/SmartDeviceLink/SDLResponseDispatcher.m
+++ b/SmartDeviceLink/SDLResponseDispatcher.m
@@ -108,10 +108,11 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)clear {
-    for (SDLRPCCorrelationId *key in self.rpcResponseHandlerMap) {
-            SDLResponseHandler f = self.rpcResponseHandlerMap[key];
-            f(self.rpcRequestDictionary[key], nil, [NSError sdl_lifecycle_notConnectedError]);
-        }
+    // When we get disconnected we have to delete all existing responseHandlers as they are not valid anymore
+    for (SDLRPCCorrelationId *correlationID in self.rpcResponseHandlerMap) {
+        SDLResponseHandler responseHandler = self.rpcResponseHandlerMap[correlationID];
+        responseHandler(self.rpcRequestDictionary[correlationID], nil, [NSError sdl_lifecycle_notConnectedError]);
+    }
     [self.rpcRequestDictionary removeAllObjects];
     [self.rpcResponseHandlerMap removeAllObjects];
     [self.commandHandlerMap removeAllObjects];


### PR DESCRIPTION
Fixes #606 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
1. Connect the device and launch the app.
2. Perform some action the initiates a file upload
3. Pull the USB cable while upload is active
4. Attempt to reconnect the device. Observe no app icon.

### Summary
* Renamed `- (void)willEnterStateShutdown` to `- (void)didEnterStateShutdown` as the `SDLStateMachine` only calls `didEnter...` functions
* Added the following code to `SDLResponseDispatcher.m` to ensure that ResponseHandlers are cleared.
```objc
for (SDLRPCCorrelationId *key in self.rpcResponseHandlerMap) {
            SDLResponseHandler f = self.rpcResponseHandlerMap[key];
            f(self.rpcRequestDictionary[key], nil, [NSError sdl_lifecycle_notConnectedError]);
        }
```


### Changelog
##### Breaking Changes
* No breaking changes

##### Enhancements
* Fixed a bug

##### Bug Fixes
* Fixed clearing upload queues

### Tasks Remaining:
