### PR TITLE
Fix SDLMenuParams `init` setting `position`

### DIFF
--- a/SmartDeviceLink/SDLMenuParams.m
+++ b/SmartDeviceLink/SDLMenuParams.m
@@ -27,7 +27,7 @@
     }
 
     self.parentID = @(parentId);
-    self.position = @(parentId);
+    self.position = @(position);
 
     return self;
 }

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLMenuParamsSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLMenuParamsSpec.m
@@ -13,8 +13,49 @@
 
 QuickSpecBegin(SDLMenuParamsSpec)
 
+describe(@"Initialization tests", ^{
+    __block UInt32 testParentId = 504320489;
+    __block UInt16 testPosition = testPosition;
+    __block NSString *testMenuName = @"Test Menu";
+
+    it(@"should properly initialize init", ^{
+        SDLMenuParams* testStruct = [[SDLMenuParams alloc] init];
+
+        expect(testStruct.parentID).to(beNil());
+        expect(testStruct.position).to(beNil());
+        expect(testStruct.menuName).to(beNil());
+    });
+
+    it(@"should properly initialize initWithDictionary", ^{
+        NSMutableDictionary* dict = [@{NAMES_parentID:@(testParentId),
+                                       NAMES_position:@(testPosition),
+                                       NAMES_menuName:testMenuName} mutableCopy];
+        SDLMenuParams* testStruct = [[SDLMenuParams alloc] initWithDictionary:dict];
+
+        expect(testStruct.parentID).to(equal(@(testParentId)));
+        expect(testStruct.position).to(equal(@(testPosition)));
+        expect(testStruct.menuName).to(equal(testMenuName));
+    });
+
+    it(@"should properly initialize initWithMenuName", ^{
+        SDLMenuParams* testStruct = [[SDLMenuParams alloc] initWithMenuName:testMenuName];
+
+        expect(testStruct.parentID).to(beNil());
+        expect(testStruct.position).to(beNil());
+        expect(testStruct.menuName).to(equal(testMenuName));
+    });
+
+    it(@"should properly initialize initWithMenuName:parentId:position:", ^{
+        SDLMenuParams* testStruct = [[SDLMenuParams alloc] initWithMenuName:testMenuName parentId:testParentId position:testPosition];
+
+        expect(testStruct.parentID).to(equal(@(testParentId)));
+        expect(testStruct.position).to(equal(@(testPosition)));
+        expect(testStruct.menuName).to(equal(testMenuName));
+    });
+});
+
 describe(@"Getter/Setter Tests", ^ {
-    it(@"Should set and get correctly", ^ {
+    it(@"Should set and get correctly", ^{
         SDLMenuParams* testStruct = [[SDLMenuParams alloc] init];
         
         testStruct.parentID = @504320489;
@@ -24,25 +65,6 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testStruct.parentID).to(equal(@504320489));
         expect(testStruct.position).to(equal(@256));
         expect(testStruct.menuName).to(equal(@"Menu"));
-    });
-    
-    it(@"Should get correctly when initialized", ^ {
-        NSMutableDictionary* dict = [@{NAMES_parentID:@504320489,
-                                       NAMES_position:@256,
-                                       NAMES_menuName:@"Menu"} mutableCopy];
-        SDLMenuParams* testStruct = [[SDLMenuParams alloc] initWithDictionary:dict];
-        
-        expect(testStruct.parentID).to(equal(@504320489));
-        expect(testStruct.position).to(equal(@256));
-        expect(testStruct.menuName).to(equal(@"Menu"));
-    });
-    
-    it(@"Should return nil if not set", ^ {
-        SDLMenuParams* testStruct = [[SDLMenuParams alloc] init];
-        
-        expect(testStruct.parentID).to(beNil());
-        expect(testStruct.position).to(beNil());
-        expect(testStruct.menuName).to(beNil());
     });
 });
 


### PR DESCRIPTION
Fixes #612 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Unit tests are included

### Summary
`SDLMenuParams initWithMenuParams:parentId:position:` should properly set `position`

##### Bug Fixes
* `SDLMenuParams initWithMenuParams:parentId:position:` should properly set `position`