### PR TITLE
Bugfix/issue 540

### DIFF
--- a/SmartDeviceLink/SDLLifecycleManager.h
+++ b/SmartDeviceLink/SDLLifecycleManager.h
@@ -44,7 +44,8 @@ extern SDLLifecycleState *const SDLLifecycleStateReconnecting;
 extern SDLLifecycleState *const SDLLifecycleStateConnected;
 extern SDLLifecycleState *const SDLLifecycleStateRegistered;
 extern SDLLifecycleState *const SDLLifecycleStateSettingUpManagers;
-extern SDLLifecycleState *const SDLLifecycleStatePostManagerProcessing;
+extern SDLLifecycleState *const SDLLifecycleStateSettingUpAppIcon;
+extern SDLLifecycleState *const SDLLifecycleStateSettingUpHMI;
 extern SDLLifecycleState *const SDLLifecycleStateUnregistering;
 extern SDLLifecycleState *const SDLLifecycleStateReady;
 

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -51,7 +51,8 @@ SDLLifecycleState *const SDLLifecycleStateReconnecting = @"Reconnecting";
 SDLLifecycleState *const SDLLifecycleStateConnected = @"Connected";
 SDLLifecycleState *const SDLLifecycleStateRegistered = @"Registered";
 SDLLifecycleState *const SDLLifecycleStateSettingUpManagers = @"SettingUpManagers";
-SDLLifecycleState *const SDLLifecycleStatePostManagerProcessing = @"PostManagerProcessing";
+SDLLifecycleState *const SDLLifecycleStateSettingUpAppIcon = @"SettingUpAppIcon";
+SDLLifecycleState *const SDLLifecycleStateSettingUpHMI = @"SettingUpHMI";
 SDLLifecycleState *const SDLLifecycleStateUnregistering = @"Unregistering";
 SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
 
@@ -153,8 +154,9 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
         SDLLifecycleStateReconnecting: @[SDLLifecycleStateStarted, SDLLifecycleStateStopped],
         SDLLifecycleStateConnected: @[SDLLifecycleStateStopped, SDLLifecycleStateReconnecting, SDLLifecycleStateRegistered],
         SDLLifecycleStateRegistered: @[SDLLifecycleStateStopped, SDLLifecycleStateReconnecting, SDLLifecycleStateSettingUpManagers],
-        SDLLifecycleStateSettingUpManagers: @[SDLLifecycleStateStopped, SDLLifecycleStateReconnecting, SDLLifecycleStatePostManagerProcessing],
-        SDLLifecycleStatePostManagerProcessing: @[SDLLifecycleStateStopped, SDLLifecycleStateReconnecting, SDLLifecycleStateReady],
+        SDLLifecycleStateSettingUpManagers: @[SDLLifecycleStateStopped, SDLLifecycleStateReconnecting, SDLLifecycleStateSettingUpAppIcon],
+        SDLLifecycleStateSettingUpAppIcon: @[SDLLifecycleStateStopped, SDLLifecycleStateReconnecting, SDLLifecycleStateSettingUpHMI],
+        SDLLifecycleStateSettingUpHMI: @[SDLLifecycleStateStopped, SDLLifecycleStateReconnecting, SDLLifecycleStateReady],
         SDLLifecycleStateUnregistering: @[SDLLifecycleStateStopped],
         SDLLifecycleStateReady: @[SDLLifecycleStateUnregistering, SDLLifecycleStateStopped, SDLLifecycleStateReconnecting]
     };
@@ -269,16 +271,27 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
 
     // When done, we want to transition, even if there were errors. They may be expected, e.g. on head units that do not support files.
     dispatch_group_notify(managerGroup, dispatch_get_main_queue(), ^{
-        [self.lifecycleStateMachine transitionToState:SDLLifecycleStatePostManagerProcessing];
+        [self.lifecycleStateMachine transitionToState:SDLLifecycleStateSettingUpAppIcon];
     });
 }
 
-- (void)didEnterStatePostManagerProcessing {
-    // We only want to send the app icon when the file manager is complete, and when that's done, set the state to ready
+- (void)didEnterStateSettingUpAppIcon {
+    // We only want to send the app icon when the file manager is complete, and when that's done, wait for hmi status to be ready
     [self sdl_sendAppIcon:self.configuration.lifecycleConfig.appIcon
            withCompletion:^{
-               [self.lifecycleStateMachine transitionToState:SDLLifecycleStateReady];
+               [self.lifecycleStateMachine transitionToState:SDLLifecycleStateSettingUpHMI];
            }];
+}
+
+- (void)didEnterStateSettingUpHMI{
+    // We want to make sure we've gotten a SDLOnHMIStatus notification
+    if (self.hmiLevel == nil) {
+        // If nil, return and wait until we get a notification
+        return;
+    }else{
+        // We are sure to have a HMIStatus, set state to ready
+        [self.lifecycleStateMachine transitionToState:SDLLifecycleStateReady];
+    }
 }
 
 - (void)didEnterStateReady {
@@ -439,10 +452,14 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
     SDLSystemContext oldSystemContext = self.systemContext;
     self.systemContext = hmiStatusNotification.systemContext;
     
+    if ([self.lifecycleStateMachine isCurrentState:SDLLifecycleStateSettingUpHMI]) {
+        [self.lifecycleStateMachine transitionToState:SDLLifecycleStateReady];
+    }
+    
     if (![self.lifecycleStateMachine isCurrentState:SDLLifecycleStateReady]) {
         return;
     }
-
+    
     if (![oldHMILevel isEqualToEnum:self.hmiLevel]) {
         [self.delegate hmiLevel:oldHMILevel didChangeToLevel:self.hmiLevel];
     }

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -288,10 +288,10 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
     if (self.hmiLevel == nil) {
         // If nil, return and wait until we get a notification
         return;
-    }else{
-        // We are sure to have a HMIStatus, set state to ready
-        [self.lifecycleStateMachine transitionToState:SDLLifecycleStateReady];
     }
+    // We are sure to have a HMIStatus, set state to ready
+    [self.lifecycleStateMachine transitionToState:SDLLifecycleStateReady];
+    
 }
 
 - (void)didEnterStateReady {


### PR DESCRIPTION
Fixes #[540]

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Testing was done by manually setting the HMI response to nil and observing the behavior. Upon a new HMI Status notification, the state is then properly set to ready. 

### Summary
The changes were mainly to the SDLLifecycleStates. The state `SDLLifecycleStatePostManagerProcessing ` was renamed to `SDLLifecycleStateSettingUpAppIcon ` to more clearly define what it actually does. 

A new state was added: `SDLLifecycleStateSettingUpHMI`. This state is called following `SDLLifecycleStateSettingUpAppIcon` and ensures that the HMI is ready. It checks that the HMI has responded and if it hasn't waits until it does before we set the state to `SDLLifecycleStateReady`

### Changelog

##### Bug Fixes
* this fixes a rare case bug where the lifeCycleState could say that it is ready when the HMI is not.
