### PR TITLE
Guarantee that HMI status is set for ready handler success

### DIFF
--- a/SmartDeviceLink/SDLLifecycleManager.h
+++ b/SmartDeviceLink/SDLLifecycleManager.h
@@ -42,7 +42,8 @@ extern SDLLifecycleState *const SDLLifecycleStateReconnecting;
 extern SDLLifecycleState *const SDLLifecycleStateConnected;
 extern SDLLifecycleState *const SDLLifecycleStateRegistered;
 extern SDLLifecycleState *const SDLLifecycleStateSettingUpManagers;
-extern SDLLifecycleState *const SDLLifecycleStatePostManagerProcessing;
+extern SDLLifecycleState *const SDLLifecycleStateSettingUpAppIcon;
+extern SDLLifecycleState *const SDLLifecycleStateSettingUpHMI;
 extern SDLLifecycleState *const SDLLifecycleStateUnregistering;
 extern SDLLifecycleState *const SDLLifecycleStateReady;
 

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -285,7 +285,6 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
     }
     // We are sure to have a HMIStatus, set state to ready
     [self.lifecycleStateMachine transitionToState:SDLLifecycleStateReady];
-    
 }
 
 - (void)didEnterStateReady {

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -49,7 +49,8 @@ SDLLifecycleState *const SDLLifecycleStateReconnecting = @"Reconnecting";
 SDLLifecycleState *const SDLLifecycleStateConnected = @"Connected";
 SDLLifecycleState *const SDLLifecycleStateRegistered = @"Registered";
 SDLLifecycleState *const SDLLifecycleStateSettingUpManagers = @"SettingUpManagers";
-SDLLifecycleState *const SDLLifecycleStatePostManagerProcessing = @"PostManagerProcessing";
+SDLLifecycleState *const SDLLifecycleStateSettingUpAppIcon = @"SettingUpAppIcon";
+SDLLifecycleState *const SDLLifecycleStateSettingUpHMI = @"SettingUpHMI";
 SDLLifecycleState *const SDLLifecycleStateUnregistering = @"Unregistering";
 SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
 
@@ -151,8 +152,9 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
         SDLLifecycleStateReconnecting: @[SDLLifecycleStateStarted, SDLLifecycleStateStopped],
         SDLLifecycleStateConnected: @[SDLLifecycleStateStopped, SDLLifecycleStateReconnecting, SDLLifecycleStateRegistered],
         SDLLifecycleStateRegistered: @[SDLLifecycleStateStopped, SDLLifecycleStateReconnecting, SDLLifecycleStateSettingUpManagers],
-        SDLLifecycleStateSettingUpManagers: @[SDLLifecycleStateStopped, SDLLifecycleStateReconnecting, SDLLifecycleStatePostManagerProcessing],
-        SDLLifecycleStatePostManagerProcessing: @[SDLLifecycleStateStopped, SDLLifecycleStateReconnecting, SDLLifecycleStateReady],
+        SDLLifecycleStateSettingUpManagers: @[SDLLifecycleStateStopped, SDLLifecycleStateReconnecting, SDLLifecycleStateSettingUpAppIcon],
+        SDLLifecycleStateSettingUpAppIcon: @[SDLLifecycleStateStopped, SDLLifecycleStateReconnecting, SDLLifecycleStateSettingUpHMI],
+        SDLLifecycleStateSettingUpHMI: @[SDLLifecycleStateStopped, SDLLifecycleStateReconnecting, SDLLifecycleStateReady],
         SDLLifecycleStateUnregistering: @[SDLLifecycleStateStopped],
         SDLLifecycleStateReady: @[SDLLifecycleStateUnregistering, SDLLifecycleStateStopped, SDLLifecycleStateReconnecting]
     };
@@ -263,16 +265,27 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
 
     // When done, we want to transition, even if there were errors. They may be expected, e.g. on head units that do not support files.
     dispatch_group_notify(managerGroup, dispatch_get_main_queue(), ^{
-        [self.lifecycleStateMachine transitionToState:SDLLifecycleStatePostManagerProcessing];
+        [self.lifecycleStateMachine transitionToState:SDLLifecycleStateSettingUpAppIcon];
     });
 }
 
-- (void)didEnterStatePostManagerProcessing {
-    // We only want to send the app icon when the file manager is complete, and when that's done, set the state to ready
+- (void)didEnterStateSettingUpAppIcon {
+    // We only want to send the app icon when the file manager is complete, and when that's done, wait for hmi status to be ready
     [self sdl_sendAppIcon:self.configuration.lifecycleConfig.appIcon
            withCompletion:^{
-               [self.lifecycleStateMachine transitionToState:SDLLifecycleStateReady];
+               [self.lifecycleStateMachine transitionToState:SDLLifecycleStateSettingUpHMI];
            }];
+}
+
+- (void)didEnterStateSettingUpHMI{
+    // We want to make sure we've gotten a SDLOnHMIStatus notification
+    if (self.hmiLevel == nil) {
+        // If nil, return and wait until we get a notification
+        return;
+    }
+    // We are sure to have a HMIStatus, set state to ready
+    [self.lifecycleStateMachine transitionToState:SDLLifecycleStateReady];
+    
 }
 
 - (void)didEnterStateReady {
@@ -466,6 +479,10 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
     SDLOnHMIStatus *hmiStatusNotification = notification.notification;
     SDLHMILevel *oldHMILevel = self.hmiLevel;
     self.hmiLevel = hmiStatusNotification.hmiLevel;
+    
+    if ([self.lifecycleStateMachine isCurrentState:SDLLifecycleStateSettingUpHMI]) {
+        [self.lifecycleStateMachine transitionToState:SDLLifecycleStateReady];
+    }
 
     if (![self.lifecycleStateMachine isCurrentState:SDLLifecycleStateReady]) {
         return;

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleManagerSpec.m
@@ -263,6 +263,21 @@ xdescribe(@"a lifecycle manager", ^{
                 });
             });
         });
+        
+        describe(@"transitioning to the Setting Up HMI state", ^{
+            context(@"before register response is a success", ^{
+                it(@"ready handler should not be called yet", ^{
+                    SDLRegisterAppInterfaceResponse *response = [[SDLRegisterAppInterfaceResponse alloc] init];
+                    response.resultCode = [SDLResult SUCCESS];
+                    testManager.registerResponse = response;
+                    
+                    [testManager.lifecycleStateMachine setToState:SDLLifecycleStateSettingUpHMI fromOldState:nil callEnterTransition:YES];
+                    
+                    expect(@(readyHandlerSuccess)).to(equal(@NO));
+                    expect(readyHandlerError).to(beNil());
+                });
+            });
+        });
 
         describe(@"transitioning to the ready state", ^{
             context(@"when the register response is a success", ^{

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleManagerSpec.m
@@ -277,6 +277,28 @@ xdescribe(@"a lifecycle manager", ^{
                     expect(readyHandlerError).to(beNil());
                 });
             });
+            
+            context(@"assume hmi status is nil", ^{
+                it(@"mock notification and ensure state changes to ready", ^{
+                    __block SDLOnHMIStatus *testHMIStatus = nil;
+                    __block SDLHMILevel *testHMILevel = nil;
+                    testHMIStatus = [[SDLOnHMIStatus alloc] init];
+                    
+                    SDLRegisterAppInterfaceResponse *response = [[SDLRegisterAppInterfaceResponse alloc] init];
+                    response.resultCode = [SDLResult SUCCESS];
+                    testManager.registerResponse = response;
+                    
+                    [testManager.lifecycleStateMachine setToState:SDLLifecycleStateSettingUpHMI fromOldState:nil callEnterTransition:YES];
+                    
+                    testHMILevel = [SDLHMILevel FULL];
+                    testHMIStatus.hmiLevel = testHMILevel;
+                    
+                    [testManager.notificationDispatcher postRPCNotificationNotification:SDLDidChangeHMIStatusNotification notification:testHMIStatus];
+                    
+                    expect(@(readyHandlerSuccess)).to(equal(@YES));
+                    expect(readyHandlerError).toNot(beNil());
+                });
+            });
         });
 
         describe(@"transitioning to the ready state", ^{


### PR DESCRIPTION
Fixes #540

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Testing first was done manually ensuring that if for some reason the HMI status was nil, that the state would indeed transition to ready as soon as we got notification that the HMI status changed. 

Additionally, a new unit test was added ensuring that during the state `SDLLifecycleStateSettingUpHMI` that the `readyHandlerSuccess` is still set to no. A second test was added to make sure the state is changed to ready on a hmi status notification 

### Summary
First, `SDLLifecycleStatePostManagerProcessing` was renamed to `SDLLifecycleStateSettingUpAppIcon` to more appropriately let the developer know whats actually happening during that state. Second, a new state `SDLLifecycleStateSettingUpHMI` was added to go between the states of `SDLLifecycleStateSettingUpAppIcon` and `SDLLifecycleStateReady`. Its purpose it to catch rare cases where the HMI status has not been received at that point, and to not allow the `readyHandler` to be set to `YES` until we can confirm that the HMI has been setup.

### Changelog

##### Bug Fixes
* This fix allows us to insure that the HMI is ready when the developer receives the `YES` response from the `readyHandler`. Before, it was not guaranteed. 
