### PR TITLE
Fix: crash when using example app with iAP

### DIFF
--- a/SmartDeviceLink_Example/Classes/ProxyManager.m
+++ b/SmartDeviceLink_Example/Classes/ProxyManager.m
@@ -71,7 +71,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)startIAP {
     [self sdlex_updateProxyState:ProxyStateSearchingForConnection];
     // Check for previous instance of sdlManager
-    if (!self.sdlManager){
+    if (self.sdlManager) { return; }
     SDLLifecycleConfiguration *lifecycleConfig = [self.class setLifecycleConfigurationPropertiesOnConfiguration:[SDLLifecycleConfiguration defaultConfigurationWithAppName:SDLAppName appId:SDLAppId]];
     
     // Assume this is production and disable logging
@@ -81,19 +81,17 @@ NS_ASSUME_NONNULL_BEGIN
     self.sdlManager = [[SDLManager alloc] initWithConfiguration:config delegate:self];
     
     [self startManager];
-    }
 }
 
 - (void)startTCP {
     [self sdlex_updateProxyState:ProxyStateSearchingForConnection];
     // Check for previous instance of sdlManager
-    if (!self.sdlManager){
+    if (self.sdlManager) { return; }
     SDLLifecycleConfiguration *lifecycleConfig = [self.class setLifecycleConfigurationPropertiesOnConfiguration:[SDLLifecycleConfiguration debugConfigurationWithAppName:SDLAppName appId:SDLAppId ipAddress:[Preferences sharedPreferences].ipAddress port:[Preferences sharedPreferences].port]];
     SDLConfiguration *config = [SDLConfiguration configurationWithLifecycle:lifecycleConfig lockScreen:[SDLLockScreenConfiguration enabledConfiguration]];
     self.sdlManager = [[SDLManager alloc] initWithConfiguration:config delegate:self];
     
     [self startManager];
-    }
 }
 
 - (void)startManager {

--- a/SmartDeviceLink_Example/Classes/ProxyManager.m
+++ b/SmartDeviceLink_Example/Classes/ProxyManager.m
@@ -70,6 +70,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)startIAP {
     [self sdlex_updateProxyState:ProxyStateSearchingForConnection];
+    // Check for previous instance of sdlManager
+    if (!self.sdlManager){
     SDLLifecycleConfiguration *lifecycleConfig = [self.class setLifecycleConfigurationPropertiesOnConfiguration:[SDLLifecycleConfiguration defaultConfigurationWithAppName:SDLAppName appId:SDLAppId]];
     
     // Assume this is production and disable logging
@@ -79,15 +81,19 @@ NS_ASSUME_NONNULL_BEGIN
     self.sdlManager = [[SDLManager alloc] initWithConfiguration:config delegate:self];
     
     [self startManager];
+    }
 }
 
 - (void)startTCP {
     [self sdlex_updateProxyState:ProxyStateSearchingForConnection];
+    // Check for previous instance of sdlManager
+    if (!self.sdlManager){
     SDLLifecycleConfiguration *lifecycleConfig = [self.class setLifecycleConfigurationPropertiesOnConfiguration:[SDLLifecycleConfiguration debugConfigurationWithAppName:SDLAppName appId:SDLAppId ipAddress:[Preferences sharedPreferences].ipAddress port:[Preferences sharedPreferences].port]];
     SDLConfiguration *config = [SDLConfiguration configurationWithLifecycle:lifecycleConfig lockScreen:[SDLLockScreenConfiguration enabledConfiguration]];
     self.sdlManager = [[SDLManager alloc] initWithConfiguration:config delegate:self];
     
     [self startManager];
+    }
 }
 
 - (void)startManager {
@@ -112,6 +118,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)reset {
     [self sdlex_updateProxyState:ProxyStateStopped];
     [self.sdlManager stop];
+    // Remove reference
+    self.sdlManager = nil;
 }
 
 - (void)showInitialData {


### PR DESCRIPTION
Fixes #625 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
This was tested extensively on 2 TDKs, on an older test version and on the newest version. I also tested this bug with previous versions of the SDL library and it was present back to 4.5.3, at which time i decided that was far back enough. 

### Summary
The issue was specifically in our example application that is baked into the library. The issue was on a forced USB disconnection and the subsequent reconnection, iAP was calling a reconnect event while  the `proxyManager`also tried to connect if the user pressed the connect button.

There were then 2 instances of the `sdlManager`. The fix was to properly check and then remove the reference when the `proxyManager` reset. 

It is also worth noting that this would almost never happen in a production application. Users are not given an option to force connect to SDL like in this instance. If we can think of a time where this could happen, it would either need more investigation or require added developer documentation to show how to remove references appropriately. 

### Changelog
##### Breaking Changes
*  No breaking changes
*  Edited `proxyManager` in the example app

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
