### PR TITLE
Fix crash on connection to some moving vehicles

### DIFF
--- a/SmartDeviceLink/SDLLockScreenPresenter.m
+++ b/SmartDeviceLink/SDLLockScreenPresenter.m
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
         return NO;
     }
 
-    return (self.viewController.isViewLoaded && self.viewController.view.window);
+    return (self.viewController.isViewLoaded && (self.viewController.view.window || self.viewController.isBeingPresented));
 }
 
 + (UIViewController *)sdl_getCurrentViewController {


### PR DESCRIPTION
Fixes #638 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
N/A, this is an additional check. Livio has added smoke testing around this issue.

### Summary
Fixes an issue where connecting with an app open to an already moving issue (which casues multiple driver distraction notifications to be dispatched) would cause a crash due to multiple lock screens being presented.

### Changelog
##### Bug Fixes
* Fixes an issue where connecting with an app open to an already moving issue (which casues multiple driver distraction notifications to be dispatched) would cause a crash due to multiple lock screens being presented.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)