### PR TITLE
adding max name length language to docs

### DIFF
--- a/SmartDeviceLink/SDLArtwork.h
+++ b/SmartDeviceLink/SDLArtwork.h
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @warning It is strongly recommended to pass the file url using an SDLFile initializer instead of the image. If you pass the UIImage, it is loaded into memory, and will be dumped to a temporary file. This will create a duplicate file. *Only pass a UIImage if the image is not stored on disk*.
  *
  *  @param image       The UIImage to be sent to the remote head unit
- *  @param name        The name of the file that will be used to reference the file in the future (for example on the remote file system). The max file name length may vary based on remote filesystem limitations.
+ *  @param name        The name of the file that will be used to reference the file in the future (for example on the remote file system). The max file name length may vary based on remote file system limitations.
  *  @param imageFormat Whether the image should be converted to a PNG or JPG before transmission. Images with transparency or few colors should be PNGs. Images with many colors should be JPGs.
  *
  *  @return An instance of this class to be passed to the file manager.
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @warning It is strongly recommended to pass the file url using an SDLFile initializer instead of the image. If you pass the UIImage, it is loaded into memory, and will be dumped to a temporary file. This will create a duplicate file. *Only pass a UIImage if the image is not stored on disk*.
  *
  *  @param image       The UIImage to be sent to the remote head unit
- *  @param name        The name of the file that will be used to reference the file in the future (for example on the remote file system). The max file name length may vary based on remote filesystem limitations.
+ *  @param name        The name of the file that will be used to reference the file in the future (for example on the remote file system). The max file name length may vary based on remote file system limitations.
  *  @param imageFormat Whether the image should be converted to a PNG or JPG before transmission. Images with transparency or few colors should be PNGs. Images with many colors should be JPGs.
  *
  *  @return An instance of this class to be passed to the file manager.
@@ -57,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  Create a file for transmission to the remote system from a UIImage.
  *
  *  @param image       The UIImage to be sent to the remote head unit
- *  @param name        The name of the file that will be used to reference the file in the future (for example on the remote file system). The max file name length may vary based on remote filesystem limitations.
+ *  @param name        The name of the file that will be used to reference the file in the future (for example on the remote file system). The max file name length may vary based on remote file system limitations.
  *  @param persistent  Whether or not the artwork should be persistent.
  *  @param imageFormat Whether the image should be converted to a PNG or JPG before transmission. Images with transparency or few colors should be PNGs. Images with many colors should be JPGs.
  *

--- a/SmartDeviceLink/SDLArtwork.h
+++ b/SmartDeviceLink/SDLArtwork.h
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @warning It is strongly recommended to pass the file url using an SDLFile initializer instead of the image. If you pass the UIImage, it is loaded into memory, and will be dumped to a temporary file. This will create a duplicate file. *Only pass a UIImage if the image is not stored on disk*.
  *
  *  @param image       The UIImage to be sent to the remote head unit
- *  @param name        The name of the file that will be used to reference the file in the future (for example on the remote file system).
+ *  @param name        The name of the file that will be used to reference the file in the future (for example on the remote file system). The max file name length may vary based on remote filesystem limitations.
  *  @param imageFormat Whether the image should be converted to a PNG or JPG before transmission. Images with transparency or few colors should be PNGs. Images with many colors should be JPGs.
  *
  *  @return An instance of this class to be passed to the file manager.
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @warning It is strongly recommended to pass the file url using an SDLFile initializer instead of the image. If you pass the UIImage, it is loaded into memory, and will be dumped to a temporary file. This will create a duplicate file. *Only pass a UIImage if the image is not stored on disk*.
  *
  *  @param image       The UIImage to be sent to the remote head unit
- *  @param name        The name of the file that will be used to reference the file in the future (for example on the remote file system).
+ *  @param name        The name of the file that will be used to reference the file in the future (for example on the remote file system). The max file name length may vary based on remote filesystem limitations.
  *  @param imageFormat Whether the image should be converted to a PNG or JPG before transmission. Images with transparency or few colors should be PNGs. Images with many colors should be JPGs.
  *
  *  @return An instance of this class to be passed to the file manager.
@@ -57,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  Create a file for transmission to the remote system from a UIImage.
  *
  *  @param image       The UIImage to be sent to the remote head unit
- *  @param name        The name of the file that will be used to reference the file in the future (for example on the remote file system).
+ *  @param name        The name of the file that will be used to reference the file in the future (for example on the remote file system). The max file name length may vary based on remote filesystem limitations.
  *  @param persistent  Whether or not the artwork should be persistent.
  *  @param imageFormat Whether the image should be converted to a PNG or JPG before transmission. Images with transparency or few colors should be PNGs. Images with many colors should be JPGs.
  *

--- a/SmartDeviceLink/SDLFile.h
+++ b/SmartDeviceLink/SDLFile.h
@@ -52,7 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  The designated initializer for an SDL File. The only major property that is not set using this is "overwrite", which defaults to NO.
  *
  *  @param url        The file URL pointing to the local data that will be pushed to the remote system.
- *  @param name       The name that the file will be stored under on the remote system and how it will be referenced from the local system.
+ *  @param name       The name that the file will be stored under on the remote system and how it will be referenced from the local system. The max file name length may vary based on remote filesystem limitations.
  *  @param persistent Whether or not the file will persist between ignition cycles.
  *
  *  @return An SDLFile object.
@@ -69,7 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @warning If this is not a readable file, this will return nil
  *
  *  @param url The url to the file that should be uploaded.
- *  @param name The name of the file that will be used to reference the file in the future (for example on the remote file system).
+ *  @param name The name of the file that will be used to reference the file in the future (for example on the remote file system). The max file name length may vary based on remote filesystem limitations.
  *
  *  @return An instance of this class, or nil if a readable file at the path could not be found.
  */
@@ -85,7 +85,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @warning If this is not a readable file, this will return nil
  *
  *  @param url The url to the file on disk that will be uploaded
- *  @param name The name of the file that will be used to reference the file in the future (for example on the remote file system).
+ *  @param name The name of the file that will be used to reference the file in the future (for example on the remote file system). The max file name length may vary based on remote filesystem limitations.
  *
  *  @return An instance of this class, or nil if a readable file at the url could not be found.
  */
@@ -95,7 +95,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  Create an SDL file using raw data. It is strongly preferred to pass a file URL instead of data, as it is currently held in memory until the file is sent.
  *
  *  @param data         The raw data to be used for the file
- *  @param name         The name of the file that will be used to reference the file in the future (for example on the remote file system).
+ *  @param name         The name of the file that will be used to reference the file in the future (for example on the remote file system). The max file name length may vary based on remote filesystem limitations.
  *  @param extension    The file extension. For example "png". Currently supported file extensions are: "bmp", "jpg", "jpeg", "png", "wav", "mp3", "aac", "json". All others will be sent as binary files.
  *  @param persistent   Whether or not the remote file with this data should be persistent
  *
@@ -109,7 +109,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  This is a persistent file, it will be persisted through sessions / ignition cycles. You will only have a limited space for all files, so be sure to only persist files that are required for all or most sessions. For example, menu artwork should be persistent.
  *
  *  @param data         The raw data to be used for the file
- *  @param name         The name of the file that will be used to reference the file in the future (for example on the remote file system).
+ *  @param name         The name of the file that will be used to reference the file in the future (for example on the remote file system). The max file name length may vary based on remote filesystem limitations.
  *  @param extension    The file extension. For example "png". Currently supported file extensions are: "bmp", "jpg", "jpeg", "png", "wav", "mp3", "aac", "json". All others will be sent as binary files.
  *
  *  @return An instance of this class
@@ -122,7 +122,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  This is an ephemeral file, it will not be persisted through sessions / ignition cycles. Any files that you do not *know* you will use in future sessions should be created through this method. For example, album / artist artwork should be ephemeral.
  *
  *  @param data         The raw data to be used for the file
- *  @param name         The name of the file that will be used to reference the file in the future (for example on the remote file system).
+ *  @param name         The name of the file that will be used to reference the file in the future (for example on the remote file system). The max file name length may vary based on remote filesystem limitations.
  *  @param extension    The file extension. For example "png". Currently supported file extensions are: "bmp", "jpg", "jpeg", "png", "wav", "mp3", "aac", "json". All others will be sent as binary files.
  *
  *  @return An instance of this class

--- a/SmartDeviceLink/SDLFile.h
+++ b/SmartDeviceLink/SDLFile.h
@@ -85,7 +85,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @warning If this is not a readable file, this will return nil
  *
  *  @param url The url to the file on disk that will be uploaded
- *  @param name The name of the file that will be used to reference the file in the future (for example on the remote file system). The max file name length may vary based on remote filesystem limitations.
+ *  @param name The name of the file that will be used to reference the file in the future (for example on the remote file system). The max file name length may vary based on remote file system limitations.
  *
  *  @return An instance of this class, or nil if a readable file at the url could not be found.
  */
@@ -95,7 +95,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  Create an SDL file using raw data. It is strongly preferred to pass a file URL instead of data, as it is currently held in memory until the file is sent.
  *
  *  @param data         The raw data to be used for the file
- *  @param name         The name of the file that will be used to reference the file in the future (for example on the remote file system). The max file name length may vary based on remote filesystem limitations.
+ *  @param name         The name of the file that will be used to reference the file in the future (for example on the remote file system). The max file name length may vary based on remote file system limitations.
  *  @param extension    The file extension. For example "png". Currently supported file extensions are: "bmp", "jpg", "jpeg", "png", "wav", "mp3", "aac", "json". All others will be sent as binary files.
  *  @param persistent   Whether or not the remote file with this data should be persistent
  *
@@ -109,7 +109,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  This is a persistent file, it will be persisted through sessions / ignition cycles. You will only have a limited space for all files, so be sure to only persist files that are required for all or most sessions. For example, menu artwork should be persistent.
  *
  *  @param data         The raw data to be used for the file
- *  @param name         The name of the file that will be used to reference the file in the future (for example on the remote file system). The max file name length may vary based on remote filesystem limitations.
+ *  @param name         The name of the file that will be used to reference the file in the future (for example on the remote file system). The max file name length may vary based on remote file system limitations.
  *  @param extension    The file extension. For example "png". Currently supported file extensions are: "bmp", "jpg", "jpeg", "png", "wav", "mp3", "aac", "json". All others will be sent as binary files.
  *
  *  @return An instance of this class
@@ -122,7 +122,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  This is an ephemeral file, it will not be persisted through sessions / ignition cycles. Any files that you do not *know* you will use in future sessions should be created through this method. For example, album / artist artwork should be ephemeral.
  *
  *  @param data         The raw data to be used for the file
- *  @param name         The name of the file that will be used to reference the file in the future (for example on the remote file system). The max file name length may vary based on remote filesystem limitations.
+ *  @param name         The name of the file that will be used to reference the file in the future (for example on the remote file system). The max file name length may vary based on remote file system limitations.
  *  @param extension    The file extension. For example "png". Currently supported file extensions are: "bmp", "jpg", "jpeg", "png", "wav", "mp3", "aac", "json". All others will be sent as binary files.
  *
  *  @return An instance of this class


### PR DESCRIPTION
Fixes #640 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
No testing, as it only changes documentation

### Summary
Added note in documentation about max file name length in appropriate classes

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
