### PR TITLE
Fix deadlock on control session disconnection

### DIFF
--- a/SmartDeviceLink/SDLIAPSession.m
+++ b/SmartDeviceLink/SDLIAPSession.m
@@ -84,6 +84,9 @@ NSTimeInterval const streamThreadWaitSecs = 1.0;
 }
 
 - (void)stop {
+    // This method must be called on the main thread
+    NSAssert([NSThread isMainThread], @"stop must be called on the main thread");
+    
     if (self.isDataSession) {
         [self.ioStreamThread cancel];
 

--- a/SmartDeviceLink/SDLIAPTransport.m
+++ b/SmartDeviceLink/SDLIAPTransport.m
@@ -389,12 +389,10 @@ int const streamOpenTimeoutSeconds = 2;
 #pragma mark Data Stream
 
 - (SDLStreamEndHandler)sdl_dataStreamEndedHandler {
-    
     __weak typeof(self) weakSelf = self;
 
     return ^(NSStream *stream) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
-        
         
         [SDLDebugTool logInfo:@"Data Stream Event End"];
         if (strongSelf.session != nil) {

--- a/SmartDeviceLink/SDLIAPTransport.m
+++ b/SmartDeviceLink/SDLIAPTransport.m
@@ -389,11 +389,8 @@ int const streamOpenTimeoutSeconds = 2;
 #pragma mark Data Stream
 
 - (SDLStreamEndHandler)sdl_dataStreamEndedHandler {
-    __weak typeof(self) weakSelf = self;
 
     return ^(NSStream *stream) {
-        __strong typeof(weakSelf) strongSelf = weakSelf;
-
         [SDLDebugTool logInfo:@"Data Stream Event End"];
         // Per the Apple documentation, stream end is received when the accessory disconnects
         // As we have observed, sometimes the EAAccessoryDidDisconnect notification is received before


### PR DESCRIPTION
Fixes #643, #637 

This PR is ready for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
This PR has been tested on multiple head units by doing repeated disconnect/reconnect USB and BT cycles.

### Summary
When the iOS device is disconnected from the head unit, iOS generates stream end events for the input and output streams for the active `EASession`, along with the `EAAccessoryDidDisconnect` notification. Which order these events arrive in is not deterministic, and if the stream events arrive before the `EAAccessoryDidDisconnect` notification, they will occur on the stream run loop. For the data session, this means the `ioStreamThread` run loop and since `[session stop]` is called, it will wait on the session `canceledSemaphore`, which will deadlock for 1s because the stop method assumes it is being called from a thread other than the stream run loop thread. After the semaphore wait times out, the cleanup code in the stop method will wipe out the references to the data session and it will not close its streams before being deallocated. The `SDLStreamDelegate` instance will also go away, but since the streams are still open and scheduled they may generate additional events that will cause the `NSStream:streamEventTrigger:` method to crash with a call to the deallocated delegate.

This is not an issue for the control session because it is scheduled on the main thread. In this PR, I am leaving the control session event handlers alone. For the data session handlers, both now call `[session stop]` on the main queue synchronously before the session delegate and session are nil'ed.

### Changelog
##### Bug Fixes
* Fixes rare cases when attempting to stop the IAP transport can lead to a crash (#643, #637?)

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
