### PR TITLE
Fix IAP control session crash on proxy dispose

### DIFF
--- a/SmartDeviceLink/SDLIAPTransport.m
+++ b/SmartDeviceLink/SDLIAPTransport.m
@@ -141,10 +141,16 @@ int const streamOpenTimeoutSeconds = 2;
     // Stop event listening here so that even if the transport is disconnected by the proxy
     // we unregister for accessory local notifications
     [self sdl_stopEventListening];
-    // Only disconnect the data session, the control session does not stay open and is handled separately
-    if (self.session != nil) {
-        [self.session stop];
-        self.session = nil;
+    if (self.controlSession) {
+        [self.controlSession.streamDelegate clearHandlers];
+        self.controlSession.streamDelegate = nil;
+        [self.controlSession stop];
+    } else {
+        if (self.session != nil) {
+            [self.session.streamDelegate clearHandlers];
+            self.session.streamDelegate = nil;
+            [self.session stop];
+        }
     }
 }
 

--- a/SmartDeviceLink/SDLIAPTransport.m
+++ b/SmartDeviceLink/SDLIAPTransport.m
@@ -142,14 +142,14 @@ int const streamOpenTimeoutSeconds = 2;
     // we unregister for accessory local notifications
     [self sdl_stopEventListening];
     if (self.controlSession) {
-        [self.controlSession.streamDelegate clearHandlers];
-        self.controlSession.streamDelegate = nil;
         [self.controlSession stop];
+        self.controlSession.streamDelegate = nil;
+        self.controlSession = nil;
     } else {
         if (self.session != nil) {
-            [self.session.streamDelegate clearHandlers];
-            self.session.streamDelegate = nil;
             [self.session stop];
+            self.session.streamDelegate = nil;
+            self.session = nil;
         }
     }
 }

--- a/SmartDeviceLink/SDLIAPTransport.m
+++ b/SmartDeviceLink/SDLIAPTransport.m
@@ -141,16 +141,14 @@ int const streamOpenTimeoutSeconds = 2;
     // Stop event listening here so that even if the transport is disconnected by the proxy
     // we unregister for accessory local notifications
     [self sdl_stopEventListening];
-    if (self.controlSession) {
+    if (self.controlSession != nil) {
         [self.controlSession stop];
         self.controlSession.streamDelegate = nil;
         self.controlSession = nil;
-    } else {
-        if (self.session != nil) {
-            [self.session stop];
-            self.session.streamDelegate = nil;
-            self.session = nil;
-        }
+    } else if (self.session != nil) {
+        [self.session stop];
+        self.session.streamDelegate = nil;
+        self.session = nil;
     }
 }
 


### PR DESCRIPTION
Fixes #648 

This PR is ready for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
This fix has been tested with multiple head units through disconnect/reconnect cycles.

### Summary
When the app calls the LifecycleManager stop API, the SDLProxy will be disposed and it will call `[transport disconnect]` as part of the dispose process.

### Changelog
##### Bug Fixes
* Fix IAP control session being left open in rare cases, leading to a crash (#648)

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
