### PR TITLE
Implement SDL 0080 multisession protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Your application must support a set of smartdevicelink protocol strings in order
 <string>com.smartdevicelink.prot1</string>
 <string>com.smartdevicelink.prot0</string>
 <string>com.ford.sync.prot0</string>
+<string>com.smartdevicelink.multisession</string>
 </array>
 ```
 

--- a/SmartDeviceLink/SDLGlobals.h
+++ b/SmartDeviceLink/SDLGlobals.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 
 #define SDL_SYSTEM_VERSION_LESS_THAN(version) ([[[UIDevice currentDevice] systemVersion] compare:version options:NSNumericSearch] == NSOrderedAscending)
+#define SDL_SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(version) ([[[UIDevice currentDevice] systemVersion] compare:version options:NSNumericSearch] != NSOrderedAscending)
 #define BLOCK_RETURN return
 
 @interface SDLGlobals : NSObject

--- a/SmartDeviceLink/SDLIAPTransport.m
+++ b/SmartDeviceLink/SDLIAPTransport.m
@@ -20,6 +20,7 @@
 NSString *const legacyProtocolString = @"com.ford.sync.prot0";
 NSString *const controlProtocolString = @"com.smartdevicelink.prot0";
 NSString *const indexedProtocolStringPrefix = @"com.smartdevicelink.prot";
+NSString *const multiSessionProtocolString = @"com.smartdevicelink.multisession";
 NSString *const backgroundTaskName = @"com.sdl.transport.iap.backgroundTask";
 
 int const createSessionRetries = 1;
@@ -183,15 +184,18 @@ int const streamOpenTimeoutSeconds = 2;
 
 - (BOOL)sdl_connectAccessory:(EAAccessory *)accessory {
     BOOL connecting = NO;
-
-    if ([accessory supportsProtocol:controlProtocolString]) {
+    
+    if ([accessory supportsProtocol:multiSessionProtocolString] && SDL_SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"9")) {
+        [self sdl_createIAPDataSessionWithAccessory:accessory forProtocol:multiSessionProtocolString];
+        connecting = YES;
+    } else if ([accessory supportsProtocol:controlProtocolString]) {
         [self sdl_createIAPControlSessionWithAccessory:accessory];
         connecting = YES;
     } else if ([accessory supportsProtocol:legacyProtocolString]) {
         [self sdl_createIAPDataSessionWithAccessory:accessory forProtocol:legacyProtocolString];
         connecting = YES;
     }
-
+    
     return connecting;
 }
 
@@ -208,7 +212,9 @@ int const streamOpenTimeoutSeconds = 2;
         }
 
         // Determine if we can start a multi-app session or a legacy (single-app) session
-        if ((sdlAccessory = [EAAccessoryManager findAccessoryForProtocol:controlProtocolString])) {
+        if ((sdlAccessory = [EAAccessoryManager findAccessoryForProtocol:multiSessionProtocolString]) && SDL_SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"9")) {
+            [self sdl_createIAPDataSessionWithAccessory:sdlAccessory forProtocol:multiSessionProtocolString];
+        } else if ((sdlAccessory = [EAAccessoryManager findAccessoryForProtocol:controlProtocolString])) {
             [self sdl_createIAPControlSessionWithAccessory:sdlAccessory];
         } else if ((sdlAccessory = [EAAccessoryManager findAccessoryForProtocol:legacyProtocolString])) {
             [self sdl_createIAPDataSessionWithAccessory:sdlAccessory forProtocol:legacyProtocolString];

--- a/SmartDeviceLink_Example/Info.plist
+++ b/SmartDeviceLink_Example/Info.plist
@@ -82,6 +82,7 @@
 		<string>com.smartdevicelink.prot1</string>
 		<string>com.smartdevicelink.prot0</string>
 		<string>com.ford.sync.prot0</string>
+		<string>com.smartdevicelink.multisession</string>
 	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>


### PR DESCRIPTION
Fixes #662 

This PR is ready for review.

### Risk
This PR makes no API changes. App developers will need to add the multisession protocol to their app's info.plist file to support this change.

### Testing Plan
This change has been tested on multiple head units, both supporting and not supporting iAP multisession protocols, through multiple connect/disconnect/reconnect cycles, with 1 to 12 SDL-enabled apps installed on a single iOS device.

### Summary
If a connected accessory supports the SDL multisession protocol and the SDL iOS app is running on iOS 9.0 or greater, SDL will preferentially connect to it.

### Changelog

##### Enhancements
* Added a check for accessory support of the multisession protocol in SDLIAPTransport.m
* Added a macro to check the system version of the iOS device in SDLGlobals.h

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
