### PR TITLE
Fix an RPCResponseDispatcher crash on clear

### DIFF
--- a/SmartDeviceLink/SDLResponseDispatcher.m
+++ b/SmartDeviceLink/SDLResponseDispatcher.m
@@ -109,7 +109,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)clear {
     // When we get disconnected we have to delete all existing responseHandlers as they are not valid anymore
-    for (SDLRPCCorrelationId *correlationID in self.rpcResponseHandlerMap) {
+    for (SDLRPCCorrelationId *correlationID in self.rpcResponseHandlerMap.dictionaryRepresentation) {
         SDLResponseHandler responseHandler = self.rpcResponseHandlerMap[correlationID];
         responseHandler(self.rpcRequestDictionary[correlationID], nil, [NSError sdl_lifecycle_notConnectedError]);
     }


### PR DESCRIPTION
Fixes #666 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Will not be unit tested

### Summary
This PR changes how the `SDLRPCResponseDispatcher` `clear` method works. Currently, before clearing all of its dictionaries, it will run through its list of RPC response handlers and call all existing handlers with an error. We've come across a case where this response handler map could be mutated while being iterated, and this is a crash. To fix this, this PR uses an immutable dictionary copy of the response handler map and iterates over that. This will not be a performance hit because `clear` is not often called, and never in performance intensive situations.

### Changelog
##### Bug Fixes
* Fix a rare crash when disconnecting and connecting quickly.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
