### PR TITLE
Fix BSON Podspec error (5.0.0)

### DIFF
--- a/SmartDeviceLink-iOS.podspec
+++ b/SmartDeviceLink-iOS.podspec
@@ -7,6 +7,7 @@ s.homepage     = "https://github.com/smartdevicelink/SmartDeviceLink-iOS"
 s.license      = { :type => "New BSD", :file => "LICENSE" }
 s.author       = { "SmartDeviceLink Team" => "developer@smartdevicelink.com" }
 s.platform     = :ios, "8.0"
+s.dependency     'BiSON', '~> 1.0'
 s.source       = { :git => "https://github.com/smartdevicelink/sdl_ios.git", :tag => s.version.to_s }
 s.requires_arc = true
 s.resource_bundles = { 'SmartDeviceLink' => ['SmartDeviceLink/Assets/**/*'] }

--- a/SmartDeviceLink.podspec
+++ b/SmartDeviceLink.podspec
@@ -6,12 +6,18 @@ s.summary      = "Connect your app with cars!"
 s.homepage     = "https://github.com/smartdevicelink/SmartDeviceLink-iOS"
 s.license      = { :type => "New BSD", :file => "LICENSE" }
 s.author       = { "SmartDeviceLink Team" => "developer@smartdevicelink.com" }
-s.platform     = :ios, "6.0"
+s.platform     = :ios, "8.0"
+s.dependency     'BiSON', '~> 1.0'
 s.source       = { :git => "https://github.com/smartdevicelink/sdl_ios.git", :tag => s.version.to_s }
-s.source_files = "SmartDeviceLink/*.{h,m}"
 s.requires_arc = true
-s.resource_bundles = { 'SmartDeviceLink' => ['SmartDeviceLink/Assets/**/*', 'SmartDeviceLink/iOS 7 Assets/*'] }
-s.public_header_files = [
+s.resource_bundles = { 'SmartDeviceLink' => ['SmartDeviceLink/Assets/**/*'] }
+
+s.default_subspecs = 'Default'
+
+s.subspec 'Default' do |ss|
+ss.source_files = 'SmartDeviceLink/*.{h,m}'
+
+ss.public_header_files = [
 'SmartDeviceLink/SmartDeviceLink.h',
 'SmartDeviceLink/SDLJingle.h',
 'SmartDeviceLink/SDLProxy.h',
@@ -19,12 +25,8 @@ s.public_header_files = [
 'SmartDeviceLink/SDLProxyListener.h',
 'SmartDeviceLink/SDLSecurityType.h',
 'SmartDeviceLink/SDLStreamingMediaManager.h',
-'SmartDeviceLink/SDLTTSChunkFactory.h',
 'SmartDeviceLink/SDLTouchManager.h',
 'SmartDeviceLink/SDLTouchManagerDelegate.h',
-'SmartDeviceLink/SDLConsoleController.h',
-'SmartDeviceLink/SDLDebugTool.h',
-'SmartDeviceLink/SDLDebugToolConsole.h',
 'SmartDeviceLink/SDLSiphonServer.h',
 'SmartDeviceLink/SDLAbstractTransport.h',
 'SmartDeviceLink/SDLIAPSessionDelegate.h',
@@ -42,7 +44,6 @@ s.public_header_files = [
 'SmartDeviceLink/SDLRPCRequest.h',
 'SmartDeviceLink/SDLRPCResponse.h',
 'SmartDeviceLink/SDLRPCStruct.h',
-'SmartDeviceLink/SDLRPCRequestFactory.h',
 'SmartDeviceLink/SDLAddCommand.h',
 'SmartDeviceLink/SDLAddSubMenu.h',
 'SmartDeviceLink/SDLAlert.h',
@@ -62,6 +63,7 @@ s.public_header_files = [
 'SmartDeviceLink/SDLGetVehicleData.h',
 'SmartDeviceLink/SDLGetWaypoints.h',
 'SmartDeviceLink/SDLListFiles.h',
+'SmartDeviceLink/SDLMacros.h',
 'SmartDeviceLink/SDLPerformAudioPassThru.h',
 'SmartDeviceLink/SDLPerformInteraction.h',
 'SmartDeviceLink/SDLPutFile.h',
@@ -289,7 +291,23 @@ s.public_header_files = [
 'SmartDeviceLink/SDLNotificationConstants.h',
 'SmartDeviceLink/SDLRequestHandler.h',
 'SmartDeviceLink/SDLRPCNotificationNotification.h',
-'SmartDeviceLink/SDLRPCResponseNotification.h'
+'SmartDeviceLink/SDLRPCResponseNotification.h',
+'SmartDeviceLink/SDLLogTarget.h',
+'SmartDeviceLink/SDLLogTargetAppleSystemLog.h',
+'SmartDeviceLink/SDLLogTargetFile.h',
+'SmartDeviceLink/SDLLogTargetOSLog.h',
+'SmartDeviceLink/SDLLogFileModule.h',
+'SmartDeviceLink/SDLLogFilter.h',
+'SmartDeviceLink/SDLLogConstants.h',
+'SmartDeviceLink/SDLLogConfiguration.h',
+'SmartDeviceLink/SDLLogManager.h',
+'SmartDeviceLink/SDLLogMacros.h'
 ]
+end
+
+s.subspec 'Swift' do |ss|
+ss.dependency 'SmartDeviceLink-iOS/Default'
+ss.source_files = 'SmartDeviceLinkSwift/*.swift'
+end
 
 end


### PR DESCRIPTION
Fixes #689

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
n/a

### Summary
Add the BiSON library as a CocoaPod dependency to support CocoaPod integrations of the SDL library.

### Changelog
##### Bug Fixes
* Fix Cocoapods not working after BSON submodule was added

### Tasks Remaining:
n/a

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)