### PR TITLE
Fix SDLMetadataType including NONE

### DIFF
--- a/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
+++ b/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
@@ -942,7 +942,7 @@
 		8B0606291F3103CE005ADB2F /* SDLMetadataTags.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B0606271F3103CE005ADB2F /* SDLMetadataTags.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8B06062A1F3103CE005ADB2F /* SDLMetadataTags.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B0606281F3103CE005ADB2F /* SDLMetadataTags.m */; };
 		8B06062C1F310ED2005ADB2F /* SDLMetadataTagsSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B06062B1F310ED2005ADB2F /* SDLMetadataTagsSpec.m */; };
-		8BD729A61F2A2CF30029AC93 /* SDLVideoStreamingCodec.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BD729A41F2A2CF30029AC93 /* SDLVideoStreamingCodec.h */; };
+		8BD729A61F2A2CF30029AC93 /* SDLVideoStreamingCodec.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BD729A41F2A2CF30029AC93 /* SDLVideoStreamingCodec.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8BD729A71F2A2CF30029AC93 /* SDLVideoStreamingCodec.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BD729A51F2A2CF30029AC93 /* SDLVideoStreamingCodec.m */; };
 		8BD729AA1F2A41F40029AC93 /* SDLVideoStreamingProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BD729A81F2A41F40029AC93 /* SDLVideoStreamingProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8BD729AB1F2A41F40029AC93 /* SDLVideoStreamingProtocol.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BD729A91F2A41F40029AC93 /* SDLVideoStreamingProtocol.m */; };

--- a/SmartDeviceLink/SDLMetadataType.h
+++ b/SmartDeviceLink/SDLMetadataType.h
@@ -116,11 +116,4 @@
  */
 + (SDLMetadataType *)HUMIDITY;
 
-/**
- The data in this field is not of a common type or should not be processed.  Any time a field does not have a type parameter it is considered as the none type.
-
- @return A SDLTextFieldType object with value of *none*
- */
-+ (SDLMetadataType *)NONE;
-
 @end

--- a/SmartDeviceLink/SDLMetadataType.m
+++ b/SmartDeviceLink/SDLMetadataType.m
@@ -20,7 +20,6 @@ SDLMetadataType *SDLMetadataType_MAXIMUM_TEMPERATURE = nil;
 SDLMetadataType *SDLMetadataType_MINIMUM_TEMPERATURE = nil;
 SDLMetadataType *SDLMetadataType_WEATHER_TERM = nil;
 SDLMetadataType *SDLMetadataType_HUMIDITY = nil;
-SDLMetadataType *SDLMetadataType_NONE = nil;
 
 NSArray *SDLMetadataType_values = nil;
 
@@ -49,8 +48,7 @@ NSArray *SDLMetadataType_values = nil;
                                    SDLMetadataType.MAXIMUM_TEMPERATURE,
                                    SDLMetadataType.MINIMUM_TEMPERATURE,
                                    SDLMetadataType.WEATHER_TERM,
-                                   SDLMetadataType.HUMIDITY,
-                                   SDLMetadataType.NONE];
+                                   SDLMetadataType.HUMIDITY];
     }
     return SDLMetadataType_values;
 }
@@ -137,13 +135,6 @@ NSArray *SDLMetadataType_values = nil;
         SDLMetadataType_HUMIDITY = [[SDLMetadataType alloc] initWithValue:@"humidity"];
     }
     return SDLMetadataType_HUMIDITY;
-}
-
-+ (SDLMetadataType *)NONE {
-    if (SDLMetadataType_NONE == nil) {
-        SDLMetadataType_NONE = [[SDLMetadataType alloc] initWithValue:@"none"];
-    }
-    return SDLMetadataType_NONE;
 }
 
 @end

--- a/SmartDeviceLinkTests/RPCSpecs/EnumSpecs/SDLMetadataTypeSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/EnumSpecs/SDLMetadataTypeSpec.m
@@ -29,7 +29,6 @@ describe(@"Individual Enum Value Tests", ^ {
         expect([SDLMetadataType MINIMUM_TEMPERATURE].value).to(equal(@"minimumTemperature"));
         expect([SDLMetadataType WEATHER_TERM].value).to(equal(@"weatherTerm"));
         expect([SDLMetadataType HUMIDITY].value).to(equal(@"humidity"));
-        expect([SDLMetadataType NONE].value).to(equal(@"none"));
     });
 });
 describe(@"ValueOf Tests", ^ {
@@ -46,7 +45,6 @@ describe(@"ValueOf Tests", ^ {
         expect([SDLMetadataType valueOf:@"minimumTemperature"]).to(equal([SDLMetadataType MINIMUM_TEMPERATURE]));
         expect([SDLMetadataType valueOf:@"weatherTerm"]).to(equal([SDLMetadataType WEATHER_TERM]));
         expect([SDLMetadataType valueOf:@"humidity"]).to(equal([SDLMetadataType HUMIDITY]));
-        expect([SDLMetadataType valueOf:@"none"]).to(equal([SDLMetadataType NONE]));
     });
 
     it(@"Should return nil when invalid", ^ {
@@ -70,8 +68,7 @@ describe(@"Value List Tests", ^ {
                            [SDLMetadataType MAXIMUM_TEMPERATURE],
                            [SDLMetadataType MINIMUM_TEMPERATURE],
                            [SDLMetadataType WEATHER_TERM],
-                           [SDLMetadataType HUMIDITY],
-                           [SDLMetadataType NONE]] copy];
+                           [SDLMetadataType HUMIDITY]] copy];
     });
 
     it(@"Should contain all defined enum values", ^ {


### PR DESCRIPTION
Fixes #700

This PR is **ready** for review.

### Risk
This PR makes **it's complicated** API changes.

### Summary
This removes an errant enum type. The type has not yet been released, so this doesn't change the overall minor version change of v4.7.

### Changelog
##### Bug Fixes
* Fix SDLMetadataType including enum value NONE, which is only on HMI_API.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
