### PR TITLE
Fix SDLMetadataType including NONE

### DIFF
--- a/SmartDeviceLink/SDLMetadataType.h
+++ b/SmartDeviceLink/SDLMetadataType.h
@@ -73,8 +73,3 @@ extern SDLMetadataType const SDLMetadataTypeWeatherTerm;
  */
 extern SDLMetadataType const SDLMetadataTypeHumidity;
 
-/**
- The data in this field is not of a common type or should not be processed.  Any time a field does not have a type parameter it is considered as the none type.
- */
-extern SDLMetadataType const SDLMetadataTypeNone;
-

--- a/SmartDeviceLink/SDLMetadataType.m
+++ b/SmartDeviceLink/SDLMetadataType.m
@@ -20,4 +20,3 @@ SDLMetadataType const SDLMetadataTypeMaximumTemperature = @"maximumTemperature";
 SDLMetadataType const SDLMetadataTypeMinimumTemperature = @"minimumTemperature";
 SDLMetadataType const SDLMetadataTypeWeatherTerm = @"weatherTerm";
 SDLMetadataType const SDLMetadataTypeHumidity = @"humidity";
-SDLMetadataType const SDLMetadataTypeNone = @"none";

--- a/SmartDeviceLinkTests/RPCSpecs/EnumSpecs/SDLMetadataTypeSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/EnumSpecs/SDLMetadataTypeSpec.m
@@ -29,7 +29,6 @@ describe(@"Individual Enum Value Tests", ^ {
         expect(SDLMetadataTypeMinimumTemperature).to(equal(@"minimumTemperature"));
         expect(SDLMetadataTypeWeatherTerm).to(equal(@"weatherTerm"));
         expect(SDLMetadataTypeHumidity).to(equal(@"humidity"));
-        expect(SDLMetadataTypeNone).to(equal(@"none"));
     });
 });
 


### PR DESCRIPTION
Fixes #700

This PR is **ready** for review.

### Risk
This PR makes **it's complicated** API changes.

### Summary
This removes an errant enum type. The type has not yet been released, so this doesn't change the overall version change.

### Changelog
##### Bug Fixes
* Fix SDLMetadataType including enum value NONE, which is only on HMI_API.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
