### PR TITLE
Added missing commas to podspec files

### DIFF
--- a/SmartDeviceLink-iOS.podspec
+++ b/SmartDeviceLink-iOS.podspec
@@ -204,7 +204,7 @@ s.public_header_files = [
 'SmartDeviceLink/SDLVehicleDataResult.h',
 'SmartDeviceLink/SDLVehicleType.h',
 'SmartDeviceLink/SDLVideoStreamingFormat.h',
-'SmartDeviceLink/SDLVideoStreamingCapability.h'
+'SmartDeviceLink/SDLVideoStreamingCapability.h',
 'SmartDeviceLink/SDLVRHelpItem.h',
 'SmartDeviceLink/SDLAmbientLightStatus.h',
 'SmartDeviceLink/SDLAppHMIType.h',

--- a/SmartDeviceLink.podspec
+++ b/SmartDeviceLink.podspec
@@ -204,7 +204,7 @@ s.public_header_files = [
 'SmartDeviceLink/SDLVehicleDataResult.h',
 'SmartDeviceLink/SDLVehicleType.h',
 'SmartDeviceLink/SDLVideoStreamingFormat.h',
-'SmartDeviceLink/SDLVideoStreamingCapability.h'
+'SmartDeviceLink/SDLVideoStreamingCapability.h',
 'SmartDeviceLink/SDLVRHelpItem.h',
 'SmartDeviceLink/SDLAmbientLightStatus.h',
 'SmartDeviceLink/SDLAppHMIType.h',


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
No test cases written

### Summary
The library does not compile when installed as a dependency via Cocoapods due to missing commas in the podspec files.

### Changelog
##### Enhancements
* Added missing commas to the pod spec files.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
