### PR TITLE
Fix #382 Timers are not appropriately stopped when deallocated.

### DIFF
--- a/SmartDeviceLink/SDLTimer.m
+++ b/SmartDeviceLink/SDLTimer.m
@@ -35,7 +35,7 @@
 @end
 
 
-@interface SDLTimer ()
+@interface SDLTimer () <SDLTimerTargetDelegate>
 
 @property (strong) NSTimer *timer;
 @property (assign) BOOL timerRunning;

--- a/SmartDeviceLink/SDLTimer.m
+++ b/SmartDeviceLink/SDLTimer.m
@@ -4,6 +4,36 @@
 
 #import "SDLTimer.h"
 
+@protocol SDLTimerTargetDelegate <NSObject>
+
+- (void)timerElapsed;
+
+@end
+
+@interface SDLTimerTarget : NSObject
+
+@property (nonatomic, weak) id<SDLTimerTargetDelegate> delegate;
+
+@end
+
+@implementation SDLTimerTarget
+
+- (instancetype)initWithDelegate:(id)delegate {
+    self = [super init];
+    if (self) {
+        _delegate = delegate;
+    }
+    return self;
+}
+
+- (void)timerElapsed {
+    if ([self.delegate conformsToProtocol:@protocol(SDLTimerTargetDelegate)]) {
+        [_delegate timerElapsed];
+    }
+}
+
+@end
+
 
 @interface SDLTimer ()
 
@@ -40,7 +70,9 @@
 - (void)start {
     if (self.duration > 0) {
         [self stopAndDestroyTimer];
-        self.timer = [NSTimer timerWithTimeInterval:self.duration target:self selector:@selector(timerElapsed) userInfo:nil repeats:self.repeat];
+        
+        SDLTimerTarget *timerTarget = [[SDLTimerTarget alloc] initWithDelegate:self];
+        self.timer = [NSTimer timerWithTimeInterval:_duration target:timerTarget selector:@selector(timerElapsed) userInfo:nil repeats:_repeat];
         [[NSRunLoop mainRunLoop] addTimer:self.timer forMode:NSRunLoopCommonModes];
         self.timerRunning = YES;
     }


### PR DESCRIPTION
Fixes #382

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
NSTimer has a strong reference to its target, therefore the SDLTimer never gets released and dealloc isn’t called.
I eliminated the deadlock by adding a separate target.

##### Enhancements
Timer is stopped when the reference to the SDLTimer is set to nil

##### Bug Fixes
Timers are not appropriately stopped when deallocated.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
