### PR TITLE
Bugfix/control frame payload init crash

### DIFF
--- a/SmartDeviceLink/SDLControlFramePayloadAudioStartServiceAck.m
+++ b/SmartDeviceLink/SDLControlFramePayloadAudioStartServiceAck.m
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     _mtu = SDLControlFrameInt64NotFound;
 
-    if (data != nil) {
+    if (data.length > 0) {
         [self sdl_parse:data];
     }
 

--- a/SmartDeviceLink/SDLControlFramePayloadEndService.m
+++ b/SmartDeviceLink/SDLControlFramePayloadEndService.m
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     _hashId = SDLControlFrameInt32NotFound;
 
-    if (data != nil) {
+    if (data.length > 0) {
         [self sdl_parse:data];
     }
 

--- a/SmartDeviceLink/SDLControlFramePayloadNak.m
+++ b/SmartDeviceLink/SDLControlFramePayloadNak.m
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
     self = [super init];
     if (!self) return nil;
 
-    if (data != nil) {
+    if (data.length > 0) {
         [self sdl_parse:data];
     }
 

--- a/SmartDeviceLink/SDLControlFramePayloadRPCStartService.m
+++ b/SmartDeviceLink/SDLControlFramePayloadRPCStartService.m
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
     self = [super init];
     if (!self) return nil;
 
-    if (data != nil) {
+    if (data.length > 0) {
         [self sdl_parse:data];
     }
 

--- a/SmartDeviceLink/SDLControlFramePayloadRPCStartServiceAck.m
+++ b/SmartDeviceLink/SDLControlFramePayloadRPCStartServiceAck.m
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
     _hashId = SDLControlFrameInt32NotFound;
     _mtu = SDLControlFrameInt64NotFound;
 
-    if (data != nil) {
+    if (data.length > 0) {
         [self sdl_parse:data];
     }
 

--- a/SmartDeviceLink/SDLControlFramePayloadVideoStartService.m
+++ b/SmartDeviceLink/SDLControlFramePayloadVideoStartService.m
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
     _height = SDLControlFrameInt32NotFound;
     _width = SDLControlFrameInt32NotFound;
 
-    if (data != nil) {
+    if (data.length > 0) {
         [self sdl_parse:data];
     }
 

--- a/SmartDeviceLink/SDLControlFramePayloadVideoStartServiceAck.m
+++ b/SmartDeviceLink/SDLControlFramePayloadVideoStartServiceAck.m
@@ -47,7 +47,7 @@
     _height = SDLControlFrameInt32NotFound;
     _width = SDLControlFrameInt32NotFound;
 
-    if (data != nil) {
+    if (data.length > 0) {
         [self sdl_parse:data];
     }
 

--- a/SmartDeviceLinkTests/ProtocolSpecs/ControlFramePayloadSpecs/SDLControlFramePayloadNakSpec.m
+++ b/SmartDeviceLinkTests/ProtocolSpecs/ControlFramePayloadSpecs/SDLControlFramePayloadNakSpec.m
@@ -54,4 +54,19 @@ describe(@"Test decoding data", ^{
     });
 });
 
+describe(@"Test nil data", ^{
+    __block SDLControlFramePayloadNak *testPayload = nil;
+    __block NSData *testData = nil;
+
+    beforeEach(^{
+
+        testPayload = [[SDLControlFramePayloadNak alloc] initWithData:testData];
+    });
+
+    it(@"should output the correct params", ^{
+        expect(testPayload.rejectedParams).to(beNil());
+    });
+});
+
+
 QuickSpecEnd

--- a/SmartDeviceLinkTests/ProtocolSpecs/ControlFramePayloadSpecs/SDLControlFramePayloadNakSpec.m
+++ b/SmartDeviceLinkTests/ProtocolSpecs/ControlFramePayloadSpecs/SDLControlFramePayloadNakSpec.m
@@ -59,7 +59,6 @@ describe(@"Test nil data", ^{
     __block NSData *testData = nil;
 
     beforeEach(^{
-
         testPayload = [[SDLControlFramePayloadNak alloc] initWithData:testData];
     });
 

--- a/SmartDeviceLinkTests/ProtocolSpecs/ControlFramePayloadSpecs/SDLControlFramePayloadVideoStartServiceSpec.m
+++ b/SmartDeviceLinkTests/ProtocolSpecs/ControlFramePayloadSpecs/SDLControlFramePayloadVideoStartServiceSpec.m
@@ -77,4 +77,18 @@ describe(@"Test decoding data", ^{
     });
 });
 
+describe(@"Test nil data", ^{
+    __block SDLControlFramePayloadVideoStartService *testPayload = nil;
+    __block NSData *testData = nil;
+
+    beforeEach(^{
+
+        testPayload = [[SDLControlFramePayloadVideoStartService alloc] initWithData:testData];
+    });
+
+    it(@"should output the correct params", ^{
+        expect(testPayload.data.length).to(equal(0));
+    });
+});
+
 QuickSpecEnd

--- a/SmartDeviceLinkTests/ProtocolSpecs/ControlFramePayloadSpecs/SDLControlFramePayloadVideoStartServiceSpec.m
+++ b/SmartDeviceLinkTests/ProtocolSpecs/ControlFramePayloadSpecs/SDLControlFramePayloadVideoStartServiceSpec.m
@@ -82,7 +82,6 @@ describe(@"Test nil data", ^{
     __block NSData *testData = nil;
 
     beforeEach(^{
-
         testPayload = [[SDLControlFramePayloadVideoStartService alloc] initWithData:testData];
     });
 

--- a/SmartDeviceLinkTests/ProtocolSpecs/ControlFramePayloadSpecs/SDLControlFrameVideoStartServiceAckSpec.m
+++ b/SmartDeviceLinkTests/ProtocolSpecs/ControlFramePayloadSpecs/SDLControlFrameVideoStartServiceAckSpec.m
@@ -88,7 +88,6 @@ describe(@"Test nil data", ^{
     __block NSData *testData = nil;
 
     beforeEach(^{
-
         testPayload = [[SDLControlFramePayloadVideoStartServiceAck alloc] initWithData:testData];
     });
 

--- a/SmartDeviceLinkTests/ProtocolSpecs/ControlFramePayloadSpecs/SDLControlFrameVideoStartServiceAckSpec.m
+++ b/SmartDeviceLinkTests/ProtocolSpecs/ControlFramePayloadSpecs/SDLControlFrameVideoStartServiceAckSpec.m
@@ -83,4 +83,18 @@ describe(@"Test decoding data", ^{
     });
 });
 
+describe(@"Test nil data", ^{
+    __block SDLControlFramePayloadVideoStartServiceAck *testPayload = nil;
+    __block NSData *testData = nil;
+
+    beforeEach(^{
+
+        testPayload = [[SDLControlFramePayloadVideoStartServiceAck alloc] initWithData:testData];
+    });
+
+    it(@"should output the correct params", ^{
+        expect(testPayload.data.length).to(equal(0));
+    });
+});
+
 QuickSpecEnd

--- a/SmartDeviceLinkTests/ProtocolSpecs/SDLControlFramePayloadAudioStartServiceAckSpec.m
+++ b/SmartDeviceLinkTests/ProtocolSpecs/SDLControlFramePayloadAudioStartServiceAckSpec.m
@@ -57,4 +57,19 @@ describe(@"Test decoding data", ^{
     });
 });
 
+describe(@"Test nil data", ^{
+    __block SDLControlFramePayloadAudioStartServiceAck *testPayload = nil;
+    __block NSData *testData = nil;
+
+    beforeEach(^{
+
+        testPayload = [[SDLControlFramePayloadAudioStartServiceAck alloc] initWithData:testData];
+    });
+
+    it(@"should output the correct params", ^{
+        expect(testPayload.mtu).to(equal(-1));
+        expect(testPayload.data.length).to(equal(0));
+    });
+});
+
 QuickSpecEnd

--- a/SmartDeviceLinkTests/ProtocolSpecs/SDLControlFramePayloadAudioStartServiceAckSpec.m
+++ b/SmartDeviceLinkTests/ProtocolSpecs/SDLControlFramePayloadAudioStartServiceAckSpec.m
@@ -62,7 +62,6 @@ describe(@"Test nil data", ^{
     __block NSData *testData = nil;
 
     beforeEach(^{
-
         testPayload = [[SDLControlFramePayloadAudioStartServiceAck alloc] initWithData:testData];
     });
 

--- a/SmartDeviceLinkTests/ProtocolSpecs/SDLControlFramePayloadEndServiceSpec.m
+++ b/SmartDeviceLinkTests/ProtocolSpecs/SDLControlFramePayloadEndServiceSpec.m
@@ -55,4 +55,19 @@ describe(@"Test decoding data", ^{
     });
 });
 
+describe(@"Test nil data", ^{
+    __block SDLControlFramePayloadEndService *testPayload = nil;
+    __block NSData *testData = nil;
+
+    beforeEach(^{
+
+        testPayload = [[SDLControlFramePayloadEndService alloc] initWithData:testData];
+    });
+
+    it(@"should output the correct params", ^{
+        expect(testPayload.hashId).to(equal(-1));
+        expect(testPayload.data.length).to(equal(0));
+    });
+});
+
 QuickSpecEnd

--- a/SmartDeviceLinkTests/ProtocolSpecs/SDLControlFramePayloadEndServiceSpec.m
+++ b/SmartDeviceLinkTests/ProtocolSpecs/SDLControlFramePayloadEndServiceSpec.m
@@ -60,7 +60,6 @@ describe(@"Test nil data", ^{
     __block NSData *testData = nil;
 
     beforeEach(^{
-
         testPayload = [[SDLControlFramePayloadEndService alloc] initWithData:testData];
     });
 

--- a/SmartDeviceLinkTests/ProtocolSpecs/SDLControlFramePayloadRPCStartServiceAckSpec.m
+++ b/SmartDeviceLinkTests/ProtocolSpecs/SDLControlFramePayloadRPCStartServiceAckSpec.m
@@ -68,4 +68,18 @@ describe(@"Test decoding data", ^{
     });
 });
 
+describe(@"Test nil data", ^{
+    __block SDLControlFramePayloadRPCStartServiceAck *testPayload = nil;
+    __block NSData *testData = nil;
+
+    beforeEach(^{
+
+        testPayload = [[SDLControlFramePayloadRPCStartServiceAck alloc] initWithData:testData];
+    });
+
+    it(@"should output the correct params", ^{
+        expect(testPayload.data.length).to(equal(0));
+    });
+});
+
 QuickSpecEnd

--- a/SmartDeviceLinkTests/ProtocolSpecs/SDLControlFramePayloadRPCStartServiceAckSpec.m
+++ b/SmartDeviceLinkTests/ProtocolSpecs/SDLControlFramePayloadRPCStartServiceAckSpec.m
@@ -73,7 +73,6 @@ describe(@"Test nil data", ^{
     __block NSData *testData = nil;
 
     beforeEach(^{
-
         testPayload = [[SDLControlFramePayloadRPCStartServiceAck alloc] initWithData:testData];
     });
 

--- a/SmartDeviceLinkTests/ProtocolSpecs/SDLControlFramePayloadRPCStartServiceSpec.m
+++ b/SmartDeviceLinkTests/ProtocolSpecs/SDLControlFramePayloadRPCStartServiceSpec.m
@@ -57,4 +57,19 @@ describe(@"Test decoding data", ^{
     });
 });
 
+describe(@"Test nil data", ^{
+    __block SDLControlFramePayloadRPCStartService *testPayload = nil;
+    __block NSData *testData = nil;
+
+    beforeEach(^{
+
+        testPayload = [[SDLControlFramePayloadRPCStartService alloc] initWithData:testData];
+    });
+
+    it(@"should output the correct params", ^{
+        expect(testPayload.protocolVersion).to(beNil());
+        expect(testPayload.data.length).to(equal(0));
+    });
+});
+
 QuickSpecEnd

--- a/SmartDeviceLinkTests/ProtocolSpecs/SDLControlFramePayloadRPCStartServiceSpec.m
+++ b/SmartDeviceLinkTests/ProtocolSpecs/SDLControlFramePayloadRPCStartServiceSpec.m
@@ -62,7 +62,6 @@ describe(@"Test nil data", ^{
     __block NSData *testData = nil;
 
     beforeEach(^{
-
         testPayload = [[SDLControlFramePayloadRPCStartService alloc] initWithData:testData];
     });
 


### PR DESCRIPTION
Fixes #715 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
added in unit test methods to test initialization with nil data

### Summary
Modifying the if statement from `if (data != nil) {}` to `if (data.length > 0) {}` fixed the issue. This change was made to all the classes with that method in the Control Frame Payloads folder

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
