### PR TITLE
Add pcmCapabilities property to RAIR

### DIFF
--- a/SmartDeviceLink/SDLNames.h
+++ b/SmartDeviceLink/SDLNames.h
@@ -295,6 +295,7 @@ extern SDLName const SDLNamePassengerDoorAjar;
 extern SDLName const SDLNamePassengerKneeAirbagDeployed;
 extern SDLName const SDLNamePassengerSideAirbagDeployed;
 extern SDLName const SDLNamePatchVersion;
+extern SDLName const SDLNamePCMStreamCapabilities;
 extern SDLName const SDLNamePDOP;
 extern SDLName const SDLNamePerformAudioPassThru;
 extern SDLName const SDLNamePerformInteraction;

--- a/SmartDeviceLink/SDLNames.m
+++ b/SmartDeviceLink/SDLNames.m
@@ -289,6 +289,7 @@ SDLName const SDLNamePassengerDoorAjar = @"passengerDoorAjar";
 SDLName const SDLNamePassengerKneeAirbagDeployed = @"passengerKneeAirbagDeployed";
 SDLName const SDLNamePassengerSideAirbagDeployed = @"passengerSideAirbagDeployed";
 SDLName const SDLNamePatchVersion = @"patchVersion";
+SDLName const SDLNamePCMStreamCapabilities = @"pcmStreamCapabilities";
 SDLName const SDLNamePDOP = @"pdop";
 SDLName const SDLNamePerformAudioPassThru = @"PerformAudioPassThru";
 SDLName const SDLNamePerformInteraction = @"PerformInteraction";

--- a/SmartDeviceLink/SDLRegisterAppInterfaceResponse.h
+++ b/SmartDeviceLink/SDLRegisterAppInterfaceResponse.h
@@ -124,6 +124,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, strong, nonatomic) NSArray<SDLAudioPassThruCapabilities *> *audioPassThruCapabilities;
 
 /**
+ @see SDLAudioPassThruCapabilities
+ */
+@property (nullable, strong, nonatomic) SDLAudioPassThruCapabilities *pcmStreamCapabilities;
+
+/**
  * Specifies the vehicle's type
  *
  * @see SDLVehicleType

--- a/SmartDeviceLink/SDLRegisterAppInterfaceResponse.m
+++ b/SmartDeviceLink/SDLRegisterAppInterfaceResponse.m
@@ -122,6 +122,14 @@ NS_ASSUME_NONNULL_BEGIN
     return [parameters sdl_objectsForName:SDLNameAudioPassThruCapabilities ofClass:SDLAudioPassThruCapabilities.class];
 }
 
+- (void)setPcmStreamCapabilities:(nullable SDLAudioPassThruCapabilities *)pcmStreamCapabilities {
+    [parameters sdl_setObject:pcmStreamCapabilities forName:SDLNamePCMStreamCapabilities];
+}
+
+- (nullable SDLAudioPassThruCapabilities *)pcmStreamCapabilities {
+    return [parameters sdl_objectForName:SDLNamePCMStreamCapabilities ofClass:SDLAudioPassThruCapabilities.class];
+}
+
 - (void)setVehicleType:(nullable SDLVehicleType *)vehicleType {
     [parameters sdl_setObject:vehicleType forName:SDLNameVehicleType];
 }

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLRegisterAppInterfaceResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLRegisterAppInterfaceResponseSpec.m
@@ -31,16 +31,17 @@ describe(@"Getter/Setter Tests", ^ {
         testResponse.language = SDLLanguageEsMx;
         testResponse.hmiDisplayLanguage = SDLLanguageRuRu;
         testResponse.displayCapabilities = info;
-        testResponse.buttonCapabilities = [@[button] mutableCopy];
-        testResponse.softButtonCapabilities = [@[softButton] mutableCopy];
+        testResponse.buttonCapabilities = @[button];
+        testResponse.softButtonCapabilities = @[softButton];
         testResponse.presetBankCapabilities = presetBank;
-        testResponse.hmiZoneCapabilities = [@[SDLHMIZoneCapabilitiesBack, SDLHMIZoneCapabilitiesFront] copy];
-        testResponse.speechCapabilities = [@[SDLSpeechCapabilitiesSAPIPhonemes, SDLSpeechCapabilitiesSilence] copy];
-        testResponse.vrCapabilities = [@[SDLVRCapabilitiesText] copy];
-        testResponse.audioPassThruCapabilities = [@[audioPassThru] mutableCopy];
+        testResponse.hmiZoneCapabilities = @[SDLHMIZoneCapabilitiesBack, SDLHMIZoneCapabilitiesFront];
+        testResponse.speechCapabilities = @[SDLSpeechCapabilitiesSAPIPhonemes, SDLSpeechCapabilitiesSilence];
+        testResponse.vrCapabilities = @[SDLVRCapabilitiesText];
+        testResponse.audioPassThruCapabilities = @[audioPassThru];
+        testResponse.pcmStreamCapabilities = audioPassThru;
         testResponse.vehicleType = vehicle;
-        testResponse.prerecordedSpeech = [@[SDLPrerecordedSpeechListen, SDLPrerecordedSpeechHelp] copy];
-        testResponse.supportedDiagModes = [@[@67, @99, @111] mutableCopy];
+        testResponse.prerecordedSpeech = @[SDLPrerecordedSpeechListen, SDLPrerecordedSpeechHelp];
+        testResponse.supportedDiagModes = @[@67, @99, @111];
         testResponse.hmiCapabilities = hmiCapabilities;
         testResponse.sdlVersion = @"sdlVersion";
         testResponse.systemSoftwareVersion = @"systemSoftwareVersion";
@@ -49,59 +50,62 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testResponse.language).to(equal(SDLLanguageEsMx));
         expect(testResponse.hmiDisplayLanguage).to(equal(SDLLanguageRuRu));
         expect(testResponse.displayCapabilities).to(equal(info));
-        expect(testResponse.buttonCapabilities).to(equal([@[button] mutableCopy]));
-        expect(testResponse.softButtonCapabilities).to(equal([@[softButton] mutableCopy]));
+        expect(testResponse.buttonCapabilities).to(equal(@[button]));
+        expect(testResponse.softButtonCapabilities).to(equal(@[softButton]));
         expect(testResponse.presetBankCapabilities).to(equal(presetBank));
-        expect(testResponse.hmiZoneCapabilities).to(equal([@[SDLHMIZoneCapabilitiesBack, SDLHMIZoneCapabilitiesFront] copy]));
-        expect(testResponse.speechCapabilities).to(equal([@[SDLSpeechCapabilitiesSAPIPhonemes, SDLSpeechCapabilitiesSilence] copy]));
-        expect(testResponse.vrCapabilities).to(equal([@[SDLVRCapabilitiesText] copy]));
-        expect(testResponse.audioPassThruCapabilities).to(equal([@[audioPassThru] mutableCopy]));
+        expect(testResponse.hmiZoneCapabilities).to(equal(@[SDLHMIZoneCapabilitiesBack, SDLHMIZoneCapabilitiesFront]));
+        expect(testResponse.speechCapabilities).to(equal(@[SDLSpeechCapabilitiesSAPIPhonemes, SDLSpeechCapabilitiesSilence]));
+        expect(testResponse.vrCapabilities).to(equal(@[SDLVRCapabilitiesText]));
+        expect(testResponse.audioPassThruCapabilities).to(equal(@[audioPassThru]));
+        expect(testResponse.pcmStreamCapabilities).to(equal(audioPassThru));
         expect(testResponse.vehicleType).to(equal(vehicle));
-        expect(testResponse.prerecordedSpeech).to(equal([@[SDLPrerecordedSpeechListen, SDLPrerecordedSpeechHelp] copy]));
-        expect(testResponse.supportedDiagModes).to(equal([@[@67, @99, @111] mutableCopy]));
+        expect(testResponse.prerecordedSpeech).to(equal(@[SDLPrerecordedSpeechListen, SDLPrerecordedSpeechHelp]));
+        expect(testResponse.supportedDiagModes).to(equal(@[@67, @99, @111]));
         expect(testResponse.hmiCapabilities).to(equal(hmiCapabilities));
         expect(testResponse.sdlVersion).to(equal(@"sdlVersion"));
         expect(testResponse.systemSoftwareVersion).to(equal(@"systemSoftwareVersion"));
     });
     
     it(@"Should get correctly when initialized", ^ {
-        NSMutableDictionary* dict = [@{SDLNameRequest:
+        NSDictionary *dict = @{SDLNameRequest:
                                            @{SDLNameParameters:
                                                  @{SDLNameSyncMessageVersion:version,
                                                    SDLNameLanguage:SDLLanguageEsMx,
                                                    SDLNameHMIDisplayLanguage:SDLLanguageRuRu,
                                                    SDLNameDisplayCapabilities:info,
-                                                   SDLNameButtonCapabilities:[@[button] mutableCopy],
-                                                   SDLNameSoftButtonCapabilities:[@[softButton] mutableCopy],
+                                                   SDLNameButtonCapabilities:@[button],
+                                                   SDLNameSoftButtonCapabilities:@[softButton],
                                                    SDLNamePresetBankCapabilities:presetBank,
-                                                   SDLNameHMIZoneCapabilities:[@[SDLHMIZoneCapabilitiesBack, SDLHMIZoneCapabilitiesFront] copy],
-                                                   SDLNameSpeechCapabilities:[@[SDLSpeechCapabilitiesSAPIPhonemes, SDLSpeechCapabilitiesSilence] copy],
-                                                   SDLNameVRCapabilities:[@[SDLVRCapabilitiesText] copy],
-                                                   SDLNameAudioPassThruCapabilities:[@[audioPassThru] mutableCopy],
+                                                   SDLNameHMIZoneCapabilities:@[SDLHMIZoneCapabilitiesBack, SDLHMIZoneCapabilitiesFront],
+                                                   SDLNameSpeechCapabilities:@[SDLSpeechCapabilitiesSAPIPhonemes, SDLSpeechCapabilitiesSilence],
+                                                   SDLNameVRCapabilities:@[SDLVRCapabilitiesText],
+                                                   SDLNameAudioPassThruCapabilities:@[audioPassThru],
+                                                   SDLNamePCMStreamCapabilities: audioPassThru,
                                                    SDLNameVehicleType:vehicle,
-                                                   SDLNamePrerecordedSpeech:[@[SDLPrerecordedSpeechListen, SDLPrerecordedSpeechHelp] mutableCopy],
-                                                   SDLNameSupportedDiagnosticModes:[@[@67, @99, @111] mutableCopy],
+                                                   SDLNamePrerecordedSpeech:@[SDLPrerecordedSpeechListen, SDLPrerecordedSpeechHelp],
+                                                   SDLNameSupportedDiagnosticModes:@[@67, @99, @111],
                                                    SDLNameHMICapabilities: hmiCapabilities,
                                                    SDLNameSDLVersion: @"sdlVersion",
                                                    SDLNameSystemSoftwareVersion: @"systemSoftwareVersion"
                                                    },
-                                             SDLNameOperationName:SDLNameRegisterAppInterface}} mutableCopy];
+                                             SDLNameOperationName:SDLNameRegisterAppInterface}};
         SDLRegisterAppInterfaceResponse* testResponse = [[SDLRegisterAppInterfaceResponse alloc] initWithDictionary:dict];
         
         expect(testResponse.syncMsgVersion).to(equal(version));
         expect(testResponse.language).to(equal(SDLLanguageEsMx));
         expect(testResponse.hmiDisplayLanguage).to(equal(SDLLanguageRuRu));
         expect(testResponse.displayCapabilities).to(equal(info));
-        expect(testResponse.buttonCapabilities).to(equal([@[button] mutableCopy]));
-        expect(testResponse.softButtonCapabilities).to(equal([@[softButton] mutableCopy]));
+        expect(testResponse.buttonCapabilities).to(equal(@[button]));
+        expect(testResponse.softButtonCapabilities).to(equal(@[softButton]));
         expect(testResponse.presetBankCapabilities).to(equal(presetBank));
-        expect(testResponse.hmiZoneCapabilities).to(equal([@[SDLHMIZoneCapabilitiesBack, SDLHMIZoneCapabilitiesFront] copy]));
-        expect(testResponse.speechCapabilities).to(equal([@[SDLSpeechCapabilitiesSAPIPhonemes, SDLSpeechCapabilitiesSilence] copy]));
-        expect(testResponse.vrCapabilities).to(equal([@[SDLVRCapabilitiesText] copy]));
-        expect(testResponse.audioPassThruCapabilities).to(equal([@[audioPassThru] mutableCopy]));
+        expect(testResponse.hmiZoneCapabilities).to(equal(@[SDLHMIZoneCapabilitiesBack, SDLHMIZoneCapabilitiesFront]));
+        expect(testResponse.speechCapabilities).to(equal(@[SDLSpeechCapabilitiesSAPIPhonemes, SDLSpeechCapabilitiesSilence]));
+        expect(testResponse.vrCapabilities).to(equal(@[SDLVRCapabilitiesText]));
+        expect(testResponse.audioPassThruCapabilities).to(equal(@[audioPassThru]));
+        expect(testResponse.pcmStreamCapabilities).to(equal(audioPassThru));
         expect(testResponse.vehicleType).to(equal(vehicle));
-        expect(testResponse.prerecordedSpeech).to(equal([@[SDLPrerecordedSpeechListen, SDLPrerecordedSpeechHelp] copy]));
-        expect(testResponse.supportedDiagModes).to(equal([@[@67, @99, @111] mutableCopy]));
+        expect(testResponse.prerecordedSpeech).to(equal(@[SDLPrerecordedSpeechListen, SDLPrerecordedSpeechHelp]));
+        expect(testResponse.supportedDiagModes).to(equal(@[@67, @99, @111]));
         expect(testResponse.hmiCapabilities).to(equal(hmiCapabilities));
         expect(testResponse.sdlVersion).to(equal(@"sdlVersion"));
         expect(testResponse.systemSoftwareVersion).to(equal(@"systemSoftwareVersion"));
@@ -121,6 +125,7 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testResponse.speechCapabilities).to(beNil());
         expect(testResponse.vrCapabilities).to(beNil());
         expect(testResponse.audioPassThruCapabilities).to(beNil());
+        expect(testResponse.pcmStreamCapabilities).to(beNil());
         expect(testResponse.vehicleType).to(beNil());
         expect(testResponse.prerecordedSpeech).to(beNil());
         expect(testResponse.supportedDiagModes).to(beNil());


### PR DESCRIPTION
Fixes #714

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Unit tests have been added

### Summary
This adds an RPC parameter that already exists on Core to the library.

### Changelog
##### Enhancements
* Add `pcmCapabilities` property to `RegisterAppInterfaceResponse`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
