### PR TITLE
Fix log level checks

### DIFF
--- a/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
+++ b/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
@@ -949,6 +949,7 @@
 		8877F5F11F34AA2D00DC128A /* SDLSendHapticDataResponseSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 8877F5F01F34AA2D00DC128A /* SDLSendHapticDataResponseSpec.m */; };
 		88B848C31F45E1A600DED768 /* TestResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 88B848C21F45E1A600DED768 /* TestResponse.m */; };
 		88B848C91F462E3600DED768 /* TestProgressResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 88B848C81F462E3600DED768 /* TestProgressResponse.m */; };
+		88D2AAE41F682BB20078D5B2 /* SDLLogConstantsSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 88D2AAE31F682BB20078D5B2 /* SDLLogConstantsSpec.m */; };
 		88EED8381F33AE1700E6C42E /* SDLHapticRect.h in Headers */ = {isa = PBXBuildFile; fileRef = 88EED8361F33AE1700E6C42E /* SDLHapticRect.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		88EED8391F33AE1700E6C42E /* SDLHapticRect.m in Sources */ = {isa = PBXBuildFile; fileRef = 88EED8371F33AE1700E6C42E /* SDLHapticRect.m */; };
 		88EED83B1F33BECB00E6C42E /* SDLHapticRectSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 88EED83A1F33BECB00E6C42E /* SDLHapticRectSpec.m */; };
@@ -2097,6 +2098,7 @@
 		88B848C21F45E1A600DED768 /* TestResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestResponse.m; sourceTree = "<group>"; };
 		88B848C71F462E3600DED768 /* TestProgressResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestProgressResponse.h; sourceTree = "<group>"; };
 		88B848C81F462E3600DED768 /* TestProgressResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestProgressResponse.m; sourceTree = "<group>"; };
+		88D2AAE31F682BB20078D5B2 /* SDLLogConstantsSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLLogConstantsSpec.m; sourceTree = "<group>"; };
 		88EED8361F33AE1700E6C42E /* SDLHapticRect.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDLHapticRect.h; sourceTree = "<group>"; };
 		88EED8371F33AE1700E6C42E /* SDLHapticRect.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLHapticRect.m; sourceTree = "<group>"; };
 		88EED83A1F33BECB00E6C42E /* SDLHapticRectSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLHapticRectSpec.m; sourceTree = "<group>"; };
@@ -2747,6 +2749,7 @@
 				5D43466A1E6F3B4C00B639C6 /* SDLLogFilterSpec.m */,
 				5D43466C1E6F522000B639C6 /* SDLLogModelSpec.m */,
 				5D43466E1E6F55BD00B639C6 /* SDLLogManagerSpec.m */,
+				88D2AAE31F682BB20078D5B2 /* SDLLogConstantsSpec.m */,
 			);
 			name = LoggingSpecs;
 			sourceTree = "<group>";
@@ -5480,6 +5483,7 @@
 				162E834D1A9BDE8B00906325 /* SDLChangeRegistrationResponseSpec.m in Sources */,
 				DA9F7EAC1DCC062400ACAE48 /* SDLUnsubscribeWaypointsResponseSpec.m in Sources */,
 				5D43466B1E6F3B4C00B639C6 /* SDLLogFilterSpec.m in Sources */,
+				88D2AAE41F682BB20078D5B2 /* SDLLogConstantsSpec.m in Sources */,
 				162E836B1A9BDE8B00906325 /* SDLSyncPDataResponseSpec.m in Sources */,
 				8B7B31AF1F2FBA0200BDC38D /* SDLVideoStreamingCapabilitySpec.m in Sources */,
 				162E839B1A9BDE8B00906325 /* SDLRPCNotificationSpec.m in Sources */,

--- a/SmartDeviceLink/SDLLogConstants.h
+++ b/SmartDeviceLink/SDLLogConstants.h
@@ -34,10 +34,10 @@ typedef NS_ENUM(NSUInteger, SDLLogBytesDirection) {
  - SDLLogFlagError:     Error level logging.
  */
 typedef NS_OPTIONS(NSUInteger, SDLLogFlag) {
-    SDLLogFlagVerbose = 1 << 0,
-    SDLLogFlagDebug = 1 << 1,
-    SDLLogFlagWarning = 1 << 2,
-    SDLLogFlagError = 1 << 3
+    SDLLogFlagError = 1 << 0,
+    SDLLogFlagWarning = 1 << 1,
+    SDLLogFlagDebug = 1 << 2,
+    SDLLogFlagVerbose = 1 << 3,
 };
 
 /**

--- a/SmartDeviceLink/SDLLogManager.m
+++ b/SmartDeviceLink/SDLLogManager.m
@@ -172,7 +172,7 @@ static dispatch_queue_t _logQueue = NULL;
 }
 
 - (void)sdl_log:(SDLLogModel *)log {
-    if ([self sdl_logLevelForFile:log.fileName] < log.level) { return; }
+    if ([self sdl_logLevelForFile:log.fileName] > log.level) { return; }
 
     for (SDLLogFilter *filter in self.filters) {
         if (!filter.filter(log)) { return; }

--- a/SmartDeviceLink/SDLLogManager.m
+++ b/SmartDeviceLink/SDLLogManager.m
@@ -172,7 +172,7 @@ static dispatch_queue_t _logQueue = NULL;
 }
 
 - (void)sdl_log:(SDLLogModel *)log {
-    if ([self sdl_logLevelForFile:log.fileName] > log.level) { return; }
+    if ([self sdl_logLevelForFile:log.fileName] < log.level) { return; }
 
     for (SDLLogFilter *filter in self.filters) {
         if (!filter.filter(log)) { return; }

--- a/SmartDeviceLinkTests/LoggingSpecs/SDLLogManagerSpec.m
+++ b/SmartDeviceLinkTests/LoggingSpecs/SDLLogManagerSpec.m
@@ -137,11 +137,10 @@ describe(@"a log manager", ^{
             __block NSString *testVerboseFormattedLog;
 
             __block int expectedLogCount;
-            __block int testLogLevel;
             __block NSMutableArray<NSString *> *expectedMessages;
             __block NSMutableArray<NSString *> *notExpectedMessages;
 
-            context(@"debug configuration", ^{
+            context(@"The type of debug messages logged depends on the SDLLogLevel", ^{
                 beforeEach(^{
                     testConfiguration = [[SDLLogConfiguration alloc] init];
                     testConfiguration.targets = [NSSet setWithObject:testLogTarget];
@@ -168,7 +167,7 @@ describe(@"a log manager", ^{
                     notExpectedMessages = [[NSMutableArray alloc] init];
                 });
 
-                describe(@"", ^{
+                describe(@"When the global log level is set", ^{
                     beforeEach(^{
                         expectedLogCount = 0;
                         expect(testLogTarget.formattedLogMessages.count).to(equal(0));
@@ -178,7 +177,6 @@ describe(@"a log manager", ^{
 
                     it(@"should not log anything when the log level is OFF", ^{
                         testConfiguration.globalLogLevel = SDLLogLevelOff;
-                        testLogLevel = SDLLogLevelOff;
                         expectedLogCount = 0;
 
                         [notExpectedMessages addObject:testWarningFormattedLog];
@@ -189,7 +187,6 @@ describe(@"a log manager", ^{
 
                     it(@"should only log errors when the log level is ERROR", ^{
                         testConfiguration.globalLogLevel = SDLLogLevelError;
-                        testLogLevel = SDLLogLevelError;
                         expectedLogCount = 1;
 
                         [expectedMessages addObject:testErrorFormattedLog];
@@ -201,7 +198,6 @@ describe(@"a log manager", ^{
 
                     it(@"should only log errors and warnings when the log level is WARNING", ^{
                         testConfiguration.globalLogLevel = SDLLogLevelWarning;
-                        testLogLevel = SDLLogLevelWarning;
                         expectedLogCount = 2;
 
                         [expectedMessages addObject:testWarningFormattedLog];
@@ -213,7 +209,6 @@ describe(@"a log manager", ^{
 
                     it(@"should only log errors, warnings, and debug logs when the log level is DEBUG", ^{
                         testConfiguration.globalLogLevel = SDLLogLevelDebug;
-                        testLogLevel = SDLLogLevelDebug;
                         expectedLogCount = 3;
 
                         [expectedMessages addObject:testWarningFormattedLog];
@@ -225,7 +220,6 @@ describe(@"a log manager", ^{
 
                     it(@"should log errors, warnings, debug, and verbose logs when the log level is VERBOSE", ^{
                         testConfiguration.globalLogLevel = SDLLogLevelVerbose;
-                        testLogLevel = SDLLogLevelVerbose;
                         expectedLogCount = 4;
 
                         [expectedMessages addObject:testWarningFormattedLog];
@@ -235,8 +229,6 @@ describe(@"a log manager", ^{
                     });
 
                     afterEach(^{
-                        SDLLogFileModule *module = [[SDLLogFileModule alloc] initWithName:@"test" files:[NSSet setWithObject:@"test"] level:testLogLevel];
-                        testConfiguration.modules = [NSSet setWithObject:module];
                         [testManager setConfiguration:testConfiguration];
 
                         // Warning

--- a/SmartDeviceLinkTests/SDLLogConstantsSpec.m
+++ b/SmartDeviceLinkTests/SDLLogConstantsSpec.m
@@ -1,0 +1,50 @@
+//
+//  SDLLogConstantsSpec.m
+//  SmartDeviceLink-iOS
+//
+//  Created by Nicole on 9/12/17.
+//  Copyright © 2017 smartdevicelink. All rights reserved.
+//
+
+#import <Quick/Quick.h>
+#import <Nimble/Nimble.h>
+
+#import "SDLLogConstants.h"
+
+QuickSpecBegin(SDLLogConstantsSpec)
+
+describe(@"log constants", ^{
+    it(@"should assigned the correct integer value to each SDLLogLevel", ^{
+        expect((int)SDLLogLevelOff).to(beGreaterThan((int)SDLLogLevelDefault));
+        expect((int)SDLLogLevelOff).to(beLessThan((int)SDLLogLevelError));
+        expect((int)SDLLogLevelOff).to(beLessThan((int)SDLLogLevelWarning));
+        expect((int)SDLLogLevelOff).to(beLessThan((int)SDLLogLevelDebug));
+        expect((int)SDLLogLevelOff).to(beLessThan((int)SDLLogLevelVerbose));
+
+        expect((int)SDLLogLevelError).to(beGreaterThan((int)SDLLogLevelDefault));
+        expect((int)SDLLogLevelError).to(beGreaterThan((int)SDLLogLevelOff));
+        expect((int)SDLLogLevelError).to(beLessThan((int)SDLLogLevelWarning));
+        expect((int)SDLLogLevelError).to(beLessThan((int)SDLLogLevelDebug));
+        expect((int)SDLLogLevelError).to(beLessThan((int)SDLLogLevelVerbose));
+
+        expect((int)SDLLogLevelWarning).to(beGreaterThan((int)SDLLogLevelDefault));
+        expect((int)SDLLogLevelWarning).to(beGreaterThan((int)SDLLogLevelOff));
+        expect((int)SDLLogLevelWarning).to(beGreaterThan((int)SDLLogLevelError));
+        expect((int)SDLLogLevelWarning).to(beLessThan((int)SDLLogLevelDebug));
+        expect((int)SDLLogLevelWarning).to(beLessThan((int)SDLLogLevelVerbose));
+
+        expect((int)SDLLogLevelDebug).to(beGreaterThan((int)SDLLogLevelDefault));
+        expect((int)SDLLogLevelDebug).to(beGreaterThan((int)SDLLogLevelOff));
+        expect((int)SDLLogLevelDebug).to(beGreaterThan((int)SDLLogLevelError));
+        expect((int)SDLLogLevelDebug).to(beGreaterThan((int)SDLLogLevelWarning));
+        expect((int)SDLLogLevelDebug).to(beLessThan((int)SDLLogLevelVerbose));
+
+        expect((int)SDLLogLevelVerbose).to(beGreaterThan((int)SDLLogLevelDefault));
+        expect((int)SDLLogLevelVerbose).to(beGreaterThan((int)SDLLogLevelOff));
+        expect((int)SDLLogLevelVerbose).to(beGreaterThan((int)SDLLogLevelError));
+        expect((int)SDLLogLevelVerbose).to(beGreaterThan((int)SDLLogLevelWarning));
+        expect((int)SDLLogLevelVerbose).to(beGreaterThan((int)SDLLogLevelDebug));
+    });
+});
+
+QuickSpecEnd


### PR DESCRIPTION
Fixes #730 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
A `SDLLogConstantsSpec` unit test case was added to the project. Test cases for checking the type of messages logged for each debug level were added to `SDLLogManagerSpec` unit test cases. 

### Summary
The `SDLLogLevel` flags were fixed. 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)