### PR TITLE
End Service sends hashId

### DIFF
--- a/SmartDeviceLink/SDLProtocolMessageAssembler.m
+++ b/SmartDeviceLink/SDLProtocolMessageAssembler.m
@@ -75,7 +75,6 @@ NS_ASSUME_NONNULL_BEGIN
         [payload appendData:dataToAppend];
 
         // Validation
-        header.bytesInPayload = (UInt32)payload.length;
         if (payload.length != self.expectedBytes) {
             SDLLogW(@"Collected bytes size of %lu not equal to expected size of %i.", (unsigned long)payload.length, (unsigned int)self.expectedBytes);
         }

--- a/SmartDeviceLink/SDLProtocolMessageDisassembler.m
+++ b/SmartDeviceLink/SDLProtocolMessageDisassembler.m
@@ -44,7 +44,6 @@ NS_ASSUME_NONNULL_BEGIN
     payloadData[0] = CFSwapInt32HostToBig((UInt32)incomingMessage.payload.length);
     payloadData[1] = CFSwapInt32HostToBig((UInt32)numberOfMessagesRequired);
     NSMutableData *firstFramePayload = [NSMutableData dataWithBytes:payloadData length:sizeof(payloadData)];
-    firstFrameHeader.bytesInPayload = (UInt32)firstFramePayload.length;
 
     SDLProtocolMessage *firstMessage = [SDLProtocolMessage messageWithHeader:firstFrameHeader andPayload:firstFramePayload];
     outgoingMessages[0] = firstMessage;
@@ -62,7 +61,6 @@ NS_ASSUME_NONNULL_BEGIN
 
         NSUInteger offsetOfDataForThisFrame = headerSize + (n * numberOfDataBytesPerMessage);
         NSData *nextFramePayload = [incomingMessage.data subdataWithRange:NSMakeRange(offsetOfDataForThisFrame, numberOfDataBytesPerMessage)];
-        nextFrameHeader.bytesInPayload = (UInt32)nextFramePayload.length;
 
         SDLProtocolMessage *nextMessage = [SDLProtocolMessage messageWithHeader:nextFrameHeader andPayload:nextFramePayload];
         outgoingMessages[n + 1] = nextMessage;
@@ -79,7 +77,6 @@ NS_ASSUME_NONNULL_BEGIN
     NSUInteger numberOfDataBytesInLastMessage = incomingPayloadSize - numberOfDataBytesSentSoFar;
     NSUInteger offsetOfDataForLastFrame = headerSize + numberOfDataBytesSentSoFar;
     NSData *lastFramePayload = [incomingMessage.data subdataWithRange:NSMakeRange(offsetOfDataForLastFrame, numberOfDataBytesInLastMessage)];
-    lastFrameHeader.bytesInPayload = (UInt32)lastFramePayload.length;
 
     SDLProtocolMessage *lastMessage = [SDLProtocolMessage messageWithHeader:lastFrameHeader andPayload:lastFramePayload];
     outgoingMessages[numberOfMessagesRequired] = lastMessage;

--- a/SmartDeviceLink/SDLV1ProtocolMessage.m
+++ b/SmartDeviceLink/SDLV1ProtocolMessage.m
@@ -13,6 +13,8 @@ NS_ASSUME_NONNULL_BEGIN
     if (self = [self init]) {
         self.header = header;
         self.payload = payload;
+
+        self.header.bytesInPayload = (UInt32)self.payload.length;
     }
     return self;
 }

--- a/SmartDeviceLink/SDLV2ProtocolMessage.m
+++ b/SmartDeviceLink/SDLV2ProtocolMessage.m
@@ -15,6 +15,8 @@ NS_ASSUME_NONNULL_BEGIN
     if (self = [self init]) {
         self.header = header;
         self.payload = payload;
+
+        self.header.bytesInPayload = (UInt32)self.payload.length;
     }
     return self;
 }


### PR DESCRIPTION
Fixes #661

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Tests continue to pass, additional tests require `SDLProtocol` to no longer be public or a major refactor of the tests.

### Summary
* Centralize setting a protocol header’s bytesInPayload when assembling the message, remove the scattered sets all over the place
* Store and send the hash Id in end service packets

### Changelog
##### Enhancements
* End Service control frames now properly send the hash id on all protocol versions

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
