### PR TITLE
Set the RPC start service payload size correctly

### DIFF
--- a/SmartDeviceLink/SDLProtocol.m
+++ b/SmartDeviceLink/SDLProtocol.m
@@ -138,7 +138,7 @@ typedef NSNumber SDLServiceTypeBox;
     header.frameType = SDLFrameType_Control;
     header.serviceType = serviceType;
     header.frameData = SDLFrameData_StartSession;
-    header.bytesInPayload = (UInt32)payload.length;
+    header.bytesInPayload = (UInt32)servicePayload.length;
 
     // Sending a StartSession with the encrypted bit set causes module to initiate SSL Handshake with a ClientHello message, which should be handled by the 'processControlService' method.
     header.encrypted = encryption;


### PR DESCRIPTION
Fixes #745

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
SDLProtocol needs to be redesigned for unit testing

### Summary
This fixes the RPC start service payload never sending the correct data size in the protocol header.

### Changelog
##### Bug Fixes
* Fix some head units being unable to connect.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
