### PR TITLE
Fix custom framerate not taken into account when presentation data is unavailable

### DIFF
--- a/SmartDeviceLink/SDLH264VideoEncoder.m
+++ b/SmartDeviceLink/SDLH264VideoEncoder.m
@@ -138,7 +138,12 @@ static NSDictionary<NSString *, id>* _defaultVideoEncoderSettings;
 
 - (BOOL)encodeFrame:(CVImageBufferRef)imageBuffer presentationTimestamp:(CMTime)presentationTimestamp {
     if (!CMTIME_IS_VALID(presentationTimestamp)) {
-        presentationTimestamp = CMTimeMake(self.currentFrameNumber, 30);
+        int32_t timeRate = 30;
+        if (self.videoEncoderSettings[(__bridge NSString *)kVTCompressionPropertyKey_ExpectedFrameRate] != nil) {
+            timeRate = ((NSNumber *)self.videoEncoderSettings[(__bridge NSString *)kVTCompressionPropertyKey_ExpectedFrameRate]).intValue;
+        }
+        
+        presentationTimestamp = CMTimeMake(self.currentFrameNumber, timeRate);
     }
     self.currentFrameNumber++;
 

--- a/SmartDeviceLink/SDLH264VideoEncoder.m
+++ b/SmartDeviceLink/SDLH264VideoEncoder.m
@@ -38,7 +38,8 @@ static NSDictionary<NSString *, id>* _defaultVideoEncoderSettings;
     
     _defaultVideoEncoderSettings = @{
                                      (__bridge NSString *)kVTCompressionPropertyKey_ProfileLevel: (__bridge NSString *)kVTProfileLevel_H264_Baseline_AutoLevel,
-                                     (__bridge NSString *)kVTCompressionPropertyKey_RealTime: @YES
+                                     (__bridge NSString *)kVTCompressionPropertyKey_RealTime: @YES,
+                                     (__bridge NSString *)kVTCompressionPropertyKey_ExpectedFrameRate: @30,
                                      };
 }
 

--- a/SmartDeviceLink/SDLStreamingMediaConfiguration.h
+++ b/SmartDeviceLink/SDLStreamingMediaConfiguration.h
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic) SDLStreamingEncryptionFlag maximumDesiredEncryption;
 
 /**
- *  Properties to use for applications that utilitze the video encoder for streaming.
+ *  Properties to use for applications that utilitze the video encoder for streaming. See VTCompressionProperties.h for more details. For example, you can set kVTCompressionPropertyKey_ExpectedFrameRate to set your expected framerate.
  */
 @property (copy, nonatomic, nullable) NSDictionary<NSString *, id> *customVideoEncoderSettings;
 

--- a/SmartDeviceLink/SDLStreamingMediaLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingMediaLifecycleManager.m
@@ -58,7 +58,7 @@ SDLAudioStreamState *const SDLAudioStreamStateStarting = @"AudioStreamStarting";
 SDLAudioStreamState *const SDLAudioStreamStateReady = @"AudioStreamReady";
 SDLAudioStreamState *const SDLAudioStreamStateShuttingDown = @"AudioStreamShuttingDown";
 
-static NSUInteger const SDLFramesToSendOnBackground = 30;
+static NSUInteger const FramesToSendOnBackground = 30;
 
 typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_Nullable capability);
 
@@ -670,8 +670,13 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
         return;
     }
 
-    const CMTime interval = CMTimeMake(1, 30);
-    for (int frameCount = 0; frameCount < SDLFramesToSendOnBackground; frameCount++) {
+    int32_t timeRate = 30;
+    if (self.videoEncoderSettings[(__bridge NSString *)kVTCompressionPropertyKey_ExpectedFrameRate] != nil) {
+        timeRate = ((NSNumber *)self.videoEncoderSettings[(__bridge NSString *)kVTCompressionPropertyKey_ExpectedFrameRate]).intValue;
+    }
+
+    const CMTime interval = CMTimeMake(1, timeRate);
+    for (int frameCount = 0; frameCount < FramesToSendOnBackground; frameCount++) {
         if (CMTIME_IS_VALID(self.lastPresentationTimestamp)) {
             self.lastPresentationTimestamp = CMTimeAdd(self.lastPresentationTimestamp, interval);
             [self.videoEncoder encodeFrame:self.backgroundingPixelBuffer presentationTimestamp:self.lastPresentationTimestamp];


### PR DESCRIPTION
Fixes #717 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
[Describe how you plan to unit test the changes in this PR]

### Summary
This PR updates current hardcoded values of "30" fps as the default to take into account custom expected framerates when applied.

### Changelog
##### Bug Fixes
* Now takes into account custom framerates when provided by the developer and not using presentation timestamps.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
