### PR TITLE
Invoke write to iAP output stream immediately after new data is enqueued

### DIFF
--- a/SmartDeviceLink/SDLIAPSession.m
+++ b/SmartDeviceLink/SDLIAPSession.m
@@ -115,29 +115,29 @@ NSTimeInterval const streamThreadWaitSecs = 1.0;
 - (void)sendData:(NSData *)data {
     // Enqueue the data for transmission on the IO thread
     [self.sendDataQueue enqueueBuffer:data.mutableCopy];
+
+    [self performSelector:@selector(sdl_dequeueAndWriteToOutputStream) onThread:self.ioStreamThread withObject:nil waitUntilDone:NO];
 }
 
-- (BOOL)sdl_dequeueAndWriteToOutputStream:(NSError **)error {
+- (void)sdl_dequeueAndWriteToOutputStream {
     NSOutputStream *ostream = self.easession.outputStream;
     NSMutableData *remainder = [self.sendDataQueue frontBuffer];
-    BOOL allDataWritten = NO;
 
-    if (error != nil && remainder != nil && ostream.streamStatus == NSStreamStatusOpen) {
+    if (remainder != nil && ostream.streamStatus == NSStreamStatusOpen) {
         NSInteger bytesRemaining = remainder.length;
         NSInteger bytesWritten = [ostream write:remainder.bytes maxLength:bytesRemaining];
         if (bytesWritten < 0) {
-            *error = ostream.streamError;
+            if (ostream.streamError != nil) {
+                [self sdl_handleOutputStreamWriteError:ostream.streamError];
+            }
         } else if (bytesWritten == bytesRemaining) {
             // Remove the data from the queue
             [self.sendDataQueue popBuffer];
-            allDataWritten = YES;
         } else {
             // Cleave the sent bytes from the data, the remainder will sit at the head of the queue
             [remainder replaceBytesInRange:NSMakeRange(0, bytesWritten) withBytes:NULL length:0];
         }
     }
-
-    return allDataWritten;
 }
 
 - (void)sdl_handleOutputStreamWriteError:(NSError *)error {
@@ -168,10 +168,7 @@ NSTimeInterval const streamThreadWaitSecs = 1.0;
         [SDLDebugTool logInfo:@"starting the event loop for accessory"];
         do {
             if (self.sendDataQueue.count > 0 && !self.sendDataQueue.frontDequeued) {
-                NSError *sendErr = nil;
-                if (![self sdl_dequeueAndWriteToOutputStream:&sendErr] && sendErr != nil) {
-                    [self sdl_handleOutputStreamWriteError:sendErr];
-                }
+                [self sdl_dequeueAndWriteToOutputStream];
             }
             // The principle here is to give the event loop enough time to process stream events while also allowing it to handle new enqueued data buffers in a timely manner. We're capping the run loop CPU time at 0.25s maximum before it will return control to the rest of the loop.
             [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.25f]];
@@ -283,11 +280,7 @@ NSTimeInterval const streamThreadWaitSecs = 1.0;
             return;
         }
 
-        NSError *sendErr = nil;
-
-        if (![strongSelf sdl_dequeueAndWriteToOutputStream:&sendErr] && sendErr != nil) {
-            [strongSelf sdl_handleOutputStreamWriteError:sendErr];
-        }
+        [strongSelf sdl_dequeueAndWriteToOutputStream];
     };
 }
 


### PR DESCRIPTION
Fixes #712

This PR is ready for review.

### Risk
This PR makes no API changes.

### Testing Plan
We performed manual testing about video streaming with some internal SDL test apps and prototype headunit hardware, covering various stream bitrate over BT and USB. 

Before applying this fix, video streaming become sluggish even in low bitrate (~120kbps).
After this fix is applied, video streaming is played smmothly at above bitrate (120kbps) over BT.
Over USB, video streaming is played smoothly even at 10mbps.

### Summary
Fixed IO degradation. In current implementation, iAP transport waits for next run-loop before sending data after IO data is enqueued.
Added a call to sdl_dequeueAndWriteToOutputStream on ioStreamThread thread right after data is enqueued to send it immediately.


### Changelog

##### Bug Fixes
* Fixed IO degradation introduced by a change in #597

### Tasks Remaining:
- [ ] [Unit test]