### PR TITLE
Fix accessory connection fails while app is in background (4.7)

### DIFF
--- a/SmartDeviceLink-iOS.podspec
+++ b/SmartDeviceLink-iOS.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 s.name         = "SmartDeviceLink-iOS"
-s.version      = "4.7.1"
+s.version      = "4.7.2"
 s.summary      = "Connect your app with cars!"
 s.homepage     = "https://github.com/smartdevicelink/SmartDeviceLink-iOS"
 s.license      = { :type => "New BSD", :file => "LICENSE" }

--- a/SmartDeviceLink.podspec
+++ b/SmartDeviceLink.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 s.name         = "SmartDeviceLink"
-s.version      = "4.7.1"
+s.version      = "4.7.2"
 s.summary      = "Connect your app with cars!"
 s.homepage     = "https://github.com/smartdevicelink/SmartDeviceLink-iOS"
 s.license      = { :type => "New BSD", :file => "LICENSE" }


### PR DESCRIPTION
Fixes #740
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
The transport is currently not unit tested

### Summary
Fixed accessory setup over a iAP connection failing when app is in background due to the background task being suspended before the setup can complete.

1. Fixed not being able to establish a session with an accessory when the app is backgrounded and when is the app is backgrounded more than once
2. Fixed the app not being able to establish a session with an accessory when the device is first connected to the accessory and the app is closed (but the app has been opened at least once)

### Changelog
##### Bug Fixes
* Fixed background task ending before accessory setup completed. This was happening in the custom `sessionSetupInProgress` setter. 
* Fixed background task not being started the second time the app is backgrounded. The app now watches for a `UIApplicationDidEnterBackgroundNotification` and starts a background task.
* Fixed errors with the accessory not re-connecting in background because the `retryCounter` already maxed out. 
    * Fixed `retryEstablishSession` method call always failing because the `retryCounter` was already maxed out.   
    * If there was an error setting up a data stream after closing the control stream, the retry attempt always failed because the `retryCounter` was already maxed out. 
    * `retryCounter` needed to be reset in several places 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
