### PR TITLE
Fixed infinite iAP connection attempts (5.0)

### DIFF
--- a/SmartDeviceLink/SDLIAPTransport.m
+++ b/SmartDeviceLink/SDLIAPTransport.m
@@ -24,8 +24,8 @@ NSString *const IndexedProtocolStringPrefix = @"com.smartdevicelink.prot";
 NSString *const MultiSessionProtocolString = @"com.smartdevicelink.multisession";
 NSString *const BackgroundTaskName = @"com.sdl.transport.iap.backgroundTask";
 
-int const CreateSessionRetries = 1;
-int const ProtocolIndexTimeoutSeconds = 20;
+int const CreateSessionRetries = 3;
+int const ProtocolIndexTimeoutSeconds = 10;
 
 @interface SDLIAPTransport () {
     BOOL _alreadyDestructed;
@@ -149,7 +149,6 @@ int const ProtocolIndexTimeoutSeconds = 20;
         [self sdl_backgroundTaskStart];
     }
     
-    self.retryCounter = 0;
     [self performSelector:@selector(sdl_connect:) withObject:accessory afterDelay:retryDelay];
 }
 
@@ -161,10 +160,11 @@ int const ProtocolIndexTimeoutSeconds = 20;
 - (void)sdl_accessoryDisconnected:(NSNotification *)notification {
     EAAccessory *accessory = [notification.userInfo objectForKey:EAAccessoryKey];
     if (accessory.connectionID != self.session.accessory.connectionID) {
-        SDLLogD(@"Accessory disconnected event (%@)", accessory);
+        SDLLogV(@"Accessory disconnected during control session (%@)", accessory);
+        self.retryCounter = 0;
     }
     if ([accessory.serialNumber isEqualToString:self.session.accessory.serialNumber]) {
-        SDLLogD(@"Connected accessory disconnected event");
+        SDLLogV(@"Accessory disconnected during data session (%@)", accessory);
         self.retryCounter = 0;
         self.sessionSetupInProgress = NO;
         [self disconnect];
@@ -184,7 +184,6 @@ int const ProtocolIndexTimeoutSeconds = 20;
 - (void)sdl_applicationWillEnterForeground:(NSNotification *)notification {
     SDLLogV(@"App foregrounded, attempting connection");
     [self sdl_backgroundTaskEnd];
-    self.retryCounter = 0;
     [self connect];
 }
 
@@ -381,7 +380,6 @@ int const ProtocolIndexTimeoutSeconds = 20;
     }
     
     // Search connected accessories
-    self.retryCounter = 0;
     [self sdl_connect:nil];
 }
 
@@ -475,7 +473,6 @@ int const ProtocolIndexTimeoutSeconds = 20;
         
         if (accessory.isConnected) {
             dispatch_async(dispatch_get_main_queue(), ^{
-                self.retryCounter = 0;
                 [strongSelf sdl_createIAPDataSessionWithAccessory:accessory forProtocol:indexedProtocolString];
             });
         }


### PR DESCRIPTION
Fixes #770

This PR is **not ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
None written
Tested with SDL_Video_Ex on iOS 11 (iPhone SE) and iOS 10 (iPhone 6)

### Summary
* When attempting to connect to a SDL enabled accessory, the app now has only 3 tries to create both a control and a data session.
* The retry counter is now only reset to 0 when the accessory is disconnected during a control or data session. 
* The `protocolIndexTimeoutSeconds` was reduced from 20 to 10 seconds.

### Changelog
### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)