### PR TITLE
Video streaming does not work when app foregrounded

### DIFF
--- a/SmartDeviceLink/SDLStreamingMediaLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingMediaLifecycleManager.m
@@ -269,10 +269,6 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
 // We should be waiting to start any OpenGL drawing until UIApplicationDidBecomeActive is called.
 - (void)didEnterStateAppActive {
     SDLLogD(@"App became active");
-    if (!self.protocol) { return; }
-
-    [self sdl_startVideoSession];
-    [self sdl_startAudioSession];
 }
 
 #pragma mark Video Streaming


### PR DESCRIPTION
Fixes #774 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Tested using smoke tests created for 5.0.0

### Summary
Fixed a bug where video streaming did not start on reconnect if the app was backgrounded and then foregrounded before the iPhone was reconnected to Core. This happened because the video setup RPCs in the `SDLStreamingMediaLifecycleManager` were being sent before the device was connected to Core. 

### Changelog
### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)