### PR TITLE
Fix missing protocol string crash (5.0)

### DIFF
--- a/SmartDeviceLink/SDLIAPTransport.m
+++ b/SmartDeviceLink/SDLIAPTransport.m
@@ -316,6 +316,13 @@ int const ProtocolIndexTimeoutSeconds = 20;
             // Connection underway, exit
             return;
         }
+
+        if ([self.class sdl_supportsRequiredProtocolStrings] != nil) {
+            NSString *failedString = [self.class sdl_supportsRequiredProtocolStrings];
+            SDLLogE(@"A required External Accessory protocol string is missing from the info.plist: %@", failedString);
+            NSAssert(NO, @"Some SDL protocol strings are not supported, check the README for all strings that must be included in your info.plist file. Missing string: %@", failedString);
+            return;
+        }
         
         // Determine if we can start a multi-app session or a legacy (single-app) session
         if ((sdlAccessory = [EAAccessoryManager findAccessoryForProtocol:MultiSessionProtocolString]) && SDL_SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"9")) {

--- a/SmartDeviceLink/SDLIAPTransport.m
+++ b/SmartDeviceLink/SDLIAPTransport.m
@@ -253,6 +253,12 @@ int const ProtocolIndexTimeoutSeconds = 20;
  */
 - (BOOL)sdl_connectAccessory:(EAAccessory *)accessory {
     BOOL connecting = NO;
+    if ([self.class sdl_supportsRequiredProtocolStrings] != nil) {
+        NSString *failedString = [self.class sdl_supportsRequiredProtocolStrings];
+        NSAssert(NO, @"Some SDL protocol strings are not supported, check the README for all strings that must be included in your info.plist file. Missing string: %@", failedString);
+        return connecting;
+    }
+
     if ([accessory supportsProtocol:MultiSessionProtocolString] && SDL_SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"9")) {
         [self sdl_createIAPDataSessionWithAccessory:accessory forProtocol:MultiSessionProtocolString];
         connecting = YES;
@@ -264,6 +270,32 @@ int const ProtocolIndexTimeoutSeconds = 20;
         connecting = YES;
     }
     return connecting;
+}
+
+/**
+ Check all required protocol strings in the info.plist dictionary.
+
+ @return A missing protocol string or nil if all strings are supported.
+ */
++ (nullable NSString *)sdl_supportsRequiredProtocolStrings {
+    NSArray<NSString *> *protocolStrings = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UISupportedExternalAccessoryProtocols"];
+
+    if (![protocolStrings containsObject:MultiSessionProtocolString]) {
+        return MultiSessionProtocolString;
+    }
+
+    if (![protocolStrings containsObject:LegacyProtocolString]) {
+        return LegacyProtocolString;
+    }
+
+    for (int i = 0; i < 30; i++) {
+        NSString *indexedProtocolString = [NSString stringWithFormat:@"%@%i", IndexedProtocolStringPrefix, i];
+        if (![protocolStrings containsObject:indexedProtocolString]) {
+            return indexedProtocolString;
+        }
+    }
+
+    return nil;
 }
 
 /**

--- a/SmartDeviceLink/SDLIAPTransport.m
+++ b/SmartDeviceLink/SDLIAPTransport.m
@@ -255,6 +255,7 @@ int const ProtocolIndexTimeoutSeconds = 20;
     BOOL connecting = NO;
     if ([self.class sdl_supportsRequiredProtocolStrings] != nil) {
         NSString *failedString = [self.class sdl_supportsRequiredProtocolStrings];
+        SDLLogE(@"A required External Accessory protocol string is missing from the info.plist: %@", failedString);
         NSAssert(NO, @"Some SDL protocol strings are not supported, check the README for all strings that must be included in your info.plist file. Missing string: %@", failedString);
         return connecting;
     }


### PR DESCRIPTION
Fixes #773

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
n/a

### Summary
This checks the app's info.plist for all required protocol strings before attempting to connect and asserts if one is not found.

### Changelog
##### Bug Fixes
* Fix crashing in a random place if a protocol string is missing

### Tasks Remaining:
- [x] Smoke testing

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
