### PR TITLE
Fix streaming media config not copied

### DIFF
--- a/SmartDeviceLink/SDLConfiguration.m
+++ b/SmartDeviceLink/SDLConfiguration.m
@@ -80,7 +80,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - NSCopying
 
 - (id)copyWithZone:(nullable NSZone *)zone {
-    SDLConfiguration *new = [[SDLConfiguration allocWithZone:zone] initWithLifecycle: _lifecycleConfig lockScreen: _lockScreenConfig logging:_loggingConfig];
+    SDLConfiguration *new = [[SDLConfiguration allocWithZone:zone] initWithLifecycle: _lifecycleConfig lockScreen: _lockScreenConfig logging:_loggingConfig streamingMedia:_streamingMediaConfig];
 
     return new;
 }


### PR DESCRIPTION
Fixes #779 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Copies are currently not tested

### Summary
This fixes a bug where the streaming media config would always be nil after being set due to it not being copied.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
