### PR TITLE
Fixed foregrounded app video stream not starting

### DIFF
--- a/SmartDeviceLink/SDLStreamingMediaLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingMediaLifecycleManager.m
@@ -158,6 +158,9 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
     [self sdl_stopVideoSession];
 
     self.restartVideoStream = NO;
+
+    self.hmiLevel = SDLHMILevelNone;
+
     [self.audioStreamStateMachine transitionToState:SDLAudioStreamStateStopped];
     [self.videoStreamStateMachine transitionToState:SDLVideoStreamStateStopped];
 }
@@ -607,6 +610,11 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
 
 - (void)sdl_startVideoSession {
     SDLLogV(@"Attempting to start video session");
+
+    if (!self.isHmiStateVideoStreamCapable) {
+        SDLLogV(@"SDL Core is not ready to stream video. Video start service request will not be sent.");
+        return;
+    }
 
     if (!self.isStreamingSupported) {
         SDLLogV(@"Streaming is not supported. Video start service request will not be sent.");


### PR DESCRIPTION
Fixes #774 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Tested on iOS 11 and iOS 11.1 using the smoke test cases for video streaming

### Summary
Fixed an issue with video setup in the `SDLStreamingMediaLifecycleManager` occurring when the app has been foregrounded but before it has connected to SDL Core. This was done by reseting the HMI level  to `NONE` in the `SDLStreamingMediaLifecycleManager ` class when app disconnects from Core.

### Changelog
### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)