### PR TITLE
Fix calling [UIApplication sharedApplication].applicationState on non main thread

### DIFF
--- a/SmartDeviceLink/SDLProxy.m
+++ b/SmartDeviceLink/SDLProxy.m
@@ -117,26 +117,28 @@ static float DefaultConnectionTimeout = 45.0;
 #pragma mark - Application Lifecycle
 
 - (void)sendMobileHMIState {
-    UIApplicationState appState = [UIApplication sharedApplication].applicationState;
-    SDLOnHMIStatus *HMIStatusRPC = [[SDLOnHMIStatus alloc] init];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        UIApplicationState appState = [UIApplication sharedApplication].applicationState;
+        SDLOnHMIStatus *HMIStatusRPC = [[SDLOnHMIStatus alloc] init];
 
-    HMIStatusRPC.audioStreamingState = SDLAudioStreamingStateNotAudible;
-    HMIStatusRPC.systemContext = SDLSystemContextMain;
+        HMIStatusRPC.audioStreamingState = SDLAudioStreamingStateNotAudible;
+        HMIStatusRPC.systemContext = SDLSystemContextMain;
 
-    switch (appState) {
-        case UIApplicationStateActive: {
-            HMIStatusRPC.hmiLevel = SDLHMILevelFull;
-        } break;
-        case UIApplicationStateBackground: // Fallthrough
-        case UIApplicationStateInactive: {
-            HMIStatusRPC.hmiLevel = SDLHMILevelBackground;
-        } break;
-        default:
-            break;
-    }
+        switch (appState) {
+            case UIApplicationStateActive: {
+                HMIStatusRPC.hmiLevel = SDLHMILevelFull;
+            } break;
+            case UIApplicationStateBackground: // Fallthrough
+            case UIApplicationStateInactive: {
+                HMIStatusRPC.hmiLevel = SDLHMILevelBackground;
+            } break;
+            default:
+                break;
+        }
 
-    SDLLogD(@"Mobile UIApplication state changed, sending to remote system: %@", HMIStatusRPC.hmiLevel);
-    [self sendRPC:HMIStatusRPC];
+        SDLLogD(@"Mobile UIApplication state changed, sending to remote system: %@", HMIStatusRPC.hmiLevel);
+        [self sendRPC:HMIStatusRPC];
+    });
 }
 
 #pragma mark - Accessors


### PR DESCRIPTION
Fixes N/A

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Call [UIApplication sharedApplication].applicationState on main thread

Fixed following warnings in application:
> 017-11-03 15:11:49.220558+0100 SDLDemo[59918:2993616] [reports] Main Thread Checker: UI API called on a background thread: -[UIApplication applicationState]
PID: 59918, TID: 2993616, Thread name: (none), Queue name: com.sdl.protocol.receive, QoS: 0
Backtrace:
4   SmartDeviceLink_iOS                 0x000000010c883b8d -[SDLProxy sendMobileHMIState] + 77
5   SmartDeviceLink_iOS                 0x000000010c886a36 -[SDLProxy handleRegisterAppInterfaceResponse:] + 838
6   SmartDeviceLink_iOS                 0x000000010c88628f -[SDLProxy handleRPCDictionary:] + 1215
7   SmartDeviceLink_iOS                 0x000000010c885d9d -[SDLProxy handleProtocolMessage:] + 93
8   SmartDeviceLink_iOS                 0x000000010c885660 -[SDLProxy onProtocolMessageReceived:] + 64
9   SmartDeviceLink_iOS                 0x000000010c87d885 -[SDLProtocol onProtocolMessageReceived:] + 597
10  SmartDeviceLink_iOS                 0x000000010c88246a -[SDLProtocolReceivedMessageRouter sdl_dispatchProtocolMessage:] + 170
11  SmartDeviceLink_iOS                 0x000000010c882364 -[SDLProtocolReceivedMessageRouter handleReceivedMessage:] + 196
12  SmartDeviceLink_iOS                 0x000000010c87bbed __30-[SDLProtocol processMessages]_block_invoke + 77
13  libdispatch.dylib                   0x00000001123f13f7 _dispatch_call_block_and_release + 12
14  libdispatch.dylib                   0x00000001123f243c _dispatch_client_callout + 8
15  libdispatch.dylib                   0x00000001123fa95b _dispatch_queue_serial_drain + 1162
16  libdispatch.dylib                   0x00000001123fb2df _dispatch_queue_invoke + 336
17  libdispatch.dylib                   0x00000001123f707d _dispatch_queue_override_invoke + 733
18  libdispatch.dylib                   0x00000001123fe1f9 _dispatch_root_queue_drain + 772
19  libdispatch.dylib                   0x00000001123fde97 _dispatch_worker_thread3 + 132
20  libsystem_pthread.dylib             0x00000001128ba1ca _pthread_wqthread + 1387
21  libsystem_pthread.dylib             0x00000001128b9c4d start_wqthread + 13
2017-11-03 15:11:49.393956+0100 SDLDemo[59918:2993612] [Proxy] Mobile UIApplication state changed, sending to remote system: FULL

### Testing Plan
None written
Tested with on iOS 11 (iPhone 7) and iOS 10 (iPhone 6)