### PR TITLE
Fix a crash on disconnects during a ListFiles response sent by the FileManager

### DIFF
--- a/SmartDeviceLink/SDLFileManager.m
+++ b/SmartDeviceLink/SDLFileManager.m
@@ -151,6 +151,11 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
 - (void)didEnterStateFetchingInitialList {
     __weak typeof(self) weakSelf = self;
     [self sdl_listRemoteFilesWithCompletionHandler:^(BOOL success, NSUInteger bytesAvailable, NSArray<NSString *> *_Nonnull fileNames, NSError *_Nullable error) {
+        // If we've already shut down by this point, just stay in the shutdown state
+        if ([weakSelf.stateMachine.currentState isEqualToString:SDLFileManagerStateShutdown]) {
+            BLOCK_RETURN;
+        }
+
         // If there was an error, we'll pass the error to the startup handler and cancel out
         if (error != nil) {
             [weakSelf.stateMachine transitionToState:SDLFileManagerStateStartupError];

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLFileManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLFileManagerSpec.m
@@ -29,7 +29,7 @@ SDLFileManagerState *const SDLFileManagerStateReady = @"Ready";
 
 QuickSpecBegin(SDLFileManagerSpec)
 
-describe(@"SDLFileManager", ^{
+fdescribe(@"SDLFileManager", ^{
     __block TestConnectionManager *testConnectionManager = nil;
     __block SDLFileManager *testFileManager = nil;
     __block NSUInteger initialSpaceAvailable = 250;
@@ -82,7 +82,7 @@ describe(@"SDLFileManager", ^{
             expect(testFileManager.currentState).to(match(SDLFileManagerStateFetchingInitialList));
         });
 
-        describe(@"after receiving a ListFiles response", ^{
+        describe(@"after going to the shutdown state and receiving a ListFiles response", ^{
             __block SDLListFilesResponse *testListFilesResponse = nil;
             __block NSSet<NSString *> *testInitialFileNames = nil;
 
@@ -94,10 +94,33 @@ describe(@"SDLFileManager", ^{
                 testListFilesResponse.spaceAvailable = @(initialSpaceAvailable);
                 testListFilesResponse.filenames = [NSArray arrayWithArray:[testInitialFileNames allObjects]];
 
+                [testFileManager stop];
+                [testConnectionManager respondToLastRequestWithResponse:testListFilesResponse];
+            });
+
+            it(@"should remain in the stopped state after receiving the response if disconnected", ^{
+
+                expect(testFileManager.currentState).toEventually(match(SDLFileManagerStateShutdown));
+            });
+        });
+
+        describe(@"after receiving a ListFiles response", ^{
+            __block SDLListFilesResponse *testListFilesResponse = nil;
+            __block NSSet<NSString *> *testInitialFileNames = nil;
+
+            beforeEach(^{
+                testInitialFileNames = [NSSet setWithArray:@[@"testFile1", @"testFile2", @"testFile3"]];
+
+                testListFilesResponse = [[SDLListFilesResponse alloc] init];
+                testListFilesResponse.success = @YES;
+                testListFilesResponse.spaceAvailable = @(initialSpaceAvailable);
+                testListFilesResponse.filenames = [NSArray arrayWithArray:[testInitialFileNames allObjects]];
                 [testConnectionManager respondToLastRequestWithResponse:testListFilesResponse];
             });
 
             it(@"the file manager should be in the correct state", ^{
+                [testConnectionManager respondToLastRequestWithResponse:testListFilesResponse];
+
                 expect(testFileManager.currentState).toEventually(match(SDLFileManagerStateReady));
                 expect(testFileManager.remoteFileNames).toEventually(equal(testInitialFileNames));
                 expect(@(testFileManager.bytesAvailable)).toEventually(equal(@(initialSpaceAvailable)));

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLFileManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLFileManagerSpec.m
@@ -29,7 +29,7 @@ SDLFileManagerState *const SDLFileManagerStateReady = @"Ready";
 
 QuickSpecBegin(SDLFileManagerSpec)
 
-fdescribe(@"SDLFileManager", ^{
+describe(@"SDLFileManager", ^{
     __block TestConnectionManager *testConnectionManager = nil;
     __block SDLFileManager *testFileManager = nil;
     __block NSUInteger initialSpaceAvailable = 250;

--- a/SmartDeviceLinkTests/ProxySpecs/SDLHapticManagerSpec.m
+++ b/SmartDeviceLinkTests/ProxySpecs/SDLHapticManagerSpec.m
@@ -10,13 +10,14 @@
 #import <OCMock/OCMock.h>
 
 #import "SDLFocusableItemLocator.h"
-#import "SDLSendHapticData.h"
+#import "SDLHapticRect.h"
+#import "SDLLifecycleManager.h"
 #import "SDLManager.h"
+#import "SDLRectangle.h"
+#import "SDLSendHapticData.h"
 #import "SDLTouchCoord.h"
 #import "SDLTouchEvent.h"
 #import "SDLTouch.h"
-#import "SDLRectangle.h"
-#import "SDLLifecycleManager.h"
 
 BOOL compareRectangle(SDLRectangle *sdlRectangle, CGRect cgRect)
 {


### PR DESCRIPTION
Fixes #789

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Unit tests have been included

### Summary
This PR fixes a crash that could occur if the app disconnects while waiting for a ListFiles response as sent by the FileManager.

### Changelog
##### Bug Fixes
* Fix a crash on disconnects during a ListFiles response sent by the FileManager

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
