### PR TITLE
Fix SDLSlider Initializer Recursion

### DIFF
--- a/SmartDeviceLink/SDLSlider.h
+++ b/SmartDeviceLink/SDLSlider.h
@@ -16,10 +16,37 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SDLSlider : SDLRPCRequest
 
+/**
+ Create an SDLSlider with only the number of ticks and position. Note that this is not enough to get a SUCCESS response. You must supply additional data. See below for required parameters.
+
+ @param numTicks The number of ticks present on the slider.
+ @param position The default starting position of the slider.
+ @return An SDLSlider RPC Request.
+ */
 - (instancetype)initWithNumTicks:(UInt8)numTicks position:(UInt8)position;
 
+/**
+ Create an SDLSlider with all required data and a static footer (or no footer).
+
+ @param numTicks The number of ticks present on the slider.
+ @param position The default starting position of the slider.
+ @param sliderHeader The header describing the slider.
+ @param sliderFooter A static footer with text, or nil for no footer.
+ @param timeout The length of time in milliseconds the popup should be displayed before automatically disappearing.
+ @return An SDLSlider RPC Request.
+ */
 - (instancetype)initWithNumTicks:(UInt8)numTicks position:(UInt8)position sliderHeader:(NSString *)sliderHeader sliderFooter:(nullable NSString *)sliderFooter timeout:(UInt16)timeout;
 
+/**
+ Create an SDLSlider with all required data and a dynamic footer (or no footer).
+
+ @param numTicks The number of ticks present on the slider.
+ @param position The default starting position of the slider.
+ @param sliderHeader The header describing the slider.
+ @param sliderFooters An array of footers. This should be the same length as `numTicks` as each footer should correspond to a tick, or no footer if nil.
+ @param timeout The length of time in milliseconds the popup should be displayed before automatically disappearing.
+ @return An SDLSlider RPC Request.
+ */
 - (instancetype)initWithNumTicks:(UInt8)numTicks position:(UInt8)position sliderHeader:(NSString *)sliderHeader sliderFooters:(nullable NSArray<NSString *> *)sliderFooters timeout:(UInt16)timeout;
 
 /**
@@ -39,7 +66,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * @abstract A text header to display
  *
- * Rquired, Max length 500 chars
+ * Required, Max length 500 chars
  */
 @property (strong, nonatomic) NSString *sliderHeader;
 
@@ -59,7 +86,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic, nullable) NSArray<NSString *> *sliderFooter;
 
 /**
- * @abstract An App defined timeout
+ * @abstract An App defined timeout in milliseconds
  *
  * @discussion Indicates how long of a timeout from the last action (i.e. sliding control resets timeout).
  *

--- a/SmartDeviceLink/SDLSlider.m
+++ b/SmartDeviceLink/SDLSlider.m
@@ -18,7 +18,12 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (instancetype)initWithNumTicks:(UInt8)numTicks position:(UInt8)position sliderHeader:(NSString *)sliderHeader sliderFooter:(nullable NSString *)sliderFooter timeout:(UInt16)timeout {
-    return [self initWithNumTicks:numTicks position:position sliderHeader:sliderHeader sliderFooters:@[sliderFooter] timeout:timeout];
+    NSArray<NSString *> *footer = nil;
+    if (sliderFooter != nil) {
+        footer = @[sliderFooter];
+    }
+
+    return [self initWithNumTicks:numTicks position:position sliderHeader:sliderHeader sliderFooters:footer timeout:timeout];
 }
 
 - (instancetype)initWithNumTicks:(UInt8)numTicks position:(UInt8)position sliderHeader:(NSString *)sliderHeader sliderFooters:(nullable NSArray<NSString *> *)sliderFooters timeout:(UInt16)timeout {

--- a/SmartDeviceLink/SDLSlider.m
+++ b/SmartDeviceLink/SDLSlider.m
@@ -18,14 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (instancetype)initWithNumTicks:(UInt8)numTicks position:(UInt8)position sliderHeader:(NSString *)sliderHeader sliderFooter:(nullable NSString *)sliderFooter timeout:(UInt16)timeout {
-    NSMutableArray *sliderFooters = [NSMutableArray arrayWithCapacity:numTicks];
-
-    // Populates array with the same footer value for each position
-    for (int i = 0; i < sliderFooters.count; i++) {
-        sliderFooters[0] = sliderFooter;
-    }
-
-    return [self initWithNumTicks:numTicks position:position sliderHeader:sliderHeader sliderFooter:[sliderFooters copy] timeout:timeout];
+    return [self initWithNumTicks:numTicks position:position sliderHeader:sliderHeader sliderFooters:@[sliderFooter] timeout:timeout];
 }
 
 - (instancetype)initWithNumTicks:(UInt8)numTicks position:(UInt8)position sliderHeader:(NSString *)sliderHeader sliderFooters:(nullable NSArray<NSString *> *)sliderFooters timeout:(UInt16)timeout {

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSliderSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSliderSpec.m
@@ -14,42 +14,87 @@
 QuickSpecBegin(SDLSliderSpec)
 
 describe(@"Getter/Setter Tests", ^ {
+    __block SDLSlider *testRequest = nil;
+    __block UInt8 testNumTicks = 4;
+    __block UInt8 testPosition = 1;
+    __block NSUInteger testTimeout = 2000;
+    __block NSString *testHeader = @"Head";
+    __block NSString *testFooter = @"Foot";
+    __block NSArray<NSString *> *testFooters = @[@"Foot1", @"Foot2"];
+
+    beforeEach(^{
+        testRequest = nil;
+        testNumTicks = 4;
+        testPosition = 1;
+        testTimeout = 2000;
+        testHeader = @"Head";
+        testFooter = @"Foot";
+        testFooters = @[@"Foot1", @"Foot2"];
+    });
+
     it(@"Should set and get correctly", ^ {
-        SDLSlider* testRequest = [[SDLSlider alloc] init];
+        testRequest = [[SDLSlider alloc] init];
         
-        testRequest.numTicks = @2;
-        testRequest.position = @1;
-        testRequest.sliderHeader = @"Head";
-        testRequest.sliderFooter = [@[@"LeftFoot", @"RightFoot"] mutableCopy];
-        testRequest.timeout = @2000;
+        testRequest.numTicks = @(testNumTicks);
+        testRequest.position = @(testPosition);
+        testRequest.sliderHeader = testHeader;
+        testRequest.sliderFooter = testFooters;
+        testRequest.timeout = @(testTimeout);
         
-        expect(testRequest.numTicks).to(equal(@2));
-        expect(testRequest.position).to(equal(@1));
-        expect(testRequest.sliderHeader).to(equal(@"Head"));
-        expect(testRequest.sliderFooter).to(equal([@[@"LeftFoot", @"RightFoot"] mutableCopy]));
-        expect(testRequest.timeout).to(equal(@2000));
+        expect(testRequest.numTicks).to(equal(testNumTicks));
+        expect(testRequest.position).to(equal(testPosition));
+        expect(testRequest.sliderHeader).to(equal(testHeader));
+        expect(testRequest.sliderFooter).to(equal(testFooters));
+        expect(testRequest.timeout).to(equal(testTimeout));
     });
     
-    it(@"Should get correctly when initialized", ^ {
-        NSMutableDictionary<NSString *, id> *dict = [@{SDLNameRequest:
-                                                           @{SDLNameParameters:
-                                                                 @{SDLNameNumberTicks:@2,
-                                                                   SDLNamePosition:@1,
-                                                                   SDLNameSliderHeader:@"Head",
-                                                                   SDLNameSliderFooter:[@[@"LeftFoot", @"RightFoot"] mutableCopy],
-                                                                   SDLNameTimeout:@2000},
-                                                             SDLNameOperationName:SDLNameSlider}} mutableCopy];
-        SDLSlider* testRequest = [[SDLSlider alloc] initWithDictionary:dict];
+    it(@"Should get correctly when initialized with a dictionary", ^ {
+        NSDictionary<NSString *, id> *dict = @{SDLNameRequest:
+                                                    @{SDLNameParameters:
+                                                          @{SDLNameNumberTicks:@(testNumTicks),
+                                                            SDLNamePosition:@(testPosition),
+                                                            SDLNameSliderHeader:testHeader,
+                                                            SDLNameSliderFooter:testFooters,
+                                                            SDLNameTimeout:@(testTimeout)},
+                                                      SDLNameOperationName:SDLNameSlider}};
+        testRequest = [[SDLSlider alloc] initWithDictionary:dict];
         
-        expect(testRequest.numTicks).to(equal(@2));
-        expect(testRequest.position).to(equal(@1));
-        expect(testRequest.sliderHeader).to(equal(@"Head"));
-        expect(testRequest.sliderFooter).to(equal([@[@"LeftFoot", @"RightFoot"] mutableCopy]));
-        expect(testRequest.timeout).to(equal(@2000));
+        expect(testRequest.numTicks).to(equal(testNumTicks));
+        expect(testRequest.position).to(equal(testPosition));
+        expect(testRequest.sliderHeader).to(equal(testHeader));
+        expect(testRequest.sliderFooter).to(equal(testFooters));
+        expect(testRequest.timeout).to(equal(testTimeout));
+    });
+
+    it(@"should correctly initialize with initWithNumTicks:position:", ^{
+        testRequest = [[SDLSlider alloc] initWithNumTicks:testNumTicks position:testPosition];
+
+        expect(testRequest.numTicks).to(equal(testNumTicks));
+        expect(testRequest.position).to(equal(testPosition));
+    });
+
+    it(@"should correctly initialize with initWithNumTicks:position:sliderHeader:sliderFooters:timeout:", ^{
+        testRequest = [[SDLSlider alloc] initWithNumTicks:testNumTicks position:testPosition sliderHeader:testHeader sliderFooters:testFooters timeout:testTimeout];
+
+        expect(testRequest.numTicks).to(equal(testNumTicks));
+        expect(testRequest.position).to(equal(testPosition));
+        expect(testRequest.sliderHeader).to(equal(testHeader));
+        expect(testRequest.sliderFooter).to(equal(testFooters));
+        expect(testRequest.timeout).to(equal(testTimeout));
+    });
+
+    it(@"should correctly initialize with initWithNumTicks:position:sliderHeader:sliderFooter:timeout:", ^{
+        testRequest = [[SDLSlider alloc] initWithNumTicks:testNumTicks position:testPosition sliderHeader:testHeader sliderFooter:testFooter timeout:testTimeout];
+
+        expect(testRequest.numTicks).to(equal(testNumTicks));
+        expect(testRequest.position).to(equal(testPosition));
+        expect(testRequest.sliderHeader).to(equal(testHeader));
+        expect(testRequest.sliderFooter).to(equal(@[testFooter]));
+        expect(testRequest.timeout).to(equal(testTimeout));
     });
     
     it(@"Should return nil if not set", ^ {
-        SDLSlider* testRequest = [[SDLSlider alloc] init];
+        testRequest = [[SDLSlider alloc] init];
         
         expect(testRequest.numTicks).to(beNil());
         expect(testRequest.position).to(beNil());


### PR DESCRIPTION
Fixes #808 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Unit tests were added to cover the case that failed

### Summary
Fixes `[SDLSlider initWithNumTicks:position:sliderHeader:sliderFooter:timeout:]` calling itself, causing infinite recursion. Also adds a ton of documentation to `SDLSlider`.

### Changelog
##### Bug Fixes
* Fixes `[SDLSlider initWithNumTicks:position:sliderHeader:sliderFooter:timeout:]` calling itself, causing infinite recursion. It now properly makes a static footer. Dynamic footers should use `[SDLSlider initWithNumTicks:position:sliderHeader:sliderFooters:timeout:]`

### Tasks Remaining:
N/A

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)