### PR TITLE
SDLManager hmiLevel should be nullable

### DIFF
--- a/SmartDeviceLink/SDLManager.h
+++ b/SmartDeviceLink/SDLManager.h
@@ -38,7 +38,7 @@ typedef void (^SDLManagerReadyBlock)(BOOL success, NSError *_Nullable error);
 /**
  *  The current HMI level of the running app.
  */
-@property (copy, nonatomic, readonly) SDLHMILevel hmiLevel;
+@property (copy, nonatomic, readonly, nullable) SDLHMILevel hmiLevel;
 
 /**
  *  The current audio streaming state of the running app.


### PR DESCRIPTION
Fixes #805 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
n/a

### Summary
Fix a possible crash when `hmiLevel`, marked as `nonnull`, but can be `nil` is checked and is `nil`.

### Changelog
##### Bug Fixes
* Fix a possible crash when accessing `SDLManager hmiLevel`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
