### PR TITLE
Automatically log a warning when a request fails

### DIFF
--- a/SmartDeviceLink/SDLResponseDispatcher.m
+++ b/SmartDeviceLink/SDLResponseDispatcher.m
@@ -15,6 +15,7 @@
 #import "SDLDeleteCommand.h"
 #import "SDLDeleteCommandResponse.h"
 #import "SDLError.h"
+#import "SDLLogMacros.h"
 #import "SDLOnAudioPassThru.h"
 #import "SDLOnButtonEvent.h"
 #import "SDLOnButtonPress.h"
@@ -174,6 +175,9 @@ NS_ASSUME_NONNULL_BEGIN
 
     // Run the response handler
     if (handler) {
+        if (!response.success.boolValue) {
+            SDLLogW(@"Request failed: %@, response: %@, error: %@", request, response, error);
+        }
         handler(request, response, error);
     }
 


### PR DESCRIPTION
Fixes #811 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
n/a

### Summary
When a request's response comes back with a `SUCCESS` failed, log a warning message with the request, response, and error.

### Changelog
##### Enhancements
* When a request's response comes back with a `SUCCESS` failed, log a warning message with the request, response, and error.

### Tasks Remaining:
n/a

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)