### PR TITLE
Wrap TCP transport connect logic inside of an operation queue

### DIFF
--- a/SmartDeviceLink/SDLTCPTransport.m
+++ b/SmartDeviceLink/SDLTCPTransport.m
@@ -46,20 +46,22 @@ static void TCPCallback(CFSocketRef socket, CFSocketCallBackType type, CFDataRef
 }
 
 - (void)connect {
-    SDLLogD(@"Attemping to connect");
-
-    int sock_fd = call_socket([self.hostName UTF8String], [self.portNumber UTF8String]);
-    if (sock_fd < 0) {
-        SDLLogE(@"Server not ready, connection failed");
-        return;
-    }
-
-    CFSocketContext socketCtxt = {0, (__bridge void *)(self), NULL, NULL, NULL};
-    socket = CFSocketCreateWithNative(kCFAllocatorDefault, sock_fd, kCFSocketDataCallBack | kCFSocketConnectCallBack, (CFSocketCallBack)&TCPCallback, &socketCtxt);
-    CFRunLoopSourceRef source = CFSocketCreateRunLoopSource(kCFAllocatorDefault, socket, 0);
-    CFRunLoopRef loop = CFRunLoopGetCurrent();
-    CFRunLoopAddSource(loop, source, kCFRunLoopDefaultMode);
-    CFRelease(source);
+    [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+        SDLLogD(@"Attemping to connect");
+        
+        int sock_fd = call_socket([self.hostName UTF8String], [self.portNumber UTF8String]);
+        if (sock_fd < 0) {
+            SDLLogE(@"Server not ready, connection failed");
+            return;
+        }
+        
+        CFSocketContext socketCtxt = {0, (__bridge void *)(self), NULL, NULL, NULL};
+        socket = CFSocketCreateWithNative(kCFAllocatorDefault, sock_fd, kCFSocketDataCallBack | kCFSocketConnectCallBack, (CFSocketCallBack)&TCPCallback, &socketCtxt);
+        CFRunLoopSourceRef source = CFSocketCreateRunLoopSource(kCFAllocatorDefault, socket, 0);
+        CFRunLoopRef loop = CFRunLoopGetCurrent();
+        CFRunLoopAddSource(loop, source, kCFRunLoopDefaultMode);
+        CFRelease(source);
+    }];
 }
 
 - (void)sendData:(NSData *)msgBytes {


### PR DESCRIPTION

Fixes #760

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
Changes should be covered under any current TCP connection unit tests. Changes have been tested against Manticore and emulated SDL core instances.

### Summary
The TCP transport's connect function is now processed on its own operation queue.

