### PR TITLE
Force `stop` to run on the main thread

### DIFF
--- a/SmartDeviceLink/SDLIAPSession.m
+++ b/SmartDeviceLink/SDLIAPSession.m
@@ -81,8 +81,16 @@ NSTimeInterval const StreamThreadWaitSecs = 1.0;
 
 - (void)stop {
     // This method must be called on the main thread
-    NSAssert([NSThread isMainThread], @"stop must be called on the main thread");
-    
+    if ([NSThread isMainThread]) {
+        [self sdl_stop];
+    } else {
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            [self sdl_stop];
+        });
+    }
+}
+
+- (void)sdl_stop {
     if (self.isDataSession) {
         [self.ioStreamThread cancel];
 


### PR DESCRIPTION
Fixes #831 
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
n/a

### Changelog
##### Bug Fixes
* Forces stopping the IAP session to run on the main thread

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
