### PR TITLE
Fixed car window not streaming video on reconnects

### DIFF
--- a/SmartDeviceLink/SDLLockScreenPresenter.m
+++ b/SmartDeviceLink/SDLLockScreenPresenter.m
@@ -95,6 +95,7 @@ NS_ASSUME_NONNULL_BEGIN
             return;
         } else if (appWindow.isKeyWindow) {
             SDLLogW(@"Attempted to dismiss lock screen, but it is already dismissed");
+            return;
         }
 
         // Let us know we are about to dismiss.


### PR DESCRIPTION
Fixes #843 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
None written

### Summary
Sometimes video is not streamed on reconnects due to a `SDLLockScreenManagerWillDismissLockScreenViewController` notification being sent erroneously on disconnects.

### Changelog
##### Bug Fixes
* Video now streams on reconnects.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)