### PR TITLE
Fix application state should not be called off of main thread

### DIFF
--- a/SmartDeviceLink/SDLProxy.m
+++ b/SmartDeviceLink/SDLProxy.m
@@ -119,6 +119,12 @@ static float DefaultConnectionTimeout = 45.0;
 #pragma mark - Application Lifecycle
 
 - (void)sendMobileHMIState {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self sdl_sendMobileHMIState];
+    });
+}
+
+- (void)sdl_sendMobileHMIState {
     UIApplicationState appState = [UIApplication sharedApplication].applicationState;
     SDLOnHMIStatus *HMIStatusRPC = [[SDLOnHMIStatus alloc] init];
 
@@ -133,8 +139,7 @@ static float DefaultConnectionTimeout = 45.0;
         case UIApplicationStateInactive: {
             HMIStatusRPC.hmiLevel = SDLHMILevelBackground;
         } break;
-        default:
-            break;
+        default: break;
     }
 
     SDLLogD(@"Mobile UIApplication state changed, sending to remote system: %@", HMIStatusRPC.hmiLevel);


### PR DESCRIPTION
Fixes #852 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
n/a

### Summary
Fix application state should not be called off of main thread

### Changelog
##### Bug Fixes
* Fix application state should not be called off of main thread. This fixes a runtime error checker error.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
