### PR TITLE
Add `additionalHMITypes` to SDLLifecycleConfiguration

### DIFF
--- a/SmartDeviceLink/SDLConfiguration.m
+++ b/SmartDeviceLink/SDLConfiguration.m
@@ -63,11 +63,11 @@ NS_ASSUME_NONNULL_BEGIN
 
     if (_streamingMediaConfig != nil) {
         // If we have a streaming config, the apptype MUST be navigation or projection
-        NSAssert(([_lifecycleConfig.appType isEqualToEnum:SDLAppHMITypeNavigation] || [_lifecycleConfig.appType isEqualToEnum:SDLAppHMITypeProjection]), @"You should only set a streaming media configuration if your app is a NAVIGATION or PROJECTION HMI type");
+        NSAssert(([_lifecycleConfig.appType isEqualToEnum:SDLAppHMITypeNavigation] || [_lifecycleConfig.appType isEqualToEnum:SDLAppHMITypeProjection] || [_lifecycleConfig.additionalAppTypes containsObject:SDLAppHMITypeNavigation] || [_lifecycleConfig.additionalAppTypes containsObject:SDLAppHMITypeProjection]), @"You should only set a streaming media configuration if your app is a NAVIGATION or PROJECTION HMI type");
         _streamingMediaConfig = streamingMediaConfig;
     } else {
         // If we don't have a streaming config, we MUST NOT be navigation or projection
-        NSAssert(!([_lifecycleConfig.appType isEqualToEnum:SDLAppHMITypeNavigation] || [_lifecycleConfig.appType isEqualToEnum:SDLAppHMITypeProjection]), @"If your app is a NAVIGATION or PROJECTION HMI type, you must set a streaming media configuration on SDLConfiguration");
+        NSAssert(!([_lifecycleConfig.appType isEqualToEnum:SDLAppHMITypeNavigation] || [_lifecycleConfig.appType isEqualToEnum:SDLAppHMITypeProjection] || [_lifecycleConfig.additionalAppTypes containsObject:SDLAppHMITypeNavigation] || [_lifecycleConfig.additionalAppTypes containsObject:SDLAppHMITypeProjection]), @"If your app is a NAVIGATION or PROJECTION HMI type, you must set a streaming media configuration on SDLConfiguration");
     }
 
     return self;

--- a/SmartDeviceLink/SDLLifecycleConfiguration.h
+++ b/SmartDeviceLink/SDLLifecycleConfiguration.h
@@ -87,6 +87,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic, null_resettable) SDLAppHMIType appType;
 
 /**
+ Additional applicatiion types beyond `appType`
+ */
+@property (copy, nonatomic, nullable) NSArray<SDLAppHMIType> *additionalAppTypes;
+
+/**
  *  The default language to use
  */
 @property (strong, nonatomic) SDLLanguage language;

--- a/SmartDeviceLink/SDLLifecycleConfiguration.h
+++ b/SmartDeviceLink/SDLLifecycleConfiguration.h
@@ -87,7 +87,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic, null_resettable) SDLAppHMIType appType;
 
 /**
- Additional applicatiion types beyond `appType`
+ Additional application types beyond `appType`
  */
 @property (copy, nonatomic, nullable) NSArray<SDLAppHMIType> *additionalAppTypes;
 

--- a/SmartDeviceLink/SDLLifecycleConfiguration.m
+++ b/SmartDeviceLink/SDLLifecycleConfiguration.m
@@ -69,7 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark Computed Properties
 
 - (BOOL)isMedia {
-    if ([self.appType isEqualToEnum:SDLAppHMITypeMedia]) {
+    if ([self.appType isEqualToEnum:SDLAppHMITypeMedia] || [self.additionalAppTypes containsObject:SDLAppHMITypeMedia]) {
         return YES;
     }
 

--- a/SmartDeviceLink/SDLLifecycleConfiguration.m
+++ b/SmartDeviceLink/SDLLifecycleConfiguration.m
@@ -102,6 +102,7 @@ NS_ASSUME_NONNULL_BEGIN
     newConfig->_tcpDebugIPAddress = _tcpDebugIPAddress;
     newConfig->_tcpDebugPort = _tcpDebugPort;
     newConfig->_appType = _appType;
+    newConfig->_additionalAppTypes = _additionalAppTypes;
     newConfig->_language = _language;
     newConfig->_languagesSupported = _languagesSupported;
     newConfig->_appIcon = _appIcon;

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -110,8 +110,10 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
     _permissionManager = [[SDLPermissionManager alloc] init];
     _lockScreenManager = [[SDLLockScreenManager alloc] initWithConfiguration:_configuration.lockScreenConfig notificationDispatcher:_notificationDispatcher presenter:[[SDLLockScreenPresenter alloc] init]];
     
-    if ([configuration.lifecycleConfig.appType isEqualToEnum:SDLAppHMITypeNavigation]
-        || [configuration.lifecycleConfig.appType isEqualToEnum:SDLAppHMITypeProjection]) {
+    if ([configuration.lifecycleConfig.appType isEqualToEnum:SDLAppHMITypeNavigation] ||
+        [configuration.lifecycleConfig.appType isEqualToEnum:SDLAppHMITypeProjection] ||
+        [configuration.lifecycleConfig.additionalAppTypes containsObject:SDLAppHMITypeNavigation] ||
+        [configuration.lifecycleConfig.additionalAppTypes containsObject:SDLAppHMITypeProjection]) {
         _streamManager = [[SDLStreamingMediaManager alloc] initWithConnectionManager:self configuration:configuration.streamingMediaConfig];
     } else {
         SDLLogV(@"Skipping StreamingMediaManager setup due to app type");

--- a/SmartDeviceLink/SDLRegisterAppInterface.h
+++ b/SmartDeviceLink/SDLRegisterAppInterface.h
@@ -92,9 +92,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithAppName:(NSString *)appName appId:(NSString *)appId languageDesired:(SDLLanguage)languageDesired;
 
-- (instancetype)initWithAppName:(NSString *)appName appId:(NSString *)appId languageDesired:(SDLLanguage)languageDesired isMediaApp:(BOOL)isMediaApp appType:(SDLAppHMIType)appType shortAppName:(nullable NSString *)shortAppName;
+- (instancetype)initWithAppName:(NSString *)appName appId:(NSString *)appId languageDesired:(SDLLanguage)languageDesired isMediaApp:(BOOL)isMediaApp appType:(SDLAppHMIType)appType shortAppName:(nullable NSString *)shortAppName __deprecated_msg(("use initWithAppName:appId:languageDesired:isMediaApp:appTypes:shortAppName:"));
 
-- (instancetype)initWithAppName:(NSString *)appName appId:(NSString *)appId languageDesired:(SDLLanguage)languageDesired isMediaApp:(BOOL)isMediaApp appType:(SDLAppHMIType)appType shortAppName:(nullable NSString *)shortAppName ttsName:(nullable NSArray<SDLTTSChunk *> *)ttsName vrSynonyms:(nullable NSArray<NSString *> *)vrSynonyms hmiDisplayLanguageDesired:(SDLLanguage)hmiDisplayLanguageDesired resumeHash:(nullable NSString *)resumeHash;
+- (instancetype)initWithAppName:(NSString *)appName appId:(NSString *)appId languageDesired:(SDLLanguage)languageDesired isMediaApp:(BOOL)isMediaApp appTypes:(NSArray<SDLAppHMIType> *)appTypes shortAppName:(nullable NSString *)shortAppName;
+
+- (instancetype)initWithAppName:(NSString *)appName appId:(NSString *)appId languageDesired:(SDLLanguage)languageDesired isMediaApp:(BOOL)isMediaApp appType:(SDLAppHMIType)appType shortAppName:(nullable NSString *)shortAppName ttsName:(nullable NSArray<SDLTTSChunk *> *)ttsName vrSynonyms:(nullable NSArray<NSString *> *)vrSynonyms hmiDisplayLanguageDesired:(SDLLanguage)hmiDisplayLanguageDesired resumeHash:(nullable NSString *)resumeHash __deprecated_msg(("use initWithAppName:appId:languageDesired:isMediaApp:appTypes:shortAppName:ttsName:vrSynonyms:hmiDisplayLanguageDesired:resumeHash:"));
+
+- (instancetype)initWithAppName:(NSString *)appName appId:(NSString *)appId languageDesired:(SDLLanguage)languageDesired isMediaApp:(BOOL)isMediaApp appTypes:(NSArray<SDLAppHMIType> *)appTypes shortAppName:(nullable NSString *)shortAppName ttsName:(nullable NSArray<SDLTTSChunk *> *)ttsName vrSynonyms:(nullable NSArray<NSString *> *)vrSynonyms hmiDisplayLanguageDesired:(SDLLanguage)hmiDisplayLanguageDesired resumeHash:(nullable NSString *)resumeHash;
 
 /**
  * @abstract The version of the SDL interface

--- a/SmartDeviceLink/SDLRegisterAppInterface.m
+++ b/SmartDeviceLink/SDLRegisterAppInterface.m
@@ -25,7 +25,18 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (instancetype)initWithLifecycleConfiguration:(SDLLifecycleConfiguration *)lifecycleConfiguration {
-    return [self initWithAppName:lifecycleConfiguration.appName appId:lifecycleConfiguration.appId languageDesired:lifecycleConfiguration.language isMediaApp:lifecycleConfiguration.isMedia appType:lifecycleConfiguration.appType shortAppName:lifecycleConfiguration.shortAppName ttsName:lifecycleConfiguration.ttsName vrSynonyms:lifecycleConfiguration.voiceRecognitionCommandNames hmiDisplayLanguageDesired:lifecycleConfiguration.language resumeHash:lifecycleConfiguration.resumeHash];
+    NSArray<SDLAppHMIType> *allHMITypes = [lifecycleConfiguration.additionalAppTypes arrayByAddingObject:lifecycleConfiguration.appType];
+
+    return [self initWithAppName:lifecycleConfiguration.appName
+                           appId:lifecycleConfiguration.appId
+                 languageDesired:lifecycleConfiguration.language
+                      isMediaApp:lifecycleConfiguration.isMedia
+                        appTypes:allHMITypes
+                    shortAppName:lifecycleConfiguration.shortAppName
+                         ttsName:lifecycleConfiguration.ttsName
+                      vrSynonyms:lifecycleConfiguration.voiceRecognitionCommandNames
+       hmiDisplayLanguageDesired:lifecycleConfiguration.language
+                      resumeHash:lifecycleConfiguration.resumeHash];
 }
 
 - (instancetype)initWithAppName:(NSString *)appName appId:(NSString *)appId languageDesired:(SDLLanguage)languageDesired {
@@ -44,28 +55,31 @@ NS_ASSUME_NONNULL_BEGIN
     self.correlationID = @1;
     
     return self;
-    
 }
 
 - (instancetype)initWithAppName:(NSString *)appName appId:(NSString *)appId languageDesired:(SDLLanguage)languageDesired isMediaApp:(BOOL)isMediaApp appType:(SDLAppHMIType)appType shortAppName:(nullable NSString *)shortAppName {
+    return [self initWithAppName:appName appId:appId languageDesired:languageDesired isMediaApp:isMediaApp appTypes:@[appType] shortAppName:shortAppName];
+}
+
+- (instancetype)initWithAppName:(NSString *)appName appId:(NSString *)appId languageDesired:(SDLLanguage)languageDesired isMediaApp:(BOOL)isMediaApp appTypes:(NSArray<SDLAppHMIType> *)appTypes shortAppName:(nullable NSString *)shortAppName {
     self = [self initWithAppName:appName appId:appId languageDesired:languageDesired];
     if (!self) {
         return nil;
     }
-    
-    self.isMediaApplication = @(isMediaApp);
 
-    if (appType != nil) {
-        self.appHMIType = [NSArray arrayWithObject:appType];
-    }
-    
+    self.isMediaApplication = @(isMediaApp);
+    self.appHMIType = appTypes;
     self.ngnMediaScreenAppName = shortAppName;
-    
+
     return self;
 }
 
 - (instancetype)initWithAppName:(NSString *)appName appId:(NSString *)appId languageDesired:(SDLLanguage)languageDesired isMediaApp:(BOOL)isMediaApp appType:(SDLAppHMIType)appType shortAppName:(nullable NSString *)shortAppName ttsName:(nullable NSArray<SDLTTSChunk *> *)ttsName vrSynonyms:(nullable NSArray<NSString *> *)vrSynonyms hmiDisplayLanguageDesired:(SDLLanguage)hmiDisplayLanguageDesired resumeHash:(nullable NSString *)resumeHash {
-    self = [self initWithAppName:appName appId:appId languageDesired:languageDesired isMediaApp:isMediaApp appType:appType shortAppName:shortAppName];
+    return [self initWithAppName:appName appId:appId languageDesired:languageDesired isMediaApp:isMediaApp appTypes:@[appType] shortAppName:shortAppName ttsName:ttsName vrSynonyms:vrSynonyms hmiDisplayLanguageDesired:hmiDisplayLanguageDesired resumeHash:resumeHash];
+}
+
+- (instancetype)initWithAppName:(NSString *)appName appId:(NSString *)appId languageDesired:(SDLLanguage)languageDesired isMediaApp:(BOOL)isMediaApp appTypes:(NSArray<SDLAppHMIType> *)appTypes shortAppName:(nullable NSString *)shortAppName ttsName:(nullable NSArray<SDLTTSChunk *> *)ttsName vrSynonyms:(nullable NSArray<NSString *> *)vrSynonyms hmiDisplayLanguageDesired:(SDLLanguage)hmiDisplayLanguageDesired resumeHash:(nullable NSString *)resumeHash {
+    self = [self initWithAppName:appName appId:appId languageDesired:languageDesired isMediaApp:isMediaApp appTypes:appTypes shortAppName:shortAppName];
     if (!self) {
         return nil;
     }

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleConfigurationSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleConfigurationSpec.m
@@ -30,6 +30,7 @@ describe(@"a lifecycle configuration", ^{
             expect(testConfig.tcpDebugIPAddress).to(match(@"192.168.0.1"));
             expect(@(testConfig.tcpDebugPort)).to(equal(@12345));
             expect(@([testConfig.appType isEqualToEnum:SDLAppHMITypeDefault])).to(equal(@YES));
+            expect(testConfig.additionalAppTypes).to(beNil());
             expect(@(testConfig.isMedia)).to(beFalsy());
             expect(@([testConfig.language isEqualToEnum:SDLLanguageEnUs])).to(equal(@YES));
             expect(@([[testConfig.languagesSupported firstObject] isEqualToEnum:SDLLanguageEnUs])).to(equal(@YES));
@@ -57,6 +58,7 @@ describe(@"a lifecycle configuration", ^{
                 someResumeHashString = @"testing";
                 
                 testConfig.appType = SDLAppHMITypeMedia;
+                testConfig.additionalAppTypes = @[SDLAppHMITypeProjection];
                 testConfig.language = SDLLanguageArSa;
                 testConfig.languagesSupported = @[SDLLanguageArSa, SDLLanguageEnAu, SDLLanguageEnUs];
                 testConfig.shortAppName = someShortAppName;
@@ -72,6 +74,7 @@ describe(@"a lifecycle configuration", ^{
                 expect(testConfig.tcpDebugIPAddress).to(match(@"192.168.0.1"));
                 expect(@(testConfig.tcpDebugPort)).to(equal(@12345));
                 expect(@([testConfig.appType isEqualToEnum:SDLAppHMITypeMedia])).to(equal(@YES));
+                expect(testConfig.additionalAppTypes.firstObject).to(match(SDLAppHMITypeProjection));
                 expect(@(testConfig.isMedia)).to(beTruthy());
                 expect(@([testConfig.language isEqualToEnum:SDLLanguageArSa])).to(equal(@YES));
                 expect(testConfig.languagesSupported).to(haveCount(@3));
@@ -106,6 +109,7 @@ describe(@"a lifecycle configuration", ^{
             expect(testConfig.tcpDebugIPAddress).to(match(someIPAddress));
             expect(@(testConfig.tcpDebugPort)).to(equal(@(somePort)));
             expect(@([testConfig.appType isEqualToEnum:SDLAppHMITypeDefault])).to(equal(@YES));
+            expect(testConfig.additionalAppTypes).to(beNil());
             expect(@([testConfig.language isEqualToEnum:SDLLanguageEnUs])).to(equal(@YES));
             expect(@([[testConfig.languagesSupported firstObject] isEqualToEnum:SDLLanguageEnUs])).to(equal(@YES));
             expect(testConfig.shortAppName).to(beNil());
@@ -146,6 +150,7 @@ describe(@"a lifecycle configuration", ^{
                 expect(testConfig.tcpDebugIPAddress).to(match(someIPAddress));
                 expect(@(testConfig.tcpDebugPort)).to(equal(@(somePort)));
                 expect(@([testConfig.appType isEqualToEnum:SDLAppHMITypeMedia])).to(equal(@YES));
+                expect(testConfig.additionalAppTypes).to(beNil());
                 expect(@(testConfig.isMedia)).to(beTruthy());
                 expect(@([testConfig.language isEqualToEnum:SDLLanguageArSa])).to(equal(@YES));
                 expect(testConfig.languagesSupported).to(haveCount(@3));


### PR DESCRIPTION
Fixes #851 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Unit tests have been added

### Summary
Add `additionalHMITypes` to SDLLifecycleConfiguration

### Changelog
##### Enhancements
* Add `additionalHMITypes` to SDLLifecycleConfiguration, allowing multiple `appTypes` to be set.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
