### PR TITLE
Fix #846

### DIFF
--- a/SmartDeviceLink/SDLAddCommand.h
+++ b/SmartDeviceLink/SDLAddCommand.h
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithId:(UInt32)commandId vrCommands:(nullable NSArray<NSString *> *)vrCommands menuName:(NSString *)menuName handler:(SDLRPCCommandNotificationHandler)handler;
 
-- (instancetype)initWithId:(UInt32)commandId vrCommands:(nullable NSArray<NSString *> *)vrCommands menuName:(NSString *)menuName parentId:(UInt32)parentId position:(UInt16)position iconValue:(NSString *)iconValue iconType:(SDLImageType)iconType handler:(nullable SDLRPCCommandNotificationHandler)handler;
+- (instancetype)initWithId:(UInt32)commandId vrCommands:(nullable NSArray<NSString *> *)vrCommands menuName:(NSString *)menuName parentId:(UInt32)parentId position:(UInt16)position iconValue:(nullable NSString *)iconValue iconType:(nullable SDLImageType)iconType handler:(nullable SDLRPCCommandNotificationHandler)handler;
 
 /**
  *  A handler that will let you know when the button you created is subscribed.

--- a/SmartDeviceLink/SDLAddCommand.h
+++ b/SmartDeviceLink/SDLAddCommand.h
@@ -49,7 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithId:(UInt32)commandId vrCommands:(nullable NSArray<NSString *> *)vrCommands handler:(nullable SDLRPCCommandNotificationHandler)handler;
 
-- (instancetype)initWithId:(UInt32)commandId vrCommands:(nullable NSArray<NSString *> *)vrCommands menuName:(NSString *)menuName handler:(SDLRPCCommandNotificationHandler)handler;
+- (instancetype)initWithId:(UInt32)commandId vrCommands:(nullable NSArray<NSString *> *)vrCommands menuName:(NSString *)menuName handler:(nullable SDLRPCCommandNotificationHandler)handler;
 
 - (instancetype)initWithId:(UInt32)commandId vrCommands:(nullable NSArray<NSString *> *)vrCommands menuName:(NSString *)menuName parentId:(UInt32)parentId position:(UInt16)position iconValue:(nullable NSString *)iconValue iconType:(nullable SDLImageType)iconType handler:(nullable SDLRPCCommandNotificationHandler)handler;
 

--- a/SmartDeviceLink/SDLAddCommand.m
+++ b/SmartDeviceLink/SDLAddCommand.m
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (instancetype)initWithId:(UInt32)commandId vrCommands:(nullable NSArray<NSString *> *)vrCommands menuName:(NSString *)menuName handler:(SDLRPCCommandNotificationHandler)handler {
+- (instancetype)initWithId:(UInt32)commandId vrCommands:(nullable NSArray<NSString *> *)vrCommands menuName:(NSString *)menuName handler:(nullable SDLRPCCommandNotificationHandler)handler {
     self = [self initWithId:commandId vrCommands:vrCommands handler:handler];
     if (!self) {
         return nil;

--- a/SmartDeviceLink/SDLAddCommand.m
+++ b/SmartDeviceLink/SDLAddCommand.m
@@ -54,7 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (instancetype)initWithId:(UInt32)commandId vrCommands:(nullable NSArray<NSString *> *)vrCommands menuName:(NSString *)menuName parentId:(UInt32)parentId position:(UInt16)position iconValue:(NSString *)iconValue iconType:(SDLImageType)iconType handler:(nullable SDLRPCCommandNotificationHandler)handler {
+- (instancetype)initWithId:(UInt32)commandId vrCommands:(nullable NSArray<NSString *> *)vrCommands menuName:(NSString *)menuName parentId:(UInt32)parentId position:(UInt16)position iconValue:(nullable NSString *)iconValue iconType:(nullable SDLImageType)iconType handler:(nullable SDLRPCCommandNotificationHandler)handler {
     self = [self initWithId:commandId vrCommands:vrCommands menuName:menuName handler:handler];
     if (!self) {
         return nil;
@@ -63,7 +63,9 @@ NS_ASSUME_NONNULL_BEGIN
     self.menuParams.parentID = @(parentId);
     self.menuParams.position = @(position);
 
-    self.cmdIcon = [[SDLImage alloc] initWithName:iconValue ofType:iconType];
+    if (iconValue != nil && iconType != nil) {
+        self.cmdIcon = [[SDLImage alloc] initWithName:iconValue ofType:iconType];
+    }
 
     return self;
 }

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLAddCommandSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLAddCommandSpec.m
@@ -15,10 +15,10 @@
 
 QuickSpecBegin(SDLAddCommandSpec)
 
-SDLMenuParams* menu = [[SDLMenuParams alloc] init];
-SDLImage* image = [[SDLImage alloc] init];
-
 describe(@"Getter/Setter Tests", ^ {
+    SDLMenuParams* menu = [[SDLMenuParams alloc] init];
+    SDLImage* image = [[SDLImage alloc] init];
+
     it(@"Should set and get correctly", ^ {
         SDLAddCommand* testRequest = [[SDLAddCommand alloc] init];
         
@@ -57,6 +57,81 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testRequest.menuParams).to(beNil());
         expect(testRequest.vrCommands).to(beNil());
         expect(testRequest.cmdIcon).to(beNil());
+    });
+});
+
+describe(@"initializers", ^{
+    __block SDLAddCommand *testCommand = nil;
+    __block UInt32 commandId = 1234;
+    __block NSArray<NSString *> *vrCommands = @[@"commands"];
+    __block NSString *menuName = @"Menu Name";
+    void (^handler)(SDLOnCommand *) = ^(SDLOnCommand *command) {};
+
+    beforeEach(^{
+        testCommand = nil;
+    });
+
+    context(@"initWithHandler", ^{
+        it(@"should initialize correctly", ^{
+            testCommand = [[SDLAddCommand alloc] initWithHandler:handler];
+
+            expect(testCommand).toNot(beNil());
+            expect(testCommand.vrCommands).to(beNil());
+            expect(testCommand.menuParams).to(beNil());
+            expect(testCommand.cmdIcon).to(beNil());
+        });
+    });
+
+    context(@"initWithId:vrCommands:handler:", ^{
+        it(@"should initialize correctly", ^{
+            testCommand = [[SDLAddCommand alloc] initWithId:commandId vrCommands:vrCommands handler:nil];
+
+            expect(testCommand.cmdID).to(equal(commandId));
+            expect(testCommand.vrCommands).to(equal(vrCommands));
+            expect(testCommand.menuParams).to(beNil());
+            expect(testCommand.cmdIcon).to(beNil());
+        });
+    });
+
+    context(@"initWithId:vrCommands:menuName:handler:", ^{
+        it(@"should initialize correctly", ^{
+            testCommand = [[SDLAddCommand alloc] initWithId:commandId vrCommands:vrCommands menuName:menuName handler:nil];
+
+            expect(testCommand.cmdID).to(equal(commandId));
+            expect(testCommand.vrCommands).to(equal(vrCommands));
+            expect(testCommand.menuParams).toNot(beNil());
+            expect(testCommand.cmdIcon).to(beNil());
+        });
+    });
+
+    context(@"initWithId:vrCommands:menuName:parentId:position:iconValue:iconType:handler:", ^{
+        __block UInt32 parentId = 1234;
+        __block UInt16 position = 2;
+
+        it(@"should initialize with an image", ^{
+            NSString *iconValue = @"Icon";
+            SDLImageType imageType = SDLImageTypeDynamic;
+
+            testCommand = [[SDLAddCommand alloc] initWithId:commandId vrCommands:vrCommands menuName:menuName parentId:parentId position:position iconValue:iconValue iconType:imageType handler:nil];
+
+            expect(testCommand.cmdID).to(equal(commandId));
+            expect(testCommand.vrCommands).to(equal(vrCommands));
+            expect(testCommand.menuParams.menuName).toNot(beNil());
+            expect(testCommand.menuParams.parentID).to(equal(parentId));
+            expect(testCommand.menuParams.position).to(equal(position));
+            expect(testCommand.cmdIcon).toNot(beNil());
+        });
+
+        it(@"should initialize without an image", ^{
+            testCommand = [[SDLAddCommand alloc] initWithId:commandId vrCommands:vrCommands menuName:menuName parentId:parentId position:position iconValue:nil iconType:nil handler:nil];
+
+            expect(testCommand.cmdID).to(equal(commandId));
+            expect(testCommand.vrCommands).to(equal(vrCommands));
+            expect(testCommand.menuParams.menuName).toNot(beNil());
+            expect(testCommand.menuParams.parentID).to(equal(parentId));
+            expect(testCommand.menuParams.position).to(equal(position));
+            expect(testCommand.cmdIcon).to(beNil());
+        });
     });
 });
 


### PR DESCRIPTION
Fixes #846 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes. Note that although this technically changes an API (normally a major version change), because it is merely opening up the API for a broader range of inputs, it is a minor version change and will not affect any current integrators.

### Testing Plan
Unit tests will be added

### Summary
Allow AddCommand initializer to create a command with a parent but no icon.

### Changelog
##### Enhancements
* Updates `SDLAddCommand initWithId:vrCommands:menuName:parentId:position:iconValue:iconType:iconTypehandler:` to take a nullable `iconValue` and `iconType` instead of nonnull. This will not create an Image to be sent.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
