### PR TITLE
finish operation when error occurred in SDLUploadFileOperation

### DIFF
--- a/SmartDeviceLink/SDLUploadFileOperation.m
+++ b/SmartDeviceLink/SDLUploadFileOperation.m
@@ -70,10 +70,12 @@ NS_ASSUME_NONNULL_BEGIN
     __block NSInteger highestCorrelationIDReceived = -1;
 
     if (self.isCancelled) {
+        [self finishOperation];
         return completion(NO, bytesAvailable, [NSError sdl_fileManager_fileUploadCanceled]);
     }
 
     if (file == nil) {
+        [self finishOperation];
         return completion(NO, bytesAvailable, [NSError sdl_fileManager_fileDoesNotExistError]);
     }
 
@@ -81,6 +83,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (self.inputStream == nil || ![self.inputStream hasBytesAvailable]) {
         // If the file does not exist or the passed data is nil, return an error
         [self sdl_closeInputStream];
+        [self finishOperation];
         return completion(NO, bytesAvailable, [NSError sdl_fileManager_fileDoesNotExistError]);
     }
 


### PR DESCRIPTION
Fixes #860 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Finish operation when error occurred in SDLUploadFileOperation to make succeeding operations executable.

### Changelog
##### Bug Fixes
* Fix to finish operation when error occurred in SDLUploadFileOperation.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
