### PR TITLE
Notify audio streaming state when SDL mangaer become Ready

### DIFF
--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -331,6 +331,11 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
 
     // Send the hmi level going from NONE to whatever we're at now (could still be NONE)
     [self.delegate hmiLevel:SDLHMILevelNone didChangeToLevel:self.hmiLevel];
+
+    // Send the audio streaming state going from NOT_AUDIBLE to whatever we're at now (could still be NOT_AUDIBLE)
+    if ([self.delegate respondsToSelector:@selector(audioStreamingState:didChangeToState:)]) {
+        [self.delegate audioStreamingState:SDLAudioStreamingStateNotAudible didChangeToState:self.audioStreamingState];
+    }
 }
 
 - (void)didEnterStateUnregistering {
@@ -485,6 +490,7 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
     self.systemContext = hmiStatusNotification.systemContext;
 
     SDLLogD(@"HMI level changed from %@ to %@", oldHMILevel, self.hmiLevel);
+    SDLLogD(@"Audio streaming state changed from %@ to %@", oldStreamingState, self.audioStreamingState);
 
 	if ([self.lifecycleStateMachine isCurrentState:SDLLifecycleStateSettingUpHMI]) {
         [self.lifecycleStateMachine transitionToState:SDLLifecycleStateReady];


### PR DESCRIPTION
Fixes #863 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Notify current audio streaming state to SDLManagerDelegate same as HMI level.

### Changelog

##### Bug Fixes
* [Bug Fix Info]
Notify current audio streaming state to SDLManagerDelegate same as HMI level.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
