### PR TITLE
Add a configuration setting to allow multiple orientations

### DIFF
--- a/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
+++ b/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
@@ -925,11 +925,9 @@
 		5DA102A51D4122C700C15826 /* NSMutableDictionary+SafeRemove.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DA102A31D4122C700C15826 /* NSMutableDictionary+SafeRemove.m */; };
 		5DA22CB71D075CF200245F5F /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5DA22CB31D075CF200245F5F /* Nimble.framework */; };
 		5DA22CB81D075CF200245F5F /* OCMock.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5DA22CB41D075CF200245F5F /* OCMock.framework */; };
-		5DA22CB91D075CF200245F5F /* OHHTTPStubs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5DA22CB51D075CF200245F5F /* OHHTTPStubs.framework */; };
 		5DA22CBA1D075CF200245F5F /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5DA22CB61D075CF200245F5F /* Quick.framework */; };
 		5DA22CBB1D075DE800245F5F /* Nimble.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5DA22CB31D075CF200245F5F /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5DA22CBC1D075DE800245F5F /* OCMock.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5DA22CB41D075CF200245F5F /* OCMock.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		5DA22CBD1D075DE800245F5F /* OHHTTPStubs.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5DA22CB51D075CF200245F5F /* OHHTTPStubs.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5DA22CBE1D075DE800245F5F /* Quick.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5DA22CB61D075CF200245F5F /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5DA22CBF1D075DEC00245F5F /* SmartDeviceLink.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5D61FA1C1A84237100846EE7 /* SmartDeviceLink.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5DA23FF01F2FA0FF009C0313 /* SDLControlFramePayloadEndServiceSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DA23FEF1F2FA0FF009C0313 /* SDLControlFramePayloadEndServiceSpec.m */; };
@@ -1203,7 +1201,6 @@
 				5DA22CBF1D075DEC00245F5F /* SmartDeviceLink.framework in CopyFiles */,
 				5DA22CBB1D075DE800245F5F /* Nimble.framework in CopyFiles */,
 				5DA22CBC1D075DE800245F5F /* OCMock.framework in CopyFiles */,
-				5DA22CBD1D075DE800245F5F /* OHHTTPStubs.framework in CopyFiles */,
 				5DA22CBE1D075DE800245F5F /* Quick.framework in CopyFiles */,
 				5D5DBF091D48E3AC00D4F914 /* FBSnapshotTestCase.framework in CopyFiles */,
 			);
@@ -2417,7 +2414,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				167ED93C1A9BCB8A00797BE5 /* SmartDeviceLink.framework in Frameworks */,
-				5DA22CB91D075CF200245F5F /* OHHTTPStubs.framework in Frameworks */,
 				5DA22CB81D075CF200245F5F /* OCMock.framework in Frameworks */,
 				5DA22CBA1D075CF200245F5F /* Quick.framework in Frameworks */,
 				5D5DBF081D48E39C00D4F914 /* FBSnapshotTestCase.framework in Frameworks */,

--- a/SmartDeviceLink/SDLCarWindow.m
+++ b/SmartDeviceLink/SDLCarWindow.m
@@ -145,9 +145,9 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     if (!self.allowMultipleOrientations
-        && (rootViewController.supportedInterfaceOrientations == UIInterfaceOrientationMaskPortrait ||
-            rootViewController.supportedInterfaceOrientations == UIInterfaceOrientationMaskLandscapeLeft ||
-            rootViewController.supportedInterfaceOrientations == UIInterfaceOrientationMaskLandscapeRight)) {
+        && !(rootViewController.supportedInterfaceOrientations == UIInterfaceOrientationMaskPortrait ||
+             rootViewController.supportedInterfaceOrientations == UIInterfaceOrientationMaskLandscapeLeft ||
+             rootViewController.supportedInterfaceOrientations == UIInterfaceOrientationMaskLandscapeRight)) {
         @throw [NSException sdl_carWindowOrientationException];
     }
 

--- a/SmartDeviceLink/SDLCarWindow.m
+++ b/SmartDeviceLink/SDLCarWindow.m
@@ -16,6 +16,7 @@
 #import "SDLImageResolution.h"
 #import "SDLLogMacros.h"
 #import "SDLNotificationConstants.h"
+#import "SDLError.h"
 #import "SDLStateMachine.h"
 #import "SDLStreamingMediaConfiguration.h"
 #import "SDLStreamingMediaLifecycleManager.h"
@@ -29,6 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (assign, nonatomic) SDLCarWindowRenderingType renderingType;
 @property (assign, nonatomic) BOOL drawsAfterScreenUpdates;
+@property (assign, nonatomic) BOOL allowMultipleOrientations;
 
 @property (assign, nonatomic, getter=isLockScreenPresenting) BOOL lockScreenPresenting;
 @property (assign, nonatomic, getter=isLockScreenDismissing) BOOL lockScreenBeingDismissed;
@@ -45,6 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     _streamManager = streamManager;
     _renderingType = configuration.carWindowRenderingType;
+    _allowMultipleOrientations = configuration.allowMultipleViewControllerOrientations;
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_didReceiveVideoStreamStarted:) name:SDLVideoStreamDidStartNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_didReceiveVideoStreamStopped:) name:SDLVideoStreamDidStopNotification object:nil];
@@ -141,9 +144,12 @@ NS_ASSUME_NONNULL_BEGIN
         return;
     }
 
-    NSAssert((rootViewController.supportedInterfaceOrientations == UIInterfaceOrientationMaskPortrait ||
-              rootViewController.supportedInterfaceOrientations == UIInterfaceOrientationMaskLandscapeLeft ||
-              rootViewController.supportedInterfaceOrientations == UIInterfaceOrientationMaskLandscapeRight), @"SDLCarWindow rootViewController must support only a single interface orientation");
+    if (!self.allowMultipleOrientations
+        && (rootViewController.supportedInterfaceOrientations == UIInterfaceOrientationMaskPortrait ||
+            rootViewController.supportedInterfaceOrientations == UIInterfaceOrientationMaskLandscapeLeft ||
+            rootViewController.supportedInterfaceOrientations == UIInterfaceOrientationMaskLandscapeRight)) {
+        @throw [NSException sdl_carWindowOrientationException];
+    }
 
     if (self.streamManager.screenSize.width != 0) {
         rootViewController.view.frame = CGRectMake(0, 0, self.streamManager.screenSize.width, self.streamManager.screenSize.height);

--- a/SmartDeviceLink/SDLError.h
+++ b/SmartDeviceLink/SDLError.h
@@ -51,6 +51,7 @@ extern SDLErrorDomain *const SDLErrorDomainFileManager;
 + (NSException *)sdl_missingHandlerException;
 + (NSException *)sdl_missingIdException;
 + (NSException *)sdl_missingFilesException;
++ (NSException *)sdl_carWindowOrientationException;
 
 @end
 

--- a/SmartDeviceLink/SDLError.m
+++ b/SmartDeviceLink/SDLError.m
@@ -195,6 +195,12 @@ SDLErrorDomain *const SDLErrorDomainFileManager = @"com.sdl.filemanager.error";
             userInfo:nil];
 }
 
++ (NSException *)sdl_carWindowOrientationException {
+    return [NSException exceptionWithName:@"com.sdl.carwindow.orientationException"
+                                   reason:@"SDLCarWindow rootViewController must support only a single interface orientation"
+                                 userInfo:nil];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLStreamingMediaConfiguration.h
+++ b/SmartDeviceLink/SDLStreamingMediaConfiguration.h
@@ -85,6 +85,11 @@ typedef NS_ENUM(NSUInteger, SDLCarWindowRenderingType) {
 @property (assign, nonatomic) BOOL enableForcedFramerateSync;
 
 /**
+ When YES, the StreamingMediaManager will disable its internal checks that the `rootViewController` only has one `supportedOrientation`. Having multiple orientations can cause streaming issues. If you wish to disable this check, set it to YES. Defaults to NO.
+ */
+@property (assign, nonatomic) BOOL allowMultipleViewControllerOrientations;
+
+/**
  Create an insecure video streaming configuration. No security managers will be provided and the encryption flag will be set to None. If you'd like custom video encoder settings, you can set the property manually.
 
  @return The configuration

--- a/SmartDeviceLink/SDLStreamingMediaConfiguration.m
+++ b/SmartDeviceLink/SDLStreamingMediaConfiguration.m
@@ -40,6 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
     _rootViewController = rootViewController;
     _carWindowRenderingType = SDLCarWindowRenderingTypeLayer;
     _enableForcedFramerateSync = YES;
+    _allowMultipleViewControllerOrientations = NO;
 
     return self;
 }
@@ -77,6 +78,8 @@ NS_ASSUME_NONNULL_BEGIN
     SDLStreamingMediaConfiguration *newConfig = [[self.class allocWithZone:zone] initWithSecurityManagers:_securityManagers encryptionFlag:_maximumDesiredEncryption videoSettings:_customVideoEncoderSettings dataSource:_dataSource rootViewController:_rootViewController];
 
     newConfig.carWindowRenderingType = self.carWindowRenderingType;
+    newConfig.enableForcedFramerateSync = self.enableForcedFramerateSync;
+    newConfig.allowMultipleViewControllerOrientations = self.allowMultipleViewControllerOrientations;
     
     return newConfig;
 }

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingMediaConfigurationSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingMediaConfigurationSpec.m
@@ -35,6 +35,7 @@ describe(@"a streaming media configuration", ^{
             expect(testConfig.securityManagers).to(contain(testFakeSecurityManager.class));
             expect(@(testConfig.maximumDesiredEncryption)).to(equal(@(SDLStreamingEncryptionFlagAuthenticateAndEncrypt)));
             expect(testConfig.customVideoEncoderSettings).to(equal(testVideoEncoderSettings));
+            expect(testConfig.allowMultipleViewControllerOrientations).to(equal(NO));
             expect(testConfig.dataSource).to(equal(testDataSource));
             expect(testConfig.rootViewController).to(equal(testViewController));
         });
@@ -49,6 +50,7 @@ describe(@"a streaming media configuration", ^{
             expect(testConfig.securityManagers).to(beNil());
             expect(@(testConfig.maximumDesiredEncryption)).to(equal(@(SDLStreamingEncryptionFlagNone)));
             expect(testConfig.customVideoEncoderSettings).to(beNil());
+            expect(testConfig.allowMultipleViewControllerOrientations).to(equal(NO));
             expect(testConfig.dataSource).to(beNil());
             expect(testConfig.rootViewController).to(beNil());
         });
@@ -67,6 +69,7 @@ describe(@"a streaming media configuration", ^{
             expect(testConfig.securityManagers).to(contain(testFakeSecurityManager.class));
             expect(@(testConfig.maximumDesiredEncryption)).to(equal(@(SDLStreamingEncryptionFlagAuthenticateAndEncrypt)));
             expect(testConfig.customVideoEncoderSettings).to(beNil());
+            expect(testConfig.allowMultipleViewControllerOrientations).to(equal(NO));
             expect(testConfig.dataSource).to(beNil());
             expect(testConfig.rootViewController).to(beNil());
         });


### PR DESCRIPTION
Fixes #867 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Tests will be added

### Summary
This adds a configuration option to prevent an exception occurring when a rootVC is set allowing multiple orientations.

### Changelog
##### Bug Fixes
* Allow preventing an exception with a CarWindow rootViewController with multiple orientations.

### Tasks Remaining:
- [x] Unit tests

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
