### PR TITLE
Close EA session before reconnect

### DIFF
--- a/SmartDeviceLink/SDLProxy.m
+++ b/SmartDeviceLink/SDLProxy.m
@@ -209,6 +209,7 @@ static float DefaultConnectionTimeout = 45.0;
         __weak typeof(self) weakSelf = self;
         self.startSessionTimer.elapsedBlock = ^{
             SDLLogW(@"Start session timed out");
+            [weakSelf.transport disconnect];
             [weakSelf performSelector:@selector(notifyProxyClosed) withObject:nil afterDelay:NotifyProxyClosedDelay];
         };
     }

--- a/SmartDeviceLink/SDLProxy.m
+++ b/SmartDeviceLink/SDLProxy.m
@@ -100,6 +100,10 @@ static float DefaultConnectionTimeout = 45.0;
     if (self.protocol.securityManager != nil) {
         [self.protocol.securityManager stop];
     }
+
+    if (self.transport != nil) {
+        [self.transport disconnect];
+    }
     
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     [[EAAccessoryManager sharedAccessoryManager] unregisterForLocalNotifications];
@@ -209,7 +213,6 @@ static float DefaultConnectionTimeout = 45.0;
         __weak typeof(self) weakSelf = self;
         self.startSessionTimer.elapsedBlock = ^{
             SDLLogW(@"Start session timed out");
-            [weakSelf.transport disconnect];
             [weakSelf performSelector:@selector(notifyProxyClosed) withObject:nil afterDelay:NotifyProxyClosedDelay];
         };
     }


### PR DESCRIPTION
Fixes #869 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Close EA session before reconnect when start session for RPC service occurred.

### Changelog
##### Bug Fixes
* Close EA session before reconnect when start session for RPC service occurred.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
