### PR TITLE
Fix SDLLogTargetFile bug

### DIFF
--- a/SmartDeviceLink/SDLLogTargetFile.m
+++ b/SmartDeviceLink/SDLLogTargetFile.m
@@ -111,9 +111,9 @@ NS_ASSUME_NONNULL_BEGIN
     NSArray<NSString *> *sortedLogFilePaths = [self sdl_sortedLogFilePaths];
 
     // If we have more files now than the max, remove the oldest ones
-    NSUInteger filesToRemove = sortedLogFilePaths.count - maxFiles;
-    for (NSUInteger i = 0; i < filesToRemove; i++) {
-        NSString *path = [[self sdl_logDirectory] stringByAppendingPathComponent:sortedLogFilePaths[i]];
+    NSInteger filesToRemove = (NSInteger)sortedLogFilePaths.count - (NSInteger)maxFiles;
+    for (NSInteger i = 0; i < filesToRemove; i++) {
+        NSString *path = [[self sdl_logDirectory] stringByAppendingPathComponent:sortedLogFilePaths[(NSUInteger)i]];
         [[NSFileManager defaultManager] removeItemAtPath:path error:nil];
     }
 }


### PR DESCRIPTION
Fixes #872 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
n/a

### Summary
When cleaning up log files, allow number of files to remove to run below zero, which means the cleanup won’t run

### Changelog
##### Bug Fixes
* When cleaning up log files, allow number of files to remove to run below zero, which means the cleanup won’t run

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
