### PR TITLE
SDL 0124 Image Upload Manager

### DIFF
--- a/SmartDeviceLink/SDLArtwork.h
+++ b/SmartDeviceLink/SDLArtwork.h
@@ -65,6 +65,17 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (instancetype)initWithImage:(UIImage *)image name:(NSString *)name persistent:(BOOL)persistent asImageFormat:(SDLArtworkImageFormat)imageFormat;
 
+/**
+ * TODO
+
+ *  @param image       The UIImage to be sent to the remote head unit
+ *  @param persistent  Whether or not the artwork should be persistent.
+ *  @param imageFormat Whether the image should be converted to a PNG or JPG before transmission. Images with transparency or few colors should be PNGs. Images with many colors should be JPGs.
+ *
+ *  @return An instance of this class to be passed to the file manager.
+ */
+- (instancetype)initWithImage:(UIImage *)image persistent:(BOOL)persistent asImageFormat:(SDLArtworkImageFormat)imageFormat;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLArtwork.h
+++ b/SmartDeviceLink/SDLArtwork.h
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @return An instance of this class to be passed to the file manager.
  */
-+ (instancetype)artworkWithImage:(UIImage *)image name:(NSString *)name asImageFormat:(SDLArtworkImageFormat)imageFormat NS_SWIFT_UNAVAILABLE("Use the standard initializer and set persistant to false");
++ (instancetype)artworkWithImage:(UIImage *)image name:(NSString *)name asImageFormat:(SDLArtworkImageFormat)imageFormat NS_SWIFT_UNAVAILABLE("Use the standard initializer and set persistant to false") __deprecated_msg("Use initWithImage:image persistent:asImageFormat: instead");
 
 /**
  *  Convenience Helper to create a persistent artwork from an image.
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @return An instance of this class to be passed to the file manager.
  */
-+ (instancetype)persistentArtworkWithImage:(UIImage *)image name:(NSString *)name asImageFormat:(SDLArtworkImageFormat)imageFormat NS_SWIFT_UNAVAILABLE("Use the standard initializer and set persistant to true");
++ (instancetype)persistentArtworkWithImage:(UIImage *)image name:(NSString *)name asImageFormat:(SDLArtworkImageFormat)imageFormat NS_SWIFT_UNAVAILABLE("Use the standard initializer and set persistant to true") __deprecated_msg("Use initWithImage:image persistent:asImageFormat: instead");
 
 /**
  *  Create a file for transmission to the remote system from a UIImage.

--- a/SmartDeviceLink/SDLArtwork.h
+++ b/SmartDeviceLink/SDLArtwork.h
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @return An instance of this class to be passed to the file manager.
  */
-+ (instancetype)artworkWithImage:(UIImage *)image name:(NSString *)name asImageFormat:(SDLArtworkImageFormat)imageFormat NS_SWIFT_UNAVAILABLE("Use the standard initializer and set persistant to false") __deprecated_msg("Use artworkWithImage:image asImageFormat: instead");
++ (instancetype)artworkWithImage:(UIImage *)image name:(NSString *)name asImageFormat:(SDLArtworkImageFormat)imageFormat NS_SWIFT_UNAVAILABLE("Use the standard initializer and set persistant to false") __deprecated_msg("Use artworkWithImage:asImageFormat: instead");
 
 /**
  *  Convenience Helper to create an ephemeral artwork from an image. A unique name will be assigned to the image. This name is a string representation of the image's data which is created by hashing the data using the MD5 algorithm.
@@ -67,7 +67,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @return An instance of this class to be passed to the file manager.
  */
-+ (instancetype)persistentArtworkWithImage:(UIImage *)image name:(NSString *)name asImageFormat:(SDLArtworkImageFormat)imageFormat NS_SWIFT_UNAVAILABLE("Use the standard initializer and set persistant to true") __deprecated_msg("Use persistentArtworkWithImage:image:asImageFormat instead");
++ (instancetype)persistentArtworkWithImage:(UIImage *)image name:(NSString *)name asImageFormat:(SDLArtworkImageFormat)imageFormat NS_SWIFT_UNAVAILABLE("Use the standard initializer and set persistant to true") __deprecated_msg("Use persistentArtworkWithImage:asImageFormat instead");
 
 /**
  *  Convenience Helper to create a persistent artwork from an image. A unique name will be assigned to the image. This name is a string representation of the image's data which is created by hashing the data using the MD5 algorithm.

--- a/SmartDeviceLink/SDLArtwork.h
+++ b/SmartDeviceLink/SDLArtwork.h
@@ -34,7 +34,23 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @return An instance of this class to be passed to the file manager.
  */
-+ (instancetype)artworkWithImage:(UIImage *)image name:(NSString *)name asImageFormat:(SDLArtworkImageFormat)imageFormat NS_SWIFT_UNAVAILABLE("Use the standard initializer and set persistant to false") __deprecated_msg("Use initWithImage:image persistent:asImageFormat: instead");
++ (instancetype)artworkWithImage:(UIImage *)image name:(NSString *)name asImageFormat:(SDLArtworkImageFormat)imageFormat NS_SWIFT_UNAVAILABLE("Use the standard initializer and set persistant to false") __deprecated_msg("Use artworkWithImage:image asImageFormat: instead");
+
+/**
+ *  Convenience Helper to create an ephemeral artwork from an image. A unique name will be assigned to the image. This name is a string representation of the image's data which is created by hashing the data using the MD5 algorithm.
+ *
+ *  This is an ephemeral file, it will not be persisted through sessions / ignition cycles. Any files that you do not *know* you will use in future sessions should be created through this method. For example, album / artist artwork should be ephemeral.
+ *
+ *  Persistent files should be created using `persistentArtworkWithImage:name:asImageFormat:`
+ *
+ *  @warning It is strongly recommended to pass the file url using an SDLFile initializer instead of the image. If you pass the UIImage, it is loaded into memory, and will be dumped to a temporary file. This will create a duplicate file. *Only pass a UIImage if the image is not stored on disk*.
+ *
+ *  @param image       The UIImage to be sent to the remote head unit
+ *  @param imageFormat Whether the image should be converted to a PNG or JPG before transmission. Images with transparency or few colors should be PNGs. Images with many colors should be JPGs.
+ *
+ *  @return An instance of this class to be passed to the file manager.
+ */
++ (instancetype)artworkWithImage:(UIImage *)image asImageFormat:(SDLArtworkImageFormat)imageFormat NS_SWIFT_UNAVAILABLE("Use the standard initializer and set persistant to false");
 
 /**
  *  Convenience Helper to create a persistent artwork from an image.
@@ -51,7 +67,23 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @return An instance of this class to be passed to the file manager.
  */
-+ (instancetype)persistentArtworkWithImage:(UIImage *)image name:(NSString *)name asImageFormat:(SDLArtworkImageFormat)imageFormat NS_SWIFT_UNAVAILABLE("Use the standard initializer and set persistant to true") __deprecated_msg("Use initWithImage:image persistent:asImageFormat: instead");
++ (instancetype)persistentArtworkWithImage:(UIImage *)image name:(NSString *)name asImageFormat:(SDLArtworkImageFormat)imageFormat NS_SWIFT_UNAVAILABLE("Use the standard initializer and set persistant to true") __deprecated_msg("Use persistentArtworkWithImage:image:asImageFormat instead");
+
+/**
+ *  Convenience Helper to create a persistent artwork from an image. A unique name will be assigned to the image. This name is a string representation of the image's data which is created by hashing the data using the MD5 algorithm.
+ *
+ *  This is a persistent file, it will be persisted through sessions / ignition cycles. You will only have a limited space for all files, so be sure to only persist files that are required for all or most sessions. For example, menu artwork should be persistent.
+ *
+ *  Ephemeral files should be created using `ephemeralArtworkWithImage:name:asImageFormat:`
+ *
+ *  @warning It is strongly recommended to pass the file url using an SDLFile initializer instead of the image. If you pass the UIImage, it is loaded into memory, and will be dumped to a temporary file. This will create a duplicate file. *Only pass a UIImage if the image is not stored on disk*.
+ *
+ *  @param image       The UIImage to be sent to the remote head unit
+ *  @param imageFormat Whether the image should be converted to a PNG or JPG before transmission. Images with transparency or few colors should be PNGs. Images with many colors should be JPGs.
+ *
+ *  @return An instance of this class to be passed to the file manager.
+ */
++ (instancetype)persistentArtworkWithImage:(UIImage *)image asImageFormat:(SDLArtworkImageFormat)imageFormat NS_SWIFT_UNAVAILABLE("Use the standard initializer and set persistant to true");
 
 /**
  *  Create a file for transmission to the remote system from a UIImage.

--- a/SmartDeviceLink/SDLArtwork.h
+++ b/SmartDeviceLink/SDLArtwork.h
@@ -66,7 +66,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithImage:(UIImage *)image name:(NSString *)name persistent:(BOOL)persistent asImageFormat:(SDLArtworkImageFormat)imageFormat;
 
 /**
- * TODO
+ *  Create a file for transmission to the remote system from a UIImage. A unique name will be assigned to the image. This name is a string representation of the image's data which is created by hashing the data using the MD5 algorithm.
 
  *  @param image       The UIImage to be sent to the remote head unit
  *  @param persistent  Whether or not the artwork should be persistent.

--- a/SmartDeviceLink/SDLArtwork.m
+++ b/SmartDeviceLink/SDLArtwork.m
@@ -35,13 +35,13 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark Private Lifecycle
 
 - (instancetype)initWithImage:(UIImage *)image name:(NSString *)name persistent:(BOOL)persistent asImageFormat:(SDLArtworkImageFormat)imageFormat {
-    return [super initWithData:[self dataForUIImage:image imageFormat:imageFormat] name:name fileExtension:[self fileExtensionForImageFormat:imageFormat] persistent:persistent];
+    return [super initWithData:[self sdl_dataForUIImage:image imageFormat:imageFormat] name:name fileExtension:[self sdl_fileExtensionForImageFormat:imageFormat] persistent:persistent];
 }
 
 - (instancetype)initWithImage:(UIImage *)image persistent:(BOOL)persistent asImageFormat:(SDLArtworkImageFormat)imageFormat {
-    NSData *imageData = [self dataForUIImage:image imageFormat:imageFormat];
-    NSString *imageName = [self md5HashFromNSData:imageData];
-    return [super initWithData:[self dataForUIImage:image imageFormat:imageFormat] name:(imageName != nil ? imageName : @"") fileExtension:[self fileExtensionForImageFormat:imageFormat] persistent:persistent];
+    NSData *imageData = [self sdl_dataForUIImage:image imageFormat:imageFormat];
+    NSString *imageName = [self sdl_md5HashFromNSData:imageData];
+    return [super initWithData:[self sdl_dataForUIImage:image imageFormat:imageFormat] name:(imageName != nil ? imageName : @"") fileExtension:[self sdl_fileExtensionForImageFormat:imageFormat] persistent:persistent];
 }
 
 /**
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param imageFormat  The image format to use when converting the UIImage to NSData
  *  @return             The image data
  */
-- (NSData *)dataForUIImage:(UIImage *)image imageFormat:(SDLArtworkImageFormat)imageFormat {
+- (NSData *)sdl_dataForUIImage:(UIImage *)image imageFormat:(SDLArtworkImageFormat)imageFormat {
     NSData *imageData = nil;
     switch (imageFormat) {
         case SDLArtworkImageFormatPNG: {
@@ -70,7 +70,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param imageFormat  Whether the image is a PNG or JPG
  *  @return             The file extension for the image format
  */
-- (NSString *)fileExtensionForImageFormat:(SDLArtworkImageFormat)imageFormat {
+- (NSString *)sdl_fileExtensionForImageFormat:(SDLArtworkImageFormat)imageFormat {
     NSString *fileExtension = nil;
     switch (imageFormat) {
         case SDLArtworkImageFormatPNG: {
@@ -89,7 +89,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param data     The data to hash
  *  @return         A MD5 hash of the data
  */
-- (NSString *)md5HashFromNSData:(NSData *)data {
+- (NSString *)sdl_md5HashFromNSData:(NSData *)data {
     if (data == nil) { return nil; }
 
     unsigned char hash[CC_MD5_DIGEST_LENGTH];

--- a/SmartDeviceLink/SDLArtwork.m
+++ b/SmartDeviceLink/SDLArtwork.m
@@ -27,21 +27,29 @@ NS_ASSUME_NONNULL_BEGIN
     return [[self alloc] initWithImage:image name:name persistent:NO asImageFormat:imageFormat];
 }
 
++ (instancetype)artworkWithImage:(UIImage *)image asImageFormat:(SDLArtworkImageFormat)imageFormat {
+    return [[self alloc] initWithImage:image persistent:NO asImageFormat:imageFormat];
+}
+
 + (instancetype)persistentArtworkWithImage:(UIImage *)image name:(NSString *)name asImageFormat:(SDLArtworkImageFormat)imageFormat {
     return [[self alloc] initWithImage:image name:name persistent:YES asImageFormat:imageFormat];
+}
+
++ (instancetype)persistentArtworkWithImage:(UIImage *)image asImageFormat:(SDLArtworkImageFormat)imageFormat {
+    return [[self alloc] initWithImage:image persistent:YES asImageFormat:imageFormat];
 }
 
 
 #pragma mark Private Lifecycle
 
 - (instancetype)initWithImage:(UIImage *)image name:(NSString *)name persistent:(BOOL)persistent asImageFormat:(SDLArtworkImageFormat)imageFormat {
-    return [super initWithData:[self sdl_dataForUIImage:image imageFormat:imageFormat] name:name fileExtension:[self sdl_fileExtensionForImageFormat:imageFormat] persistent:persistent];
+    return [super initWithData:[self.class sdl_dataForUIImage:image imageFormat:imageFormat] name:name fileExtension:[self.class sdl_fileExtensionForImageFormat:imageFormat] persistent:persistent];
 }
 
 - (instancetype)initWithImage:(UIImage *)image persistent:(BOOL)persistent asImageFormat:(SDLArtworkImageFormat)imageFormat {
-    NSData *imageData = [self sdl_dataForUIImage:image imageFormat:imageFormat];
-    NSString *imageName = [self sdl_md5HashFromNSData:imageData];
-    return [super initWithData:[self sdl_dataForUIImage:image imageFormat:imageFormat] name:(imageName != nil ? imageName : @"") fileExtension:[self sdl_fileExtensionForImageFormat:imageFormat] persistent:persistent];
+    NSData *imageData = [self.class sdl_dataForUIImage:image imageFormat:imageFormat];
+    NSString *imageName = [self.class sdl_md5HashFromNSData:imageData];
+    return [super initWithData:[self.class sdl_dataForUIImage:image imageFormat:imageFormat] name:(imageName != nil ? imageName : @"") fileExtension:[self.class sdl_fileExtensionForImageFormat:imageFormat] persistent:persistent];
 }
 
 /**
@@ -51,7 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param imageFormat  The image format to use when converting the UIImage to NSData
  *  @return             The image data
  */
-- (NSData *)sdl_dataForUIImage:(UIImage *)image imageFormat:(SDLArtworkImageFormat)imageFormat {
++ (NSData *)sdl_dataForUIImage:(UIImage *)image imageFormat:(SDLArtworkImageFormat)imageFormat {
     NSData *imageData = nil;
     switch (imageFormat) {
         case SDLArtworkImageFormatPNG: {
@@ -70,7 +78,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param imageFormat  Whether the image is a PNG or JPG
  *  @return             The file extension for the image format
  */
-- (NSString *)sdl_fileExtensionForImageFormat:(SDLArtworkImageFormat)imageFormat {
++ (NSString *)sdl_fileExtensionForImageFormat:(SDLArtworkImageFormat)imageFormat {
     NSString *fileExtension = nil;
     switch (imageFormat) {
         case SDLArtworkImageFormatPNG: {
@@ -91,7 +99,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param data     The data to hash
  *  @return         A MD5 hash of the data
  */
-- (NSString *)sdl_md5HashFromNSData:(NSData *)data {
++ (NSString *)sdl_md5HashFromNSData:(NSData *)data {
     if (data == nil) { return nil; }
 
     unsigned char hash[CC_MD5_DIGEST_LENGTH];

--- a/SmartDeviceLink/SDLArtwork.m
+++ b/SmartDeviceLink/SDLArtwork.m
@@ -86,6 +86,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Creates a string representation of NSData by hashing the data using the MD5 hash function. This string is not guaranteed to be unique as collisions can occur, however collisions are extremely rare.
  *
+ *  Sourced from https://stackoverflow.com/questions/2018550/how-do-i-create-an-md5-hash-of-a-string-in-cocoa
+ *
  *  @param data     The data to hash
  *  @return         A MD5 hash of the data
  */

--- a/SmartDeviceLink/SDLArtwork.m
+++ b/SmartDeviceLink/SDLArtwork.m
@@ -40,9 +40,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithImage:(UIImage *)image persistent:(BOOL)persistent asImageFormat:(SDLArtworkImageFormat)imageFormat {
     NSData *imageData = [self dataForUIImage:image imageFormat:imageFormat];
-    return [super initWithData:[self dataForUIImage:image imageFormat:imageFormat] name:[self md5HashFromNSData:imageData] fileExtension:[self fileExtensionForImageFormat:imageFormat] persistent:persistent];
+    NSString *imageName = [self md5HashFromNSData:imageData];
+    return [super initWithData:[self dataForUIImage:image imageFormat:imageFormat] name:(imageName != nil ? imageName : @"") fileExtension:[self fileExtensionForImageFormat:imageFormat] persistent:persistent];
 }
 
+/**
+ * Returns the JPG or PNG image data for a UIImage.
+ *
+ *  @param image        A UIImage
+ *  @param imageFormat  The image format to use when converting the UIImage to NSData
+ *  @return             The image data
+ */
 - (NSData *)dataForUIImage:(UIImage *)image imageFormat:(SDLArtworkImageFormat)imageFormat {
     NSData *imageData = nil;
     switch (imageFormat) {
@@ -56,6 +64,12 @@ NS_ASSUME_NONNULL_BEGIN
     return imageData;
 }
 
+/**
+ *  Returns the file extension for the image format.
+ *
+ *  @param imageFormat  Whether the image is a PNG or JPG
+ *  @return             The file extension for the image format
+ */
 - (NSString *)fileExtensionForImageFormat:(SDLArtworkImageFormat)imageFormat {
     NSString *fileExtension = nil;
     switch (imageFormat) {
@@ -69,8 +83,14 @@ NS_ASSUME_NONNULL_BEGIN
     return fileExtension;
 }
 
+/**
+ *  Creates a string representation of NSData by hashing the data using the MD5 hash function. This string is not guaranteed to be unique as collisions can occur, however collisions are extremely rare.
+ *
+ *  @param data     The data to hash
+ *  @return         A MD5 hash of the data
+ */
 - (NSString *)md5HashFromNSData:(NSData *)data {
-    if (data == nil) { return @""; }
+    if (data == nil) { return nil; }
 
     unsigned char hash[CC_MD5_DIGEST_LENGTH];
     CC_MD5([data bytes], (CC_LONG)[data length], hash);

--- a/SmartDeviceLink/SDLError.h
+++ b/SmartDeviceLink/SDLError.h
@@ -43,6 +43,7 @@ extern SDLErrorDomain *const SDLErrorDomainFileManager;
 + (NSError *)sdl_fileManager_unableToDelete_ErrorWithUserInfo:(NSDictionary *)userInfo;
 + (NSError *)sdl_fileManager_fileDoesNotExistError;
 + (NSError *)sdl_fileManager_fileUploadCanceled;
++ (NSError *)sdl_fileManager_dataMissingError;
 
 @end
 

--- a/SmartDeviceLink/SDLError.m
+++ b/SmartDeviceLink/SDLError.m
@@ -157,6 +157,15 @@ SDLErrorDomain *const SDLErrorDomainFileManager = @"com.sdl.filemanager.error";
     return [NSError errorWithDomain:SDLErrorDomainFileManager code:SDLFileManagerUploadCanceled userInfo:userInfo];
 }
 
++ (NSError *)sdl_fileManager_dataMissingError {
+    NSDictionary<NSString *, NSString *> *userInfo = @{
+                                                       NSLocalizedDescriptionKey: NSLocalizedString(@"The file upload was canceled", nil),
+                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"The data for the file is missing", nil),
+                                                       NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"Make sure the data used to create the file is valid", nil)
+                                                       };
+    return [NSError errorWithDomain:SDLErrorDomainFileManager code:SDLFileManagerErrorFileDataMissing userInfo:userInfo];
+}
+
 #pragma mark SDLUploadFileOperation
 
 + (NSError *)sdl_fileManager_fileDoesNotExistError {

--- a/SmartDeviceLink/SDLErrorConstants.h
+++ b/SmartDeviceLink/SDLErrorConstants.h
@@ -78,4 +78,8 @@ typedef NS_ENUM(NSInteger, SDLFileManagerError) {
      *  One or more of multiple files being uploaded or deleted failed.
      */
     SDLFileManagerMultipleFileDeleteTasksFailed = -8,
+    /*
+     *  The file data is nil or empty.
+     */
+    SDLFileManagerErrorFileDataMissing = -9,
 };

--- a/SmartDeviceLink/SDLFileManager.h
+++ b/SmartDeviceLink/SDLFileManager.h
@@ -99,7 +99,7 @@ typedef void (^SDLFileManagerStartupCompletionHandler)(BOOL success, NSError *__
 /**
  *  Upload a file to the remote file system. If a file with the [SDLFile name] already exists, this will overwrite that file. If you do not want that to happen, check remoteFileNames before uploading, or change allowOverwrite to NO.
  *
- *  @param file       A SDLFile that contains metadata about the file to be sent
+ *  @param file       An SDLFile that contains metadata about the file to be sent
  *  @param completion An optional completion handler that sends an error should one occur.
  */
 - (void)uploadFile:(SDLFile *)file completionHandler:(nullable SDLFileManagerUploadCompletionHandler)completion NS_SWIFT_NAME(upload(file:completionHandler:));

--- a/SmartDeviceLink/SDLFileManager.h
+++ b/SmartDeviceLink/SDLFileManager.h
@@ -105,14 +105,6 @@ typedef void (^SDLFileManagerStartupCompletionHandler)(BOOL success, NSError *__
 - (void)uploadFile:(SDLFile *)file completionHandler:(nullable SDLFileManagerUploadCompletionHandler)completion NS_SWIFT_NAME(upload(file:completionHandler:));
 
 /**
- *  Uploads an artwork file to the remote file system and returns the name of the uploaded artwork once completed. If an artwork with the same name is already on the remote system, the artwork is not uploaded and the artwork name is simply returned.
- *
- *  @param artwork      A SDLArwork containing an image to be sent
- *  @param completion   An optional completion handler that returns the name of the uploaded artwork. It also returns an error if the upload fails.
- */
-- (void)uploadArtwork:(SDLArtwork *)artwork completionHandler:(nullable SDLFileManagerUploadArtworkCompletionHandler)completion NS_SWIFT_NAME(upload(artwork:completionHandler:));
-
-/**
  *  Uploads an array of files to the remote file system. The files will be uploaded in the order in which they are added to the array, with the first file to be uploaded at index 0. The upload queue is sequential, meaning that once a upload request is sent to Core, the queue waits until a response is received from Core before the next the next upload request is sent.
  *
  *  The optional progress handler can be used to keep track of the upload progress. After each file upload, the progress handler returns the upload percentage and an error, if one occured during the upload process. The progress handler also includes an option to cancel the upload of all remaining files in queue.
@@ -126,10 +118,37 @@ typedef void (^SDLFileManagerStartupCompletionHandler)(BOOL success, NSError *__
 /**
  *  Uploads an array of files to the remote file system. The files will be uploaded in the order in which they are added to the array, with the first file to be uploaded at index 0. The upload queue is sequential, meaning that once a upload request is sent to Core, the queue waits until a response is received from Core before the next the next upload request is sent.
  *
- *  @param files  An array of SDLFiles to be sent
- *  @param completionHandler  an optional SDLFileManagerMultiUploadCompletionHandler
+ *  @param files                An array of SDLFiles to be sent
+ *  @param completionHandler    An optional SDLFileManagerMultiUploadCompletionHandler
  */
 - (void)uploadFiles:(NSArray<SDLFile *> *)files completionHandler:(nullable SDLFileManagerMultiUploadCompletionHandler)completionHandler NS_SWIFT_NAME(upload(files:completionHandler:));
+
+/**
+ *  Uploads an artwork file to the remote file system and returns the name of the uploaded artwork once completed. If an artwork with the same name is already on the remote system, the artwork is not uploaded and the artwork name is simply returned.
+ *
+ *  @param artwork      A SDLArwork containing an image to be sent
+ *  @param completion   An optional completion handler that returns the name of the uploaded artwork. It also returns an error if the upload fails.
+ */
+- (void)uploadArtwork:(SDLArtwork *)artwork completionHandler:(nullable SDLFileManagerUploadArtworkCompletionHandler)completion NS_SWIFT_NAME(upload(artwork:completionHandler:));
+
+/**
+ *  Uploads an array of artworks to the remote file system. The artworks will be uploaded in the order in which they are added to the array, with the first file to be uploaded at index 0. The upload queue is sequential, meaning that once a upload request is sent to Core, the queue waits until a response is received from Core before the next the next upload request is sent.
+ *
+ *  @param artworks     An array of SDLArtworks to be sent
+ *  @param completion   An optional SDLFileManagerMultiUploadArtworkCompletionHandler
+ */
+- (void)uploadArtworks:(NSArray<SDLArtwork *> *)artworks completionHandler:(nullable SDLFileManagerMultiUploadArtworkCompletionHandler)completion NS_SWIFT_NAME(upload(artworks:completionHandler:));
+
+/**
+ *  Uploads an array of artworks to the remote file system. The artworks will be uploaded in the order in which they are added to the array, with the first file to be uploaded at index 0. The upload queue is sequential, meaning that once a upload request is sent to Core, the queue waits until a response is received from Core before the next the next upload request is sent.
+ *
+ *  The optional progress handler can be used to keep track of the upload progress. After each artwork upload, the progress handler returns the artwork name, the upload percentage and an error, if one occured during the upload process. The progress handler also includes an option to cancel the upload of all remaining files in queue.
+ *
+ *  @param artworks         An array of SDLArtworks to be sent
+ *  @param progressHandler  An optional SDLFileManagerMultiUploadArtworkProgressHandler
+ *  @param completion       An optional SDLFileManagerMultiUploadArtworkCompletionHandler
+ */
+- (void)uploadArtworks:(NSArray<SDLArtwork *> *)artworks progressHandler:(nullable SDLFileManagerMultiUploadArtworkProgressHandler)progressHandler completionHandler:(nullable SDLFileManagerMultiUploadArtworkCompletionHandler)completion NS_SWIFT_NAME(upload(artworks:progressHandler:completionHandler:));
 
 /**
  *  A URL to the directory where temporary files are stored. When an SDLFile is created with NSData, it writes to a temporary file until the file manager finishes uploading it.

--- a/SmartDeviceLink/SDLFileManager.h
+++ b/SmartDeviceLink/SDLFileManager.h
@@ -8,6 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
+#import "SDLArtwork.h"
 #import "SDLFileManagerConstants.h"
 
 @class SDLFile;
@@ -102,6 +103,14 @@ typedef void (^SDLFileManagerStartupCompletionHandler)(BOOL success, NSError *__
  *  @param completion An optional completion handler that sends an error should one occur.
  */
 - (void)uploadFile:(SDLFile *)file completionHandler:(nullable SDLFileManagerUploadCompletionHandler)completion NS_SWIFT_NAME(upload(file:completionHandler:));
+
+/**
+ *  TODO
+ *
+ *  @param artwork TODO
+ *  @param completion TODO
+ */
+- (void)uploadArtwork:(SDLArtwork *)artwork completionHandler:(nullable SDLFileManagerUploadArtworkCompletionHandler)completion NS_SWIFT_NAME(upload(artwork:completionHandler:));
 
 /**
  *  Uploads an array of files to the remote file system. The files will be uploaded in the order in which they are added to the array, with the first file to be uploaded at index 0. The upload queue is sequential, meaning that once a upload request is sent to Core, the queue waits until a response is received from Core before the next the next upload request is sent.

--- a/SmartDeviceLink/SDLFileManager.h
+++ b/SmartDeviceLink/SDLFileManager.h
@@ -99,16 +99,16 @@ typedef void (^SDLFileManagerStartupCompletionHandler)(BOOL success, NSError *__
 /**
  *  Upload a file to the remote file system. If a file with the [SDLFile name] already exists, this will overwrite that file. If you do not want that to happen, check remoteFileNames before uploading, or change allowOverwrite to NO.
  *
- *  @param file       An SDLFile that contains metadata about the file to be sent
+ *  @param file       A SDLFile that contains metadata about the file to be sent
  *  @param completion An optional completion handler that sends an error should one occur.
  */
 - (void)uploadFile:(SDLFile *)file completionHandler:(nullable SDLFileManagerUploadCompletionHandler)completion NS_SWIFT_NAME(upload(file:completionHandler:));
 
 /**
- *  TODO
+ *  Uploads an artwork file to the remote file system and returns the name of the uploaded artwork once completed. If an artwork with the same name is already on the remote system, the artwork is not uploaded and the artwork name is simply returned.
  *
- *  @param artwork TODO
- *  @param completion TODO
+ *  @param artwork      A SDLArwork containing an image to be sent
+ *  @param completion   An optional completion handler that returns the name of the uploaded artwork. It also returns an error if the upload fails.
  */
 - (void)uploadArtwork:(SDLArtwork *)artwork completionHandler:(nullable SDLFileManagerUploadArtworkCompletionHandler)completion NS_SWIFT_NAME(upload(artwork:completionHandler:));
 

--- a/SmartDeviceLink/SDLFileManager.m
+++ b/SmartDeviceLink/SDLFileManager.m
@@ -342,7 +342,7 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
 }
 
 - (void)uploadFile:(SDLFile *)file completionHandler:(nullable SDLFileManagerUploadCompletionHandler)handler {
-    if (file == nil || file.data == nil || file.data.length == 0) {
+    if (file == nil || file.data.length == 0) {
         if (handler != nil) {
             handler(NO, self.bytesAvailable, [NSError sdl_fileManager_dataMissingError]);
         }
@@ -427,7 +427,6 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
     [self uploadFiles:artworks progressHandler:^BOOL(SDLFileName * _Nonnull fileName, float uploadPercentage, NSError * _Nullable error) {
         if (progressHandler == nil) { return YES; }
         if ([self isErrorACannotOverwriteError:error]) {
-            // Artwork with same name already uploaded to remote
             return progressHandler(fileName, uploadPercentage, nil);
         }
         return progressHandler(fileName, uploadPercentage, error);
@@ -445,13 +444,13 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
                 if (![self isErrorACannotOverwriteError:[error.userInfo objectForKey:erroredArtworkName]]) {
                     [successfulArtworkUploadNames removeObject:erroredArtworkName];
                 } else {
-                    // An overwrite error means that the artwork is already uploaded to the remote
+                    // An overwrite error means that an artwork with the same name is already uploaded to the remote
                     [unsuccessfulArtworkUploadErrorUserInfo removeObjectForKey:erroredArtworkName];
                 }
             }
         }
 
-        return completion([NSArray arrayWithArray:[successfulArtworkUploadNames allObjects]], unsuccessfulArtworkUploadErrorUserInfo == nil || unsuccessfulArtworkUploadErrorUserInfo.count == 0 ? nil : [[NSError alloc] initWithDomain:error.domain code:error.code userInfo:unsuccessfulArtworkUploadErrorUserInfo]);
+        return completion([NSArray arrayWithArray:[successfulArtworkUploadNames allObjects]], unsuccessfulArtworkUploadErrorUserInfo.count == 0 ? nil : [[NSError alloc] initWithDomain:error.domain code:error.code userInfo:unsuccessfulArtworkUploadErrorUserInfo]);
     }];
 }
 

--- a/SmartDeviceLink/SDLFileManager.m
+++ b/SmartDeviceLink/SDLFileManager.m
@@ -261,7 +261,7 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
 }
 
 - (void)uploadArtwork:(SDLArtwork *)artwork completionHandler:(nullable SDLFileManagerUploadArtworkCompletionHandler)completion {
-    if ([self.remoteFileNames containsObject:artwork.name]) {
+    if ([self.remoteFileNames containsObject:artwork.name] && !artwork.overwrite) {
         // Artwork with same name already uploaded to remote; return artwork name
         if (completion == nil) { return; }
         return completion(true, artwork.name, self.bytesAvailable, nil);

--- a/SmartDeviceLink/SDLFileManager.m
+++ b/SmartDeviceLink/SDLFileManager.m
@@ -260,6 +260,19 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
     [self uploadFiles:files progressHandler:nil completionHandler:completionHandler];
 }
 
+- (void)uploadArtwork:(SDLArtwork *)artwork completionHandler:(nullable SDLFileManagerUploadArtworkCompletionHandler)completion NS_SWIFT_NAME(upload(artwork:completionHandler:)) {
+    if ([self.remoteFileNames containsObject:artwork.name]) {
+        // Artwork already uploaded; return artwork name
+        if (completion == nil) { return; }
+        completion(true, artwork.name, self.bytesAvailable, nil);
+    } else {
+        // Upload artwork and return artwork name when finished
+        [self uploadFile:artwork completionHandler:^(BOOL success, NSUInteger bytesAvailable, NSError * _Nullable error) {
+            completion(success, artwork.name, bytesAvailable, error);
+        }];
+    }
+}
+
 - (void)uploadFiles:(NSArray<SDLFile *> *)files progressHandler:(nullable SDLFileManagerMultiUploadProgressHandler)progressHandler completionHandler:(nullable SDLFileManagerMultiUploadCompletionHandler)completionHandler {
     if (files.count == 0) {
         @throw [NSException sdl_missingFilesException];

--- a/SmartDeviceLink/SDLFileManager.m
+++ b/SmartDeviceLink/SDLFileManager.m
@@ -445,13 +445,13 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
                 if (![self isErrorACannotOverwriteError:[error.userInfo objectForKey:erroredArtworkName]]) {
                     [successfulArtworkUploadNames removeObject:erroredArtworkName];
                 } else {
-                    // An overwrite error means that the artwork is alread uploaded to the remote
+                    // An overwrite error means that the artwork is already uploaded to the remote
                     [unsuccessfulArtworkUploadErrorUserInfo removeObjectForKey:erroredArtworkName];
                 }
             }
         }
 
-        return completion(successfulArtworkUploadNames == nil || successfulArtworkUploadNames.count == 0 ? [NSArray array] : [NSArray arrayWithArray:[successfulArtworkUploadNames allObjects]], unsuccessfulArtworkUploadErrorUserInfo == nil || unsuccessfulArtworkUploadErrorUserInfo.count == 0 ? nil : [[NSError alloc] initWithDomain:error.domain code:error.code userInfo:unsuccessfulArtworkUploadErrorUserInfo]);
+        return completion([NSArray arrayWithArray:[successfulArtworkUploadNames allObjects]], unsuccessfulArtworkUploadErrorUserInfo == nil || unsuccessfulArtworkUploadErrorUserInfo.count == 0 ? nil : [[NSError alloc] initWithDomain:error.domain code:error.code userInfo:unsuccessfulArtworkUploadErrorUserInfo]);
     }];
 }
 

--- a/SmartDeviceLink/SDLFileManager.m
+++ b/SmartDeviceLink/SDLFileManager.m
@@ -263,12 +263,68 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
 - (void)uploadArtwork:(SDLArtwork *)artwork completionHandler:(nullable SDLFileManagerUploadArtworkCompletionHandler)completion {
     [self uploadFile:artwork completionHandler:^(BOOL success, NSUInteger bytesAvailable, NSError * _Nullable error) {
         if (completion == nil) { return; }
-        if (error != nil && error.code == SDLFileManagerErrorCannotOverwrite) {
+        if ([self isErrorACannotOverwriteError:error]) {
             // Artwork with same name already uploaded to remote
             return completion(true, artwork.name, bytesAvailable, nil);
         }
         completion(success, artwork.name, bytesAvailable, error);
     }];
+}
+
+- (void)uploadArtworks:(NSArray<SDLArtwork *> *)artworks completionHandler:(nullable SDLFileManagerMultiUploadArtworkCompletionHandler)completion {
+    [self uploadArtworks:artworks progressHandler:nil completionHandler:completion];
+}
+
+- (void)uploadArtworks:(NSArray<SDLArtwork *> *)artworks progressHandler:(nullable SDLFileManagerMultiUploadArtworkProgressHandler)progressHandler completionHandler:(nullable SDLFileManagerMultiUploadArtworkCompletionHandler)completion {
+    if (artworks.count == 0) {
+        @throw [NSException sdl_missingFilesException];
+    }
+
+    [self uploadFiles:artworks progressHandler:^BOOL(SDLFileName * _Nonnull fileName, float uploadPercentage, NSError * _Nullable error) {
+        if (progressHandler == nil) { return YES; }
+        if ([self isErrorACannotOverwriteError:error]) {
+            // Artwork with same name already uploaded to remote
+            return progressHandler(fileName, uploadPercentage, nil);
+        }
+        return progressHandler(fileName, uploadPercentage, error);
+    } completionHandler:^(NSError * _Nullable error) {
+        if (completion == nil) { return; }
+
+        NSMutableArray<NSString *> *successfulArtworkUploadNames = [NSMutableArray array];
+        for (SDLArtwork *artwork in artworks) {
+            [successfulArtworkUploadNames addObject:artwork.name];
+        }
+
+        if (error != nil) {
+            // Some or all of the artworks failed to upload
+            NSMutableDictionary *unsuccessfulArtworkUploadErrorUserInfo = [[NSMutableDictionary alloc] initWithDictionary:error.userInfo];
+            for (NSString *erroredArtworkName in error.userInfo) {
+                if ([self isErrorACannotOverwriteError:[error.userInfo objectForKey:erroredArtworkName]]) {
+                    // Since artwork with same name already uploaded to remote, remove the artwork name from the error list
+                    [unsuccessfulArtworkUploadErrorUserInfo removeObjectForKey:erroredArtworkName];
+                } else {
+                    // Since artwork upload failed, remove the artwork name from the list of successful artwork uploads
+                    for (NSUInteger i = 0; i < successfulArtworkUploadNames.count; i += 1) {
+                        if ([successfulArtworkUploadNames[i] isEqualToString:erroredArtworkName]) {
+                            [successfulArtworkUploadNames removeObjectAtIndex:i];
+                            break;
+                        }
+                    }
+                }
+                return completion(successfulArtworkUploadNames, unsuccessfulArtworkUploadErrorUserInfo == nil || unsuccessfulArtworkUploadErrorUserInfo.count == 0 ? nil : [[NSError alloc] initWithDomain:error.domain code:error.code userInfo:unsuccessfulArtworkUploadErrorUserInfo]);
+            }
+        } else {
+            // All artworks uploaded successfully
+            return completion(successfulArtworkUploadNames, nil);
+        }
+    }];
+}
+
+- (BOOL)isErrorACannotOverwriteError:(NSError * _Nullable)error {
+    if (error != nil && error.code == SDLFileManagerErrorCannotOverwrite) {
+        return YES;
+    }
+    return NO;
 }
 
 - (void)uploadFiles:(NSArray<SDLFile *> *)files progressHandler:(nullable SDLFileManagerMultiUploadProgressHandler)progressHandler completionHandler:(nullable SDLFileManagerMultiUploadCompletionHandler)completionHandler {

--- a/SmartDeviceLink/SDLFileManager.m
+++ b/SmartDeviceLink/SDLFileManager.m
@@ -260,17 +260,18 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
     [self uploadFiles:files progressHandler:nil completionHandler:completionHandler];
 }
 
-- (void)uploadArtwork:(SDLArtwork *)artwork completionHandler:(nullable SDLFileManagerUploadArtworkCompletionHandler)completion NS_SWIFT_NAME(upload(artwork:completionHandler:)) {
+- (void)uploadArtwork:(SDLArtwork *)artwork completionHandler:(nullable SDLFileManagerUploadArtworkCompletionHandler)completion {
     if ([self.remoteFileNames containsObject:artwork.name]) {
-        // Artwork already uploaded; return artwork name
+        // Artwork with same name already uploaded to remote; return artwork name
         if (completion == nil) { return; }
-        completion(true, artwork.name, self.bytesAvailable, nil);
-    } else {
-        // Upload artwork and return artwork name when finished
-        [self uploadFile:artwork completionHandler:^(BOOL success, NSUInteger bytesAvailable, NSError * _Nullable error) {
-            completion(success, artwork.name, bytesAvailable, error);
-        }];
+        return completion(true, artwork.name, self.bytesAvailable, nil);
     }
+
+    // Upload artwork and return artwork name when finished
+    [self uploadFile:artwork completionHandler:^(BOOL success, NSUInteger bytesAvailable, NSError * _Nullable error) {
+        if (completion == nil) { return; }
+        completion(success, artwork.name, bytesAvailable, error);
+    }];
 }
 
 - (void)uploadFiles:(NSArray<SDLFile *> *)files progressHandler:(nullable SDLFileManagerMultiUploadProgressHandler)progressHandler completionHandler:(nullable SDLFileManagerMultiUploadCompletionHandler)completionHandler {
@@ -380,7 +381,6 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
         if (handler != nil) {
             handler(NO, self.bytesAvailable, [NSError sdl_fileManager_cannotOverwriteError]);
         }
-
         return;
     }
 

--- a/SmartDeviceLink/SDLFileManager.m
+++ b/SmartDeviceLink/SDLFileManager.m
@@ -455,13 +455,6 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
     }];
 }
 
-- (void)printArray:(NSArray<NSString *> *)array location:(NSString *)location {
-    NSLog(@"\n%@Artwork names:", location);
-    for (NSString *name in array) {
-        NSLog(@"\n\tname: %@", name);
-    }
-}
-
 - (BOOL)isErrorACannotOverwriteError:(NSError * _Nullable)error {
     if (error != nil && error.code == SDLFileManagerErrorCannotOverwrite) {
         return YES;

--- a/SmartDeviceLink/SDLFileManagerConstants.h
+++ b/SmartDeviceLink/SDLFileManagerConstants.h
@@ -24,16 +24,6 @@ typedef NSString SDLFileName;
 typedef void (^SDLFileManagerUploadCompletionHandler)(BOOL success, NSUInteger bytesAvailable, NSError *__nullable error);
 
 /**
- *  A completion handler called after a response from Core to a artwork upload request.
- *
- *  @param success             Whether or not the upload was successful
- *  @param artworkName         The unique identifier for the uploaded file.
- *  @param bytesAvailable      The amount of space left for files on Core
- *  @param error               The error that occurred during the request if one occurred, nil if not
- */
-typedef void (^SDLFileManagerUploadArtworkCompletionHandler)(BOOL success, NSString *artworkName, NSUInteger bytesAvailable, NSError *__nullable error);
-
-/**
  *  A completion handler called after a set of upload requests has completed.
  *
  *  @param error                The userInfo dictionary property, of type <SDLFileName: NSError>, contains information on all failed uploads. The key is the name of the file that did not upload properly, the value is an error describing what went wrong on that particular upload attempt. If all files are uploaded successfully, nil is returned
@@ -76,5 +66,33 @@ typedef void(^SDLFileManagerMultiDeleteCompletionHandler)(NSError *__nullable er
  */
 typedef void (^SDLFileManagerListFilesCompletionHandler)(BOOL success, NSUInteger bytesAvailable, NSArray<NSString *> *fileNames, NSError *__nullable error);
 
+/**
+ *  A completion handler called after a response from Core to a artwork upload request.
+ *
+ *  @param success             Whether or not the upload was successful
+ *  @param artworkName         The unique identifier for the uploaded file.
+ *  @param bytesAvailable      The amount of space left for files on Core
+ *  @param error               The error that occurred during the request if one occurred, nil if not
+ */
+typedef void (^SDLFileManagerUploadArtworkCompletionHandler)(BOOL success, NSString *artworkName, NSUInteger bytesAvailable, NSError *__nullable error);
+
+/**
+ *  A completion handler called after a set of upload artwork requests has completed.
+ *
+ *  @param artworkNames         The names of the artwork files successfully uploaded to the remote
+ *  @param error                The userInfo dictionary property, of type <NSString: NSError>, contains information on all failed uploads. The key is the name of the artwork that did not upload properly, the value is an error describing what went wrong on that particular upload attempt. If all artworks are uploaded successfully, nil is returned
+ */
+typedef void (^SDLFileManagerMultiUploadArtworkCompletionHandler)(NSArray<NSString *> *artworkNames, NSError *__nullable error);
+
+/**
+ *  In a multiple request send, a handler called after each response from Core to an artwork upload request.
+ *
+ *  @param artworkName      The unique identifier for the uploaded file
+ *  @param uploadPercentage The percentage of uploaded data. The upload percentage is calculated as the total file size of all attempted artwork uploads (regardless of the successfulness of the upload) divided by the sum of the data in all the files
+ *  @param error            The error that occurred during the upload request if one occurred, nil if no error occured
+ *
+ *  @return                 Return NO to cancel any artworks that have not yet been sent. Return YES to continue sending artworks
+ */
+typedef BOOL (^SDLFileManagerMultiUploadArtworkProgressHandler)(NSString *artworkName, float uploadPercentage, NSError *__nullable error);
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLFileManagerConstants.h
+++ b/SmartDeviceLink/SDLFileManagerConstants.h
@@ -19,7 +19,7 @@ typedef NSString SDLFileName;
  *
  *  @param success              Whether or not the upload was successful
  *  @param bytesAvailable       The amount of space left for files on Core
- *  @param error                The error that occurred during the request if one occurred, nil if not error occured
+ *  @param error                The error that occurred during the request if one occurred, nil if no error occured
  */
 typedef void (^SDLFileManagerUploadCompletionHandler)(BOOL success, NSUInteger bytesAvailable, NSError *__nullable error);
 

--- a/SmartDeviceLink/SDLFileManagerConstants.h
+++ b/SmartDeviceLink/SDLFileManagerConstants.h
@@ -19,9 +19,19 @@ typedef NSString SDLFileName;
  *
  *  @param success              Whether or not the upload was successful
  *  @param bytesAvailable       The amount of space left for files on Core
- *  @param error                The error that occurred during the request if one occurred, nil if no error occured
+ *  @param error                The error that occurred during the request if one occurred, nil if not error occured
  */
 typedef void (^SDLFileManagerUploadCompletionHandler)(BOOL success, NSUInteger bytesAvailable, NSError *__nullable error);
+
+/**
+ *  A completion handler called after a response from Core to a artwork upload request.
+ *
+ *  @param success             Whether or not the upload was successful
+ *  @param artworkName         The unique identifier for the uploaded file.
+ *  @param bytesAvailable      The amount of space left for files on Core
+ *  @param error               The error that occurred during the request if one occurred, nil if not
+ */
+typedef void (^SDLFileManagerUploadArtworkCompletionHandler)(BOOL success, NSString *artworkName, NSUInteger bytesAvailable, NSError *__nullable error);
 
 /**
  *  A completion handler called after a set of upload requests has completed.

--- a/SmartDeviceLink/SDLImage.h
+++ b/SmartDeviceLink/SDLImage.h
@@ -17,6 +17,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithName:(NSString *)name ofType:(SDLImageType)imageType;
 
+- (instancetype)initWithName:(NSString *)name;
+
+- (instancetype)initWithStaticImageValue:(UInt16)staticImageValue;
+
 /**
  * @abstract The static hex icon value or the binary image file name identifier (sent by SDLPutFile)
  *
@@ -25,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic) NSString *value;
 
 /**
- * @abstract Describes, whether it is a static or dynamic image
+ * @abstract Describes whether the image is static or dynamic
  *
  * Required
  */

--- a/SmartDeviceLink/SDLImage.m
+++ b/SmartDeviceLink/SDLImage.m
@@ -22,6 +22,15 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (instancetype)initWithName:(NSString *)name {
+    return [self initWithName:name ofType:SDLImageTypeDynamic];
+}
+
+- (instancetype)initWithStaticImageValue:(UInt16)staticImageValue {
+    NSString *value = [NSString stringWithFormat:@"%hu", staticImageValue];
+    return [self initWithName:value ofType:SDLImageTypeStatic];
+}
+
 - (void)setValue:(NSString *)value {
     [store sdl_setObject:value forName:SDLNameValue];
 }

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLArtworkSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLArtworkSpec.m
@@ -4,88 +4,146 @@
 #import "SDLArtwork.h"
 #import "SDLFileType.h"
 
+@interface SDLArtwork()
+- (NSString *)md5HashFromNSData:(NSData *)data;
+@end
+
 QuickSpecBegin(SDLArtworkSpec)
 
 describe(@"SDLArtwork", ^{
-    __block SDLArtwork *testArtwork = nil;
-    
-    describe(@"when created", ^{
-        context(@"As a PNG", ^{
-            __block NSString *testArtworkName = nil;
-            __block UIImage *testImage = nil;
-            __block SDLArtworkImageFormat testFormat = NSNotFound;
-            
-            beforeEach(^{
-                testImage = [UIImage imageNamed:@"testImagePNG" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil];
-                testArtworkName = @"Test Artwork";
-                testFormat = SDLArtworkImageFormatPNG;
-                
-                testArtwork = [[SDLArtwork alloc] initWithImage:testImage name:testArtworkName persistent:NO asImageFormat:testFormat];
+    __block SDLArtwork *expectedArtwork = nil;
+    __block UIImage *testImagePNG = nil;
+    __block UIImage *testImagePNG2 = nil;
+    __block UIImage *testImageJPG = nil;
+
+    beforeEach(^{
+        testImagePNG = [UIImage imageNamed:@"testImagePNG" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil];
+        testImagePNG2 = [UIImage imageNamed:@"TestLockScreenAppIcon" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil];
+        testImageJPG = [UIImage imageNamed:@"testImageJPG.jpg" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil];
+    });
+
+    context(@"On creation", ^{
+        describe(@"When setting the image", ^{
+            __block NSData *expectedImageData = nil;
+
+            it(@"should set the image data successfully for an image with a name", ^ {
+                expectedImageData = UIImagePNGRepresentation(testImagePNG);
+                expectedArtwork = [[SDLArtwork alloc] initWithImage:testImagePNG name:@"testImage" persistent:true asImageFormat:SDLArtworkImageFormatPNG];
             });
-            
-            it(@"should correctly store image data", ^{
-                expect(testArtwork.data).to(equal(UIImagePNGRepresentation(testImage)));
+
+            it(@"should set the image data successfully for an image without a name", ^ {
+                expectedImageData = UIImagePNGRepresentation(testImagePNG);
+                expectedArtwork = [[SDLArtwork alloc] initWithImage:testImagePNG persistent:true asImageFormat:SDLArtworkImageFormatPNG];
             });
-            
-            it(@"should correctly store name", ^{
-                expect(testArtwork.name).to(equal(testArtworkName));
+
+            it(@"should not set the image data if the image is nil", ^{
+                UIImage *testImage = nil;
+                expectedImageData = UIImagePNGRepresentation(testImage);
+                expectedArtwork = [[SDLArtwork alloc] initWithImage:testImage persistent:true asImageFormat:SDLArtworkImageFormatPNG];
             });
-            
-            it(@"should correctly store format", ^{
-                expect(testArtwork.fileType).to(equal(SDLFileTypePNG));
-            });
-            
-            it(@"should correctly store persistence", ^{
-                expect(@(testArtwork.persistent)).to(equal(@NO));
-            });
-        });
-        
-        context(@"As a JPG", ^{
-            __block NSString *testArtworkName = nil;
-            __block UIImage *testImage = nil;
-            __block SDLArtworkImageFormat testFormat = NSNotFound;
-            
-            beforeEach(^{
-                testImage = [UIImage imageNamed:@"testImagePNG" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil];
-                testArtworkName = @"Test Artwork";
-                testFormat = SDLArtworkImageFormatJPG;
-                
-                testArtwork = [[SDLArtwork alloc] initWithImage:testImage name:testArtworkName persistent:NO asImageFormat:testFormat];
-            });
-            
-            it(@"should correctly store image data", ^{
-                expect(testArtwork.data).to(equal(UIImageJPEGRepresentation(testImage, 0.85)));
-            });
-            
-            it(@"should correctly store name", ^{
-                expect(testArtwork.name).to(equal(testArtworkName));
-            });
-            
-            it(@"should correctly store format", ^{
-                expect(testArtwork.fileType).to(equal(SDLFileTypeJPEG));
-            });
-            
-            it(@"should correctly store persistence", ^{
-                expect(@(testArtwork.persistent)).to(equal(@NO));
+
+            afterEach(^{
+                if (expectedImageData == nil) {
+                    expect(expectedArtwork.data).to(beNil());
+                } else {
+                    expect(expectedImageData).to(equal(expectedArtwork.data));
+                }
             });
         });
-        
-        describe(@"to be persistent", ^{
-            __block NSString *testArtworkName = nil;
-            __block UIImage *testImage = nil;
-            __block SDLArtworkImageFormat testFormat = NSNotFound;
-            
-            beforeEach(^{
-                testImage = [UIImage imageNamed:@"testImagePNG" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil];
-                testArtworkName = @"Test Artwork";
-                testFormat = SDLArtworkImageFormatPNG;
-                
-                testArtwork = [[SDLArtwork alloc] initWithImage:testImage name:testArtworkName persistent:YES asImageFormat:testFormat];
+
+        describe(@"When setting the name", ^{
+            __block NSString *expectedName = nil;
+
+            it(@"should set the passed name correctly", ^{
+                NSString *imageName = @"TestImageName";
+                expectedName = imageName;
+                expectedArtwork = [[SDLArtwork alloc] initWithImage:testImagePNG name:imageName persistent:true asImageFormat:SDLArtworkImageFormatPNG];
             });
-            
-            it(@"is persistent", ^{
-                expect(@(testArtwork.persistent)).to(equal(@YES));
+
+            context(@"When no name is provided", ^{
+                it(@"should create a unique name based on the hash of the image", ^{
+                    expectedName = [[SDLArtwork alloc] md5HashFromNSData:UIImagePNGRepresentation(testImagePNG)];
+                    expectedArtwork = [[SDLArtwork alloc] initWithImage:testImagePNG persistent:true asImageFormat:SDLArtworkImageFormatPNG];
+                });
+
+                it(@"should create an empty string if the image is nil", ^{
+                    UIImage *testNilImage = nil;
+                    expectedName = @"";
+                    expectedArtwork = [[SDLArtwork alloc] initWithImage:testNilImage persistent:true asImageFormat:SDLArtworkImageFormatPNG];
+                });
             });
+
+            afterEach(^{
+                if (expectedName.length == 0) {
+                    expect(expectedArtwork.name).to(beNil());
+                } else {
+                    expect(expectedName).to(equal(expectedArtwork.name));
+                }
+            });
+        });
+
+        describe(@"When setting the image format", ^{
+            __block SDLFileType expectedImageFormat = nil;
+            __block NSData *expectedImageData = nil;
+
+            it(@"should create a PNG image successfully", ^{
+                expectedImageFormat = SDLFileTypePNG;
+                expectedImageData = UIImagePNGRepresentation(testImagePNG);
+                expectedArtwork = [[SDLArtwork alloc] initWithImage:testImagePNG name:@"testImagePNG" persistent:true asImageFormat:SDLArtworkImageFormatPNG];
+            });
+
+            it(@"should create a JPG image successfully", ^{
+                expectedImageFormat = SDLFileTypeJPEG;
+                expectedImageData = UIImageJPEGRepresentation(testImageJPG, 0.85);
+                expectedArtwork = [[SDLArtwork alloc] initWithImage:testImageJPG name:@"testImageJPG" persistent:true asImageFormat:SDLArtworkImageFormatJPG];
+            });
+
+            afterEach(^{
+                expect(expectedImageFormat).to(equal(expectedArtwork.fileType));
+                expect(expectedImageData).to(equal(expectedArtwork.data));
+            });
+        });
+
+        describe(@"When setting the image persistence", ^{
+            __block Boolean expectedPersistance = false;
+
+            it(@"should set the image persistence to ephemeral successfully", ^{
+                Boolean persistance = false;
+                expectedPersistance = persistance;
+                expectedArtwork = [[SDLArtwork alloc] initWithImage:testImagePNG name:@"testImagePNG" persistent:persistance asImageFormat:SDLArtworkImageFormatPNG];
+            });
+
+            it(@"should set the image persistence to permanent successfully", ^{
+                Boolean persistance = true;
+                expectedPersistance = persistance;
+                expectedArtwork = [[SDLArtwork alloc] initWithImage:testImagePNG name:@"testImagePNG" persistent:persistance asImageFormat:SDLArtworkImageFormatPNG];
+            });
+
+            afterEach(^{
+                expect(expectedPersistance).to(equal(expectedArtwork.persistent));
+            });
+        });
+    });
+
+    context(@"A name created from hashing the image data should be unique to the image", ^{
+        __block NSString *expectedName1 = nil;
+        __block NSString *expectedName2 = nil;
+
+        beforeEach(^{
+            expectedName1 = nil;
+            expectedName2 = nil;
+        });
+
+        it(@"should create the same name for the same image", ^{
+            expectedName1 = [[SDLArtwork alloc] md5HashFromNSData:UIImagePNGRepresentation(testImagePNG)];
+            expectedName2 = [[SDLArtwork alloc] md5HashFromNSData:UIImagePNGRepresentation(testImagePNG)];
+            expect(expectedName1).to(equal(expectedName2));
+        });
+
+        it(@"should not create the same name for different images", ^{
+            expectedName1 = [[SDLArtwork alloc] md5HashFromNSData:UIImagePNGRepresentation(testImagePNG)];
+            expectedName2 = [[SDLArtwork alloc] md5HashFromNSData:UIImagePNGRepresentation(testImagePNG2)];
+            expect(expectedName1).toNot(equal(expectedName2));
         });
     });
 });

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLArtworkSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLArtworkSpec.m
@@ -5,7 +5,7 @@
 #import "SDLFileType.h"
 
 @interface SDLArtwork()
-- (NSString *)md5HashFromNSData:(NSData *)data;
+- (NSString *)sdl_md5HashFromNSData:(NSData *)data;
 @end
 
 QuickSpecBegin(SDLArtworkSpec)
@@ -62,7 +62,7 @@ describe(@"SDLArtwork", ^{
 
             context(@"When no name is provided", ^{
                 it(@"should create a unique name based on the hash of the image", ^{
-                    expectedName = [[SDLArtwork alloc] md5HashFromNSData:UIImagePNGRepresentation(testImagePNG)];
+                    expectedName = [[SDLArtwork alloc] sdl_md5HashFromNSData:UIImagePNGRepresentation(testImagePNG)];
                     expectedArtwork = [[SDLArtwork alloc] initWithImage:testImagePNG persistent:true asImageFormat:SDLArtworkImageFormatPNG];
                 });
 
@@ -135,14 +135,14 @@ describe(@"SDLArtwork", ^{
         });
 
         it(@"should create the same name for the same image", ^{
-            expectedName1 = [[SDLArtwork alloc] md5HashFromNSData:UIImagePNGRepresentation(testImagePNG)];
-            expectedName2 = [[SDLArtwork alloc] md5HashFromNSData:UIImagePNGRepresentation(testImagePNG)];
+            expectedName1 = [[SDLArtwork alloc] sdl_md5HashFromNSData:UIImagePNGRepresentation(testImagePNG)];
+            expectedName2 = [[SDLArtwork alloc] sdl_md5HashFromNSData:UIImagePNGRepresentation(testImagePNG)];
             expect(expectedName1).to(equal(expectedName2));
         });
 
         it(@"should not create the same name for different images", ^{
-            expectedName1 = [[SDLArtwork alloc] md5HashFromNSData:UIImagePNGRepresentation(testImagePNG)];
-            expectedName2 = [[SDLArtwork alloc] md5HashFromNSData:UIImagePNGRepresentation(testImagePNG2)];
+            expectedName1 = [[SDLArtwork alloc] sdl_md5HashFromNSData:UIImagePNGRepresentation(testImagePNG)];
+            expectedName2 = [[SDLArtwork alloc] sdl_md5HashFromNSData:UIImagePNGRepresentation(testImagePNG2)];
             expect(expectedName1).toNot(equal(expectedName2));
         });
     });

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLArtworkSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLArtworkSpec.m
@@ -5,7 +5,7 @@
 #import "SDLFileType.h"
 
 @interface SDLArtwork()
-- (NSString *)sdl_md5HashFromNSData:(NSData *)data;
++ (NSString *)sdl_md5HashFromNSData:(NSData *)data;
 @end
 
 QuickSpecBegin(SDLArtworkSpec)
@@ -62,7 +62,7 @@ describe(@"SDLArtwork", ^{
 
             context(@"When no name is provided", ^{
                 it(@"should create a unique name based on the hash of the image", ^{
-                    expectedName = [[SDLArtwork alloc] sdl_md5HashFromNSData:UIImagePNGRepresentation(testImagePNG)];
+                    expectedName = [SDLArtwork sdl_md5HashFromNSData:UIImagePNGRepresentation(testImagePNG)];
                     expectedArtwork = [[SDLArtwork alloc] initWithImage:testImagePNG persistent:true asImageFormat:SDLArtworkImageFormatPNG];
                 });
 
@@ -135,14 +135,14 @@ describe(@"SDLArtwork", ^{
         });
 
         it(@"should create the same name for the same image", ^{
-            expectedName1 = [[SDLArtwork alloc] sdl_md5HashFromNSData:UIImagePNGRepresentation(testImagePNG)];
-            expectedName2 = [[SDLArtwork alloc] sdl_md5HashFromNSData:UIImagePNGRepresentation(testImagePNG)];
+            expectedName1 = [SDLArtwork sdl_md5HashFromNSData:UIImagePNGRepresentation(testImagePNG)];
+            expectedName2 = [SDLArtwork sdl_md5HashFromNSData:UIImagePNGRepresentation(testImagePNG)];
             expect(expectedName1).to(equal(expectedName2));
         });
 
         it(@"should not create the same name for different images", ^{
-            expectedName1 = [[SDLArtwork alloc] sdl_md5HashFromNSData:UIImagePNGRepresentation(testImagePNG)];
-            expectedName2 = [[SDLArtwork alloc] sdl_md5HashFromNSData:UIImagePNGRepresentation(testImagePNG2)];
+            expectedName1 = [SDLArtwork sdl_md5HashFromNSData:UIImagePNGRepresentation(testImagePNG)];
+            expectedName2 = [SDLArtwork sdl_md5HashFromNSData:UIImagePNGRepresentation(testImagePNG2)];
             expect(expectedName1).toNot(equal(expectedName2));
         });
     });

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLFileManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLFileManagerSpec.m
@@ -436,6 +436,24 @@ describe(@"SDLFileManager", ^{
                     });
                 });
             });
+
+            describe(@"uploading artwork file", ^{
+                beforeEach(^{
+
+                });
+
+                it(@"should return the artwork name when the artwork has already been uploaded", ^{
+
+                });
+
+                it(@"should upload the art and return the artwork name if the artwork has not yet been uploaded", ^{
+
+                });
+
+                afterEach(^{
+
+                });
+            });
         });
 
         afterEach(^{

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLFileManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLFileManagerSpec.m
@@ -1107,13 +1107,13 @@ describe(@"SDLFileManager uploading/deleting multiple files", ^{
                             [expectedSuccessfulFileNames addObject:testArtwork.name];
                             testFileManagerResponses[testArtwork.name] = [[TestResponse alloc] initWithResponse:successfulResponse error:nil];
 
-                            testFileManagerProgressResponses[testArtwork.name] = [[TestProgressResponse alloc] initWithFileName:testArtwork.name testUploadPercentage:0 error:nil];
+                            testFileManagerProgressResponses[testArtwork.name] = [[TestFileProgressResponse alloc] initWithFileName:testArtwork.name testUploadPercentage:0 error:nil];
                         }
 
                         float testTotalBytesUploaded = 0.0;
                         for (SDLArtwork *artwork in testArtworks) {
                             testTotalBytesUploaded += artwork.fileSize;
-                            TestProgressResponse *response = testFileManagerProgressResponses[artwork.name];
+                            TestFileProgressResponse *response = testFileManagerProgressResponses[artwork.name];
                             response.testUploadPercentage = testTotalBytesUploaded / testTotalBytesToUpload;
                         }
 
@@ -1125,7 +1125,7 @@ describe(@"SDLFileManager uploading/deleting multiple files", ^{
                 afterEach(^{
                     waitUntilTimeout(10, ^(void (^done)(void)){
                         [testFileManager uploadArtworks:testArtworks progressHandler:^BOOL(NSString * _Nonnull artworkName, float uploadPercentage, NSError * _Nullable error) {
-                            TestProgressResponse *testProgressResponse = testFileManagerProgressResponses[artworkName];
+                            TestFileProgressResponse *testProgressResponse = testFileManagerProgressResponses[artworkName];
                             expect(artworkName).to(equal(testProgressResponse.testFileName));
                             expect(uploadPercentage).to(equal(testProgressResponse.testUploadPercentage));
                             expect(error).to(testProgressResponse.testError == nil ? beNil() : equal(testProgressResponse.testError));

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleConfigurationSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleConfigurationSpec.m
@@ -201,7 +201,7 @@ describe(@"a lifecycle configuration", ^{
                 update.ttsName = test;
                 expect(update.appName).to(beNil());
                 expect(update.shortAppName).to(beNil());
-                expect(update.ttsName).to(match(test));
+                expect(update.ttsName).to(equal(test));
                 expect(update.voiceRecognitionCommandNames).to(beNil());
             });
                        
@@ -211,7 +211,7 @@ describe(@"a lifecycle configuration", ^{
                 expect(update.appName).to(beNil());
                 expect(update.shortAppName).to(beNil());
                 expect(update.ttsName).to(beNil());
-                expect(update.voiceRecognitionCommandNames).to(match(test));
+                expect(update.voiceRecognitionCommandNames).to(equal(test));
             });
         });
         
@@ -251,7 +251,7 @@ describe(@"a lifecycle configuration", ^{
                 
                 expect(update.appName).to(beNil());
                 expect(update.shortAppName).to(beNil());
-                expect(update.ttsName).to(match(test));
+                expect(update.ttsName).to(equal(test));
                 expect(update.voiceRecognitionCommandNames).to(beNil());
             });
             
@@ -262,7 +262,7 @@ describe(@"a lifecycle configuration", ^{
                 expect(update.appName).to(beNil());
                 expect(update.shortAppName).to(beNil());
                 expect(update.ttsName).to(beNil());
-                expect(update.voiceRecognitionCommandNames).to(match(test));
+                expect(update.voiceRecognitionCommandNames).to(equal(test));
             });
         });
     });

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLImageSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLImageSpec.m
@@ -15,31 +15,68 @@
 
 QuickSpecBegin(SDLImageSpec)
 
-describe(@"Getter/Setter Tests", ^ {
-    it(@"Should set and get correctly", ^ {
-        SDLImage* testStruct = [[SDLImage alloc] init];
-        
-        testStruct.value = @"value";
-        testStruct.imageType = SDLImageTypeStatic;
-        
-        expect(testStruct.value).to(equal(@"value"));
-        expect(testStruct.imageType).to(equal(SDLImageTypeStatic));
+describe(@"Getter/Setter Tests", ^{
+    context(@"When creating", ^{
+        __block SDLImage *testSDLImage = nil;
+        __block NSString *expectedValue;
+        __block SDLImageType expectedImageType;
+
+        beforeEach(^{
+            testSDLImage = nil;
+            expectedValue = nil;
+            expectedImageType = nil;
+        });
+
+        it(@"Should set and get correctly", ^{
+            NSString *value = @"value";
+            SDLImageType imageType = SDLImageTypeDynamic;
+
+            testSDLImage = [[SDLImage alloc] init];
+            testSDLImage.value = value;
+            testSDLImage.imageType = imageType;
+
+            expectedValue = value;
+            expectedImageType = imageType;
+        });
+
+        it(@"Should get correctly when initialized as a dictionary", ^{
+            NSString *value = @"value";
+            SDLImageType imageType = SDLImageTypeStatic;
+
+            NSMutableDictionary* dict = [@{SDLNameValue:value,
+                                           SDLNameImageType:imageType} mutableCopy];
+            testSDLImage = [[SDLImage alloc] initWithDictionary:dict];
+
+            expectedValue = value;
+            expectedImageType = imageType;
+        });
+
+        it(@"Should get correctly when initialized with a name only", ^{
+            NSString *name = @"value";
+            testSDLImage = [[SDLImage alloc] initWithName:name];
+
+            expectedValue = name;
+            expectedImageType = SDLImageTypeDynamic;
+        });
+
+        it(@"Should get correctly when initialized with static image value", ^{
+            UInt16 staticImageValue = 2568;
+            testSDLImage = [[SDLImage alloc] initWithStaticImageValue:staticImageValue];
+
+            expectedValue = @"2568";
+            expectedImageType = SDLImageTypeStatic;
+        });
+
+        afterEach(^{
+            expect(testSDLImage.value).to(equal(expectedValue));
+            expect(testSDLImage.imageType).to(equal(expectedImageType));
+        });
     });
-    
-    it(@"Should get correctly when initialized", ^ {
-        NSMutableDictionary* dict = [@{SDLNameValue:@"value",
-                                       SDLNameImageType:SDLImageTypeStatic} mutableCopy];
-        SDLImage* testStruct = [[SDLImage alloc] initWithDictionary:dict];
-        
-        expect(testStruct.value).to(equal(@"value"));
-        expect(testStruct.imageType).to(equal(SDLImageTypeStatic));
-    });
-    
-    it(@"Should return nil if not set", ^ {
-        SDLImage* testStruct = [[SDLImage alloc] init];
-        
-        expect(testStruct.value).to(beNil());
-        expect(testStruct.imageType).to(beNil());
+
+    it(@"Should return nil if not set", ^{
+        SDLImage *testSDLImage = [[SDLImage alloc] init];
+        expect(testSDLImage.value).to(beNil());
+        expect(testSDLImage.imageType).to(beNil());
     });
 });
 

--- a/SmartDeviceLinkTests/TestMultipleFilesConnectionManager.m
+++ b/SmartDeviceLinkTests/TestMultipleFilesConnectionManager.m
@@ -21,7 +21,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)sendManagerRequest:(__kindof SDLRPCRequest *)request withResponseHandler:(nullable SDLResponseHandler)handler {
     [super sendManagerRequest:request withResponseHandler:handler];
 
-    // Send a response if the request is a putfile
     if ([[request name] isEqualToString:SDLNamePutFile]) {
         SDLPutFile *putfileRequest = (SDLPutFile *)request;
         TestResponse *response = self.responses[putfileRequest.syncFileName];

--- a/SmartDeviceLink_Example/Classes/ProxyManager.m
+++ b/SmartDeviceLink_Example/Classes/ProxyManager.m
@@ -173,8 +173,8 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 + (SDLLifecycleConfiguration *)sdlex_setLifecycleConfigurationPropertiesOnConfiguration:(SDLLifecycleConfiguration *)config {
-    SDLArtwork *appIconArt = [SDLArtwork persistentArtworkWithImage:[UIImage imageNamed:@"AppIcon60x60@2x"] name:@"AppIcon" asImageFormat:SDLArtworkImageFormatPNG];
-    
+    SDLArtwork *appIconArt = [SDLArtwork persistentArtworkWithImage:[UIImage imageNamed:@"AppIcon60x60@2x"] asImageFormat:SDLArtworkImageFormatPNG];
+
     config.shortAppName = @"SDL Example";
     config.appIcon = appIconArt;
     config.voiceRecognitionCommandNames = @[@"S D L Example"];

--- a/SmartDeviceLink_Example/Classes/ProxyManager.m
+++ b/SmartDeviceLink_Example/Classes/ProxyManager.m
@@ -172,11 +172,12 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 + (SDLLogConfiguration *)sdlex_logConfiguration {
+    // The default configuration shows Error, Warning and Debug logs. The only logs not shown with the default log configuration is Verbose.
     SDLLogConfiguration *logConfig = [SDLLogConfiguration defaultConfiguration];
     SDLLogFileModule *sdlExampleModule = [SDLLogFileModule moduleWithName:@"SDL Example" files:[NSSet setWithArray:@[@"ProxyManager"]]];
     logConfig.modules = [logConfig.modules setByAddingObject:sdlExampleModule];
     logConfig.targets = [logConfig.targets setByAddingObject:[SDLLogTargetFile logger]];
-    logConfig.globalLogLevel = SDLLogLevelVerbose;
+    // logConfig.globalLogLevel = SDLLogLevelVerbose;
 
     return logConfig;
 }
@@ -284,7 +285,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)sdlex_sendPerformOnlyChoiceInteractionWithManager:(SDLManager *)manager {
     SDLPerformInteraction *performOnlyChoiceInteraction = [[SDLPerformInteraction alloc] initWithInitialPrompt:@"Choose an item from the list" initialText:@"Choose the only option! You have 5 seconds..." interactionChoiceSetIDList:@[@0] helpPrompt:@"Select an item from the list" timeoutPrompt:@"The list is closing" interactionMode:SDLInteractionModeBoth timeout:5000 vrHelp:nil];
     performOnlyChoiceInteraction.interactionLayout = SDLLayoutModeListOnly;
-    
+
     [manager sendRequest:performOnlyChoiceInteraction withResponseHandler:^(__kindof SDLRPCRequest * _Nullable request, __kindof SDLPerformInteractionResponse * _Nullable response, NSError * _Nullable error) {
         SDLLogD(@"Perform Interaction fired");
         if ((response == nil) || (error != nil)) {


### PR DESCRIPTION
Fixes #865

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Test cases added to:
* SDLArtworkSpec
* SDLImageSpec
* SDLFileManagerSpec

### Summary
* Added a convenience init to the `SDLArtwork` class that takes a `UIImage` and generates a unique name based on the hash of the image data.
* Added two convenience inits to the `SDLImage` class. 
* Added a function to `SDLFileManager` that adds a layer of abstraction to sending a `SDLArtwork`. The function handles checking if the remote already has a file with the same name and sends the artwork if not. The handler for the function returns the artwork name.  
    * `uploadArtwork:completionHandler:`
    * `uploadArtworks:completionHandler:`
    * `uploadArtworks:progressHandler:completionHandler:`
* Updated the example app to use the new `uploadArtwork:completionHandler:` function. 

### Changelog
##### Breaking Changes
* None

##### Bug Fixes
* Moved the HAX fix for ephemeral images (HAX: #827) from the `uploadFiles:` to `uploadFile:` function. Test cases were fixed and added for uploading files with the HAX implemented. 
* Added error handling for `nil` or empty `data` and made the returned error more specific.
* Fixed test cases in the SDLLifecycleConfigurationSpec

### Tasks Remaining:
- [x] Complete documentation
- [x] Need to handle case where the `SDLArtwork` is set to `overwrite`
- [x] Add example to Example App

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)