### PR TITLE
Video stream is stopped as soon as app enters background

### DIFF
--- a/SmartDeviceLink/SDLStreamingMediaLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingMediaLifecycleManager.m
@@ -291,7 +291,9 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
 
     [self sdl_sendBackgroundFrames];
     [self.touchManager cancelPendingTouches];
-    self.restartVideoStream = YES;
+
+    [self sdl_stopAudioSession];
+    [self sdl_stopVideoSession];
 }
 
 // Per Apple's guidelines: https://developer.apple.com/library/content/documentation/iPhone/Conceptual/iPhoneOSProgrammingGuide/StrategiesforHandlingAppStateTransitions/StrategiesforHandlingAppStateTransitions.html


### PR DESCRIPTION
Fixes #858

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Completed the smoke tests for video streaming from the SDL_iOS test plan.

### Summary
* Video streaming was not stopped when the app on the phone entered the background. When the app re-entered the foreground, video streaming was stopped and then immediately restarted. Video streaming is now stopped as soon as the app enters the background.

### Changelog
##### Breaking Changes
* None

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)