### PR TITLE
Pan gesture blocks single taps

### DIFF
--- a/SmartDeviceLink/SDLTouchManager.h
+++ b/SmartDeviceLink/SDLTouchManager.h
@@ -41,6 +41,13 @@ typedef void(^SDLTouchEventHandler)(SDLTouch *touch, SDLTouchType type);
 @property (nonatomic, assign) CGFloat tapDistanceThreshold;
 
 /**
+ Minimum distance for a pan gesture in the head unit's coordinate system, used for registering pan callbacks.
+ 
+ @note Defaults to 8 px.
+ */
+@property (nonatomic, assign) CGFloat panDistanceThreshold;
+
+/**
  *  @abstract
  *      Time (in seconds) between tap events to register a double-tap callback.
  *  @remark

--- a/SmartDeviceLink/SDLTouchManager.m
+++ b/SmartDeviceLink/SDLTouchManager.m
@@ -246,8 +246,7 @@ static NSUInteger const MaximumNumberOfTouches = 2;
     
     CGFloat xDelta = fabs(touch.location.x - self.firstTouch.location.x);
     CGFloat yDelta = fabs(touch.location.y - self.firstTouch.location.y);
-    if (xDelta <= self.panDistanceThreshold && yDelta <= self.panDistanceThreshold)
-    {
+    if (xDelta <= self.panDistanceThreshold && yDelta <= self.panDistanceThreshold) {
         return;
     }
 

--- a/SmartDeviceLink/SDLTouchManager.m
+++ b/SmartDeviceLink/SDLTouchManager.m
@@ -43,7 +43,13 @@ static NSUInteger const MaximumNumberOfTouches = 2;
 
 /*!
  *  @abstract
- *      First Touch received from onOnTouchEvent.
+ *      First touch received from onOnTouchEvent.
+ */
+@property (nonatomic, strong, nullable) SDLTouch *firstTouch;
+
+/*!
+ *  @abstract
+ *      Previous touch received from onOnTouchEvent.
  */
 @property (nonatomic, strong, nullable) SDLTouch *previousTouch;
 
@@ -106,6 +112,7 @@ static NSUInteger const MaximumNumberOfTouches = 2;
     _movementTimeThreshold = 0.05f;
     _tapTimeThreshold = 0.4f;
     _tapDistanceThreshold = 50.0f;
+    _panDistanceThreshold = 8.0f;
     _touchEnabled = YES;
     _enableSyncedPanning = YES;
 
@@ -235,6 +242,13 @@ static NSUInteger const MaximumNumberOfTouches = 2;
         return; // no-op
     }
 #pragma clang diagnostic pop
+    
+    CGFloat xDelta = fabs(touch.location.x - self.firstTouch.location.x);
+    CGFloat yDelta = fabs(touch.location.y - self.firstTouch.location.y);
+    if (xDelta <= self.panDistanceThreshold && yDelta <= self.panDistanceThreshold)
+    {
+        return;
+    }
 
     switch (self.performingTouchType) {
         case SDLPerformingTouchTypeMultiTouch: {

--- a/SmartDeviceLink/SDLTouchManager.m
+++ b/SmartDeviceLink/SDLTouchManager.m
@@ -215,6 +215,7 @@ static NSUInteger const MaximumNumberOfTouches = 2;
 
     switch (touch.identifier) {
         case SDLTouchIdentifierFirstFinger: {
+            self.firstTouch = touch;
             self.previousTouch = touch;
         } break;
         case SDLTouchIdentifierSecondFinger: {
@@ -338,6 +339,7 @@ static NSUInteger const MaximumNumberOfTouches = 2;
         case SDLPerformingTouchTypeNone: break;
     }
 
+    self.firstTouch = nil;
     self.previousTouch = nil;
     _performingTouchType = SDLPerformingTouchTypeNone;
 }
@@ -377,6 +379,7 @@ static NSUInteger const MaximumNumberOfTouches = 2;
         case SDLPerformingTouchTypeNone: break;
     }
 
+    self.firstTouch = nil;
     self.previousTouch = nil;
     _performingTouchType = SDLPerformingTouchTypeNone;
 }

--- a/SmartDeviceLinkTests/UtilitiesSpecs/Touches/SDLTouchManagerSpec.m
+++ b/SmartDeviceLinkTests/UtilitiesSpecs/Touches/SDLTouchManagerSpec.m
@@ -257,7 +257,54 @@ describe(@"SDLTouchManager Tests", ^{
                     expectedNumTimesHandlerCalled = 2;
                 });
             });
+            
+            describe(@"when receiving a single tap with small movement", ^{
+                
+                __block CGPoint movePoint;
+                __block SDLOnTouchEvent* firstOnTouchEventMove;
+                
+                beforeEach(^{
+                    const CGFloat moveDistance = touchManager.panDistanceThreshold;
+                    movePoint = CGPointMake(controlPoint.x + moveDistance, controlPoint.y + moveDistance);
+                    
+                    SDLTouchCoord* firstTouchCoordMove = [[SDLTouchCoord alloc] init];
+                    firstTouchCoordMove.x = @(movePoint.x);
+                    firstTouchCoordMove.y = @(movePoint.y);
+                    
+                    SDLTouchEvent* touchEventMove = [[SDLTouchEvent alloc] init];
+                    touchEventMove.touchEventId = @0;
+                    touchEventMove.coord = [NSArray arrayWithObject:firstTouchCoordMove];
+                    touchEventMove.timeStamp = [NSArray arrayWithObject:@(firstTouchTimeStamp)];
+                    
+                    firstOnTouchEventMove = [[SDLOnTouchEvent alloc] init];
+                    firstOnTouchEventMove.type = SDLTouchTypeMove;
+                    firstOnTouchEventMove.event = [NSArray arrayWithObject:touchEventMove];
+                    
+                    firstOnTouchEventEnd = [[SDLOnTouchEvent alloc] init];
+                    firstOnTouchEventEnd.type = SDLTouchTypeEnd;
+                    firstOnTouchEventEnd.event = [NSArray arrayWithObject:touchEventMove];
+                });
+                
+                it(@"should correctly handle a single tap", ^{
+                    singleTapTests = ^(NSInvocation* invocation) {
+                        __unsafe_unretained SDLTouchManager* touchManagerCallback;
+                        CGPoint point;
+                        [invocation getArgument:&touchManagerCallback atIndex:2];
+                        [invocation getArgument:&point atIndex:4];
+                        
+                        expect(touchManagerCallback).to(equal(touchManager));
+                        expect(@(CGPointEqualToPoint(point, movePoint))).to(beTruthy());
+                    };
 
+                    performTouchEvent(touchManager, firstOnTouchEventStart);
+                    performTouchEvent(touchManager, firstOnTouchEventMove);
+                    performTouchEvent(touchManager, firstOnTouchEventEnd);
+
+                    expectedDidCallSingleTap = YES;
+                    expectedNumTimesHandlerCalled = 3;
+                });
+            });
+            
             describe(@"when receiving a double tap", ^{
                 __block CGPoint averagePoint;
                 __block SDLTouchEvent* secondTouchEvent;


### PR DESCRIPTION
Fixes #879 

This PR is ready for review.

### Risk
This PR makes minor API changes.

### Testing Plan
I already added the test case: 'when receiving a single tap with small movement'

### Summary
Added a pan threshold distance to prevent pan gestures being recognised for small movements.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)