### PR TITLE
Fixed incorrect target membership for class (CocoaPods)

### DIFF
--- a/SmartDeviceLink-iOS.podspec
+++ b/SmartDeviceLink-iOS.podspec
@@ -138,6 +138,7 @@ ss.public_header_files = [
 'SmartDeviceLink/SDLLanguage.h',
 'SmartDeviceLink/SDLLayoutMode.h',
 'SmartDeviceLink/SDLLifecycleConfiguration.h',
+'SmartDeviceLink/SDLLifecycleConfigurationUpdate.h',
 'SmartDeviceLink/SDLListFiles.h',
 'SmartDeviceLink/SDLListFilesResponse.h',
 'SmartDeviceLink/SDLLocationCoordinate.h',

--- a/SmartDeviceLink.podspec
+++ b/SmartDeviceLink.podspec
@@ -138,6 +138,7 @@ ss.public_header_files = [
 'SmartDeviceLink/SDLLanguage.h',
 'SmartDeviceLink/SDLLayoutMode.h',
 'SmartDeviceLink/SDLLifecycleConfiguration.h',
+'SmartDeviceLink/SDLLifecycleConfigurationUpdate.h',
 'SmartDeviceLink/SDLListFiles.h',
 'SmartDeviceLink/SDLListFilesResponse.h',
 'SmartDeviceLink/SDLLocationCoordinate.h',


### PR DESCRIPTION
Fixes #877

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
I installed and compiled this PR in a test project.

### Summary
* When the SDL_iOS library was installed via CocoaPodas, the `SDLLifecycleConfigurationUpdate.h` file's target membership was set to **private** when it should have been **public**. To fix this, `SDLLifecycleConfigurationUpdate.h` was added to the `.podspec` files.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)