### PR TITLE
Fix #893 - AppHMIType fails if additional app types are not set

### DIFF
--- a/SmartDeviceLink/SDLRegisterAppInterface.m
+++ b/SmartDeviceLink/SDLRegisterAppInterface.m
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (instancetype)initWithLifecycleConfiguration:(SDLLifecycleConfiguration *)lifecycleConfiguration {
-    NSArray<SDLAppHMIType> *allHMITypes = [lifecycleConfiguration.additionalAppTypes arrayByAddingObject:lifecycleConfiguration.appType];
+    NSArray<SDLAppHMIType> *allHMITypes = lifecycleConfiguration.additionalAppTypes ? [lifecycleConfiguration.additionalAppTypes arrayByAddingObject:lifecycleConfiguration.appType] : @[lifecycleConfiguration.appType];
 
     return [self initWithAppName:lifecycleConfiguration.appName
                            appId:lifecycleConfiguration.appId


### PR DESCRIPTION
Fixes #893

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
n/a

### Summary
Allows appHMIType to be sent in RAI if only the primary appHMIType is set

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
