### PR TITLE
Fixed change registration not sent

### DIFF
--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -492,7 +492,9 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
 }
 
 - (void)sendConnectionRequest:(__kindof SDLRPCRequest *)request withResponseHandler:(nullable SDLResponseHandler)handler {
-    if (![self.lifecycleStateMachine isCurrentState:SDLLifecycleStateReady]) {
+    if (![self.lifecycleStateMachine isCurrentState:SDLLifecycleStateReady]
+        && !([self.lifecycleStateMachine isCurrentState:SDLLifecycleStateSettingUpManagers]
+             && [request isKindOfClass:SDLChangeRegistration.class])) {
         SDLLogW(@"Manager not ready, message not sent (%@)", request);
         if (handler) {
             dispatch_async(dispatch_get_main_queue(), ^{

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -323,8 +323,8 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
         changeRegistration.ngnMediaScreenAppName = configUpdate.shortAppName;
         changeRegistration.ttsName = configUpdate.ttsName;
         changeRegistration.vrSynonyms = configUpdate.voiceRecognitionCommandNames;
-      
-        [self sendRequest:changeRegistration];
+
+        [self sendConnectionManagerRequest:changeRegistration withResponseHandler:nil];
     }
     
     [self.lifecycleStateMachine transitionToState:SDLLifecycleStateSettingUpManagers];
@@ -492,9 +492,7 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
 }
 
 - (void)sendConnectionRequest:(__kindof SDLRPCRequest *)request withResponseHandler:(nullable SDLResponseHandler)handler {
-    if (![self.lifecycleStateMachine isCurrentState:SDLLifecycleStateReady]
-        && !([self.lifecycleStateMachine isCurrentState:SDLLifecycleStateSettingUpManagers]
-             && [request isKindOfClass:SDLChangeRegistration.class])) {
+    if (![self.lifecycleStateMachine isCurrentState:SDLLifecycleStateReady]) {
         SDLLogW(@"Manager not ready, message not sent (%@)", request);
         if (handler) {
             dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
Fixes #902 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Smoke tests

### Summary
* In the `SDLLifecycleManager`'s `didEnterStateUpdatingConfiguration:` method, the the change registration request is now sent with via `sendConnectionManagerRequest:handler` instead of `sendRequest:`. This bypasses the current state machine check. 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)