### PR TITLE
Fix a crash on iOS 9 when video streaming is started

### DIFF
--- a/SmartDeviceLink/SDLStreamingMediaLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingMediaLifecycleManager.m
@@ -736,7 +736,11 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
 
 - (void)sdl_displayLinkFired:(CADisplayLink *)displayLink {
     NSAssert([NSThread isMainThread], @"Display link should always fire on the main thread");
-    SDLLogV(@"DisplayLink frame fired, duration: %f, last frame timestamp: %f, target timestamp: %f", displayLink.duration, displayLink.timestamp, displayLink.targetTimestamp);
+    if (@available(iOS 10.0, *)) {
+        SDLLogV(@"DisplayLink frame fired, duration: %f, last frame timestamp: %f, target timestamp: %f", displayLink.duration, displayLink.timestamp, displayLink.targetTimestamp);
+    } else {
+        SDLLogV(@"DisplayLink frame fired, duration: %f, last frame timestamp: %f, target timestamp: (not available)", displayLink.duration, displayLink.timestamp);
+    }
 
     [self.touchManager syncFrame];
     [self.carWindow syncFrame];


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_ios/issues/904

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Tested on iOS 9.0.2 device and confirmed that the crash does not reproduce.

### Summary
This PR prohibits accessing CADisplayLink.targetTimestamp on iOS 9 (and before) devices.

### Changelog
##### Bug Fixes
* Fix a crash on iOS 9 when video streaming is started

### Tasks Remaining:
- None

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
