### PR TITLE
WIP: Screen Manager extensions and fixes

### DIFF
--- a/SmartDeviceLink/SDLScreenManager.h
+++ b/SmartDeviceLink/SDLScreenManager.h
@@ -32,6 +32,7 @@ typedef void(^SDLScreenManagerUpdateCompletionHandler)(NSError *__nullable error
 @property (copy, nonatomic, nullable) NSString *textField2;
 @property (copy, nonatomic, nullable) NSString *textField3;
 @property (copy, nonatomic, nullable) NSString *textField4;
+@property (copy, nonatomic, nullable) NSString *mediaTrackTextField;
 @property (strong, nonatomic, nullable) SDLArtwork *primaryGraphic;
 @property (strong, nonatomic, nullable) SDLArtwork *secondaryGraphic;
 

--- a/SmartDeviceLink/SDLScreenManager.m
+++ b/SmartDeviceLink/SDLScreenManager.m
@@ -62,6 +62,10 @@ NS_ASSUME_NONNULL_BEGIN
     self.textAndGraphicManager.textField4 = textField4;
 }
 
+- (void)setMediaTrackTextField:(nullable NSString *)mediaTrackTextField {
+    self.textAndGraphicManager.mediaTrackTextField = mediaTrackTextField;
+}
+
 - (void)setPrimaryGraphic:(nullable SDLArtwork *)primaryGraphic {
     if (primaryGraphic == nil) {
         self.textAndGraphicManager.primaryGraphic = self.textAndGraphicManager.blankArtwork;
@@ -120,6 +124,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable NSString *)textField4 {
     return _textAndGraphicManager.textField4;
+}
+
+- (nullable NSString *)mediaTrackTextField {
+    return _textAndGraphicManager.mediaTrackTextField;
 }
 
 - (nullable SDLArtwork *)primaryGraphic {

--- a/SmartDeviceLink/SDLSoftButtonManager.m
+++ b/SmartDeviceLink/SDLSoftButtonManager.m
@@ -13,7 +13,9 @@
 #import "SDLError.h"
 #import "SDLFileManager.h"
 #import "SDLLogMacros.h"
+#import "SDLOnHMIStatus.h"
 #import "SDLRegisterAppInterfaceResponse.h"
+#import "SDLRPCNotificationNotification.h"
 #import "SDLRPCResponseNotification.h"
 #import "SDLSetDisplayLayoutResponse.h"
 #import "SDLShow.h"
@@ -45,8 +47,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic) BOOL hasQueuedUpdate;
 @property (copy, nonatomic, nullable) SDLSoftButtonUpdateCompletionHandler queuedUpdateHandler;
 
+@property (copy, nonatomic, nullable) SDLHMILevel currentLevel;
 @property (strong, nonatomic, nullable) SDLDisplayCapabilities *displayCapabilities;
 @property (strong, nonatomic, nullable) SDLSoftButtonCapabilities *softButtonCapabilities;
+
+@property (assign, nonatomic) BOOL waitingOnHMILevelUpdateToSetButtons;
 
 @end
 
@@ -60,13 +65,22 @@ NS_ASSUME_NONNULL_BEGIN
     _fileManager = fileManager;
     _softButtonObjects = @[];
 
+    _waitingOnHMILevelUpdateToSetButtons = NO;
+
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_registerResponse:) name:SDLDidReceiveRegisterAppInterfaceResponse object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_displayLayoutResponse:) name:SDLDidReceiveSetDisplayLayoutResponse object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_hmiStatusNotification:) name:SDLDidChangeHMIStatusNotification object:nil];
 
     return self;
 }
 
 - (void)setSoftButtonObjects:(NSArray<SDLSoftButtonObject *> *)softButtonObjects {
+    if ([self.currentLevel isEqualToString:SDLHMILevelNone]) {
+        _waitingOnHMILevelUpdateToSetButtons = YES;
+        _softButtonObjects = softButtonObjects;
+        return;
+    }
+
     self.inProgressUpdate = nil;
     if (self.inProgressHandler != nil) {
         self.inProgressHandler([NSError sdl_softButtonManager_pendingUpdateSuperseded]);
@@ -161,6 +175,11 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)sdl_updateWithCompletionHandler:(nullable SDLSoftButtonUpdateCompletionHandler)handler {
+    // Don't send if we're in HMI NONE
+    if ([self.currentLevel isEqualToString:SDLHMILevelNone]) {
+        return;
+    }
+
     SDLLogD(@"Updating soft buttons");
     if (self.inProgressUpdate != nil) {
         SDLLogV(@"In progress update exists, queueing update");
@@ -301,6 +320,22 @@ NS_ASSUME_NONNULL_BEGIN
 
     // Auto-send an updated Show
     [self updateWithCompletionHandler:nil];
+}
+
+- (void)sdl_hmiStatusNotification:(SDLRPCNotificationNotification *)notification {
+    SDLOnHMIStatus *hmiStatus = (SDLOnHMIStatus *)notification.notification;
+
+    SDLHMILevel oldHMILevel = self.currentLevel;
+    self.currentLevel = hmiStatus.hmiLevel;
+
+    // Auto-send an updated show if we were in NONE and now we are not
+    if ([oldHMILevel isEqualToString:SDLHMILevelNone] && ![self.currentLevel isEqualToString:SDLHMILevelNone]) {
+        if (self.waitingOnHMILevelUpdateToSetButtons) {
+            [self setSoftButtonObjects:_softButtonObjects];
+        } else {
+            [self sdl_updateWithCompletionHandler:nil];
+        }
+    }
 }
 
 @end

--- a/SmartDeviceLink/SDLSoftButtonObject.h
+++ b/SmartDeviceLink/SDLSoftButtonObject.h
@@ -68,7 +68,9 @@ NS_ASSUME_NONNULL_BEGIN
  @param stateName The next state.
  @return YES if a state was found with that name, NO otherwise.
  */
-- (BOOL)transitionToState:(NSString *)stateName;
+- (BOOL)transitionToStateNamed:(NSString *)stateName;
+
+- (void)transitionToNextState;
 
 /**
  Return a state from the state array with a specific name.

--- a/SmartDeviceLink/SDLSoftButtonObject.m
+++ b/SmartDeviceLink/SDLSoftButtonObject.m
@@ -47,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
     return [self initWithName:name states:@[state] initialStateName:state.name handler:eventHandler];
 }
 
-- (BOOL)transitionToState:(NSString *)stateName {
+- (BOOL)transitionToStateNamed:(NSString *)stateName {
     if ([self stateWithName:stateName] == nil) {
         SDLLogE(@"Attempted to transition to state: %@ on soft button: %@ but no state with that name was found", stateName, self.name);
         return NO;
@@ -58,6 +58,19 @@ NS_ASSUME_NONNULL_BEGIN
     [self.manager updateWithCompletionHandler:nil];
 
     return YES;
+}
+
+- (void)transitionToNextState {
+    NSString *nextStateName = nil;
+    for (NSUInteger i = 0; i < self.states.count; i++) {
+        if ([self.states[i].name isEqualToString:self.currentStateName]) {
+            NSUInteger nextStateNumber = (i == self.states.count) ? 0 : i;
+            nextStateName = self.states[nextStateNumber].name;
+            break;
+        }
+    }
+
+    [self transitionToStateNamed:nextStateName];
 }
 
 - (SDLSoftButtonState *)currentState {

--- a/SmartDeviceLink/SDLTextAndGraphicManager.h
+++ b/SmartDeviceLink/SDLTextAndGraphicManager.h
@@ -35,6 +35,7 @@ typedef void(^SDLTextAndGraphicUpdateCompletionHandler)(NSError *__nullable erro
 @property (copy, nonatomic, nullable) NSString *textField2;
 @property (copy, nonatomic, nullable) NSString *textField3;
 @property (copy, nonatomic, nullable) NSString *textField4;
+@property (copy, nonatomic, nullable) NSString *mediaTrackTextField;
 @property (strong, nonatomic, nullable) SDLArtwork *primaryGraphic;
 @property (strong, nonatomic, nullable) SDLArtwork *secondaryGraphic;
 

--- a/SmartDeviceLink/SDLTextAndGraphicManager.m
+++ b/SmartDeviceLink/SDLTextAndGraphicManager.m
@@ -210,6 +210,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (SDLShow *)sdl_assembleShowText:(SDLShow *)show {
     [self sdl_setBlankTextFieldsWithShow:show];
+
+    if (self.mediaTrackTextField != nil) {
+        show.mediaTrack = self.mediaTrackTextField;
+    } else {
+        show.mediaTrack = @"";
+    }
+    
     NSArray *nonNilFields = [self sdl_findNonNilTextFields];
     if (nonNilFields.count == 0) { return show; }
 
@@ -489,6 +496,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)setTextField4:(nullable NSString *)textField4 {
     _textField4 = textField4;
+    if (!self.isBatchingUpdates) {
+        [self sdl_updateWithCompletionHandler:nil];
+    } else {
+        _isDirty = YES;
+    }
+}
+
+- (void)setMediaTrackTextField:(nullable NSString *)mediaTrackTextField {
+    _mediaTrackTextField = mediaTrackTextField;
     if (!self.isBatchingUpdates) {
         [self sdl_updateWithCompletionHandler:nil];
     } else {

--- a/SmartDeviceLink_Example/Classes/ProxyManager.m
+++ b/SmartDeviceLink_Example/Classes/ProxyManager.m
@@ -150,7 +150,7 @@ NS_ASSUME_NONNULL_BEGIN
     _hexagonEnabled = hexagonEnabled;
 
     SDLSoftButtonObject *object = [self.sdlManager.screenManager softButtonObjectNamed:@"HexagonButton"];
-    [object transitionToState:(hexagonEnabled ? @"onState" : @"offState")];
+    [object transitionToStateNamed:(hexagonEnabled ? @"onState" : @"offState")];
 }
 
 - (void)sdlex_updateScreen {
@@ -373,7 +373,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         weakself.textEnabled = !weakself.textEnabled;
         SDLSoftButtonObject *object = [weakself.sdlManager.screenManager softButtonObjectNamed:@"TextButton"];
-        [object transitionToState:(weakself.textEnabled ? @"onState" : @"offState")];
+        [object transitionToNextState];
 
         SDLLogD(@"Text visibility soft button press fired %d", weakself.textEnabled);
     }];
@@ -388,7 +388,7 @@ NS_ASSUME_NONNULL_BEGIN
         weakself.imagesEnabled = !weakself.imagesEnabled;
 
         SDLSoftButtonObject *object = [weakself.sdlManager.screenManager softButtonObjectNamed:@"ImagesButton"];
-        [object transitionToState:(weakself.imagesEnabled ? @"onState" : @"offState")];
+        [object transitionToNextState];
 
         SDLLogD(@"Image visibility soft button press fired %d", weakself.imagesEnabled);
     }];


### PR DESCRIPTION
Fixes #906 

This PR is **not ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Tests will be added

### Summary
This PR adds a few minor extensions to the screen manager:

1. If the app is in HMI NONE, Show updates are still sent. They should be held until a non-NONE state is reached.
2. Add the media track Show field
3. Add an addition to SoftButtonObject to allow transitioning to the next state without knowing the name.

### Tasks Remaining:
- [ ] Tests

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)