### PR TITLE
fix: memory leaks in the SDLLifecycleManager

### DIFF
--- a/SmartDeviceLink/SDLFileManager.m
+++ b/SmartDeviceLink/SDLFileManager.m
@@ -147,7 +147,10 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
     [self.class sdl_clearTemporaryFileDirectory];
     self.bytesAvailable = 0;
 
-    self.startupCompletionHandler = nil;
+    if (self.startupCompletionHandler != nil) {
+        self.startupCompletionHandler(NO, [NSError sdl_fileManager_unableToStartError]);
+        self.startupCompletionHandler = nil;
+    }
 }
 
 - (void)didEnterStateFetchingInitialList {

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -361,7 +361,10 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
 
     // When done, we want to transition, even if there were errors. They may be expected, e.g. on head units that do not support files.
     dispatch_group_notify(managerGroup, self.lifecycleQueue, ^{
-        [self.lifecycleStateMachine transitionToState:SDLLifecycleStateSettingUpAppIcon];
+        // We could have been shut down while waiting for the completion of starting file manager and permission manager.
+        if (self.lifecycleState == SDLLifecycleStateSettingUpManagers) {
+            [self.lifecycleStateMachine transitionToState:SDLLifecycleStateSettingUpAppIcon];
+        }
     });
 }
 

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLFileManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLFileManagerSpec.m
@@ -62,11 +62,14 @@ describe(@"SDLFileManager", ^{
     describe(@"after receiving a start message", ^{
         __block BOOL startupSuccess = NO;
         __block NSError *startupError = nil;
+        __block BOOL completionHandlerCalled = NO;
 
         beforeEach(^{
+            completionHandlerCalled = NO;
             [testFileManager startWithCompletionHandler:^(BOOL success, NSError * _Nullable error) {
                 startupSuccess = success;
                 startupError = error;
+                completionHandlerCalled = YES;
             }];
 
             testFileManager.suspended = NO;
@@ -101,6 +104,7 @@ describe(@"SDLFileManager", ^{
 
             it(@"should remain in the stopped state after receiving the response if disconnected", ^{
                 expect(testFileManager.currentState).toEventually(match(SDLFileManagerStateShutdown));
+                expect(@(completionHandlerCalled)).toEventually(equal(@YES));
             });
         });
 


### PR DESCRIPTION
Fixes #919 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Confirmed with our internal devboard.

### Summary
startupCompletionHandler of SDLLifecycleManager is not called when it is shut down before transition to Ready state.
This causes that SDLLifecycleManager continues waiting dispatch_group. As a result, memory leaks occurs.

### Changelog
##### Bug Fixes
* Fix memory leak in SDLLifecycleManager.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
