### PR TITLE
reset retry counter when accessory is connected

### DIFF
--- a/SmartDeviceLink/SDLIAPTransport.m
+++ b/SmartDeviceLink/SDLIAPTransport.m
@@ -146,7 +146,8 @@ int const ProtocolIndexTimeoutSeconds = 10;
         SDLLogD(@"Accessory connected while app is in background. Starting background task.");
         [self sdl_backgroundTaskStart];
     }
-    
+
+    self.retryCounter = 0;
     [self performSelector:@selector(sdl_connect:) withObject:nil afterDelay:retryDelay];
 }
 


### PR DESCRIPTION
Fixes #921 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
I confirmed the fix in our internal HU devboard.

### Summary
Reset retry counter when accessory is connected.

### Changelog
##### Bug Fixes
* Reset retry counter when accessory is connected.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
