### PR TITLE
Fix manager should not notify delegates of nil -> nil changes

### DIFF
--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -614,16 +614,19 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
     }
 
     dispatch_async(dispatch_get_main_queue(), ^{
-        if (![oldHMILevel isEqualToEnum:self.hmiLevel]) {
+        if (![oldHMILevel isEqualToEnum:self.hmiLevel]
+            && !(oldHMILevel == nil && self.hmiLevel == nil)) {
             [self.delegate hmiLevel:oldHMILevel didChangeToLevel:self.hmiLevel];
         }
 
         if (![oldStreamingState isEqualToEnum:self.audioStreamingState]
+            && !(oldStreamingState == nil && self.audioStreamingState == nil)
             && [self.delegate respondsToSelector:@selector(audioStreamingState:didChangeToState:)]) {
             [self.delegate audioStreamingState:oldStreamingState didChangeToState:self.audioStreamingState];
         }
 
         if (![oldSystemContext isEqualToEnum:self.systemContext]
+            && !(oldSystemContext == nil && self.systemContext == nil)
             && [self.delegate respondsToSelector:@selector(systemContext:didChangeToContext:)]) {
             [self.delegate systemContext:oldSystemContext didChangeToContext:self.systemContext];
         }


### PR DESCRIPTION
Fixes #918 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
n/a

### Summary
This change causes `SDLManager` delegates to no longer be called if the change would be from `nil` to `nil`.

### Changelog
##### Bug Fixes
* `SDLManager` delegates will no longer be called if the change would be from `nil` to `nil`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)