### PR TITLE
fix SDLTouchManager to handle all touch events in SDLOnTouchEvent

### DIFF
--- a/SmartDeviceLink/SDLTouchManager.m
+++ b/SmartDeviceLink/SDLTouchManager.m
@@ -183,28 +183,29 @@ static NSUInteger const MaximumNumberOfTouches = 2;
     SDLOnTouchEvent* onTouchEvent = (SDLOnTouchEvent*)notification.notification;
 
     SDLTouchType touchType = onTouchEvent.type;
-    SDLTouchEvent *touchEvent = onTouchEvent.event.firstObject;
-    SDLTouch *touch = [[SDLTouch alloc] initWithTouchEvent:touchEvent];
+    [onTouchEvent.event enumerateObjectsUsingBlock:^(SDLTouchEvent *touchEvent, NSUInteger idx, BOOL *stop) {
+        SDLTouch *touch = [[SDLTouch alloc] initWithTouchEvent:touchEvent];
 
-    if (self.touchEventHandler) {
-        self.touchEventHandler(touch, touchType);
-    }
-
-    if (!self.touchEventDelegate || (touch.identifier > MaximumNumberOfTouches)) {
-        return;
-    }
-
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if ([onTouchEvent.type isEqualToEnum:SDLTouchTypeBegin]) {
-            [self sdl_handleTouchBegan:touch];
-        } else if ([onTouchEvent.type isEqualToEnum:SDLTouchTypeMove]) {
-            [self sdl_handleTouchMoved:touch];
-        } else if ([onTouchEvent.type isEqualToEnum:SDLTouchTypeEnd]) {
-            [self sdl_handleTouchEnded:touch];
-        } else if ([onTouchEvent.type isEqualToEnum:SDLTouchTypeCancel]) {
-            [self sdl_handleTouchCanceled:touch];
+        if (self.touchEventHandler) {
+            self.touchEventHandler(touch, touchType);
         }
-    });
+
+        if (!self.touchEventDelegate || (touch.identifier > MaximumNumberOfTouches)) {
+            return;
+        }
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if ([onTouchEvent.type isEqualToEnum:SDLTouchTypeBegin]) {
+                [self sdl_handleTouchBegan:touch];
+            } else if ([onTouchEvent.type isEqualToEnum:SDLTouchTypeMove]) {
+                [self sdl_handleTouchMoved:touch];
+            } else if ([onTouchEvent.type isEqualToEnum:SDLTouchTypeEnd]) {
+                [self sdl_handleTouchEnded:touch];
+            } else if ([onTouchEvent.type isEqualToEnum:SDLTouchTypeCancel]) {
+                [self sdl_handleTouchCanceled:touch];
+            }
+        });
+    }];
 }
 
 #pragma mark - Private


### PR DESCRIPTION
Fixes #934

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Unit test is also updated.

### Summary
Fix SDLTouchManager to handle all touch events in SDLOnTouchEvent.

### Changelog
##### Bug Fixes
* fix SDLTouchManager to handle all touch events in SDLOnTouchEvent

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
