### PR TITLE
add nil check for lockViewController

### DIFF
--- a/SmartDeviceLink/SDLLockScreenManager.m
+++ b/SmartDeviceLink/SDLLockScreenManager.m
@@ -82,7 +82,9 @@ NS_ASSUME_NONNULL_BEGIN
     self.canPresent = NO;
 
     // Remove the lock screen if presented, don't allow it to present again until we start
-    [self.presenter dismiss];
+    if (self.presenter.lockViewController != nil) {
+        [self.presenter dismiss];
+    }
 }
 
 - (nullable UIViewController *)lockScreenViewController {

--- a/SmartDeviceLink/SDLLockScreenPresenter.m
+++ b/SmartDeviceLink/SDLLockScreenPresenter.m
@@ -96,6 +96,9 @@ NS_ASSUME_NONNULL_BEGIN
         } else if (appWindow.isKeyWindow) {
             SDLLogW(@"Attempted to dismiss lock screen, but it is already dismissed");
             return;
+        } else if (self.lockViewController == nil) {
+            SDLLogW(@"Attempted to dismiss lock screen, but lockViewController is not set");
+            return;
         }
 
         // Let us know we are about to dismiss.


### PR DESCRIPTION
Fixes #937 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
I tested this fix our internal SDL iOS App and internal HU devboard.

### Summary
SDLLockScreenManager does not check presenter has a non-nil lockViewController at stop.
When lock screen configuration is "disabled", SDLLockScreenManager does not set lockViewController in presenter on start.

This cause presenter only send SDLLockScreenManagerWillDismissLockScreenViewController but does not send SDLLockScreenManagerDidDismissLockScreenViewController. As a result, SDLLockScreenManagerWillDismissLockScreenViewController receiver (like SDLCarWindow) may keep their state in "Dismissing".

### Changelog
##### Bug Fixes
* add nil check for lockViewController in SDLLockScreenManager

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
