### PR TITLE
Fixed incorrect VR capability in the system capability manager

### DIFF
--- a/SmartDeviceLink/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.m
@@ -101,7 +101,7 @@ NS_ASSUME_NONNULL_BEGIN
     self.hmiZoneCapabilities = response.hmiZoneCapabilities;
     self.speechCapabilities = response.speechCapabilities;
     self.prerecordedSpeechCapabilities = response.prerecordedSpeech;
-    self.vrCapability = (response.vrCapabilities.count > 0 && [response.vrCapabilities.firstObject isEqualToEnum: SDLVRCapabilitiesText]) ? YES : NO;
+    self.vrCapability = (response.vrCapabilities.count > 0 && [response.vrCapabilities.firstObject isEqualToEnum:SDLVRCapabilitiesText]) ? YES : NO;
     self.audioPassThruCapabilities = response.audioPassThruCapabilities;
     self.pcmStreamCapability = response.pcmStreamCapabilities;
 }

--- a/SmartDeviceLink/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.m
@@ -101,7 +101,7 @@ NS_ASSUME_NONNULL_BEGIN
     self.hmiZoneCapabilities = response.hmiZoneCapabilities;
     self.speechCapabilities = response.speechCapabilities;
     self.prerecordedSpeechCapabilities = response.prerecordedSpeech;
-    self.vrCapability = (response.vrCapabilities.count > 0 && response.vrCapabilities.firstObject == SDLVRCapabilitiesText) ? YES : NO;
+    self.vrCapability = (response.vrCapabilities.count > 0 && [response.vrCapabilities.firstObject isEqualToEnum: SDLVRCapabilitiesText]) ? YES : NO;
     self.audioPassThruCapabilities = response.audioPassThruCapabilities;
     self.pcmStreamCapability = response.pcmStreamCapabilities;
 }


### PR DESCRIPTION
Fixes #950 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Test already written

### Summary
* The `vrCapability` is now set correctly in the `SystemCapabilityManager`.

### Changelog
##### Enhancements
* The `SystemCapabilityManager` did not set the `vrCapability` correctly because the enum comparison using `==` always failed.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)