### PR TITLE
Reset screen manager after disconnects

### DIFF
--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -228,6 +228,7 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
     [self.fileManager stop];
     [self.permissionManager stop];
     [self.lockScreenManager stop];
+    [self.screenManager stop];
     [self.streamManager stop];
     [self.systemCapabilityManager stop];
     [self.responseDispatcher clear];

--- a/SmartDeviceLink/SDLMenuManager.h
+++ b/SmartDeviceLink/SDLMenuManager.h
@@ -27,6 +27,11 @@ typedef void(^SDLMenuUpdateCompletionHandler)(NSError *__nullable error);
 
 - (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager fileManager:(SDLFileManager *)fileManager;
 
+/**
+ *  Stops the manager. This method is used internally.
+ */
+- (void)stop;
+
 @property (copy, nonatomic) NSArray<SDLMenuCell *> *menuCells;
 
 @end

--- a/SmartDeviceLink/SDLMenuManager.m
+++ b/SmartDeviceLink/SDLMenuManager.m
@@ -379,7 +379,7 @@ UInt32 const MenuCellIdMin = 1;
 
 - (BOOL)sdl_callHandlerForCells:(NSArray<SDLMenuCell *> *)cells command:(SDLOnCommand *)onCommand {
     for (SDLMenuCell *cell in cells) {
-        if (cell.cellId == onCommand.cmdID.unsignedIntegerValue) {
+        if (cell.cellId == onCommand.cmdID.unsignedIntegerValue && cell.handler != nil) {
             cell.handler(onCommand.triggerSource);
             return YES;
         }

--- a/SmartDeviceLink/SDLMenuManager.m
+++ b/SmartDeviceLink/SDLMenuManager.m
@@ -101,7 +101,7 @@ UInt32 const MenuCellIdMin = 1;
     _inProgressUpdate = nil;
     _hasQueuedUpdate = NO;
     _waitingOnHMIUpdate = NO;
-    _waitingUpdateMenuCells = NO;
+    _waitingUpdateMenuCells = nil;
 }
 
 #pragma mark - Setters

--- a/SmartDeviceLink/SDLMenuManager.m
+++ b/SmartDeviceLink/SDLMenuManager.m
@@ -101,7 +101,7 @@ UInt32 const MenuCellIdMin = 1;
     _inProgressUpdate = nil;
     _hasQueuedUpdate = NO;
     _waitingOnHMIUpdate = NO;
-    _waitingUpdateMenuCells = nil;
+    _waitingUpdateMenuCells = @[];
 }
 
 #pragma mark - Setters

--- a/SmartDeviceLink/SDLMenuManager.m
+++ b/SmartDeviceLink/SDLMenuManager.m
@@ -90,6 +90,20 @@ UInt32 const MenuCellIdMin = 1;
     return self;
 }
 
+- (void)stop {
+    _lastMenuId = MenuCellIdMin;
+    _menuCells = @[];
+    _oldMenuCells = @[];
+
+    _currentHMILevel = SDLHMILevelNone;
+    _currentSystemContext = SDLSystemContextMain;
+    _displayCapabilities = nil;
+    _inProgressUpdate = nil;
+    _hasQueuedUpdate = NO;
+    _waitingOnHMIUpdate = NO;
+    _waitingUpdateMenuCells = NO;
+}
+
 #pragma mark - Setters
 
 - (void)setMenuCells:(NSArray<SDLMenuCell *> *)menuCells {

--- a/SmartDeviceLink/SDLScreenManager.h
+++ b/SmartDeviceLink/SDLScreenManager.h
@@ -52,6 +52,11 @@ typedef void(^SDLScreenManagerUpdateCompletionHandler)(NSError *__nullable error
 - (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager fileManager:(SDLFileManager *)fileManager;
 
 /**
+ *  Stops the manager. This method is used internally.
+ */
+- (void)stop;
+
+/**
  Delays all screen updates until endUpdatesWithCompletionHandler: is called.
  */
 - (void)beginUpdates;

--- a/SmartDeviceLink/SDLScreenManager.m
+++ b/SmartDeviceLink/SDLScreenManager.m
@@ -45,6 +45,13 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (void)stop {
+    [self.textAndGraphicManager stop];
+    [self.softButtonManager stop];
+    [self.menuManager stop];
+    [self.voiceCommandMenuManager stop];
+}
+
 - (nullable SDLSoftButtonObject *)softButtonObjectNamed:(NSString *)name {
     return [self.softButtonManager softButtonObjectNamed:name];
 }

--- a/SmartDeviceLink/SDLSoftButtonManager.h
+++ b/SmartDeviceLink/SDLSoftButtonManager.h
@@ -49,6 +49,11 @@ typedef void(^SDLSoftButtonUpdateCompletionHandler)(NSError *__nullable error);
 - (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager fileManager:(SDLFileManager *)fileManager;
 
 /**
+ *  Stops the manager. This method is used internally.
+ */
+- (void)stop;
+
+/**
  Cause all transitions in between `beginUpdates` and this method call to occur in one RPC update.
 
  @param handler The handler called once the update is completed.

--- a/SmartDeviceLink/SDLSoftButtonManager.m
+++ b/SmartDeviceLink/SDLSoftButtonManager.m
@@ -220,7 +220,7 @@ NS_ASSUME_NONNULL_BEGIN
         SDLLogV(@"Soft button objects are nil, sending an empty array");
         self.inProgressUpdate.softButtons = @[];
     } else if (([self sdl_currentStateHasImages] && ![self sdl_allCurrentStateImagesAreUploaded])
-               || (self.softButtonCapabilities ? !self.softButtonCapabilities.imageSupported : YES)) {
+               && (self.softButtonCapabilities ? !self.softButtonCapabilities.imageSupported : YES)) {
         // The images don't yet exist on the head unit, or we cannot use images, send a text update if possible, otherwise, don't send anything yet
         NSArray<SDLSoftButton *> *textOnlyButtons = [self sdl_textButtonsForCurrentState];
         if (textOnlyButtons != nil) {

--- a/SmartDeviceLink/SDLSoftButtonManager.m
+++ b/SmartDeviceLink/SDLSoftButtonManager.m
@@ -74,6 +74,13 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (void)stop {
+    _softButtonObjects = @[];
+    _currentMainField1 = nil;
+    _currentLevel = SDLHMILevelNone;
+    _waitingOnHMILevelUpdateToSetButtons = NO
+}
+
 - (void)setSoftButtonObjects:(NSArray<SDLSoftButtonObject *> *)softButtonObjects {
     if (self.currentLevel == nil || [self.currentLevel isEqualToString:SDLHMILevelNone]) {
         _waitingOnHMILevelUpdateToSetButtons = YES;

--- a/SmartDeviceLink/SDLSoftButtonManager.m
+++ b/SmartDeviceLink/SDLSoftButtonManager.m
@@ -77,8 +77,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)stop {
     _softButtonObjects = @[];
     _currentMainField1 = nil;
+
+    _inProgressUpdate = nil;
+    _inProgressHandler = nil;
+    _hasQueuedUpdate = NO;
+    _queuedUpdateHandler = nil;
     _currentLevel = SDLHMILevelNone;
-    _waitingOnHMILevelUpdateToSetButtons = NO
+    _displayCapabilities = nil;
+    _softButtonCapabilities = nil;
+    _waitingOnHMILevelUpdateToSetButtons = NO;
 }
 
 - (void)setSoftButtonObjects:(NSArray<SDLSoftButtonObject *> *)softButtonObjects {
@@ -213,7 +220,7 @@ NS_ASSUME_NONNULL_BEGIN
         SDLLogV(@"Soft button objects are nil, sending an empty array");
         self.inProgressUpdate.softButtons = @[];
     } else if (([self sdl_currentStateHasImages] && ![self sdl_allCurrentStateImagesAreUploaded])
-               && (self.softButtonCapabilities ? !self.softButtonCapabilities.imageSupported : YES)) {
+               || (self.softButtonCapabilities ? !self.softButtonCapabilities.imageSupported : YES)) {
         // The images don't yet exist on the head unit, or we cannot use images, send a text update if possible, otherwise, don't send anything yet
         NSArray<SDLSoftButton *> *textOnlyButtons = [self sdl_textButtonsForCurrentState];
         if (textOnlyButtons != nil) {

--- a/SmartDeviceLink/SDLTextAndGraphicManager.h
+++ b/SmartDeviceLink/SDLTextAndGraphicManager.h
@@ -48,7 +48,7 @@ typedef void(^SDLTextAndGraphicUpdateCompletionHandler)(NSError *__nullable erro
 /**
  If you want to make a graphic blank, set it to this artwork
  */
-@property (strong, nonatomic, readonly) SDLArtwork *blankArtwork;
+@property (strong, nonatomic, readonly, nullable) SDLArtwork *blankArtwork;
 
 @property (assign, nonatomic, getter=isBatchingUpdates) BOOL batchUpdates;
 

--- a/SmartDeviceLink/SDLTextAndGraphicManager.h
+++ b/SmartDeviceLink/SDLTextAndGraphicManager.h
@@ -62,6 +62,11 @@ typedef void(^SDLTextAndGraphicUpdateCompletionHandler)(NSError *__nullable erro
 - (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager fileManager:(SDLFileManager *)fileManager;
 
 /**
+ *  Stops the manager. This method is used internally.
+ */
+- (void)stop;
+
+/**
  Update text fields with new text set into the text field properties. Pass an empty string `\@""` to clear the text field.
 
  If the system does not support a full 4 fields, this will automatically be concatenated and properly send the field available.

--- a/SmartDeviceLink/SDLTextAndGraphicManager.h
+++ b/SmartDeviceLink/SDLTextAndGraphicManager.h
@@ -46,7 +46,9 @@ typedef void(^SDLTextAndGraphicUpdateCompletionHandler)(NSError *__nullable erro
 @property (copy, nonatomic, nullable) SDLMetadataType textField4Type;
 
 /**
- If you want to make a graphic blank, set it to this artwork
+ *  If you want to remove the current artwork, set it to this blank artwork.
+ *
+ *  This artwork is set to null on disconnects to prevent a `sdl_fileManager_fileDoesNotExistError` error when the artwork is sent again on reconnects.
  */
 @property (strong, nonatomic, readonly, nullable) SDLArtwork *blankArtwork;
 

--- a/SmartDeviceLink/SDLTextAndGraphicManager.m
+++ b/SmartDeviceLink/SDLTextAndGraphicManager.m
@@ -79,6 +79,31 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (void)stop {
+    _textField1 = nil;
+    _textField2 = nil;
+    _textField3 = nil;
+    _textField4 = nil;
+    _mediaTrackTextField = nil;
+    _primaryGraphic = nil;
+    _secondaryGraphic = nil;
+    _alignment = SDLTextAlignmentCenter;
+    _textField1Type = nil;
+    _textField2Type = nil;
+    _textField3Type = nil;
+    _textField4Type = nil;
+
+    _inProgressUpdate = nil;
+    _inProgressHandler = nil;
+    _queuedImageUpdate = nil;
+    _hasQueuedUpdate = NO;
+    _queuedUpdateHandler = nil;
+    _displayCapabilities = nil;
+    _currentLevel = SDLHMILevelNone;
+    _blankArtwork = nil;
+    _isDirty = NO;
+}
+
 #pragma mark - Upload / Send
 
 - (void)updateWithCompletionHandler:(nullable SDLTextAndGraphicUpdateCompletionHandler)handler {

--- a/SmartDeviceLink/SDLTextAndGraphicManager.m
+++ b/SmartDeviceLink/SDLTextAndGraphicManager.m
@@ -52,7 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic, nullable) SDLDisplayCapabilities *displayCapabilities;
 @property (strong, nonatomic, nullable) SDLHMILevel currentLevel;
 
-@property (strong, nonatomic) SDLArtwork *blankArtwork;
+@property (strong, nonatomic, nullable) SDLArtwork *blankArtwork;
 
 @property (assign, nonatomic) BOOL isDirty;
 
@@ -614,7 +614,7 @@ NS_ASSUME_NONNULL_BEGIN
     return (_hasQueuedUpdate || _queuedUpdateHandler != nil);
 }
 
-- (SDLArtwork *)blankArtwork {
+- (nullable SDLArtwork *)blankArtwork {
     if (_blankArtwork != nil) {
         return _blankArtwork;
     }

--- a/SmartDeviceLink/SDLVoiceCommandManager.h
+++ b/SmartDeviceLink/SDLVoiceCommandManager.h
@@ -26,6 +26,11 @@ typedef void(^SDLMenuUpdateCompletionHandler)(NSError *__nullable error);
 
 - (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager;
 
+/**
+ *  Stops the manager. This method is used internally.
+ */
+- (void)stop;
+
 @property (copy, nonatomic) NSArray<SDLVoiceCommand *> *voiceCommands;
 
 @end

--- a/SmartDeviceLink/SDLVoiceCommandManager.m
+++ b/SmartDeviceLink/SDLVoiceCommandManager.m
@@ -71,6 +71,17 @@ UInt32 const VoiceCommandIdMin = 1900000000;
     return self;
 }
 
+- (void)stop {
+    _lastVoiceCommandId = VoiceCommandIdMin;
+    _voiceCommands = @[];
+    _oldVoiceCommands = @[];
+
+    _waitingOnHMIUpdate = NO;
+    _currentHMILevel = SDLHMILevelNone;
+    _inProgressUpdate = nil;
+    _hasQueuedUpdate = NO;
+}
+
 #pragma mark - Setters
 
 - (void)setVoiceCommands:(NSArray<SDLVoiceCommand *> *)voiceCommands {

--- a/SmartDeviceLink/SDLVoiceCommandManager.m
+++ b/SmartDeviceLink/SDLVoiceCommandManager.m
@@ -201,7 +201,8 @@ UInt32 const VoiceCommandIdMin = 1900000000;
 - (NSArray<SDLDeleteCommand *> *)sdl_deleteCommandsForVoiceCommands:(NSArray<SDLVoiceCommand *> *)voiceCommands {
     NSMutableArray<SDLDeleteCommand *> *mutableDeletes = [NSMutableArray array];
     for (SDLVoiceCommand *command in voiceCommands) {
-        SDLDeleteCommand *delete = [[SDLDeleteCommand alloc] initWithId:command.commandId];
+        SDLDeleteCommand *delete = [[SDLDeleteCommand alloc] init];
+        delete.cmdID = @(command.commandId);
         [mutableDeletes addObject:delete];
     }
 

--- a/SmartDeviceLink/SDLVoiceCommandManager.m
+++ b/SmartDeviceLink/SDLVoiceCommandManager.m
@@ -201,8 +201,7 @@ UInt32 const VoiceCommandIdMin = 1900000000;
 - (NSArray<SDLDeleteCommand *> *)sdl_deleteCommandsForVoiceCommands:(NSArray<SDLVoiceCommand *> *)voiceCommands {
     NSMutableArray<SDLDeleteCommand *> *mutableDeletes = [NSMutableArray array];
     for (SDLVoiceCommand *command in voiceCommands) {
-        SDLDeleteCommand *delete = [[SDLDeleteCommand alloc] init];
-        delete.cmdID = @(command.commandId);
+        SDLDeleteCommand *delete = [[SDLDeleteCommand alloc] initWithId:command.commandId];
         [mutableDeletes addObject:delete];
     }
 


### PR DESCRIPTION
Fixes #952, #953

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Smoke tests

### Summary
Fixes the `SDLScreenManager` not being reset when the app is reconnected to a head unit during a session. Menus, images, and buttons were not being set correctly on reconnects due the saved settings in the `SDLScreenManager`'s sub managers. 

### Changelog
##### Enhancements
* The `SDLTextAndGraphicManager`, `SDLSoftButtonManager`, `SDLMenuManager`, and `SDLVoiceCommandManager` are now reset when the app disconnects from the head unit. 

##### Bug Fixes
* Added a `nil` check for a menu cell's handler before it is called.

##### Tasks Remaining
- [x] Fix broken test cases

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)