### PR TITLE
Fixed image soft buttons getting sent early

### DIFF
--- a/SmartDeviceLink/SDLSoftButtonManager.m
+++ b/SmartDeviceLink/SDLSoftButtonManager.m
@@ -203,14 +203,12 @@ NS_ASSUME_NONNULL_BEGIN
     self.inProgressUpdate = [[SDLShow alloc] init];
     self.inProgressUpdate.mainField1 = self.currentMainField1 ?: @"";
 
-    BOOL buttonHasImages = [self sdl_currentStateHasImages];
-    BOOL allButtonImagesAreUploaded = [self sdl_allCurrentStateImagesAreUploaded];
     BOOL headUnitSupportsImages = self.softButtonCapabilities ? self.softButtonCapabilities.imageSupported.boolValue : NO;
 
     if (self.softButtonObjects == nil) {
         SDLLogV(@"Soft button objects are nil, sending an empty array");
         self.inProgressUpdate.softButtons = @[];
-    } else if ((buttonHasImages && !allButtonImagesAreUploaded)
+    } else if (([self sdl_currentStateHasImages] && ![self sdl_allCurrentStateImagesAreUploaded])
                || !headUnitSupportsImages) {
         // The images don't yet exist on the head unit, or we cannot use images, send a text update, if possible. Otherwise, don't send anything yet.
         NSArray<SDLSoftButton *> *textOnlyButtons = [self sdl_textButtonsForCurrentState];

--- a/SmartDeviceLink/SDLSoftButtonManager.m
+++ b/SmartDeviceLink/SDLSoftButtonManager.m
@@ -202,13 +202,17 @@ NS_ASSUME_NONNULL_BEGIN
     self.inProgressHandler = [handler copy];
     self.inProgressUpdate = [[SDLShow alloc] init];
     self.inProgressUpdate.mainField1 = self.currentMainField1 ?: @"";
+
+    BOOL buttonHasImages = [self sdl_currentStateHasImages];
+    BOOL allButtonImagesAreUploaded = [self sdl_allCurrentStateImagesAreUploaded];
+    BOOL headUnitSupportsImages = self.softButtonCapabilities ? self.softButtonCapabilities.imageSupported.boolValue : NO;
+
     if (self.softButtonObjects == nil) {
         SDLLogV(@"Soft button objects are nil, sending an empty array");
         self.inProgressUpdate.softButtons = @[];
-    } else if ((([self sdl_currentStateHasImages] && ![self sdl_allCurrentStateImagesAreUploaded])
-               && (self.softButtonCapabilities ? self.softButtonCapabilities.imageSupported.boolValue : NO))
-               || (self.softButtonCapabilities ? !self.softButtonCapabilities.imageSupported.boolValue : YES)){
-        // The images don't yet exist on the head unit, or we cannot use images, send a text update if possible, otherwise, don't send anything yet
+    } else if ((buttonHasImages && !allButtonImagesAreUploaded)
+               || !headUnitSupportsImages) {
+        // The images don't yet exist on the head unit, or we cannot use images, send a text update, if possible. Otherwise, don't send anything yet.
         NSArray<SDLSoftButton *> *textOnlyButtons = [self sdl_textButtonsForCurrentState];
         if (textOnlyButtons != nil) {
             SDLLogV(@"Soft button images unavailable, sending text buttons");

--- a/SmartDeviceLink/SDLSoftButtonManager.m
+++ b/SmartDeviceLink/SDLSoftButtonManager.m
@@ -205,8 +205,9 @@ NS_ASSUME_NONNULL_BEGIN
     if (self.softButtonObjects == nil) {
         SDLLogV(@"Soft button objects are nil, sending an empty array");
         self.inProgressUpdate.softButtons = @[];
-    } else if (([self sdl_currentStateHasImages] && ![self sdl_allCurrentStateImagesAreUploaded])
-               && (self.softButtonCapabilities ? !self.softButtonCapabilities.imageSupported : YES)) {
+    } else if ((([self sdl_currentStateHasImages] && ![self sdl_allCurrentStateImagesAreUploaded])
+               && (self.softButtonCapabilities ? self.softButtonCapabilities.imageSupported.boolValue : NO))
+               || (self.softButtonCapabilities ? !self.softButtonCapabilities.imageSupported.boolValue : YES)){
         // The images don't yet exist on the head unit, or we cannot use images, send a text update if possible, otherwise, don't send anything yet
         NSArray<SDLSoftButton *> *textOnlyButtons = [self sdl_textButtonsForCurrentState];
         if (textOnlyButtons != nil) {


### PR DESCRIPTION
Fixes #955

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Added additional test cases to the *SDLSoftButtonManagerSpec*.

### Summary
* Previously, the image soft buttons were getting sent even if the artworks where not yet uploaded to the remote because `softButtonCapabilities.imageSupported` always returned `false`. This is due to  the `imageSupported` datatype being a `NSNumber`.

### Changelog
##### Bug Fix
* Image soft buttons are no longer sent by the *SDLSoftButtonManager* before the image is uploaded to the remote.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)