### PR TITLE
Fix permission manager reset when the connection closes

### DIFF
--- a/SmartDeviceLink/SDLPermissionManager.m
+++ b/SmartDeviceLink/SDLPermissionManager.m
@@ -55,7 +55,9 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)stop {
-    // Nothing to do here right now
+    _permissions = [NSMutableDictionary<SDLPermissionRPCName, SDLPermissionItem *> dictionary];
+    _filters = [NSMutableArray<SDLPermissionFilter *> array];
+    _currentHMILevel = nil;
 }
 
 

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLPermissionsManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLPermissionsManagerSpec.m
@@ -8,10 +8,19 @@
 #import "SDLOnHMIStatus.h"
 #import "SDLOnPermissionsChange.h"
 #import "SDLParameterPermissions.h"
+#import "SDLPermissionFilter.h"
 #import "SDLPermissionItem.h"
 #import "SDLPermissionManager.h"
 #import "SDLRPCNotificationNotification.h"
 #import "SDLRPCResponseNotification.h"
+
+@interface SDLPermissionManager ()
+
+@property (strong, nonatomic) NSMutableDictionary<SDLPermissionRPCName, SDLPermissionItem *> *permissions;
+@property (strong, nonatomic) NSMutableArray<SDLPermissionFilter *> *filters;
+@property (copy, nonatomic, nullable) SDLHMILevel currentHMILevel;
+
+@end
 
 QuickSpecBegin(SDLPermissionsManagerSpec)
 
@@ -110,6 +119,14 @@ describe(@"SDLPermissionsManager", ^{
         limitedHMINotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidChangeHMIStatusNotification object:nil rpcNotification:testLimitedHMIStatus];
         backgroundHMINotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidChangeHMIStatusNotification object:nil rpcNotification:testBackgroundHMIStatus];
         noneHMINotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidChangeHMIStatusNotification object:nil rpcNotification:testNoneHMIStatus];
+    });
+
+    it(@"should clear when stopped", ^{
+        [testPermissionsManager stop];
+
+        expect(testPermissionsManager.filters).to(beEmpty());
+        expect(testPermissionsManager.permissions).to(beEmpty());
+        expect(testPermissionsManager.currentHMILevel).to(beNil());
     });
     
     describe(@"checking if a permission is allowed", ^{


### PR DESCRIPTION
Fixes #957 (Part 1 only)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Test added

### Summary
When the connection resets, reset the permission manager's internal data

### Changelog
##### Bug Fixes
* Fix permission manager data being incorrect on reconnection

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
