### PR TITLE
Stops reconnect on AppUnauthorized notifications

### DIFF
--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -669,6 +669,8 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
         [self.lifecycleStateMachine transitionToState:SDLLifecycleStateStopped];
     } else if ([self.lifecycleStateMachine isCurrentState:SDLLifecycleStateStopped]) {
         return;
+    } else if ([appUnregisteredNotification.reason isEqualToEnum:SDLAppInterfaceUnregisteredReasonAppUnauthorized]) {
+        [self.lifecycleStateMachine transitionToState:SDLLifecycleStateStopped];
     } else {
         [self.lifecycleStateMachine transitionToState:SDLLifecycleStateReconnecting];
     }


### PR DESCRIPTION
Fixes #977 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Due to the size of the change the PR doesn't include a unit test. 

### Summary
Sets the lifecycle manager state to STOPPED if the app is unregistered with the reason AppUnauthorized.

##### Bug Fixes
Stops the lifecycle manager to reconnect endlessly.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
