### PR TITLE
Truncated the generated `SDLArtwork` filename to 16 characters

### DIFF
--- a/SmartDeviceLink/SDLArtwork.m
+++ b/SmartDeviceLink/SDLArtwork.m
@@ -106,9 +106,9 @@ NS_ASSUME_NONNULL_BEGIN
 
     unsigned char hash[CC_MD5_DIGEST_LENGTH];
     CC_MD5([data bytes], (CC_LONG)[data length], hash);
-    NSMutableString *formattedHash = [NSMutableString stringWithCapacity:CC_MD5_DIGEST_LENGTH * 2];
+    NSMutableString *formattedHash = [NSMutableString stringWithCapacity:CC_MD5_DIGEST_LENGTH];
     // HAX: To shorten the string to 16 characters, the loop has been shortened to 8 fom 16.
-    for (int i = 0; i < 8; i += 1) {
+    for (int i = 0; i < CC_MD5_DIGEST_LENGTH / 2; i += 1) {
         [formattedHash appendFormat:@"%02x", hash[i]];
     }
     return formattedHash;

--- a/SmartDeviceLink/SDLArtwork.m
+++ b/SmartDeviceLink/SDLArtwork.m
@@ -94,6 +94,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Creates a string representation of NSData by hashing the data using the MD5 hash function. This string is not guaranteed to be unique as collisions can occur, however collisions are extremely rare.
  *
+ *  HAX: A MD5 hash always creates a string with 32 characters (128-bits). Due to some versions of Core not following the spec, file names that are too long are being rejected. To try to accommodate this setup, hashed file names are being truncated to 16 characters.
+ *
  *  Sourced from https://stackoverflow.com/questions/2018550/how-do-i-create-an-md5-hash-of-a-string-in-cocoa
  *
  *  @param data     The data to hash
@@ -105,7 +107,8 @@ NS_ASSUME_NONNULL_BEGIN
     unsigned char hash[CC_MD5_DIGEST_LENGTH];
     CC_MD5([data bytes], (CC_LONG)[data length], hash);
     NSMutableString *formattedHash = [NSMutableString stringWithCapacity:CC_MD5_DIGEST_LENGTH * 2];
-    for (int i = 0; i < CC_MD5_DIGEST_LENGTH; i += 1) {
+    // HAX: To shorten the string to 16 characters, the loop has been shortened to 8 fom 16.
+    for (int i = 0; i < 8; i += 1) {
         [formattedHash appendFormat:@"%02x", hash[i]];
     }
     return formattedHash;

--- a/SmartDeviceLink/SDLArtwork.m
+++ b/SmartDeviceLink/SDLArtwork.m
@@ -94,7 +94,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Creates a string representation of NSData by hashing the data using the MD5 hash function. This string is not guaranteed to be unique as collisions can occur, however collisions are extremely rare.
  *
- *  HAX: A MD5 hash always creates a string with 32 characters (128-bits). Due to some versions of Core not following the spec, file names that are too long are being rejected. To try to accommodate this setup, hashed file names are being truncated to 16 characters.
+ *  HAX: A MD5 hash always creates a string with 32 characters (128-bits). Due to some implementations of Core not following the spec, file names that are too long are being rejected. To try to accommodate this setup, hashed file names are being truncated to 16 characters.
  *
  *  Sourced from https://stackoverflow.com/questions/2018550/how-do-i-create-an-md5-hash-of-a-string-in-cocoa
  *

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLArtworkSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLArtworkSpec.m
@@ -146,6 +146,19 @@ describe(@"SDLArtwork", ^{
             expect(expectedName1).toNot(equal(expectedName2));
         });
     });
+
+    context(@"If generating a name for the artwork using the md5 hash", ^{
+        __block NSString *expectedName = nil;
+
+        beforeEach(^{
+            expectedName = nil;
+        });
+
+        it(@"should be truncated to 16 characters", ^{
+            expectedName = [SDLArtwork sdl_md5HashFromNSData:UIImagePNGRepresentation(testImagePNG)];
+            expect(expectedName.length).to(equal(16));
+        });
+    });
 });
 
 QuickSpecEnd


### PR DESCRIPTION
Fixes #976 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Test cases added to the *SDLArtworkSpec*

### Summary
 A MD5 hash always creates a string with 32 characters (128-bits). Due to some implementations of Core not following the spec, file names that are too long are being rejected. To try to accommodate this setup, hashed file names are now being truncated to 16 characters.

### Changelog
##### Bug Fixes
* Automatically generated `SDLArtwork` file names are now truncated to 16 characters to accommodate file systems that reject files names with 32 characters.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)