### PR TITLE
Fix softbuttons disappearing when exiting HMI NONE

### DIFF
--- a/SmartDeviceLink/SDLSoftButtonManager.m
+++ b/SmartDeviceLink/SDLSoftButtonManager.m
@@ -116,11 +116,11 @@ NS_ASSUME_NONNULL_BEGIN
         }
     }
 
-    _softButtonObjects = softButtonObjects;
-
-    for (SDLSoftButtonObject *button in _softButtonObjects) {
+    for (SDLSoftButtonObject *button in softButtonObjects) {
         button.manager = self;
     }
+
+    _softButtonObjects = softButtonObjects;
 
     [self updateWithCompletionHandler:nil];
 }

--- a/SmartDeviceLink/SDLSoftButtonManager.m
+++ b/SmartDeviceLink/SDLSoftButtonManager.m
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic, nullable) SDLDisplayCapabilities *displayCapabilities;
 @property (strong, nonatomic, nullable) SDLSoftButtonCapabilities *softButtonCapabilities;
 
-@property (assign, nonatomic) BOOL waitingOnHMILevelUpdateToSetButtons;
+@property (assign, nonatomic) BOOL waitingOnHMILevelUpdateToUpdate;
 
 @end
 
@@ -65,7 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
     _softButtonObjects = @[];
 
     _currentLevel = nil;
-    _waitingOnHMILevelUpdateToSetButtons = NO;
+    _waitingOnHMILevelUpdateToUpdate = NO;
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_registerResponse:) name:SDLDidReceiveRegisterAppInterfaceResponse object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_displayLayoutResponse:) name:SDLDidReceiveSetDisplayLayoutResponse object:nil];
@@ -85,15 +85,12 @@ NS_ASSUME_NONNULL_BEGIN
     _currentLevel = nil;
     _displayCapabilities = nil;
     _softButtonCapabilities = nil;
-    _waitingOnHMILevelUpdateToSetButtons = NO;
+    _waitingOnHMILevelUpdateToUpdate = NO;
 }
 
 - (void)setSoftButtonObjects:(NSArray<SDLSoftButtonObject *> *)softButtonObjects {
-    if (self.currentLevel == nil || [self.currentLevel isEqualToString:SDLHMILevelNone]) {
-        _waitingOnHMILevelUpdateToSetButtons = YES;
-        _softButtonObjects = softButtonObjects;
-        return;
-    }
+    // Only update if something changed. This prevents, for example, an empty array being reset
+    if (_softButtonObjects == softButtonObjects) { return; }
 
     self.inProgressUpdate = nil;
     if (self.inProgressHandler != nil) {
@@ -125,51 +122,7 @@ NS_ASSUME_NONNULL_BEGIN
         button.manager = self;
     }
 
-    NSMutableArray<SDLArtwork *> *initialStatesToBeUploaded = [NSMutableArray array];
-    NSMutableArray<SDLArtwork *> *otherStatesToBeUploaded = [NSMutableArray array];
-    if (self.displayCapabilities ? self.displayCapabilities.graphicSupported.boolValue : YES) {
-        // Upload all soft button images, the initial state images first, then the other states. We need to send updates when the initial state is ready.
-        for (SDLSoftButtonObject *object in self.softButtonObjects) {
-            if (object.currentState.artwork != nil && ![self.fileManager hasUploadedFile:object.currentState.artwork]) {
-                [initialStatesToBeUploaded addObject:object.currentState.artwork];
-            }
-        }
-        for (SDLSoftButtonObject *object in self.softButtonObjects) {
-            for (SDLSoftButtonState *state in object.states) {
-                if ([state.name isEqualToString:object.currentState.name]) { continue; }
-                if (state.artwork != nil && ![self.fileManager hasUploadedFile:state.artwork]) {
-                    [otherStatesToBeUploaded addObject:state.artwork];
-                }
-            }
-        }
-    }
-
-    // Upload initial images, then other state images
-    if (initialStatesToBeUploaded.count > 0) {
-        SDLLogD(@"Uploading soft button initial artworks");
-        [self.fileManager uploadArtworks:[initialStatesToBeUploaded copy] completionHandler:^(NSArray<NSString *> * _Nonnull artworkNames, NSError * _Nullable error) {
-            if (error != nil) {
-                SDLLogE(@"Error uploading soft button artworks: %@", error);
-            }
-
-            SDLLogD(@"Soft button initial artworks uploaded");
-            [self sdl_updateWithCompletionHandler:nil];
-        }];
-    }
-    if (otherStatesToBeUploaded.count > 0) {
-        SDLLogD(@"Uploading soft button other state artworks");
-        [self.fileManager uploadArtworks:[otherStatesToBeUploaded copy] completionHandler:^(NSArray<NSString *> * _Nonnull artworkNames, NSError * _Nullable error) {
-            if (error != nil) {
-                SDLLogE(@"Error uploading soft button artworks: %@", error);
-            }
-
-            SDLLogD(@"Soft button other state artworks uploaded");
-            // In case our soft button states have changed in the meantime
-            [self sdl_updateWithCompletionHandler:nil];
-        }];
-    }
-
-    [self sdl_updateWithCompletionHandler:nil];
+    [self updateWithCompletionHandler:nil];
 }
 
 - (nullable SDLSoftButtonObject *)softButtonObjectNamed:(NSString *)name {
@@ -183,17 +136,21 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)updateWithCompletionHandler:(nullable SDLSoftButtonUpdateCompletionHandler)handler {
+    // Don't send if we're batching
     if (self.isBatchingUpdates) { return; }
+
+    // Don't send if we're in HMI NONE
+    if (self.currentLevel == nil || [self.currentLevel isEqualToString:SDLHMILevelNone]) {
+        self.waitingOnHMILevelUpdateToUpdate = YES;
+        return;
+    } else {
+        self.waitingOnHMILevelUpdateToUpdate = NO;
+    }
 
     [self sdl_updateWithCompletionHandler:handler];
 }
 
 - (void)sdl_updateWithCompletionHandler:(nullable SDLSoftButtonUpdateCompletionHandler)handler {
-    // Don't send if we're in HMI NONE
-    if (self.currentLevel == nil || [self.currentLevel isEqualToString:SDLHMILevelNone]) {
-        return;
-    }
-
     SDLLogD(@"Updating soft buttons");
     if (self.inProgressUpdate != nil) {
         SDLLogV(@"In progress update exists, queueing update");
@@ -217,13 +174,16 @@ NS_ASSUME_NONNULL_BEGIN
     self.inProgressUpdate = [[SDLShow alloc] init];
     self.inProgressUpdate.mainField1 = self.currentMainField1 ?: @"";
 
-    BOOL headUnitSupportsImages = self.softButtonCapabilities ? self.softButtonCapabilities.imageSupported.boolValue : NO;
+    if ([self sdl_supportsSoftButtonImages]) {
+        [self sdl_uploadInitialStateImages];
+        [self sdl_uploadOtherStateImages];
+    }
 
     if (self.softButtonObjects == nil) {
         SDLLogV(@"Soft button objects are nil, sending an empty array");
         self.inProgressUpdate.softButtons = @[];
     } else if (([self sdl_currentStateHasImages] && ![self sdl_allCurrentStateImagesAreUploaded])
-               || !headUnitSupportsImages) {
+               || ![self sdl_supportsSoftButtonImages]) {
         // The images don't yet exist on the head unit, or we cannot use images, send a text update, if possible. Otherwise, don't send anything yet.
         NSArray<SDLSoftButton *> *textOnlyButtons = [self sdl_textButtonsForCurrentState];
         if (textOnlyButtons != nil) {
@@ -281,6 +241,62 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     return YES;
+}
+
+- (BOOL)sdl_supportsSoftButtonImages {
+    BOOL supportsGraphics = self.displayCapabilities ? self.displayCapabilities.graphicSupported.boolValue : YES;
+    BOOL supportsSoftButtonImages = self.softButtonCapabilities ? self.softButtonCapabilities.imageSupported.boolValue : NO;
+
+    return (supportsGraphics && supportsSoftButtonImages);
+}
+
+- (void)sdl_uploadInitialStateImages {
+    NSMutableArray<SDLArtwork *> *initialStatesToBeUploaded = [NSMutableArray array];
+    // Upload all soft button images, the initial state images first, then the other states. We need to send updates when the initial state is ready.
+    for (SDLSoftButtonObject *object in self.softButtonObjects) {
+        if (object.currentState.artwork != nil && ![self.fileManager hasUploadedFile:object.currentState.artwork]) {
+            [initialStatesToBeUploaded addObject:object.currentState.artwork];
+        }
+    }
+
+    // Upload initial images, then other state images
+    if (initialStatesToBeUploaded.count > 0) {
+        SDLLogD(@"Uploading soft button initial artworks");
+        [self.fileManager uploadArtworks:[initialStatesToBeUploaded copy] completionHandler:^(NSArray<NSString *> * _Nonnull artworkNames, NSError * _Nullable error) {
+            if (error != nil) {
+                SDLLogE(@"Error uploading soft button artworks: %@", error);
+            }
+
+            SDLLogD(@"Soft button initial artworks uploaded");
+            [self updateWithCompletionHandler:nil];
+        }];
+    }
+}
+
+- (void)sdl_uploadOtherStateImages {
+    NSMutableArray<SDLArtwork *> *otherStatesToBeUploaded = [NSMutableArray array];
+    // Upload all soft button images, the initial state images first, then the other states. We need to send updates when the initial state is ready.
+    for (SDLSoftButtonObject *object in self.softButtonObjects) {
+        for (SDLSoftButtonState *state in object.states) {
+            if ([state.name isEqualToString:object.currentState.name]) { continue; }
+            if (state.artwork != nil && ![self.fileManager hasUploadedFile:state.artwork]) {
+                [otherStatesToBeUploaded addObject:state.artwork];
+            }
+        }
+    }
+
+    if (otherStatesToBeUploaded.count > 0) {
+        SDLLogD(@"Uploading soft button other state artworks");
+        [self.fileManager uploadArtworks:[otherStatesToBeUploaded copy] completionHandler:^(NSArray<NSString *> * _Nonnull artworkNames, NSError * _Nullable error) {
+            if (error != nil) {
+                SDLLogE(@"Error uploading soft button artworks: %@", error);
+            }
+
+            SDLLogD(@"Soft button other state artworks uploaded");
+            // In case our soft button states have changed in the meantime
+            [self updateWithCompletionHandler:nil];
+        }];
+    }
 }
 
 #pragma mark - Creating Soft Buttons
@@ -346,12 +362,8 @@ NS_ASSUME_NONNULL_BEGIN
     self.currentLevel = hmiStatus.hmiLevel;
 
     // Auto-send an updated show if we were in NONE and now we are not
-    if ([oldHMILevel isEqualToString:SDLHMILevelNone] && ![self.currentLevel isEqualToString:SDLHMILevelNone]) {
-        if (self.waitingOnHMILevelUpdateToSetButtons) {
-            [self setSoftButtonObjects:_softButtonObjects];
-        } else {
-            [self sdl_updateWithCompletionHandler:nil];
-        }
+    if ([oldHMILevel isEqualToString:SDLHMILevelNone] && ![self.currentLevel isEqualToString:SDLHMILevelNone] && self.waitingOnHMILevelUpdateToUpdate) {
+        [self sdl_updateWithCompletionHandler:nil];
     }
 }
 

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLSoftButtonManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLSoftButtonManagerSpec.m
@@ -24,22 +24,22 @@
 
 @interface SDLSoftButtonManager()
 
+@property (strong, nonatomic) NSArray<SDLSoftButton *> *currentSoftButtons;
+
 @property (weak, nonatomic) id<SDLConnectionManagerType> connectionManager;
 @property (weak, nonatomic) SDLFileManager *fileManager;
-
-@property (strong, nonatomic) NSArray<SDLSoftButton *> *currentSoftButtons;
 
 @property (strong, nonatomic, nullable) SDLShow *inProgressUpdate;
 @property (copy, nonatomic, nullable) SDLSoftButtonUpdateCompletionHandler inProgressHandler;
 
-@property (strong, nonatomic, nullable) SDLShow *queuedImageUpdate;
 @property (assign, nonatomic) BOOL hasQueuedUpdate;
 @property (copy, nonatomic, nullable) SDLSoftButtonUpdateCompletionHandler queuedUpdateHandler;
-@property (strong, nonatomic, nullable) SDLHMILevel currentLevel;
-@property (assign, nonatomic) BOOL waitingOnHMILevelUpdateToSetButtons;
 
+@property (copy, nonatomic, nullable) SDLHMILevel currentLevel;
 @property (strong, nonatomic, nullable) SDLDisplayCapabilities *displayCapabilities;
 @property (strong, nonatomic, nullable) SDLSoftButtonCapabilities *softButtonCapabilities;
+
+@property (assign, nonatomic) BOOL waitingOnHMILevelUpdateToUpdate;
 
 @end
 
@@ -91,22 +91,22 @@ describe(@"a soft button manager", ^{
         expect(testManager.hasQueuedUpdate).to(beFalse());
         expect(testManager.displayCapabilities).to(beNil());
         expect(testManager.softButtonCapabilities).to(beNil());
-        expect(testManager.waitingOnHMILevelUpdateToSetButtons).to(beFalse());
+        expect(testManager.waitingOnHMILevelUpdateToUpdate).to(beFalse());
     });
 
     context(@"when in HMI NONE", ^{
         beforeEach(^{
             testManager.currentLevel = SDLHMILevelNone;
 
-            NSString *sameName = @"Same name";
-            testObject1 = [[SDLSoftButtonObject alloc] initWithName:sameName states:@[object1State1, object1State2] initialStateName:object1State1Name handler:nil];
-            testObject2 = [[SDLSoftButtonObject alloc] initWithName:sameName state:object2State1 handler:nil];
+            testObject1 = [[SDLSoftButtonObject alloc] initWithName:@"name1" states:@[object1State1, object1State2] initialStateName:object1State1Name handler:nil];
+            testObject2 = [[SDLSoftButtonObject alloc] initWithName:@"name2" state:object2State1 handler:nil];
 
             testManager.softButtonObjects = @[testObject1, testObject2];
         });
 
-        it(@"should not set the soft buttons", ^{
-            expect(testManager.waitingOnHMILevelUpdateToSetButtons).to(beTrue());
+        it(@"should set the soft buttons, but not update", ^{
+            expect(testManager.softButtonObjects).toNot(beEmpty());
+            expect(testManager.waitingOnHMILevelUpdateToUpdate).to(beTrue());
             expect(testManager.inProgressUpdate).to(beNil());
         });
     });
@@ -115,15 +115,15 @@ describe(@"a soft button manager", ^{
         beforeEach(^{
             testManager.currentLevel = nil;
 
-            NSString *sameName = @"Same name";
-            testObject1 = [[SDLSoftButtonObject alloc] initWithName:sameName states:@[object1State1, object1State2] initialStateName:object1State1Name handler:nil];
-            testObject2 = [[SDLSoftButtonObject alloc] initWithName:sameName state:object2State1 handler:nil];
+            testObject1 = [[SDLSoftButtonObject alloc] initWithName:@"name1" states:@[object1State1, object1State2] initialStateName:object1State1Name handler:nil];
+            testObject2 = [[SDLSoftButtonObject alloc] initWithName:@"name2" state:object2State1 handler:nil];
 
             testManager.softButtonObjects = @[testObject1, testObject2];
         });
 
-        it(@"should not set the soft buttons", ^{
-            expect(testManager.waitingOnHMILevelUpdateToSetButtons).to(beTrue());
+        it(@"should set the soft buttons, but not update", ^{
+            expect(testManager.softButtonObjects).toNot(beEmpty());
+            expect(testManager.waitingOnHMILevelUpdateToUpdate).to(beTrue());
             expect(testManager.inProgressUpdate).to(beNil());
         });
     });
@@ -359,7 +359,7 @@ describe(@"a soft button manager", ^{
             expect(testManager.currentLevel).to(beNil());
             expect(testManager.displayCapabilities).to(beNil());
             expect(testManager.softButtonCapabilities).to(beNil());
-            expect(testManager.waitingOnHMILevelUpdateToSetButtons).to(beFalse());
+            expect(testManager.waitingOnHMILevelUpdateToUpdate).to(beFalse());
         });
     });
 });


### PR DESCRIPTION
Fixes #1000

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Unit tests were run and smoke tests performed

### Summary
This PR makes fixes for developers who are not using the screen manager in their app.

### Changelog
##### Bug Fixes
* When running the app without using the soft button manager, buttons should not reset when exiting HMI NONE.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
