### PR TITLE
Check class type to account for the reason enum being “-1”

### DIFF
--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -670,6 +670,7 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
     } else if ([self.lifecycleStateMachine isCurrentState:SDLLifecycleStateStopped]) {
         return;
     } else if ([appUnregisteredNotification.reason isKindOfClass:[NSString class]] && [appUnregisteredNotification.reason isEqualToEnum:SDLAppInterfaceUnregisteredReasonAppUnauthorized]) {
+        // HAX: The string check is due to a core "feature" that could cause -1 to be sent as the enum value, which will crash here.
         [self.lifecycleStateMachine transitionToState:SDLLifecycleStateStopped];
     } else {
         [self.lifecycleStateMachine transitionToState:SDLLifecycleStateReconnecting];

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -669,7 +669,7 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
         [self.lifecycleStateMachine transitionToState:SDLLifecycleStateStopped];
     } else if ([self.lifecycleStateMachine isCurrentState:SDLLifecycleStateStopped]) {
         return;
-    } else if ([appUnregisteredNotification.reason isEqualToEnum:SDLAppInterfaceUnregisteredReasonAppUnauthorized]) {
+    } else if ([appUnregisteredNotification.reason isKindOfClass:[NSString class]] && [appUnregisteredNotification.reason isEqualToEnum:SDLAppInterfaceUnregisteredReasonAppUnauthorized]) {
         [self.lifecycleStateMachine transitionToState:SDLLifecycleStateStopped];
     } else {
         [self.lifecycleStateMachine transitionToState:SDLLifecycleStateReconnecting];


### PR DESCRIPTION
Fixes #998

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Unregistering was tested, but not with "-1", because I was unable to replicate that.

### Summary
Checks the type of data the unregister reason is before attempting to read it.

### Changelog
##### Bug Fixes
* Fix an unregister reason of "-1" crashing the library.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
