### PR TITLE
Fix Start Service test case can fail with incorrect version number

### DIFF
--- a/SmartDeviceLinkTests/ProtocolSpecs/MessageSpecs/SDLProtocolSpec.m
+++ b/SmartDeviceLinkTests/ProtocolSpecs/MessageSpecs/SDLProtocolSpec.m
@@ -10,6 +10,7 @@
 #import <OCMock/OCMock.h>
 
 #import "SDLTransportType.h"
+#import "SDLGlobals.h"
 #import "SDLProtocolHeader.h"
 #import "SDLProtocol.h"
 #import "SDLProtocolMessage.h"
@@ -35,6 +36,10 @@ NSDictionary* dictionaryV2 = @{SDLNameCommandId:@55};
 describe(@"Send StartService Tests", ^ {
     context(@"Unsecure", ^{
         it(@"Should send the correct data", ^ {
+            // Reset max protocol version before test. (This test case expects V1 header. If other test ran
+            // prior to this one, SDLGlobals would keep the max protocol version and this test case would fail.)
+            [[SDLGlobals sharedGlobals] setMaxHeadUnitVersion:@"1.0.0"];
+
             SDLProtocol* testProtocol = [[SDLProtocol alloc] init];
             
             __block BOOL verified = NO;


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_ios/issues/1016

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Run the unit tests under `SDLProtocolSpec` and confirm no failure is observed.

### Summary
This PR updates `Send_StartService_Tests__Unsecure__Should_send_the_correct_data` test case by resetting max head unit version in SDLGlobals. This will make sure that the implementation always outputs V1 protocol header.

### Changelog
##### Breaking Changes
* None

##### Enhancements
* None

##### Bug Fixes
* Fix Start Service test case can fail with incorrect version number

### Tasks Remaining:
- None

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
