### PR TITLE
Implement SDL-0014 - Audio File Playback in TTSChunk

### DIFF
--- a/SmartDeviceLink/SDLSpeechCapabilities.h
+++ b/SmartDeviceLink/SDLSpeechCapabilities.h
@@ -35,3 +35,8 @@ extern SDLSpeechCapabilities const SDLSpeechCapabilitiesPrerecorded;
  The SDL platform can speak Silence.
  */
 extern SDLSpeechCapabilities const SDLSpeechCapabilitiesSilence;
+
+/**
+ The SDL platform can play a file
+ */
+extern SDLSpeechCapabilities const SDLSpeechCapabilitiesFile;

--- a/SmartDeviceLink/SDLSpeechCapabilities.m
+++ b/SmartDeviceLink/SDLSpeechCapabilities.m
@@ -9,3 +9,4 @@ SDLSpeechCapabilities const SDLSpeechCapabilitiesSAPIPhonemes = @"SAPI_PHONEMES"
 SDLSpeechCapabilities const SDLSpeechCapabilitiesLHPlusPhonemes = @"LHPLUS_PHONEMES";
 SDLSpeechCapabilities const SDLSpeechCapabilitiesPrerecorded = @"PRE_RECORDED";
 SDLSpeechCapabilities const SDLSpeechCapabilitiesSilence = @"SILENCE";
+SDLSpeechCapabilities const SDLSpeechCapabilitiesFile = @"FILE";

--- a/SmartDeviceLink/SDLTTSChunk.h
+++ b/SmartDeviceLink/SDLTTSChunk.h
@@ -66,9 +66,16 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (NSArray<SDLTTSChunk *> *)silenceChunks;
 
+/**
+ Create "TTS" to play an audio file previously uploaded to the system.
+
+ @param fileName The name of the file used in the SDLFile or PutFile that was uploaded
+ @return The RPC
+ */
++ (NSArray<SDLTTSChunk *> *)fileChunksWithName:(NSString *)fileName;
 
 /**
- * Text to be spoken, or a phoneme specification, or the name of a pre-recorded sound. The contents of this field are indicated by the "type" field.
+ * Text to be spoken, a phoneme specification, or the name of a pre-recorded / pre-uploaded sound. The contents of this field are indicated by the "type" field.
  *
  * Required, Max length 500
  */

--- a/SmartDeviceLink/SDLTTSChunk.m
+++ b/SmartDeviceLink/SDLTTSChunk.m
@@ -39,15 +39,19 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 + (NSArray<SDLTTSChunk *> *)silenceChunks {
-    return [self sdl_chunksFromString:nil type:SDLSpeechCapabilitiesSilence];
+    return [self sdl_chunksFromString:@"" type:SDLSpeechCapabilitiesSilence];
+}
+
++ (NSArray<SDLTTSChunk *> *)fileChunksWithName:(NSString *)fileName {
+    return [self sdl_chunksFromString:fileName type:SDLSpeechCapabilitiesFile];
 }
 
 + (nullable NSArray<SDLTTSChunk *> *)sdl_chunksFromString:(nullable NSString *)string type:(SDLSpeechCapabilities)type {
-    if (string.length == 0) {
+    if (string == nil) {
         return nil;
     }
 
-    return [NSArray arrayWithObject:[[[self class] alloc] initWithText:string type:type]];
+    return @[[[SDLTTSChunk alloc] initWithText:string type:type]];
 }
 
 - (void)setText:(NSString *)text {

--- a/SmartDeviceLinkTests/RPCSpecs/EnumSpecs/SDLSpeechCapabilitiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/EnumSpecs/SDLSpeechCapabilitiesSpec.m
@@ -19,6 +19,7 @@ describe(@"Individual Enum Value Tests", ^ {
         expect(SDLSpeechCapabilitiesLHPlusPhonemes).to(equal(@"LHPLUS_PHONEMES"));
         expect(SDLSpeechCapabilitiesPrerecorded).to(equal(@"PRE_RECORDED"));
         expect(SDLSpeechCapabilitiesSilence).to(equal(@"SILENCE"));
+        expect(SDLSpeechCapabilitiesFile).to(equal(@"FILE"));
     });
 });
 

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTTSChunkSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTTSChunkSpec.m
@@ -15,32 +15,98 @@
 
 QuickSpecBegin(SDLTTSChunkSpec)
 
-describe(@"Getter/Setter Tests", ^ {
-    it(@"Should set and get correctly", ^ {
-        SDLTTSChunk* testStruct = [[SDLTTSChunk alloc] init];
-        
-        testStruct.text = @"TEXT";
-        testStruct.type = SDLSpeechCapabilitiesPrerecorded;
-        
-        expect(testStruct.text).to(equal(@"TEXT"));
-        expect(testStruct.type).to(equal(SDLSpeechCapabilitiesPrerecorded));
+describe(@"TTS Chunk Tests", ^{
+    __block SDLTTSChunk *testStruct = nil;
+    __block NSArray<SDLTTSChunk *> *testChunks = nil;
+    __block NSString *testText = @"Text";
+    __block SDLSpeechCapabilities testCapabilities = SDLSpeechCapabilitiesFile;
+
+    describe(@"initializers", ^{
+        it(@"should correctly initialize with init", ^{
+            testStruct = [[SDLTTSChunk alloc] init];
+
+            expect(testStruct.text).to(beNil());
+            expect(testStruct.type).to(beNil());
+        });
+
+        it(@"should correctly initialize with initWithDictionary", ^{
+            NSDictionary* dict = @{SDLNameText: testText,
+                                   SDLNameType: testCapabilities};
+            testStruct = [[SDLTTSChunk alloc] initWithDictionary:dict];
+
+            expect(testStruct.text).to(equal(testText));
+            expect(testStruct.type).to(equal(testCapabilities));
+        });
+
+        it(@"should correctly initialize with initWithText:type:", ^{
+            testStruct = [[SDLTTSChunk alloc] initWithText:testText type:testCapabilities];
+
+            expect(testStruct.text).to(equal(testText));
+            expect(testStruct.type).to(equal(testCapabilities));
+        });
+
+        it(@"should correctly initialize with textChunksFromString:", ^{
+            testChunks = [SDLTTSChunk textChunksFromString:testText];
+
+            expect(testChunks).to(haveCount(1));
+            expect(testChunks[0].text).to(equal(testText));
+            expect(testChunks[0].type).to(equal(SDLSpeechCapabilitiesText));
+        });
+
+        it(@"should correctly initialize with sapiChunksFromString:", ^{
+            testChunks = [SDLTTSChunk sapiChunksFromString:testText];
+
+            expect(testChunks).to(haveCount(1));
+            expect(testChunks[0].text).to(equal(testText));
+            expect(testChunks[0].type).to(equal(SDLSpeechCapabilitiesSAPIPhonemes));
+        });
+
+        it(@"should correctly initialize with lhPlusChunksFromString:", ^{
+            testChunks = [SDLTTSChunk lhPlusChunksFromString:testText];
+
+            expect(testChunks).to(haveCount(1));
+            expect(testChunks[0].text).to(equal(testText));
+            expect(testChunks[0].type).to(equal(SDLSpeechCapabilitiesLHPlusPhonemes));
+        });
+
+        it(@"should correctly initialize with prerecordedChunksFromString:", ^{
+            testChunks = [SDLTTSChunk prerecordedChunksFromString:testText];
+
+            expect(testChunks).to(haveCount(1));
+            expect(testChunks[0].text).to(equal(testText));
+            expect(testChunks[0].type).to(equal(SDLSpeechCapabilitiesPrerecorded));
+        });
+
+        it(@"should correctly initialize with silenceChunksFromString:", ^{
+            testChunks = [SDLTTSChunk silenceChunks];
+
+            expect(testChunks).to(haveCount(1));
+            expect(testChunks[0].text).to(beEmpty());
+            expect(testChunks[0].type).to(equal(SDLSpeechCapabilitiesSilence));
+        });
+
+        it(@"should correctly initialize with fileChunksWithName:", ^{
+            testChunks = [SDLTTSChunk fileChunksWithName:testText];
+
+            expect(testChunks).to(haveCount(1));
+            expect(testChunks[0].text).to(equal(testText));
+            expect(testChunks[0].type).to(equal(SDLSpeechCapabilitiesFile));
+        });
     });
-    
-    it(@"Should get correctly when initialized", ^ {
-        NSMutableDictionary* dict = [@{SDLNameText:@"TEXT",
-                                       SDLNameType:SDLSpeechCapabilitiesPrerecorded} mutableCopy];
-        SDLTTSChunk* testStruct = [[SDLTTSChunk alloc] initWithDictionary:dict];
-        
-        expect(testStruct.text).to(equal(@"TEXT"));
-        expect(testStruct.type).to(equal(SDLSpeechCapabilitiesPrerecorded));
-    });
-    
-    it(@"Should return nil if not set", ^ {
-        SDLTTSChunk* testStruct = [[SDLTTSChunk alloc] init];
-        
-        expect(testStruct.text).to(beNil());
-        expect(testStruct.type).to(beNil());
+
+    describe(@"Getter/Setter Tests", ^ {
+        it(@"Should set and get correctly", ^ {
+            SDLTTSChunk* testStruct = [[SDLTTSChunk alloc] init];
+
+            testStruct.text = testText;
+            testStruct.type = testCapabilities;
+
+            expect(testStruct.text).to(equal(testText));
+            expect(testStruct.type).to(equal(testCapabilities));
+        });
     });
 });
+
+
 
 QuickSpecEnd


### PR DESCRIPTION
Fixes #524 

This PR is **not ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Unit tests have been added

### Summary
This PR implements [SDL-0014](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0014-adding-audio-file-playback-to-ttschunk.md). This allows previously uploaded audio files to be played via `Alert`, `PerformAudioPassthrough`, `PerformInteraction`, `SetGlobalProperties` and `Speak`.

### Changelog
##### Enhancements
* Audio files can now be uploaded through the SDLFileManager and played via `Alert`, `PerformAudioPassthrough`, `PerformInteraction`, `SetGlobalProperties` and `Speak` through the addition to `SDLTTSChunk` [SDL-0014](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0014-adding-audio-file-playback-to-ttschunk.md).

### Tasks Remaining:
- [x] Test against Core 5.0

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)