### PR TITLE
Implement SDL-0102 - Electronic Park Brake Status Vehicle Data

### DIFF
--- a/SmartDeviceLink-iOS.podspec
+++ b/SmartDeviceLink-iOS.podspec
@@ -90,6 +90,7 @@ ss.public_header_files = [
 'SmartDeviceLink/SDLDriverDistractionState.h',
 'SmartDeviceLink/SDLECallConfirmationStatus.h',
 'SmartDeviceLink/SDLECallInfo.h',
+'SmartDeviceLink/SDLElectronicParkBrakeStatus.h',
 'SmartDeviceLink/SDLEmergencyEvent.h',
 'SmartDeviceLink/SDLEmergencyEventType.h',
 'SmartDeviceLink/SDLEncodedSyncPData.h',

--- a/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
+++ b/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
@@ -1070,6 +1070,9 @@
 		5DD67CC31E68AE82009CD394 /* SDLLogFileModuleMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DD67CC11E68AE82009CD394 /* SDLLogFileModuleMap.h */; };
 		5DD67CC41E68AE82009CD394 /* SDLLogFileModuleMap.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DD67CC21E68AE82009CD394 /* SDLLogFileModuleMap.m */; };
 		5DD67CC71E68B568009CD394 /* SDLLogMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DD67CC51E68B568009CD394 /* SDLLogMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5DD8406220FCD6C10082CE04 /* SDLElectronicParkBrakeStatus.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DD8406020FCD6C10082CE04 /* SDLElectronicParkBrakeStatus.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5DD8406320FCD6C10082CE04 /* SDLElectronicParkBrakeStatus.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DD8406120FCD6C10082CE04 /* SDLElectronicParkBrakeStatus.m */; };
+		5DD8406520FCE21A0082CE04 /* SDLElectronicParkBrakeStatusSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DD8406420FCE21A0082CE04 /* SDLElectronicParkBrakeStatusSpec.m */; };
 		5DE35E4520CAFC5D0034BE5A /* SDLChoiceCellSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DE35E4420CAFC5D0034BE5A /* SDLChoiceCellSpec.m */; };
 		5DE35E4720CB0AB90034BE5A /* SDLChoiceSetSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DE35E4620CB0AB90034BE5A /* SDLChoiceSetSpec.m */; };
 		5DE35E4A20CB1BF70034BE5A /* SDLChoiceSetManagerSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DE35E4920CB1BF70034BE5A /* SDLChoiceSetManagerSpec.m */; };
@@ -2448,6 +2451,9 @@
 		5DD67CC11E68AE82009CD394 /* SDLLogFileModuleMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDLLogFileModuleMap.h; sourceTree = "<group>"; };
 		5DD67CC21E68AE82009CD394 /* SDLLogFileModuleMap.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLLogFileModuleMap.m; sourceTree = "<group>"; };
 		5DD67CC51E68B568009CD394 /* SDLLogMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDLLogMacros.h; sourceTree = "<group>"; };
+		5DD8406020FCD6C10082CE04 /* SDLElectronicParkBrakeStatus.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDLElectronicParkBrakeStatus.h; sourceTree = "<group>"; };
+		5DD8406120FCD6C10082CE04 /* SDLElectronicParkBrakeStatus.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLElectronicParkBrakeStatus.m; sourceTree = "<group>"; };
+		5DD8406420FCE21A0082CE04 /* SDLElectronicParkBrakeStatusSpec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLElectronicParkBrakeStatusSpec.m; sourceTree = "<group>"; };
 		5DE35E4420CAFC5D0034BE5A /* SDLChoiceCellSpec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SDLChoiceCellSpec.m; path = DevAPISpecs/SDLChoiceCellSpec.m; sourceTree = "<group>"; };
 		5DE35E4620CB0AB90034BE5A /* SDLChoiceSetSpec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SDLChoiceSetSpec.m; path = DevAPISpecs/SDLChoiceSetSpec.m; sourceTree = "<group>"; };
 		5DE35E4920CB1BF70034BE5A /* SDLChoiceSetManagerSpec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SDLChoiceSetManagerSpec.m; path = DevAPISpecs/SDLChoiceSetManagerSpec.m; sourceTree = "<group>"; };
@@ -2731,6 +2737,7 @@
 				162E81F11A9BDE8A00906325 /* SDLDisplayTypeSpec.m */,
 				162E81F21A9BDE8A00906325 /* SDLDriverDistractionStateSpec.m */,
 				162E81F31A9BDE8A00906325 /* SDLECallConfirmationStatusSpec.m */,
+				5DD8406420FCE21A0082CE04 /* SDLElectronicParkBrakeStatusSpec.m */,
 				162E81F41A9BDE8A00906325 /* SDLEmergencyEventTypeSpec.m */,
 				162E81F51A9BDE8A00906325 /* SDLFileTypeSpec.m */,
 				162E81F61A9BDE8A00906325 /* SDLFuelCutoffStatusSpec.m */,
@@ -3909,6 +3916,8 @@
 				5D61FAA81A84238A00846EE7 /* SDLDriverDistractionState.m */,
 				5D61FAA91A84238A00846EE7 /* SDLECallConfirmationStatus.h */,
 				5D61FAAA1A84238A00846EE7 /* SDLECallConfirmationStatus.m */,
+				5DD8406020FCD6C10082CE04 /* SDLElectronicParkBrakeStatus.h */,
+				5DD8406120FCD6C10082CE04 /* SDLElectronicParkBrakeStatus.m */,
 				5D61FAAF1A84238A00846EE7 /* SDLEmergencyEventType.h */,
 				5D61FAB01A84238A00846EE7 /* SDLEmergencyEventType.m */,
 				5D61FABC1A84238A00846EE7 /* SDLFileType.h */,
@@ -5303,6 +5312,7 @@
 				5D61FC9C1A84238C00846EE7 /* SDLEmergencyEventType.h in Headers */,
 				5D61FD131A84238C00846EE7 /* SDLOnLanguageChange.h in Headers */,
 				5D61FDE71A84238C00846EE7 /* SDLUnsubscribeButton.h in Headers */,
+				5DD8406220FCD6C10082CE04 /* SDLElectronicParkBrakeStatus.h in Headers */,
 				5D61FCAB1A84238C00846EE7 /* SDLFuelCutoffStatus.h in Headers */,
 				5D9FC2A31FD8814A00ACA5C2 /* SDLAudioFile.h in Headers */,
 				5DB9965C1F268F97002D8795 /* SDLControlFramePayloadVideoStartService.h in Headers */,
@@ -6126,6 +6136,7 @@
 				5D9FDA931F2A7D3400A495C8 /* bson_util.c in Sources */,
 				5D61FD511A84238C00846EE7 /* SDLProxy.m in Sources */,
 				5D61FD461A84238C00846EE7 /* SDLProtocolHeader.m in Sources */,
+				5DD8406320FCD6C10082CE04 /* SDLElectronicParkBrakeStatus.m in Sources */,
 				8BBEA6071F324165003EEA26 /* SDLMetadataType.m in Sources */,
 				5D61FDBC1A84238C00846EE7 /* SDLSystemAction.m in Sources */,
 				5D61FC381A84238C00846EE7 /* SDLAlert.m in Sources */,
@@ -6525,6 +6536,7 @@
 				162E83141A9BDE8B00906325 /* SDLOnDriverDistractionSpec.m in Sources */,
 				162E83371A9BDE8B00906325 /* SDLResetGlobalPropertiesSpec.m in Sources */,
 				162E82DF1A9BDE8B00906325 /* SDLGlobalProperySpec.m in Sources */,
+				5DD8406520FCE21A0082CE04 /* SDLElectronicParkBrakeStatusSpec.m in Sources */,
 				162E82F61A9BDE8B00906325 /* SDLRequestTypeSpec.m in Sources */,
 				5DE35E4520CAFC5D0034BE5A /* SDLChoiceCellSpec.m in Sources */,
 				162E82FB1A9BDE8B00906325 /* SDLSpeechCapabilitiesSpec.m in Sources */,

--- a/SmartDeviceLink.podspec
+++ b/SmartDeviceLink.podspec
@@ -90,6 +90,7 @@ ss.public_header_files = [
 'SmartDeviceLink/SDLDriverDistractionState.h',
 'SmartDeviceLink/SDLECallConfirmationStatus.h',
 'SmartDeviceLink/SDLECallInfo.h',
+'SmartDeviceLink/SDLElectronicParkBrakeStatus.h',
 'SmartDeviceLink/SDLEmergencyEvent.h',
 'SmartDeviceLink/SDLEmergencyEventType.h',
 'SmartDeviceLink/SDLEncodedSyncPData.h',

--- a/SmartDeviceLink/SDLElectronicParkBrakeStatus.h
+++ b/SmartDeviceLink/SDLElectronicParkBrakeStatus.h
@@ -1,0 +1,35 @@
+//  SDLElectronicParkBrakeStatus.h
+//
+
+
+#import "SDLEnum.h"
+
+/**
+ Reflects the status of the Electronic Parking Brake. A Vehicle Data Type.
+ */
+typedef SDLEnum SDLElectronicParkBrakeStatus SDL_SWIFT_ENUM;
+
+/**
+ Parking brake actuators have been fully applied.
+ */
+extern SDLElectronicParkBrakeStatus const SDLElectronicParkBrakeStatusClosed;
+
+/**
+ Parking brake actuators are transitioning to either Apply/Closed or Release/Open state.
+ */
+extern SDLElectronicParkBrakeStatus const SDLElectronicParkBrakeStatusTransition;
+
+/**
+ Parking brake actuators are released.
+ */
+extern SDLElectronicParkBrakeStatus const SDLElectronicParkBrakeStatusOpen;
+
+/**
+ When driver pulls the Electronic Parking Brake switch while driving "at speed".
+ */
+extern SDLElectronicParkBrakeStatus const SDLElectronicParkBrakeStatusDriveActive;
+
+/**
+ When system has a fault or is under maintenance.
+ */
+extern SDLElectronicParkBrakeStatus const SDLElectronicParkBrakeStatusFault;

--- a/SmartDeviceLink/SDLElectronicParkBrakeStatus.m
+++ b/SmartDeviceLink/SDLElectronicParkBrakeStatus.m
@@ -1,0 +1,18 @@
+//
+//  SDLElectronicParkBrakeStatus.m
+//  SmartDeviceLink
+//
+//  Created by Joel Fischer on 7/16/18.
+//  Copyright © 2018 smartdevicelink. All rights reserved.
+//
+
+#import "SDLElectronicParkBrakeStatus.h"
+
+typedef SDLEnum SDLElectronicParkBrakeStatus SDL_SWIFT_ENUM;
+
+
+SDLElectronicParkBrakeStatus const SDLElectronicParkBrakeStatusClosed = @"CLOSED";
+SDLElectronicParkBrakeStatus const SDLElectronicParkBrakeStatusTransition = @"TRANSITION";
+SDLElectronicParkBrakeStatus const SDLElectronicParkBrakeStatusOpen = @"OPEN";
+SDLElectronicParkBrakeStatus const SDLElectronicParkBrakeStatusDriveActive = @"DRIVE_ACTIVE";
+SDLElectronicParkBrakeStatus const SDLElectronicParkBrakeStatusFault = @"FAULT";

--- a/SmartDeviceLink/SDLGetVehicleData.h
+++ b/SmartDeviceLink/SDLGetVehicleData.h
@@ -60,6 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param deviceStatus                Get deviceStatus data
  *  @param driverBraking               Get driverBraking data
  *  @param eCallInfo                   Get eCallInfo data
+ *  @param electronicParkBrakeStatus  Get electronicParkBrakeStatus data
  *  @param emergencyEvent              Get emergencyEvent data
  *  @param engineOilLife               Get engineOilLife data
  *  @param engineTorque                Get engineTorque data
@@ -81,7 +82,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param wiperStatus                 Get wiperStatus data
  *  @return                            A SDLGetVehicleData object
  */
-- (instancetype)initWithAccelerationPedalPosition:(BOOL)accelerationPedalPosition airbagStatus:(BOOL)airbagStatus beltStatus:(BOOL)beltStatus bodyInformation:(BOOL)bodyInformation clusterModeStatus:(BOOL)clusterModeStatus deviceStatus:(BOOL)deviceStatus driverBraking:(BOOL)driverBraking eCallInfo:(BOOL)eCallInfo emergencyEvent:(BOOL)emergencyEvent engineOilLife:(BOOL)engineOilLife engineTorque:(BOOL)engineTorque externalTemperature:(BOOL)externalTemperature fuelLevel:(BOOL)fuelLevel fuelLevelState:(BOOL)fuelLevelState fuelRange:(BOOL)fuelRange gps:(BOOL)gps headLampStatus:(BOOL)headLampStatus instantFuelConsumption:(BOOL)instantFuelConsumption myKey:(BOOL)myKey odometer:(BOOL)odometer prndl:(BOOL)prndl rpm:(BOOL)rpm speed:(BOOL)speed steeringWheelAngle:(BOOL)steeringWheelAngle tirePressure:(BOOL)tirePressure vin:(BOOL)vin wiperStatus:(BOOL)wiperStatus;
+- (instancetype)initWithAccelerationPedalPosition:(BOOL)accelerationPedalPosition airbagStatus:(BOOL)airbagStatus beltStatus:(BOOL)beltStatus bodyInformation:(BOOL)bodyInformation clusterModeStatus:(BOOL)clusterModeStatus deviceStatus:(BOOL)deviceStatus driverBraking:(BOOL)driverBraking eCallInfo:(BOOL)eCallInfo electronicParkBrakeStatus:(BOOL)electronicParkBrakeStatus emergencyEvent:(BOOL)emergencyEvent engineOilLife:(BOOL)engineOilLife engineTorque:(BOOL)engineTorque externalTemperature:(BOOL)externalTemperature fuelLevel:(BOOL)fuelLevel fuelLevelState:(BOOL)fuelLevelState fuelRange:(BOOL)fuelRange gps:(BOOL)gps headLampStatus:(BOOL)headLampStatus instantFuelConsumption:(BOOL)instantFuelConsumption myKey:(BOOL)myKey odometer:(BOOL)odometer prndl:(BOOL)prndl rpm:(BOOL)rpm speed:(BOOL)speed steeringWheelAngle:(BOOL)steeringWheelAngle tirePressure:(BOOL)tirePressure vin:(BOOL)vin wiperStatus:(BOOL)wiperStatus;
 
 /**
  * A boolean value. If true, requests GPS data.
@@ -217,6 +218,11 @@ NS_ASSUME_NONNULL_BEGIN
  * A boolean value. If true, requests MyKey data.
  */
 @property (nullable, strong, nonatomic) NSNumber<SDLBool> *myKey;
+
+/**
+ A boolean value. If true, requests Electronic Parking Brake status data.
+ */
+@property (nullable, strong, nonatomic) NSNumber<SDLBool> *electronicParkBrakeStatus;
 
 @end
 

--- a/SmartDeviceLink/SDLGetVehicleData.m
+++ b/SmartDeviceLink/SDLGetVehicleData.m
@@ -18,10 +18,10 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (instancetype)initWithAccelerationPedalPosition:(BOOL)accelerationPedalPosition airbagStatus:(BOOL)airbagStatus beltStatus:(BOOL)beltStatus bodyInformation:(BOOL)bodyInformation clusterModeStatus:(BOOL)clusterModeStatus deviceStatus:(BOOL)deviceStatus driverBraking:(BOOL)driverBraking eCallInfo:(BOOL)eCallInfo emergencyEvent:(BOOL)emergencyEvent engineTorque:(BOOL)engineTorque externalTemperature:(BOOL)externalTemperature fuelLevel:(BOOL)fuelLevel fuelLevelState:(BOOL)fuelLevelState gps:(BOOL)gps headLampStatus:(BOOL)headLampStatus instantFuelConsumption:(BOOL)instantFuelConsumption myKey:(BOOL)myKey odometer:(BOOL)odometer prndl:(BOOL)prndl rpm:(BOOL)rpm speed:(BOOL)speed steeringWheelAngle:(BOOL)steeringWheelAngle tirePressure:(BOOL)tirePressure vin:(BOOL)vin wiperStatus:(BOOL)wiperStatus {
-    return [self initWithAccelerationPedalPosition:accelerationPedalPosition airbagStatus:airbagStatus beltStatus:beltStatus bodyInformation:bodyInformation clusterModeStatus:clusterModeStatus deviceStatus:deviceStatus driverBraking:driverBraking eCallInfo:eCallInfo emergencyEvent:emergencyEvent engineOilLife:NO engineTorque:engineTorque externalTemperature:externalTemperature fuelLevel:fuelLevel fuelLevelState:fuelLevelState fuelRange:NO gps:gps headLampStatus:headLampStatus instantFuelConsumption:instantFuelConsumption myKey:myKey odometer:odometer prndl:prndl rpm:rpm speed:speed steeringWheelAngle:steeringWheelAngle tirePressure:tirePressure vin:vin wiperStatus:wiperStatus];
+    return [self initWithAccelerationPedalPosition:accelerationPedalPosition airbagStatus:airbagStatus beltStatus:beltStatus bodyInformation:bodyInformation clusterModeStatus:clusterModeStatus deviceStatus:deviceStatus driverBraking:driverBraking eCallInfo:eCallInfo electronicParkBrakeStatus:NO emergencyEvent:emergencyEvent engineOilLife:NO engineTorque:engineTorque externalTemperature:externalTemperature fuelLevel:fuelLevel fuelLevelState:fuelLevelState fuelRange:NO gps:gps headLampStatus:headLampStatus instantFuelConsumption:instantFuelConsumption myKey:myKey odometer:odometer prndl:prndl rpm:rpm speed:speed steeringWheelAngle:steeringWheelAngle tirePressure:tirePressure vin:vin wiperStatus:wiperStatus];
 }
 
-- (instancetype)initWithAccelerationPedalPosition:(BOOL)accelerationPedalPosition airbagStatus:(BOOL)airbagStatus beltStatus:(BOOL)beltStatus bodyInformation:(BOOL)bodyInformation clusterModeStatus:(BOOL)clusterModeStatus deviceStatus:(BOOL)deviceStatus driverBraking:(BOOL)driverBraking eCallInfo:(BOOL)eCallInfo emergencyEvent:(BOOL)emergencyEvent engineOilLife:(BOOL)engineOilLife engineTorque:(BOOL)engineTorque externalTemperature:(BOOL)externalTemperature fuelLevel:(BOOL)fuelLevel fuelLevelState:(BOOL)fuelLevelState fuelRange:(BOOL)fuelRange gps:(BOOL)gps headLampStatus:(BOOL)headLampStatus instantFuelConsumption:(BOOL)instantFuelConsumption myKey:(BOOL)myKey odometer:(BOOL)odometer prndl:(BOOL)prndl rpm:(BOOL)rpm speed:(BOOL)speed steeringWheelAngle:(BOOL)steeringWheelAngle tirePressure:(BOOL)tirePressure vin:(BOOL)vin wiperStatus:(BOOL)wiperStatus {
+- (instancetype)initWithAccelerationPedalPosition:(BOOL)accelerationPedalPosition airbagStatus:(BOOL)airbagStatus beltStatus:(BOOL)beltStatus bodyInformation:(BOOL)bodyInformation clusterModeStatus:(BOOL)clusterModeStatus deviceStatus:(BOOL)deviceStatus driverBraking:(BOOL)driverBraking eCallInfo:(BOOL)eCallInfo electronicParkBrakeStatus:(BOOL)electronicParkBrakeStatus emergencyEvent:(BOOL)emergencyEvent engineOilLife:(BOOL)engineOilLife engineTorque:(BOOL)engineTorque externalTemperature:(BOOL)externalTemperature fuelLevel:(BOOL)fuelLevel fuelLevelState:(BOOL)fuelLevelState fuelRange:(BOOL)fuelRange gps:(BOOL)gps headLampStatus:(BOOL)headLampStatus instantFuelConsumption:(BOOL)instantFuelConsumption myKey:(BOOL)myKey odometer:(BOOL)odometer prndl:(BOOL)prndl rpm:(BOOL)rpm speed:(BOOL)speed steeringWheelAngle:(BOOL)steeringWheelAngle tirePressure:(BOOL)tirePressure vin:(BOOL)vin wiperStatus:(BOOL)wiperStatus {
     self = [self init];
     if (!self) {
         return nil;
@@ -35,6 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
     self.deviceStatus = @(deviceStatus);
     self.driverBraking = @(driverBraking);
     self.eCallInfo = @(eCallInfo);
+    self.electronicParkBrakeStatus = @(electronicParkBrakeStatus);
     self.emergencyEvent = @(emergencyEvent);
     self.engineOilLife = @(engineOilLife);
     self.engineTorque = @(engineTorque);
@@ -272,6 +273,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable NSNumber<SDLBool> *)myKey {
     return [parameters sdl_objectForName:SDLNameMyKey];
+}
+
+- (void)setElectronicParkBrakeStatus:(nullable NSNumber<SDLBool> *)electronicParkBrakeStatus {
+    [parameters sdl_setObject:electronicParkBrakeStatus forName:SDLNameElectronicParkBrakeStatus];
+}
+
+- (nullable NSNumber<SDLBool> *)electronicParkBrakeStatus {
+    return [parameters sdl_objectForName:SDLNameElectronicParkBrakeStatus];
 }
 
 @end

--- a/SmartDeviceLink/SDLGetVehicleDataResponse.h
+++ b/SmartDeviceLink/SDLGetVehicleDataResponse.h
@@ -4,6 +4,7 @@
 #import "SDLRPCResponse.h"
 
 #import "SDLComponentVolumeStatus.h"
+#import "SDLElectronicParkBrakeStatus.h"
 #import "SDLPRNDL.h"
 #import "SDLVehicleDataEventStatus.h"
 #import "SDLWiperStatus.h"
@@ -168,6 +169,11 @@ NS_ASSUME_NONNULL_BEGIN
  Information related to the MyKey feature
  */
 @property (nullable, strong, nonatomic) SDLMyKey *myKey;
+
+/**
+ The status of the electronic parking brake
+ */
+@property (nullable, strong, nonatomic) SDLElectronicParkBrakeStatus electronicParkBrakeStatus;
 
 @end
 

--- a/SmartDeviceLink/SDLGetVehicleDataResponse.m
+++ b/SmartDeviceLink/SDLGetVehicleDataResponse.m
@@ -245,6 +245,14 @@ NS_ASSUME_NONNULL_BEGIN
     return [parameters sdl_objectForName:SDLNameMyKey ofClass:SDLMyKey.class];
 }
 
+- (void)setElectronicParkBrakeStatus:(nullable SDLElectronicParkBrakeStatus)electronicParkBrakeStatus {
+    [parameters sdl_setObject:electronicParkBrakeStatus forName:SDLNameElectronicParkBrakeStatus];
+}
+
+- (nullable SDLElectronicParkBrakeStatus)electronicParkBrakeStatus {
+    return [parameters sdl_objectForName:SDLNameElectronicParkBrakeStatus];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLNames.h
+++ b/SmartDeviceLink/SDLNames.h
@@ -138,6 +138,7 @@ extern SDLName const SDLNameECallInfo;
 extern SDLName const SDLNameECallNotificationStatus;
 extern SDLName const SDLNameECUHeader;
 extern SDLName const SDLNameECUName;
+extern SDLName const SDLNameElectronicParkBrakeStatus;
 extern SDLName const SDLNameEmergencyEvent;
 extern SDLName const SDLNameEmergencyEventType;
 extern SDLName const SDLNameEncodedSyncPData;

--- a/SmartDeviceLink/SDLNames.m
+++ b/SmartDeviceLink/SDLNames.m
@@ -134,6 +134,7 @@ SDLName const SDLNameECallInfo = @"eCallInfo";
 SDLName const SDLNameECallNotificationStatus = @"eCallNotificationStatus";
 SDLName const SDLNameECUHeader = @"ecuHeader";
 SDLName const SDLNameECUName = @"ecuName";
+SDLName const SDLNameElectronicParkBrakeStatus = @"electronicParkBrakeStatus";
 SDLName const SDLNameEmergencyEvent = @"emergencyEvent";
 SDLName const SDLNameEmergencyEventType = @"emergencyEventType";
 SDLName const SDLNameEncodedSyncPData = @"EncodedSyncPData";

--- a/SmartDeviceLink/SDLOnVehicleData.h
+++ b/SmartDeviceLink/SDLOnVehicleData.h
@@ -4,6 +4,7 @@
 #import "SDLRPCNotification.h"
 
 #import "SDLComponentVolumeStatus.h"
+#import "SDLElectronicParkBrakeStatus.h"
 #import "SDLPRNDL.h"
 #import "SDLVehicleDataEventStatus.h"
 #import "SDLWiperStatus.h"
@@ -169,6 +170,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nullable, strong, nonatomic) SDLMyKey *myKey;
 
+/**
+ The status of the electronic parking brake
+ */
+@property (nullable, strong, nonatomic) SDLElectronicParkBrakeStatus electronicParkBrakeStatus;
 
 @end
 

--- a/SmartDeviceLink/SDLOnVehicleData.m
+++ b/SmartDeviceLink/SDLOnVehicleData.m
@@ -245,6 +245,14 @@ NS_ASSUME_NONNULL_BEGIN
     return [parameters sdl_objectForName:SDLNameMyKey ofClass:SDLMyKey.class];
 }
 
+- (void)setElectronicParkBrakeStatus:(nullable SDLElectronicParkBrakeStatus)electronicParkBrakeStatus {
+    [parameters sdl_setObject:electronicParkBrakeStatus forName:SDLNameElectronicParkBrakeStatus];
+}
+
+- (nullable SDLElectronicParkBrakeStatus)electronicParkBrakeStatus {
+    return [parameters sdl_objectForName:SDLNameElectronicParkBrakeStatus];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLSubscribeVehicleData.h
+++ b/SmartDeviceLink/SDLSubscribeVehicleData.h
@@ -61,6 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param deviceStatus                 Subscribe to deviceStatus
  *  @param driverBraking                Subscribe to driverBraking
  *  @param eCallInfo                    Subscribe to eCallInfo
+ *  @param electronicParkBrakeStatus    Subscribe to electronicParkBrakeStatus
  *  @param emergencyEvent               Subscribe to emergencyEvent
  *  @param engineOilLife                Subscribe to engineOilLife
  *  @param engineTorque                 Subscribe to engineTorque
@@ -81,7 +82,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param wiperStatus                  Subscribe to wiperStatus
  *  @return                             A SDLSubscribeVehicleData object
  */
-- (instancetype)initWithAccelerationPedalPosition:(BOOL)accelerationPedalPosition airbagStatus:(BOOL)airbagStatus beltStatus:(BOOL)beltStatus bodyInformation:(BOOL)bodyInformation clusterModeStatus:(BOOL)clusterModeStatus deviceStatus:(BOOL)deviceStatus driverBraking:(BOOL)driverBraking eCallInfo:(BOOL)eCallInfo emergencyEvent:(BOOL)emergencyEvent engineOilLife:(BOOL)engineOilLife engineTorque:(BOOL)engineTorque externalTemperature:(BOOL)externalTemperature fuelLevel:(BOOL)fuelLevel fuelLevelState:(BOOL)fuelLevelState fuelRange:(BOOL)fuelRange gps:(BOOL)gps headLampStatus:(BOOL)headLampStatus instantFuelConsumption:(BOOL)instantFuelConsumption myKey:(BOOL)myKey odometer:(BOOL)odometer prndl:(BOOL)prndl rpm:(BOOL)rpm speed:(BOOL)speed steeringWheelAngle:(BOOL)steeringWheelAngle tirePressure:(BOOL)tirePressure wiperStatus:(BOOL)wiperStatus;
+- (instancetype)initWithAccelerationPedalPosition:(BOOL)accelerationPedalPosition airbagStatus:(BOOL)airbagStatus beltStatus:(BOOL)beltStatus bodyInformation:(BOOL)bodyInformation clusterModeStatus:(BOOL)clusterModeStatus deviceStatus:(BOOL)deviceStatus driverBraking:(BOOL)driverBraking eCallInfo:(BOOL)eCallInfo electronicParkBrakeStatus:(BOOL)electronicParkBrakeStatus emergencyEvent:(BOOL)emergencyEvent engineOilLife:(BOOL)engineOilLife engineTorque:(BOOL)engineTorque externalTemperature:(BOOL)externalTemperature fuelLevel:(BOOL)fuelLevel fuelLevelState:(BOOL)fuelLevelState fuelRange:(BOOL)fuelRange gps:(BOOL)gps headLampStatus:(BOOL)headLampStatus instantFuelConsumption:(BOOL)instantFuelConsumption myKey:(BOOL)myKey odometer:(BOOL)odometer prndl:(BOOL)prndl rpm:(BOOL)rpm speed:(BOOL)speed steeringWheelAngle:(BOOL)steeringWheelAngle tirePressure:(BOOL)tirePressure wiperStatus:(BOOL)wiperStatus;
 
 /**
  * A boolean value. If true, subscribes GPS data.
@@ -212,6 +213,11 @@ NS_ASSUME_NONNULL_BEGIN
  * A boolean value. If true, subscribes myKey data.
  */
 @property (strong, nonatomic, nullable) NSNumber<SDLBool> *myKey;
+
+/**
+ A boolean value. If true, subscribes to the electronic parking brake status
+ */
+@property (strong, nonatomic, nullable) NSNumber<SDLBool> *electronicParkBrakeStatus;
 
 @end
 

--- a/SmartDeviceLink/SDLSubscribeVehicleData.m
+++ b/SmartDeviceLink/SDLSubscribeVehicleData.m
@@ -18,10 +18,10 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (instancetype)initWithAccelerationPedalPosition:(BOOL)accelerationPedalPosition airbagStatus:(BOOL)airbagStatus beltStatus:(BOOL)beltStatus bodyInformation:(BOOL)bodyInformation clusterModeStatus:(BOOL)clusterModeStatus deviceStatus:(BOOL)deviceStatus driverBraking:(BOOL)driverBraking eCallInfo:(BOOL)eCallInfo emergencyEvent:(BOOL)emergencyEvent engineTorque:(BOOL)engineTorque externalTemperature:(BOOL)externalTemperature fuelLevel:(BOOL)fuelLevel fuelLevelState:(BOOL)fuelLevelState gps:(BOOL)gps headLampStatus:(BOOL)headLampStatus instantFuelConsumption:(BOOL)instantFuelConsumption myKey:(BOOL)myKey odometer:(BOOL)odometer prndl:(BOOL)prndl rpm:(BOOL)rpm speed:(BOOL)speed steeringWheelAngle:(BOOL)steeringWheelAngle tirePressure:(BOOL)tirePressure wiperStatus:(BOOL)wiperStatus {
-    return [self initWithAccelerationPedalPosition:accelerationPedalPosition airbagStatus:airbagStatus beltStatus:beltStatus bodyInformation:bodyInformation clusterModeStatus:clusterModeStatus deviceStatus:deviceStatus driverBraking:driverBraking eCallInfo:eCallInfo emergencyEvent:emergencyEvent engineOilLife:NO engineTorque:engineTorque externalTemperature:externalTemperature fuelLevel:fuelLevel fuelLevelState:fuelLevelState fuelRange:NO gps:gps headLampStatus:headLampStatus instantFuelConsumption:instantFuelConsumption myKey:myKey odometer:odometer prndl:prndl rpm:rpm speed:speed steeringWheelAngle:steeringWheelAngle tirePressure:tirePressure wiperStatus:wiperStatus];
+    return [self initWithAccelerationPedalPosition:accelerationPedalPosition airbagStatus:airbagStatus beltStatus:beltStatus bodyInformation:bodyInformation clusterModeStatus:clusterModeStatus deviceStatus:deviceStatus driverBraking:driverBraking eCallInfo:eCallInfo electronicParkBrakeStatus:NO emergencyEvent:emergencyEvent engineOilLife:NO engineTorque:engineTorque externalTemperature:externalTemperature fuelLevel:fuelLevel fuelLevelState:fuelLevelState fuelRange:NO gps:gps headLampStatus:headLampStatus instantFuelConsumption:instantFuelConsumption myKey:myKey odometer:odometer prndl:prndl rpm:rpm speed:speed steeringWheelAngle:steeringWheelAngle tirePressure:tirePressure wiperStatus:wiperStatus];
 }
 
-- (instancetype)initWithAccelerationPedalPosition:(BOOL)accelerationPedalPosition airbagStatus:(BOOL)airbagStatus beltStatus:(BOOL)beltStatus bodyInformation:(BOOL)bodyInformation clusterModeStatus:(BOOL)clusterModeStatus deviceStatus:(BOOL)deviceStatus driverBraking:(BOOL)driverBraking eCallInfo:(BOOL)eCallInfo emergencyEvent:(BOOL)emergencyEvent engineOilLife:(BOOL)engineOilLife engineTorque:(BOOL)engineTorque externalTemperature:(BOOL)externalTemperature fuelLevel:(BOOL)fuelLevel fuelLevelState:(BOOL)fuelLevelState fuelRange:(BOOL)fuelRange gps:(BOOL)gps headLampStatus:(BOOL)headLampStatus instantFuelConsumption:(BOOL)instantFuelConsumption myKey:(BOOL)myKey odometer:(BOOL)odometer prndl:(BOOL)prndl rpm:(BOOL)rpm speed:(BOOL)speed steeringWheelAngle:(BOOL)steeringWheelAngle tirePressure:(BOOL)tirePressure wiperStatus:(BOOL)wiperStatus {
+- (instancetype)initWithAccelerationPedalPosition:(BOOL)accelerationPedalPosition airbagStatus:(BOOL)airbagStatus beltStatus:(BOOL)beltStatus bodyInformation:(BOOL)bodyInformation clusterModeStatus:(BOOL)clusterModeStatus deviceStatus:(BOOL)deviceStatus driverBraking:(BOOL)driverBraking eCallInfo:(BOOL)eCallInfo electronicParkBrakeStatus:(BOOL)electronicParkBrakeStatus emergencyEvent:(BOOL)emergencyEvent engineOilLife:(BOOL)engineOilLife engineTorque:(BOOL)engineTorque externalTemperature:(BOOL)externalTemperature fuelLevel:(BOOL)fuelLevel fuelLevelState:(BOOL)fuelLevelState fuelRange:(BOOL)fuelRange gps:(BOOL)gps headLampStatus:(BOOL)headLampStatus instantFuelConsumption:(BOOL)instantFuelConsumption myKey:(BOOL)myKey odometer:(BOOL)odometer prndl:(BOOL)prndl rpm:(BOOL)rpm speed:(BOOL)speed steeringWheelAngle:(BOOL)steeringWheelAngle tirePressure:(BOOL)tirePressure wiperStatus:(BOOL)wiperStatus {
     self = [self init];
     if (!self) {
         return nil;
@@ -35,6 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
     self.deviceStatus = @(deviceStatus);
     self.driverBraking = @(driverBraking);
     self.eCallInfo = @(eCallInfo);
+    self.electronicParkBrakeStatus = @(electronicParkBrakeStatus);
     self.emergencyEvent = @(emergencyEvent);
     self.engineOilLife = @(engineOilLife);
     self.engineTorque = @(engineTorque);
@@ -263,6 +264,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable NSNumber<SDLBool> *)myKey {
     return [parameters sdl_objectForName:SDLNameMyKey];
+}
+
+- (void)setElectronicParkBrakeStatus:(nullable NSNumber<SDLBool> *)electronicParkBrakeStatus {
+    [parameters sdl_setObject:electronicParkBrakeStatus forName:SDLNameElectronicParkBrakeStatus];
+}
+
+- (nullable NSNumber<SDLBool> *)electronicParkBrakeStatus {
+    return [parameters sdl_objectForName:SDLNameElectronicParkBrakeStatus];
 }
 
 @end

--- a/SmartDeviceLink/SDLSubscribeVehicleDataResponse.h
+++ b/SmartDeviceLink/SDLSubscribeVehicleDataResponse.h
@@ -198,6 +198,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (strong, nonatomic, nullable) SDLVehicleDataResult *myKey;
 
+/**
+ The result of requesting to subscribe to the electronic parking brake status
+
+ Optional
+ */
+@property (strong, nonatomic, nullable) SDLVehicleDataResult *electronicParkBrakeStatus;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLSubscribeVehicleDataResponse.m
+++ b/SmartDeviceLink/SDLSubscribeVehicleDataResponse.m
@@ -226,6 +226,14 @@ NS_ASSUME_NONNULL_BEGIN
     return [parameters sdl_objectForName:SDLNameMyKey ofClass:SDLVehicleDataResult.class];
 }
 
+- (void)setElectronicParkBrakeStatus:(nullable SDLVehicleDataResult *)electronicParkBrakeStatus {
+    [parameters sdl_setObject:electronicParkBrakeStatus forName:SDLNameElectronicParkBrakeStatus];
+}
+
+- (nullable SDLVehicleDataResult *)electronicParkBrakeStatus {
+    return [parameters sdl_objectForName:SDLNameElectronicParkBrakeStatus ofClass:[SDLVehicleDataResult class]];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLUnsubscribeVehicleData.h
+++ b/SmartDeviceLink/SDLUnsubscribeVehicleData.h
@@ -63,6 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param deviceStatus                 Unsubscribe to deviceStatus
  *  @param driverBraking                Unsubscribe to driverBraking
  *  @param eCallInfo                    Unsubscribe to eCallInfo
+ *  @param electronicParkBrakeStatus    Unsubscribe to electronicParkBrakeStatus
  *  @param emergencyEvent               Unsubscribe to emergencyEvent
  *  @param engineOilLife                Unsubscribe to engineOilLife
  *  @param engineTorque                 Unsubscribe to engineTorque
@@ -83,7 +84,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param wiperStatus                  Unsubscribe to wiperStatus
  *  @return                             A SDLUnsubscribeVehicleData object
  */
-- (instancetype)initWithAccelerationPedalPosition:(BOOL)accelerationPedalPosition airbagStatus:(BOOL)airbagStatus beltStatus:(BOOL)beltStatus bodyInformation:(BOOL)bodyInformation clusterModeStatus:(BOOL)clusterModeStatus deviceStatus:(BOOL)deviceStatus driverBraking:(BOOL)driverBraking eCallInfo:(BOOL)eCallInfo emergencyEvent:(BOOL)emergencyEvent engineOilLife:(BOOL)engineOilLife engineTorque:(BOOL)engineTorque externalTemperature:(BOOL)externalTemperature fuelLevel:(BOOL)fuelLevel fuelLevelState:(BOOL)fuelLevelState fuelRange:(BOOL)fuelRange gps:(BOOL)gps headLampStatus:(BOOL)headLampStatus instantFuelConsumption:(BOOL)instantFuelConsumption myKey:(BOOL)myKey odometer:(BOOL)odometer prndl:(BOOL)prndl rpm:(BOOL)rpm speed:(BOOL)speed steeringWheelAngle:(BOOL)steeringWheelAngle tirePressure:(BOOL)tirePressure wiperStatus:(BOOL)wiperStatus;
+- (instancetype)initWithAccelerationPedalPosition:(BOOL)accelerationPedalPosition airbagStatus:(BOOL)airbagStatus beltStatus:(BOOL)beltStatus bodyInformation:(BOOL)bodyInformation clusterModeStatus:(BOOL)clusterModeStatus deviceStatus:(BOOL)deviceStatus driverBraking:(BOOL)driverBraking eCallInfo:(BOOL)eCallInfo electronicParkBrakeStatus:(BOOL)electronicParkBrakeStatus emergencyEvent:(BOOL)emergencyEvent engineOilLife:(BOOL)engineOilLife engineTorque:(BOOL)engineTorque externalTemperature:(BOOL)externalTemperature fuelLevel:(BOOL)fuelLevel fuelLevelState:(BOOL)fuelLevelState fuelRange:(BOOL)fuelRange gps:(BOOL)gps headLampStatus:(BOOL)headLampStatus instantFuelConsumption:(BOOL)instantFuelConsumption myKey:(BOOL)myKey odometer:(BOOL)odometer prndl:(BOOL)prndl rpm:(BOOL)rpm speed:(BOOL)speed steeringWheelAngle:(BOOL)steeringWheelAngle tirePressure:(BOOL)tirePressure wiperStatus:(BOOL)wiperStatus;
 
 /**
  * If true, unsubscribes from GPS
@@ -214,6 +215,11 @@ NS_ASSUME_NONNULL_BEGIN
  * If true, unsubscribes from My Key
  */
 @property (strong, nonatomic, nullable) NSNumber<SDLBool> *myKey;
+
+/**
+ A boolean value. If true, unsubscribes to the electronic parking brake status
+ */
+@property (strong, nonatomic, nullable) NSNumber<SDLBool> *electronicParkBrakeStatus;
 
 @end
 

--- a/SmartDeviceLink/SDLUnsubscribeVehicleData.m
+++ b/SmartDeviceLink/SDLUnsubscribeVehicleData.m
@@ -18,10 +18,10 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (instancetype)initWithAccelerationPedalPosition:(BOOL)accelerationPedalPosition airbagStatus:(BOOL)airbagStatus beltStatus:(BOOL)beltStatus bodyInformation:(BOOL)bodyInformation clusterModeStatus:(BOOL)clusterModeStatus deviceStatus:(BOOL)deviceStatus driverBraking:(BOOL)driverBraking eCallInfo:(BOOL)eCallInfo emergencyEvent:(BOOL)emergencyEvent engineTorque:(BOOL)engineTorque externalTemperature:(BOOL)externalTemperature fuelLevel:(BOOL)fuelLevel fuelLevelState:(BOOL)fuelLevelState gps:(BOOL)gps headLampStatus:(BOOL)headLampStatus instantFuelConsumption:(BOOL)instantFuelConsumption myKey:(BOOL)myKey odometer:(BOOL)odometer prndl:(BOOL)prndl rpm:(BOOL)rpm speed:(BOOL)speed steeringWheelAngle:(BOOL)steeringWheelAngle tirePressure:(BOOL)tirePressure wiperStatus:(BOOL)wiperStatus {
-    return [self initWithAccelerationPedalPosition:accelerationPedalPosition airbagStatus:airbagStatus beltStatus:beltStatus bodyInformation:bodyInformation clusterModeStatus:clusterModeStatus deviceStatus:deviceStatus driverBraking:driverBraking eCallInfo:eCallInfo emergencyEvent:emergencyEvent engineOilLife:NO engineTorque:engineTorque externalTemperature:externalTemperature fuelLevel:fuelLevel fuelLevelState:fuelLevelState fuelRange:NO gps:gps headLampStatus:headLampStatus instantFuelConsumption:instantFuelConsumption myKey:myKey odometer:odometer prndl:prndl rpm:rpm speed:speed steeringWheelAngle:steeringWheelAngle tirePressure:tirePressure wiperStatus:wiperStatus];
+    return [self initWithAccelerationPedalPosition:accelerationPedalPosition airbagStatus:airbagStatus beltStatus:beltStatus bodyInformation:bodyInformation clusterModeStatus:clusterModeStatus deviceStatus:deviceStatus driverBraking:driverBraking eCallInfo:eCallInfo electronicParkBrakeStatus:NO emergencyEvent:emergencyEvent engineOilLife:NO engineTorque:engineTorque externalTemperature:externalTemperature fuelLevel:fuelLevel fuelLevelState:fuelLevelState fuelRange:NO gps:gps headLampStatus:headLampStatus instantFuelConsumption:instantFuelConsumption myKey:myKey odometer:odometer prndl:prndl rpm:rpm speed:speed steeringWheelAngle:steeringWheelAngle tirePressure:tirePressure wiperStatus:wiperStatus];
 }
 
-- (instancetype)initWithAccelerationPedalPosition:(BOOL)accelerationPedalPosition airbagStatus:(BOOL)airbagStatus beltStatus:(BOOL)beltStatus bodyInformation:(BOOL)bodyInformation clusterModeStatus:(BOOL)clusterModeStatus deviceStatus:(BOOL)deviceStatus driverBraking:(BOOL)driverBraking eCallInfo:(BOOL)eCallInfo emergencyEvent:(BOOL)emergencyEvent engineOilLife:(BOOL)engineOilLife engineTorque:(BOOL)engineTorque externalTemperature:(BOOL)externalTemperature fuelLevel:(BOOL)fuelLevel fuelLevelState:(BOOL)fuelLevelState fuelRange:(BOOL)fuelRange gps:(BOOL)gps headLampStatus:(BOOL)headLampStatus instantFuelConsumption:(BOOL)instantFuelConsumption myKey:(BOOL)myKey odometer:(BOOL)odometer prndl:(BOOL)prndl rpm:(BOOL)rpm speed:(BOOL)speed steeringWheelAngle:(BOOL)steeringWheelAngle tirePressure:(BOOL)tirePressure wiperStatus:(BOOL)wiperStatus {
+- (instancetype)initWithAccelerationPedalPosition:(BOOL)accelerationPedalPosition airbagStatus:(BOOL)airbagStatus beltStatus:(BOOL)beltStatus bodyInformation:(BOOL)bodyInformation clusterModeStatus:(BOOL)clusterModeStatus deviceStatus:(BOOL)deviceStatus driverBraking:(BOOL)driverBraking eCallInfo:(BOOL)eCallInfo electronicParkBrakeStatus:(BOOL)electronicParkBrakeStatus emergencyEvent:(BOOL)emergencyEvent engineOilLife:(BOOL)engineOilLife engineTorque:(BOOL)engineTorque externalTemperature:(BOOL)externalTemperature fuelLevel:(BOOL)fuelLevel fuelLevelState:(BOOL)fuelLevelState fuelRange:(BOOL)fuelRange gps:(BOOL)gps headLampStatus:(BOOL)headLampStatus instantFuelConsumption:(BOOL)instantFuelConsumption myKey:(BOOL)myKey odometer:(BOOL)odometer prndl:(BOOL)prndl rpm:(BOOL)rpm speed:(BOOL)speed steeringWheelAngle:(BOOL)steeringWheelAngle tirePressure:(BOOL)tirePressure wiperStatus:(BOOL)wiperStatus {
     self = [self init];
     if (!self) {
         return nil;
@@ -35,6 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
     self.deviceStatus = @(deviceStatus);
     self.driverBraking = @(driverBraking);
     self.eCallInfo = @(eCallInfo);
+    self.electronicParkBrakeStatus = @(electronicParkBrakeStatus);
     self.emergencyEvent = @(emergencyEvent);
     self.engineOilLife = @(engineOilLife);
     self.engineTorque = @(engineTorque);
@@ -263,6 +264,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable NSNumber<SDLBool> *)myKey {
     return [parameters sdl_objectForName:SDLNameMyKey];
+}
+
+- (void)setElectronicParkBrakeStatus:(nullable NSNumber<SDLBool> *)electronicParkBrakeStatus {
+    [parameters sdl_setObject:electronicParkBrakeStatus forName:SDLNameElectronicParkBrakeStatus];
+}
+
+- (nullable NSNumber<SDLBool> *)electronicParkBrakeStatus {
+    return [parameters sdl_objectForName:SDLNameElectronicParkBrakeStatus];
 }
 
 @end

--- a/SmartDeviceLink/SDLUnsubscribeVehicleDataResponse.h
+++ b/SmartDeviceLink/SDLUnsubscribeVehicleDataResponse.h
@@ -16,186 +16,193 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SDLUnsubscribeVehicleDataResponse : SDLRPCResponse
 
 /**
- The result of requesting to subscribe to the GPSData.
+ The result of requesting to unsubscribe to the GPSData.
 
  Optional
  */
 @property (strong, nonatomic, nullable) SDLVehicleDataResult *gps;
 
 /**
- The result of requesting to subscribe to the vehicle speed in kilometers per hour.
+ The result of requesting to unsubscribe to the vehicle speed in kilometers per hour.
 
  Optional
  */
 @property (strong, nonatomic, nullable) SDLVehicleDataResult *speed;
 
 /**
- The result of requesting to subscribe to the number of revolutions per minute of the engine.
+ The result of requesting to unsubscribe to the number of revolutions per minute of the engine.
 
  Optional
  */
 @property (strong, nonatomic, nullable) SDLVehicleDataResult *rpm;
 
 /**
- The result of requesting to subscribe to the fuel level in the tank (percentage)
+ The result of requesting to unsubscribe to the fuel level in the tank (percentage)
 
  Optional
  */
 @property (strong, nonatomic, nullable) SDLVehicleDataResult *fuelLevel;
 
 /**
- The result of requesting to subscribe to the fuel level state.
+ The result of requesting to unsubscribe to the fuel level state.
 
  Optional
  */
 @property (strong, nonatomic, nullable) SDLVehicleDataResult *fuelLevel_State;
 
 /**
- The result of requesting to subscribe to the fuel range.
+ The result of requesting to unsubscribe to the fuel range.
 
  Optional
  */
 @property (strong, nonatomic, nullable) SDLVehicleDataResult *fuelRange;
 
 /**
- The result of requesting to subscribe to the instantaneous fuel consumption in microlitres.
+ The result of requesting to unsubscribe to the instantaneous fuel consumption in microlitres.
 
  Optional
  */
 @property (strong, nonatomic, nullable) SDLVehicleDataResult *instantFuelConsumption;
 
 /**
- The result of requesting to subscribe to the external temperature in degrees celsius.
+ The result of requesting to unsubscribe to the external temperature in degrees celsius.
 
  Optional
  */
 @property (strong, nonatomic, nullable) SDLVehicleDataResult *externalTemperature;
 
 /**
- The result of requesting to subscribe to the PRNDL status.
+ The result of requesting to unsubscribe to the PRNDL status.
 
  Optional
  */
 @property (strong, nonatomic, nullable) SDLVehicleDataResult *prndl;
 
 /**
- The result of requesting to subscribe to the tireStatus.
+ The result of requesting to unsubscribe to the tireStatus.
 
  Optional
  */
 @property (strong, nonatomic, nullable) SDLVehicleDataResult *tirePressure;
 
 /**
- The result of requesting to subscribe to the odometer in km.
+ The result of requesting to unsubscribe to the odometer in km.
 
  Optional
  */
 @property (strong, nonatomic, nullable) SDLVehicleDataResult *odometer;
 
 /**
- The result of requesting to subscribe to the status of the seat belts.
+ The result of requesting to unsubscribe to the status of the seat belts.
 
  Optional
  */
 @property (strong, nonatomic, nullable) SDLVehicleDataResult *beltStatus;
 
 /**
- The result of requesting to subscribe to the body information including power modes.
+ The result of requesting to unsubscribe to the body information including power modes.
 
  Optional
  */
 @property (strong, nonatomic, nullable) SDLVehicleDataResult *bodyInformation;
 
 /**
- The result of requesting to subscribe to the device status including signal and battery strength.
+ The result of requesting to unsubscribe to the device status including signal and battery strength.
 
  Optional
  */
 @property (strong, nonatomic, nullable) SDLVehicleDataResult *deviceStatus;
 
 /**
- The result of requesting to subscribe to the status of the brake pedal.
+ The result of requesting to unsubscribe to the status of the brake pedal.
 
  Optional
  */
 @property (strong, nonatomic, nullable) SDLVehicleDataResult *driverBraking;
 
 /**
- The result of requesting to subscribe to the status of the wipers.
+ The result of requesting to unsubscribe to the status of the wipers.
 
  Optional
  */
 @property (strong, nonatomic, nullable) SDLVehicleDataResult *wiperStatus;
 
 /**
- The result of requesting to subscribe to the status of the head lamps.
+ The result of requesting to unsubscribe to the status of the head lamps.
 
  Optional
  */
 @property (strong, nonatomic, nullable) SDLVehicleDataResult *headLampStatus;
 
 /**
- The result of requesting to subscribe to the estimated percentage of remaining oil life of the engine.
+ The result of requesting to unsubscribe to the estimated percentage of remaining oil life of the engine.
 
  Optional
  */
 @property (strong, nonatomic, nullable) SDLVehicleDataResult *engineOilLife;
 
 /**
- The result of requesting to subscribe to the torque value for engine (in Nm) on non-diesel variants.
+ The result of requesting to unsubscribe to the torque value for engine (in Nm) on non-diesel variants.
 
  Optional
  */
 @property (strong, nonatomic, nullable) SDLVehicleDataResult *engineTorque;
 
 /**
- The result of requesting to subscribe to the accelerator pedal position (percentage depressed)
+ The result of requesting to unsubscribe to the accelerator pedal position (percentage depressed)
 
  Optional
  */
 @property (strong, nonatomic, nullable) SDLVehicleDataResult *accPedalPosition;
 
 /**
- The result of requesting to subscribe to the current angle of the steering wheel (in deg)
+ The result of requesting to unsubscribe to the current angle of the steering wheel (in deg)
 
  Optional
  */
 @property (strong, nonatomic, nullable) SDLVehicleDataResult *steeringWheelAngle;
 
 /**
- The result of requesting to subscribe to the emergency call info
+ The result of requesting to unsubscribe to the emergency call info
 
  Optional
  */
 @property (strong, nonatomic, nullable) SDLVehicleDataResult *eCallInfo;
 
 /**
- The result of requesting to subscribe to the airbag status
+ The result of requesting to unsubscribe to the airbag status
 
  Optional
  */
 @property (strong, nonatomic, nullable) SDLVehicleDataResult *airbagStatus;
 
 /**
- The result of requesting to subscribe to the emergency event
+ The result of requesting to unsubscribe to the emergency event
 
  Optional
  */
 @property (strong, nonatomic, nullable) SDLVehicleDataResult *emergencyEvent;
 
 /**
- The result of requesting to subscribe to the cluster modes
+ The result of requesting to unsubscribe to the cluster modes
 
  Optional
  */
 @property (strong, nonatomic, nullable) SDLVehicleDataResult *clusterModes;
 
 /**
- The result of requesting to subscribe to the myKey status
+ The result of requesting to unsubscribe to the myKey status
 
  Optional
  */
 @property (strong, nonatomic, nullable) SDLVehicleDataResult *myKey;
+
+/**
+ The result of requesting to unsubscribe to the electronic parking brake status
+
+ Optional
+ */
+@property (strong, nonatomic, nullable) SDLVehicleDataResult *electronicParkBrakeStatus;
 
 @end
 

--- a/SmartDeviceLink/SDLUnsubscribeVehicleDataResponse.m
+++ b/SmartDeviceLink/SDLUnsubscribeVehicleDataResponse.m
@@ -226,6 +226,13 @@ NS_ASSUME_NONNULL_BEGIN
     return [parameters sdl_objectForName:SDLNameMyKey ofClass:SDLVehicleDataResult.class];
 }
 
+- (void)setElectronicParkBrakeStatus:(nullable SDLVehicleDataResult *)electronicParkBrakeStatus {
+    [parameters sdl_setObject:electronicParkBrakeStatus forName:SDLNameElectronicParkBrakeStatus];
+}
+
+- (nullable SDLVehicleDataResult *)electronicParkBrakeStatus {
+    return [parameters sdl_objectForName:SDLNameElectronicParkBrakeStatus ofClass:[SDLVehicleDataResult class]];
+}
 
 @end
 

--- a/SmartDeviceLink/SDLVehicleDataType.h
+++ b/SmartDeviceLink/SDLVehicleDataType.h
@@ -148,3 +148,8 @@ extern SDLVehicleDataType const SDLVehicleDataTypeAccelerationPedal;
  Vehicle steering wheel data
  */
 extern SDLVehicleDataType const SDLVehicleDataTypeSteeringWheel;
+
+/**
+ Electronic parking brake status
+ */
+extern SDLVehicleDataType const SDLVehicleDataTypeElectronicParkBrakeStatus;

--- a/SmartDeviceLink/SDLVehicleDataType.m
+++ b/SmartDeviceLink/SDLVehicleDataType.m
@@ -32,3 +32,4 @@ SDLVehicleDataType const SDLVehicleDataTypeEngineOilLife = @"VEHICLEDATA_ENGINEO
 SDLVehicleDataType const SDLVehicleDataTypeEngineTorque = @"VEHICLEDATA_ENGINETORQUE";
 SDLVehicleDataType const SDLVehicleDataTypeAccelerationPedal = @"VEHICLEDATA_ACCPEDAL";
 SDLVehicleDataType const SDLVehicleDataTypeSteeringWheel = @"VEHICLEDATA_STEERINGWHEEL";
+SDLVehicleDataType const SDLVehicleDataTypeElectronicParkBrakeStatus = @"VEHICLEDATA_ELECTRONICPARKBRAKESTATUS";

--- a/SmartDeviceLink/SmartDeviceLink.h
+++ b/SmartDeviceLink/SmartDeviceLink.h
@@ -230,6 +230,7 @@ FOUNDATION_EXPORT const unsigned char SmartDeviceLinkVersionString[];
 #import "SDLDisplayType.h"
 #import "SDLDriverDistractionState.h"
 #import "SDLECallConfirmationStatus.h"
+#import "SDLElectronicParkBrakeStatus.h"
 #import "SDLEmergencyEventType.h"
 #import "SDLFileType.h"
 #import "SDLFuelCutoffStatus.h"

--- a/SmartDeviceLinkTests/RPCSpecs/EnumSpecs/SDLElectronicParkBrakeStatusSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/EnumSpecs/SDLElectronicParkBrakeStatusSpec.m
@@ -1,0 +1,18 @@
+#import <Quick/Quick.h>
+#import <Nimble/Nimble.h>
+
+#import "SDLElectronicParkBrakeStatus.h"
+
+QuickSpecBegin(SDLElectronicParkBrakeStatusSpec)
+
+describe(@"Individual Enum Value Tests", ^ {
+    it(@"Should match internal values", ^ {
+        expect(SDLElectronicParkBrakeStatusClosed).to(equal(@"CLOSED"));
+        expect(SDLElectronicParkBrakeStatusTransition).to(equal(@"TRANSITION"));
+        expect(SDLElectronicParkBrakeStatusOpen).to(equal(@"OPEN"));
+        expect(SDLElectronicParkBrakeStatusDriveActive).to(equal(@"DRIVE_ACTIVE"));
+        expect(SDLElectronicParkBrakeStatusFault).to(equal(@"FAULT"));
+    });
+});
+
+QuickSpecEnd

--- a/SmartDeviceLinkTests/RPCSpecs/EnumSpecs/SDLVehicleDataTypeSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/EnumSpecs/SDLVehicleDataTypeSpec.m
@@ -42,6 +42,7 @@ describe(@"Individual Enum Value Tests", ^ {
         expect(SDLVehicleDataTypeEngineTorque).to(equal(@"VEHICLEDATA_ENGINETORQUE"));
         expect(SDLVehicleDataTypeAccelerationPedal).to(equal(@"VEHICLEDATA_ACCPEDAL"));
         expect(SDLVehicleDataTypeSteeringWheel).to(equal(@"VEHICLEDATA_STEERINGWHEEL"));
+        expect(SDLVehicleDataTypeElectronicParkBrakeStatus).to(equal(@"VEHICLEDATA_ELECTRONICPARKBRAKESTATUS"));
     });
 });
 

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnVehicleDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnVehicleDataSpec.m
@@ -39,6 +39,7 @@ describe(@"Getter/Setter Tests", ^ {
         testNotification.deviceStatus = device;
         testNotification.driverBraking = SDLVehicleDataEventStatusYes;
         testNotification.eCallInfo = eCall;
+        testNotification.electronicParkBrakeStatus = SDLElectronicParkBrakeStatusDriveActive;
         testNotification.emergencyEvent = event;
         testNotification.engineOilLife = @34.45;
         testNotification.engineTorque = @-200.124;
@@ -67,6 +68,7 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testNotification.deviceStatus).to(equal(device));
         expect(testNotification.driverBraking).to(equal(SDLVehicleDataEventStatusYes));
         expect(testNotification.eCallInfo).to(equal(eCall));
+        expect(testNotification.electronicParkBrakeStatus).to(equal(SDLElectronicParkBrakeStatusDriveActive));
         expect(testNotification.emergencyEvent).to(equal(event));
         expect(testNotification.engineOilLife).to(equal(@34.45));
         expect(testNotification.engineTorque).to(equal(@-200.124));
@@ -99,6 +101,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                    SDLNameDeviceStatus:device,
                                                    SDLNameDriverBraking:SDLVehicleDataEventStatusYes,
                                                    SDLNameECallInfo:eCall,
+                                                   SDLNameElectronicParkBrakeStatus:SDLElectronicParkBrakeStatusDriveActive,
                                                    SDLNameEmergencyEvent:event,
                                                    SDLNameEngineOilLife:@45.1,
                                                    SDLNameEngineTorque:@-200.124,
@@ -129,6 +132,7 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testNotification.deviceStatus).to(equal(device));
         expect(testNotification.driverBraking).to(equal(SDLVehicleDataEventStatusYes));
         expect(testNotification.eCallInfo).to(equal(eCall));
+        expect(testNotification.electronicParkBrakeStatus).to(equal(SDLElectronicParkBrakeStatusDriveActive));
         expect(testNotification.emergencyEvent).to(equal(event));
         expect(testNotification.engineOilLife).to(equal(@45.1));
         expect(testNotification.engineTorque).to(equal(@-200.124));
@@ -161,6 +165,7 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testNotification.deviceStatus).to(beNil());
         expect(testNotification.driverBraking).to(beNil());
         expect(testNotification.eCallInfo).to(beNil());
+        expect(testNotification.electronicParkBrakeStatus).to(beNil());
         expect(testNotification.emergencyEvent).to(beNil());
         expect(testNotification.engineOilLife).to(beNil());
         expect(testNotification.engineTorque).to(beNil());

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetVehicleDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetVehicleDataSpec.m
@@ -25,6 +25,7 @@ describe(@"Getter/Setter Tests", ^ {
         testRequest.deviceStatus = @NO;
         testRequest.driverBraking = @YES;
         testRequest.eCallInfo = @YES;
+        testRequest.electronicParkBrakeStatus = @YES;
         testRequest.emergencyEvent = @YES;
         testRequest.engineOilLife = @YES;
         testRequest.engineTorque = @NO;
@@ -52,6 +53,7 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testRequest.deviceStatus).to(equal(@NO));
         expect(testRequest.driverBraking).to(equal(@YES));
         expect(testRequest.eCallInfo).to(equal(@YES));
+        expect(testRequest.electronicParkBrakeStatus).to(equal(@YES));
         expect(testRequest.emergencyEvent).to(equal(@YES));
         expect(testRequest.engineOilLife).to(equal(@YES));
         expect(testRequest.engineTorque).to(equal(@NO));
@@ -83,6 +85,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                                    SDLNameDeviceStatus:@YES,
                                                                    SDLNameDriverBraking:@YES,
                                                                    SDLNameECallInfo:@YES,
+                                                                   SDLNameElectronicParkBrakeStatus:@YES,
                                                                    SDLNameEmergencyEvent:@NO,
                                                                    SDLNameEngineOilLife:@YES,
                                                                    SDLNameEngineTorque:@YES,
@@ -112,6 +115,7 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testRequest.deviceStatus).to(equal(@YES));
         expect(testRequest.driverBraking).to(equal(@YES));
         expect(testRequest.eCallInfo).to(equal(@YES));
+        expect(testRequest.electronicParkBrakeStatus).to(equal(@YES));
         expect(testRequest.emergencyEvent).to(equal(@NO));
         expect(testRequest.engineOilLife).to(equal(@YES));
         expect(testRequest.engineTorque).to(equal(@YES));
@@ -145,6 +149,7 @@ describe(@"initializers", ^{
         expect(testRequest.deviceStatus).to(beNil());
         expect(testRequest.driverBraking).to(beNil());
         expect(testRequest.eCallInfo).to(beNil());
+        expect(testRequest.electronicParkBrakeStatus).to(beNil());
         expect(testRequest.emergencyEvent).to(beNil());
         expect(testRequest.engineOilLife).to(beNil());
         expect(testRequest.engineTorque).to(beNil());
@@ -176,6 +181,7 @@ describe(@"initializers", ^{
         expect(testRequest.deviceStatus).to(equal(@YES));
         expect(testRequest.driverBraking).to(equal(@YES));
         expect(testRequest.eCallInfo).to(equal(@YES));
+        expect(testRequest.electronicParkBrakeStatus).to(equal(@NO));
         expect(testRequest.emergencyEvent).to(equal(@YES));
         expect(testRequest.engineOilLife).to(equal(@NO));
         expect(testRequest.engineTorque).to(equal(@YES));
@@ -197,7 +203,7 @@ describe(@"initializers", ^{
     });
 
     context(@"initWithAccelerationPedalPosition:airbagStatus:beltStatus:bodyInformation:clusterModeStatus:deviceStatus:driverBraking:eCallInfo:emergencyEvent:engineOilLife:engineTorque:externalTemperature:fuelLevel:fuelLevelState:gps:headLampStatus:instantFuelConsumption:myKey:odometer:prndl:rpm:speed:steeringWheelAngle:tirePressure:wiperStatus:", ^{
-        SDLGetVehicleData *testRequest = [[SDLGetVehicleData alloc] initWithAccelerationPedalPosition:YES airbagStatus:YES beltStatus:YES bodyInformation:YES clusterModeStatus:YES deviceStatus:YES driverBraking:YES eCallInfo:YES emergencyEvent:YES engineOilLife:YES engineTorque:YES externalTemperature:YES fuelLevel:YES fuelLevelState:YES fuelRange:YES gps:YES headLampStatus:YES instantFuelConsumption:YES myKey:YES odometer:YES prndl:YES rpm:YES speed:YES steeringWheelAngle:YES tirePressure:YES vin:YES wiperStatus:YES];
+        SDLGetVehicleData *testRequest = [[SDLGetVehicleData alloc] initWithAccelerationPedalPosition:YES airbagStatus:YES beltStatus:YES bodyInformation:YES clusterModeStatus:YES deviceStatus:YES driverBraking:YES eCallInfo:YES electronicParkBrakeStatus:YES emergencyEvent:YES engineOilLife:YES engineTorque:YES externalTemperature:YES fuelLevel:YES fuelLevelState:YES fuelRange:YES gps:YES headLampStatus:YES instantFuelConsumption:YES myKey:YES odometer:YES prndl:YES rpm:YES speed:YES steeringWheelAngle:YES tirePressure:YES vin:YES wiperStatus:YES];
 
         expect(testRequest.accPedalPosition).to(equal(@YES));
         expect(testRequest.airbagStatus).to(equal(@YES));
@@ -207,6 +213,7 @@ describe(@"initializers", ^{
         expect(testRequest.deviceStatus).to(equal(@YES));
         expect(testRequest.driverBraking).to(equal(@YES));
         expect(testRequest.eCallInfo).to(equal(@YES));
+        expect(testRequest.electronicParkBrakeStatus).to(equal(@YES));
         expect(testRequest.emergencyEvent).to(equal(@YES));
         expect(testRequest.engineOilLife).to(equal(@YES));
         expect(testRequest.engineTorque).to(equal(@YES));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSubscribeVehicleDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSubscribeVehicleDataSpec.m
@@ -25,6 +25,7 @@ describe(@"Getter/Setter Tests", ^ {
         testRequest.deviceStatus = @NO;
         testRequest.driverBraking = @YES;
         testRequest.eCallInfo = @YES;
+        testRequest.electronicParkBrakeStatus = @YES;
         testRequest.emergencyEvent = @YES;
         testRequest.engineOilLife = @YES;
         testRequest.engineTorque = @NO;
@@ -52,6 +53,7 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testRequest.deviceStatus).to(equal(@NO));
         expect(testRequest.driverBraking).to(equal(@YES));
         expect(testRequest.eCallInfo).to(equal(@YES));
+        expect(testRequest.electronicParkBrakeStatus).to(equal(@YES));
         expect(testRequest.emergencyEvent).to(equal(@YES));
         expect(testRequest.engineOilLife).to(equal(@YES));
         expect(testRequest.engineTorque).to(equal(@NO));
@@ -83,6 +85,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                                      SDLNameDeviceStatus:@YES,
                                                                      SDLNameDriverBraking:@YES,
                                                                      SDLNameECallInfo:@YES,
+                                                                   SDLNameElectronicParkBrakeStatus: @YES,
                                                                      SDLNameEmergencyEvent:@NO,
                                                                      SDLNameEngineOilLife:@YES,
                                                                      SDLNameEngineTorque:@YES,
@@ -112,6 +115,7 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testRequest.deviceStatus).to(equal(@YES));
         expect(testRequest.driverBraking).to(equal(@YES));
         expect(testRequest.eCallInfo).to(equal(@YES));
+        expect(testRequest.electronicParkBrakeStatus).to(equal(@YES));
         expect(testRequest.emergencyEvent).to(equal(@NO));
         expect(testRequest.engineOilLife).to(equal(@YES));
         expect(testRequest.engineTorque).to(equal(@YES));
@@ -145,6 +149,7 @@ describe(@"initializers", ^{
         expect(testRequest.deviceStatus).to(beNil());
         expect(testRequest.driverBraking).to(beNil());
         expect(testRequest.eCallInfo).to(beNil());
+        expect(testRequest.electronicParkBrakeStatus).to(beNil());
         expect(testRequest.emergencyEvent).to(beNil());
         expect(testRequest.engineOilLife).to(beNil());
         expect(testRequest.engineTorque).to(beNil());
@@ -166,7 +171,7 @@ describe(@"initializers", ^{
     });
 
     context(@"initWithAccelerationPedalPosition:airbagStatus:beltStatus:bodyInformation:clusterModeStatus:deviceStatus:driverBraking:eCallInfo:emergencyEvent:engineOilLife:engineTorque:externalTemperature:fuelLevel:fuelLevelState:gps:headLampStatus:instantFuelConsumption:myKey:odometer:prndl:rpm:speed:steeringWheelAngle:tirePressure:wiperStatus:", ^{
-        SDLSubscribeVehicleData* testRequest = [[SDLSubscribeVehicleData alloc] initWithAccelerationPedalPosition:YES airbagStatus:YES beltStatus:YES bodyInformation:YES clusterModeStatus:YES deviceStatus:YES driverBraking:YES eCallInfo:YES emergencyEvent:YES engineOilLife:YES engineTorque:YES externalTemperature:YES fuelLevel:YES fuelLevelState:YES fuelRange:YES gps:YES headLampStatus:YES instantFuelConsumption:YES myKey:YES odometer:YES prndl:YES rpm:YES speed:YES steeringWheelAngle:YES tirePressure:YES wiperStatus:YES];
+        SDLSubscribeVehicleData* testRequest = [[SDLSubscribeVehicleData alloc] initWithAccelerationPedalPosition:YES airbagStatus:YES beltStatus:YES bodyInformation:YES clusterModeStatus:YES deviceStatus:YES driverBraking:YES eCallInfo:YES electronicParkBrakeStatus:YES emergencyEvent:YES engineOilLife:YES engineTorque:YES externalTemperature:YES fuelLevel:YES fuelLevelState:YES fuelRange:YES gps:YES headLampStatus:YES instantFuelConsumption:YES myKey:YES odometer:YES prndl:YES rpm:YES speed:YES steeringWheelAngle:YES tirePressure:YES wiperStatus:YES];
 
         expect(testRequest.accPedalPosition).to(equal(@YES));
         expect(testRequest.airbagStatus).to(equal(@YES));
@@ -176,6 +181,7 @@ describe(@"initializers", ^{
         expect(testRequest.deviceStatus).to(equal(@YES));
         expect(testRequest.driverBraking).to(equal(@YES));
         expect(testRequest.eCallInfo).to(equal(@YES));
+        expect(testRequest.electronicParkBrakeStatus).to(equal(@YES));
         expect(testRequest.emergencyEvent).to(equal(@YES));
         expect(testRequest.engineOilLife).to(equal(@YES));
         expect(testRequest.engineTorque).to(equal(@YES));
@@ -207,6 +213,7 @@ describe(@"initializers", ^{
         expect(testRequest.deviceStatus).to(equal(@YES));
         expect(testRequest.driverBraking).to(equal(@YES));
         expect(testRequest.eCallInfo).to(equal(@YES));
+        expect(testRequest.electronicParkBrakeStatus).to(equal(@NO));
         expect(testRequest.emergencyEvent).to(equal(@YES));
         expect(testRequest.engineOilLife).to(equal(@NO));
         expect(testRequest.engineTorque).to(equal(@YES));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLUnsubscribeVehicleDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLUnsubscribeVehicleDataSpec.m
@@ -25,6 +25,7 @@ describe(@"Getter/Setter Tests", ^ {
         testRequest.deviceStatus = @YES;
         testRequest.driverBraking = @YES;
         testRequest.eCallInfo = @YES;
+        testRequest.electronicParkBrakeStatus = @YES;
         testRequest.emergencyEvent = @YES;
         testRequest.engineOilLife = @YES;
         testRequest.engineTorque = @YES;
@@ -52,6 +53,7 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testRequest.deviceStatus).to(equal(@YES));
         expect(testRequest.driverBraking).to(equal(@YES));
         expect(testRequest.eCallInfo).to(equal(@YES));
+        expect(testRequest.electronicParkBrakeStatus).to(equal(@YES));
         expect(testRequest.emergencyEvent).to(equal(@YES));
         expect(testRequest.engineOilLife).to(equal(@YES));
         expect(testRequest.engineTorque).to(equal(@YES));
@@ -83,6 +85,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                                      SDLNameDeviceStatus:@YES,
                                                                      SDLNameDriverBraking:@YES,
                                                                      SDLNameECallInfo:@YES,
+                                                                   SDLNameElectronicParkBrakeStatus: @YES,
                                                                      SDLNameEmergencyEvent:@YES,
                                                                      SDLNameEngineOilLife:@YES,
                                                                      SDLNameEngineTorque:@YES,
@@ -112,6 +115,7 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testRequest.deviceStatus).to(equal(@YES));
         expect(testRequest.driverBraking).to(equal(@YES));
         expect(testRequest.eCallInfo).to(equal(@YES));
+        expect(testRequest.electronicParkBrakeStatus).to(equal(@YES));
         expect(testRequest.emergencyEvent).to(equal(@YES));
         expect(testRequest.engineOilLife).to(equal(@YES));
         expect(testRequest.engineTorque).to(equal(@YES));
@@ -145,6 +149,7 @@ describe(@"initializers", ^{
         expect(testRequest.deviceStatus).to(beNil());
         expect(testRequest.driverBraking).to(beNil());
         expect(testRequest.eCallInfo).to(beNil());
+        expect(testRequest.electronicParkBrakeStatus).to(beNil());
         expect(testRequest.emergencyEvent).to(beNil());
         expect(testRequest.engineOilLife).to(beNil());
         expect(testRequest.engineTorque).to(beNil());
@@ -166,7 +171,7 @@ describe(@"initializers", ^{
     });
 
     context(@"initWithAccelerationPedalPosition:airbagStatus:beltStatus:bodyInformation:clusterModeStatus:deviceStatus:driverBraking:eCallInfo:emergencyEvent:engineOilLife:engineTorque:externalTemperature:fuelLevel:fuelLevelState:gps:headLampStatus:instantFuelConsumption:myKey:odometer:prndl:rpm:speed:steeringWheelAngle:tirePressure:wiperStatus:", ^{
-        SDLUnsubscribeVehicleData *testRequest = [[SDLUnsubscribeVehicleData alloc] initWithAccelerationPedalPosition:YES airbagStatus:YES beltStatus:YES bodyInformation:YES clusterModeStatus:YES deviceStatus:YES driverBraking:YES eCallInfo:YES emergencyEvent:YES engineOilLife:YES engineTorque:YES externalTemperature:YES fuelLevel:YES fuelLevelState:YES fuelRange:YES gps:YES headLampStatus:YES instantFuelConsumption:YES myKey:YES odometer:YES prndl:YES rpm:YES speed:YES steeringWheelAngle:YES tirePressure:YES wiperStatus:YES];
+        SDLUnsubscribeVehicleData *testRequest = [[SDLUnsubscribeVehicleData alloc] initWithAccelerationPedalPosition:YES airbagStatus:YES beltStatus:YES bodyInformation:YES clusterModeStatus:YES deviceStatus:YES driverBraking:YES eCallInfo:YES electronicParkBrakeStatus:YES emergencyEvent:YES engineOilLife:YES engineTorque:YES externalTemperature:YES fuelLevel:YES fuelLevelState:YES fuelRange:YES gps:YES headLampStatus:YES instantFuelConsumption:YES myKey:YES odometer:YES prndl:YES rpm:YES speed:YES steeringWheelAngle:YES tirePressure:YES wiperStatus:YES];
 
         expect(testRequest.accPedalPosition).to(equal(@YES));
         expect(testRequest.airbagStatus).to(equal(@YES));
@@ -176,6 +181,7 @@ describe(@"initializers", ^{
         expect(testRequest.deviceStatus).to(equal(@YES));
         expect(testRequest.driverBraking).to(equal(@YES));
         expect(testRequest.eCallInfo).to(equal(@YES));
+        expect(testRequest.electronicParkBrakeStatus).to(equal(@YES));
         expect(testRequest.emergencyEvent).to(equal(@YES));
         expect(testRequest.engineOilLife).to(equal(@YES));
         expect(testRequest.engineTorque).to(equal(@YES));
@@ -207,6 +213,7 @@ describe(@"initializers", ^{
         expect(testRequest.deviceStatus).to(equal(@YES));
         expect(testRequest.driverBraking).to(equal(@YES));
         expect(testRequest.eCallInfo).to(equal(@YES));
+        expect(testRequest.electronicParkBrakeStatus).to(equal(@NO));
         expect(testRequest.emergencyEvent).to(equal(@YES));
         expect(testRequest.engineOilLife).to(equal(@NO));
         expect(testRequest.engineTorque).to(equal(@YES));

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetVehicleDataResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetVehicleDataResponseSpec.m
@@ -39,6 +39,7 @@ describe(@"Getter/Setter Tests", ^ {
         testResponse.deviceStatus = device;
         testResponse.driverBraking = SDLVehicleDataEventStatusNoEvent;
         testResponse.eCallInfo = eCall;
+        testResponse.electronicParkBrakeStatus = SDLElectronicParkBrakeStatusDriveActive;
         testResponse.emergencyEvent = event;
         testResponse.engineOilLife = @56.3;
         testResponse.engineTorque = @630.4;
@@ -67,6 +68,7 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testResponse.deviceStatus).to(equal(device));
         expect(testResponse.driverBraking).to(equal(SDLVehicleDataEventStatusNoEvent));
         expect(testResponse.eCallInfo).to(equal(eCall));
+        expect(testResponse.electronicParkBrakeStatus).to(equal(SDLElectronicParkBrakeStatusDriveActive));
         expect(testResponse.emergencyEvent).to(equal(event));
         expect(testResponse.engineOilLife).to(equal(@56.3));
         expect(testResponse.engineTorque).to(equal(@630.4));
@@ -100,6 +102,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                      SDLNameDeviceStatus:device,
                                                      SDLNameDriverBraking:SDLVehicleDataEventStatusNoEvent,
                                                      SDLNameECallInfo:eCall,
+                                                     SDLNameElectronicParkBrakeStatus:SDLElectronicParkBrakeStatusDriveActive,
                                                      SDLNameEmergencyEvent:event,
                                                      SDLNameEngineOilLife:@23.22,
                                                      SDLNameEngineTorque:@630.4,
@@ -130,6 +133,7 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testResponse.deviceStatus).to(equal(device));
         expect(testResponse.driverBraking).to(equal(SDLVehicleDataEventStatusNoEvent));
         expect(testResponse.eCallInfo).to(equal(eCall));
+        expect(testResponse.electronicParkBrakeStatus).to(equal(SDLElectronicParkBrakeStatusDriveActive));
         expect(testResponse.emergencyEvent).to(equal(event));
         expect(testResponse.engineOilLife).to(equal(@23.22));
         expect(testResponse.engineTorque).to(equal(@630.4));
@@ -162,6 +166,7 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testResponse.deviceStatus).to(beNil());
         expect(testResponse.driverBraking).to(beNil());
         expect(testResponse.eCallInfo).to(beNil());
+        expect(testResponse.electronicParkBrakeStatus).to(beNil());
         expect(testResponse.emergencyEvent).to(beNil());
         expect(testResponse.engineOilLife).to(beNil());
         expect(testResponse.engineTorque).to(beNil());

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLSubscribeVehicleDataResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLSubscribeVehicleDataResponseSpec.m
@@ -29,6 +29,7 @@ describe(@"Getter/Setter Tests", ^ {
         testResponse.deviceStatus = vehicleDataResult;
         testResponse.driverBraking = vehicleDataResult;
         testResponse.eCallInfo = vehicleDataResult;
+        testResponse.electronicParkBrakeStatus = vehicleDataResult;
         testResponse.emergencyEvent = vehicleDataResult;
         testResponse.engineOilLife = vehicleDataResult;
         testResponse.engineTorque = vehicleDataResult;
@@ -56,6 +57,7 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testResponse.deviceStatus).to(equal(vehicleDataResult));
         expect(testResponse.driverBraking).to(equal(vehicleDataResult));
         expect(testResponse.eCallInfo).to(equal(vehicleDataResult));
+        expect(testResponse.electronicParkBrakeStatus).to(equal(vehicleDataResult));
         expect(testResponse.emergencyEvent).to(equal(vehicleDataResult));
         expect(testResponse.engineOilLife).to(equal(vehicleDataResult));
         expect(testResponse.engineTorque).to(equal(vehicleDataResult));
@@ -87,6 +89,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                                    SDLNameDeviceStatus:vehicleDataResult,
                                                                    SDLNameDriverBraking:vehicleDataResult,
                                                                    SDLNameECallInfo:vehicleDataResult,
+                                                                   SDLNameElectronicParkBrakeStatus:vehicleDataResult,
                                                                    SDLNameEmergencyEvent:vehicleDataResult,
                                                                    SDLNameEngineOilLife:vehicleDataResult,
                                                                    SDLNameEngineTorque:vehicleDataResult,
@@ -116,6 +119,7 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testResponse.deviceStatus).to(equal(vehicleDataResult));
         expect(testResponse.driverBraking).to(equal(vehicleDataResult));
         expect(testResponse.eCallInfo).to(equal(vehicleDataResult));
+        expect(testResponse.electronicParkBrakeStatus).to(equal(vehicleDataResult));
         expect(testResponse.emergencyEvent).to(equal(vehicleDataResult));
         expect(testResponse.engineOilLife).to(equal(vehicleDataResult));
         expect(testResponse.engineTorque).to(equal(vehicleDataResult));
@@ -147,6 +151,7 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testResponse.deviceStatus).to(beNil());
         expect(testResponse.driverBraking).to(beNil());
         expect(testResponse.eCallInfo).to(beNil());
+        expect(testResponse.electronicParkBrakeStatus).to(beNil());
         expect(testResponse.emergencyEvent).to(beNil());
         expect(testResponse.engineOilLife).to(beNil());
         expect(testResponse.engineTorque).to(beNil());

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLUnsubscribeVehicleDataResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLUnsubscribeVehicleDataResponseSpec.m
@@ -47,6 +47,7 @@ describe(@"Getter/Setter Tests", ^ {
         testResponse.emergencyEvent = vehicleDataResult;
         testResponse.clusterModes = vehicleDataResult;
         testResponse.myKey = vehicleDataResult;
+        testResponse.electronicParkBrakeStatus = vehicleDataResult;
         
         expect(testResponse.gps).to(equal(vehicleDataResult));
         expect(testResponse.speed).to(equal(vehicleDataResult));
@@ -74,6 +75,7 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testResponse.emergencyEvent).to(equal(vehicleDataResult));
         expect(testResponse.clusterModes).to(equal(vehicleDataResult));
         expect(testResponse.myKey).to(equal(vehicleDataResult));
+        expect(testResponse.electronicParkBrakeStatus).to(equal(vehicleDataResult));
     });
     
     it(@"Should get correctly when initialized", ^ {
@@ -104,7 +106,9 @@ describe(@"Getter/Setter Tests", ^ {
                                                                    SDLNameAirbagStatus:vehicleDataResult,
                                                                    SDLNameEmergencyEvent:vehicleDataResult,
                                                                    SDLNameClusterModes:vehicleDataResult,
-                                                                   SDLNameMyKey:vehicleDataResult},
+                                                                   SDLNameMyKey:vehicleDataResult,
+                                                                   SDLNameElectronicParkBrakeStatus:vehicleDataResult,
+                                                                   },
                                                              SDLNameOperationName:SDLNameUnsubscribeVehicleData}} mutableCopy];
         SDLUnsubscribeVehicleDataResponse* testResponse = [[SDLUnsubscribeVehicleDataResponse alloc] initWithDictionary:dict];
         
@@ -134,6 +138,7 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testResponse.emergencyEvent).to(equal(vehicleDataResult));
         expect(testResponse.clusterModes).to(equal(vehicleDataResult));
         expect(testResponse.myKey).to(equal(vehicleDataResult));
+        expect(testResponse.electronicParkBrakeStatus).to(equal(vehicleDataResult));
     });
     
     it(@"Should return nil if not set", ^ {
@@ -165,6 +170,7 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testResponse.emergencyEvent).to(beNil());
         expect(testResponse.clusterModes).to(beNil());
         expect(testResponse.myKey).to(beNil());
+        expect(testResponse.electronicParkBrakeStatus).to(beNil());
     });
 });
 

--- a/SmartDeviceLink_Example/AppConstants.h
+++ b/SmartDeviceLink_Example/AppConstants.h
@@ -82,6 +82,7 @@ extern NSString * const ACClusterModeStatusMenuName;
 extern NSString * const ACDeviceStatusMenuName;
 extern NSString * const ACDriverBrakingMenuName;
 extern NSString * const ACECallInfoMenuName;
+extern NSString * const ACElectronicParkBrakeStatus;
 extern NSString * const ACEmergencyEventMenuName;
 extern NSString * const ACEngineOilLifeMenuName;
 extern NSString * const ACEngineTorqueMenuName;

--- a/SmartDeviceLink_Example/AppConstants.m
+++ b/SmartDeviceLink_Example/AppConstants.m
@@ -80,6 +80,7 @@ NSString * const ACClusterModeStatusMenuName = @"Cluster Mode Status";
 NSString * const ACDeviceStatusMenuName = @"Device Status";
 NSString * const ACDriverBrakingMenuName = @"Driver Braking";
 NSString * const ACECallInfoMenuName = @"eCall Info";
+NSString * const ACElectronicParkBrakeStatus = @"Electronic Parking Brake Status";
 NSString * const ACEmergencyEventMenuName = @"Emergency Event";
 NSString * const ACEngineOilLifeMenuName = @"Engine Oil Life";
 NSString * const ACEngineTorqueMenuName = @"Engine Torque";

--- a/SmartDeviceLink_Example/MenuManager.m
+++ b/SmartDeviceLink_Example/MenuManager.m
@@ -59,7 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 + (NSArray<NSString *> *)sdlex_allVehicleDataTypes {
-    return @[ACAccelerationPedalPositionMenuName, ACAirbagStatusMenuName, ACBeltStatusMenuName, ACBodyInformationMenuName, ACClusterModeStatusMenuName, ACDeviceStatusMenuName, ACDriverBrakingMenuName, ACECallInfoMenuName, ACEmergencyEventMenuName, ACEngineOilLifeMenuName, ACEngineTorqueMenuName, ACExternalTemperatureMenuName, ACFuelLevelMenuName, ACFuelLevelStateMenuName, ACFuelRangeMenuName, ACGPSMenuName, ACHeadLampStatusMenuName, ACInstantFuelConsumptionMenuName, ACMyKeyMenuName, ACOdometerMenuName, ACPRNDLMenuName, ACRPMMenuName, ACSpeedMenuName, ACSteeringWheelAngleMenuName, ACTirePressureMenuName, ACVINMenuName, ACWiperStatusMenuName];
+    return @[ACAccelerationPedalPositionMenuName, ACAirbagStatusMenuName, ACBeltStatusMenuName, ACBodyInformationMenuName, ACClusterModeStatusMenuName, ACDeviceStatusMenuName, ACDriverBrakingMenuName, ACECallInfoMenuName, ACElectronicParkBrakeStatus, ACEmergencyEventMenuName, ACEngineOilLifeMenuName, ACEngineTorqueMenuName, ACExternalTemperatureMenuName, ACFuelLevelMenuName, ACFuelLevelStateMenuName, ACFuelRangeMenuName, ACGPSMenuName, ACHeadLampStatusMenuName, ACInstantFuelConsumptionMenuName, ACMyKeyMenuName, ACOdometerMenuName, ACPRNDLMenuName, ACRPMMenuName, ACSpeedMenuName, ACSteeringWheelAngleMenuName, ACTirePressureMenuName, ACVINMenuName, ACWiperStatusMenuName];
 }
 
 + (SDLMenuCell *)sdlex_menuCellShowPerformInteractionWithManager:(SDLManager *)manager performManager:(PerformInteractionManager *)performManager {

--- a/SmartDeviceLink_Example/MenuManager.swift
+++ b/SmartDeviceLink_Example/MenuManager.swift
@@ -59,7 +59,7 @@ private extension MenuManager {
     /// - Returns: A SDLMenuCell object
     class func menuCellGetAllVehicleData(with manager: SDLManager) -> SDLMenuCell {
         let submenuItems = allVehicleDataTypes.map { submenuName in
-            SDLMenuCell(title: submenuName, icon: nil, voiceCommands: [submenuName], handler: { triggerSource in
+            SDLMenuCell(title: submenuName, icon: nil, voiceCommands: nil, handler: { triggerSource in
                 VehicleDataManager.getAllVehicleData(with: manager, triggerSource: triggerSource, vehicleDataType: submenuName)
             })
         }
@@ -69,7 +69,7 @@ private extension MenuManager {
 
     /// A list of all possible vehicle data types
     static var allVehicleDataTypes: [String] {
-        return [ACAccelerationPedalPositionMenuName, ACAirbagStatusMenuName, ACBeltStatusMenuName, ACBodyInformationMenuName, ACClusterModeStatusMenuName, ACDeviceStatusMenuName, ACDriverBrakingMenuName, ACECallInfoMenuName, ACEmergencyEventMenuName, ACEngineOilLifeMenuName, ACEngineTorqueMenuName, ACExternalTemperatureMenuName, ACFuelLevelMenuName, ACFuelLevelStateMenuName, ACFuelRangeMenuName, ACGPSMenuName, ACHeadLampStatusMenuName, ACInstantFuelConsumptionMenuName, ACMyKeyMenuName, ACOdometerMenuName, ACPRNDLMenuName, ACRPMMenuName, ACSpeedMenuName, ACSteeringWheelAngleMenuName, ACTirePressureMenuName, ACVINMenuName, ACWiperStatusMenuName]
+        return [ACAccelerationPedalPositionMenuName, ACAirbagStatusMenuName, ACBeltStatusMenuName, ACBodyInformationMenuName, ACClusterModeStatusMenuName, ACDeviceStatusMenuName, ACDriverBrakingMenuName, ACECallInfoMenuName, ACElectronicParkBrakeStatus, ACEmergencyEventMenuName, ACEngineOilLifeMenuName, ACEngineTorqueMenuName, ACExternalTemperatureMenuName, ACFuelLevelMenuName, ACFuelLevelStateMenuName, ACFuelRangeMenuName, ACGPSMenuName, ACHeadLampStatusMenuName, ACInstantFuelConsumptionMenuName, ACMyKeyMenuName, ACOdometerMenuName, ACPRNDLMenuName, ACRPMMenuName, ACSpeedMenuName, ACSteeringWheelAngleMenuName, ACTirePressureMenuName, ACVINMenuName, ACWiperStatusMenuName]
     }
 
     /// Menu item that shows a custom menu (i.e. a Perform Interaction Choice Set) when selected
@@ -122,7 +122,7 @@ private extension MenuManager {
         var submenuItems = [SDLMenuCell]()
         for i in 0 ..< 10 {
             let submenuTitle = "Submenu Item \(i)"
-            submenuItems.append(SDLMenuCell(title: submenuTitle, icon: SDLArtwork(image: UIImage(named: MenuBWIconImageName)!.withRenderingMode(.alwaysTemplate), persistent: true, as: .PNG), voiceCommands: [submenuTitle, "Item \(i)", "\(i)"], handler: { (triggerSource) in
+            submenuItems.append(SDLMenuCell(title: submenuTitle, icon: SDLArtwork(image: UIImage(named: MenuBWIconImageName)!.withRenderingMode(.alwaysTemplate), persistent: true, as: .PNG), voiceCommands: nil, handler: { (triggerSource) in
                 let message = "\(submenuTitle) selected!"
                 switch triggerSource {
                 case .menu:

--- a/SmartDeviceLink_Example/VehicleDataManager.m
+++ b/SmartDeviceLink_Example/VehicleDataManager.m
@@ -141,7 +141,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     SDLLogD(@"App has permission to access vehicle data. Requesting vehicle data...");
-    SDLGetVehicleData *getVehicleSpeed = [[SDLGetVehicleData alloc] initWithAccelerationPedalPosition:YES airbagStatus:YES beltStatus:YES bodyInformation:YES clusterModeStatus:YES deviceStatus:YES driverBraking:YES eCallInfo:YES emergencyEvent:YES engineOilLife:YES engineTorque:YES externalTemperature:YES fuelLevel:YES fuelLevelState:YES fuelRange:YES gps:YES headLampStatus:YES instantFuelConsumption:YES myKey:YES odometer:YES prndl:YES rpm:YES speed:YES steeringWheelAngle:YES tirePressure:YES vin:YES wiperStatus:YES];
+    SDLGetVehicleData *getVehicleSpeed = [[SDLGetVehicleData alloc] initWithAccelerationPedalPosition:YES airbagStatus:YES beltStatus:YES bodyInformation:YES clusterModeStatus:YES deviceStatus:YES driverBraking:YES eCallInfo:YES electronicParkBrakeStatus:YES emergencyEvent:YES engineOilLife:YES engineTorque:YES externalTemperature:YES fuelLevel:YES fuelLevelState:YES fuelRange:YES gps:YES headLampStatus:YES instantFuelConsumption:YES myKey:YES odometer:YES prndl:YES rpm:YES speed:YES steeringWheelAngle:YES tirePressure:YES vin:YES wiperStatus:YES];
 
     [manager sendRequest:getVehicleSpeed withResponseHandler:^(__kindof SDLRPCRequest * _Nullable request, __kindof SDLRPCResponse * _Nullable response, NSError * _Nullable error) {
         if (error || ![response isKindOfClass:SDLGetVehicleDataResponse.class]) {
@@ -193,6 +193,8 @@ NS_ASSUME_NONNULL_BEGIN
         vehicleDataDescription = vehicleData.driverBraking.description;
     } else if ([vehicleDataType isEqualToString:ACECallInfoMenuName]) {
         vehicleDataDescription = vehicleData.eCallInfo.description;
+    } else if ([vehicleDataType isEqualToEnum:ACElectronicParkBrakeStatus]) {
+        vehicleDataDescription = vehicleData.electronicParkBrakeStatus.description;
     } else if ([vehicleDataType isEqualToString:ACEmergencyEventMenuName]) {
         vehicleDataDescription = vehicleData.emergencyEvent.description;
     } else if ([vehicleDataType isEqualToString:ACEngineOilLifeMenuName]) {

--- a/SmartDeviceLink_Example/VehicleDataManager.swift
+++ b/SmartDeviceLink_Example/VehicleDataManager.swift
@@ -111,7 +111,7 @@ extension VehicleDataManager {
         guard hasPermissionToAccessVehicleData(with: manager) else { return }
 
         SDLLog.d("App has permission to access vehicle data. Requesting all vehicle data...")
-        let getAllVehicleData = SDLGetVehicleData(accelerationPedalPosition: true, airbagStatus: true, beltStatus: true, bodyInformation: true, clusterModeStatus: true, deviceStatus: true, driverBraking: true, eCallInfo: true, emergencyEvent: true, engineOilLife: true, engineTorque: true, externalTemperature: true, fuelLevel: true, fuelLevelState: true, fuelRange: true, gps: true, headLampStatus: true, instantFuelConsumption: true, myKey: true, odometer: true, prndl: true, rpm: true, speed: true, steeringWheelAngle: true, tirePressure: true, vin: true, wiperStatus: true)
+        let getAllVehicleData = SDLGetVehicleData(accelerationPedalPosition: true, airbagStatus: true, beltStatus: true, bodyInformation: true, clusterModeStatus: true, deviceStatus: true, driverBraking: true, eCallInfo: true, electronicParkBrakeStatus: true, emergencyEvent: true, engineOilLife: true, engineTorque: true, externalTemperature: true, fuelLevel: true, fuelLevelState: true, fuelRange: true, gps: true, headLampStatus: true, instantFuelConsumption: true, myKey: true, odometer: true, prndl: true, rpm: true, speed: true, steeringWheelAngle: true, tirePressure: true, vin: true, wiperStatus: true)
 
         manager.send(request: getAllVehicleData) { (request, response, error) in
             guard didAccessVehicleDataSuccessfully(with: manager, response: response, error: error) else { return }
@@ -125,13 +125,13 @@ extension VehicleDataManager {
                 SDLLog.d("This app does not have the required permissions to access vehicle data")
                 alertMessage = "Disallowed"
             case .success, .dataNotAvailable:
-                SDLLog.d("Request for vehicle data successful")
                 if let vehicleData = response as? SDLGetVehicleDataResponse {
                     alertMessage = vehicleDataDescription(vehicleData, vehicleDataType: vehicleDataType)
                 } else {
                     SDLLog.e("No vehicle data returned")
                     alertMessage = "No vehicle data returned"
                 }
+                SDLLog.d("Request for vehicle data successful, \(alertMessage)")
             default: break
             }
 
@@ -176,6 +176,8 @@ extension VehicleDataManager {
             vehicleDataDescription += vehicleData.driverBraking?.rawValue.rawValue ?? notAvailable
         case ACECallInfoMenuName:
             vehicleDataDescription += vehicleData.eCallInfo?.description ?? notAvailable
+        case ACElectronicParkBrakeStatus:
+            vehicleDataDescription += vehicleData.electronicParkBrakeStatus?.rawValue.rawValue ?? notAvailable
         case ACEmergencyEventMenuName:
             vehicleDataDescription += vehicleData.emergencyEvent?.description ?? notAvailable
         case ACEngineOilLifeMenuName:


### PR DESCRIPTION
Fixes #761 

This PR is **Ready** for review.

### Risk
This PR makes **minor** API changes. (Technically major, but only modifying added APIs in this version)

### Testing Plan
Unit tests added, tested against Core 5.0 implementation

### Summary
Implements [SDL-0102](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0102-New-vehicle-data-ElectronicParkBrakeStatus.md), new vehicle data Electronic Park Brake Status.

### Changelog
##### Enhancements
* Add new vehicle data Electronic Park Brake Status [SDL-0102] [#761](https://github.com/smartdevicelink/sdl_ios/issues/761).

### Tasks Remaining:
- [ ] Test against SDL Core 5.0

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)