### PR TITLE
WIP: Implement SDL-0175 - Updating GPS Data

### DIFF
--- a/SmartDeviceLink/SDLGPSData.h
+++ b/SmartDeviceLink/SDLGPSData.h
@@ -36,74 +36,74 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * Required, Integer, 2010 - 2100
  */
-@property (strong, nonatomic) NSNumber<SDLInt> *utcYear;
+@property (strong, nonatomic, nullable) NSNumber<SDLInt> *utcYear;
 
 /**
  * utc month
  *
  * Required, Integer, 1 - 12
  */
-@property (strong, nonatomic) NSNumber<SDLInt> *utcMonth;
+@property (strong, nonatomic, nullable) NSNumber<SDLInt> *utcMonth;
 
 /**
  * utc day
  *
  * Required, Integer, 1 - 31
  */
-@property (strong, nonatomic) NSNumber<SDLInt> *utcDay;
+@property (strong, nonatomic, nullable) NSNumber<SDLInt> *utcDay;
 
 /**
  * utc hours
  *
  * Required, Integer, 0 - 23
  */
-@property (strong, nonatomic) NSNumber<SDLInt> *utcHours;
+@property (strong, nonatomic, nullable) NSNumber<SDLInt> *utcHours;
 
 /**
  * utc minutes
  *
  * Required, Integer, 0 - 59
  */
-@property (strong, nonatomic) NSNumber<SDLInt> *utcMinutes;
+@property (strong, nonatomic, nullable) NSNumber<SDLInt> *utcMinutes;
 
 /**
  * utc seconds
  *
  * Required, Integer, 0 - 59
  */
-@property (strong, nonatomic) NSNumber<SDLInt> *utcSeconds;
+@property (strong, nonatomic, nullable) NSNumber<SDLInt> *utcSeconds;
 
 /**
  * Potential Compass Directions
  */
-@property (strong, nonatomic) SDLCompassDirection compassDirection;
+@property (strong, nonatomic, nullable) SDLCompassDirection compassDirection;
 
 /**
  * The 3D positional dilution of precision.
  *
  * @discussion If undefined or unavailable, then value shall be set to 0
  *
- * Required, Float, 0.0 - 10.0
+ * Required, Float, 0.0 - 1000.0
  */
-@property (strong, nonatomic) NSNumber<SDLFloat> *pdop;
+@property (strong, nonatomic, nullable) NSNumber<SDLFloat> *pdop;
 
 /**
  * The horizontal dilution of precision
  *
  * @discussion If undefined or unavailable, then value shall be set to 0
  *
- * Required, Float, 0.0 - 10.0
+ * Required, Float, 0.0 - 1000.0
  */
-@property (strong, nonatomic) NSNumber<SDLFloat> *hdop;
+@property (strong, nonatomic, nullable) NSNumber<SDLFloat> *hdop;
 
 /**
  * the vertical dilution of precision
  *
  * @discussion If undefined or unavailable, then value shall be set to 0
  *
- * Required, Float, 0.0 - 10.0
+ * Required, Float, 0.0 - 1000.0
  */
-@property (strong, nonatomic) NSNumber<SDLFloat> *vdop;
+@property (strong, nonatomic, nullable) NSNumber<SDLFloat> *vdop;
 
 /**
  * What the coordinates are based on
@@ -112,28 +112,28 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * Required, Boolean
  */
-@property (strong, nonatomic) NSNumber<SDLBool> *actual;
+@property (strong, nonatomic, nullable) NSNumber<SDLBool> *actual;
 
 /**
  * The number of satellites in view
  *
  * Required, Integer, 0 - 31
  */
-@property (strong, nonatomic) NSNumber<SDLInt> *satellites;
+@property (strong, nonatomic, nullable) NSNumber<SDLInt> *satellites;
 
 /**
  * The supported dimensions of the GPS
  *
  * Required
  */
-@property (strong, nonatomic) SDLDimension dimension;
+@property (strong, nonatomic, nullable) SDLDimension dimension;
 
 /**
  * Altitude in meters
  *
  * Required, Float, -10000.0 - 10000.0
  */
-@property (strong, nonatomic) NSNumber<SDLFloat> *altitude;
+@property (strong, nonatomic, nullable) NSNumber<SDLFloat> *altitude;
 
 /**
  * Heading based on the GPS data.
@@ -142,14 +142,25 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * Required, Float, 0.0 - 359.99
  */
-@property (strong, nonatomic) NSNumber<SDLFloat> *heading;
+@property (strong, nonatomic, nullable) NSNumber<SDLFloat> *heading;
 
 /**
  * Speed in KPH
  *
  * Required, Float, 0.0 - 500.0
  */
-@property (strong, nonatomic) NSNumber<SDLFloat> *speed;
+@property (strong, nonatomic, nullable) NSNumber<SDLFloat> *speed;
+
+/**
+ Whether or not the GPS has been shifted for proprietary purposes.
+
+ True, if GPS lat/long, time, and altitude have been purposefully shifted (requiring a proprietary algorithm to unshift).
+ False, if the GPS data is raw and un-shifted.
+ If not provided, then value is assumed False.
+
+ Optional, Boolean
+ */
+@property (strong, nonatomic, nullable) NSNumber<SDLBool> *shifted;
 
 @end
 

--- a/SmartDeviceLink/SDLGPSData.m
+++ b/SmartDeviceLink/SDLGPSData.m
@@ -26,132 +26,140 @@ NS_ASSUME_NONNULL_BEGIN
     return [store sdl_objectForName:SDLNameLatitudeDegrees];
 }
 
-- (void)setUtcYear:(NSNumber<SDLInt> *)utcYear {
+- (void)setUtcYear:(nullable NSNumber<SDLInt> *)utcYear {
     [store sdl_setObject:utcYear forName:SDLNameUTCYear];
 }
 
-- (NSNumber<SDLInt> *)utcYear {
+- (nullable NSNumber<SDLInt> *)utcYear {
     return [store sdl_objectForName:SDLNameUTCYear];
 }
 
-- (void)setUtcMonth:(NSNumber<SDLInt> *)utcMonth {
+- (void)setUtcMonth:(nullable NSNumber<SDLInt> *)utcMonth {
     [store sdl_setObject:utcMonth forName:SDLNameUTCMonth];
 }
 
-- (NSNumber<SDLInt> *)utcMonth {
+- (nullable NSNumber<SDLInt> *)utcMonth {
     return [store sdl_objectForName:SDLNameUTCMonth];
 }
 
-- (void)setUtcDay:(NSNumber<SDLInt> *)utcDay {
+- (void)setUtcDay:(nullable NSNumber<SDLInt> *)utcDay {
     [store sdl_setObject:utcDay forName:SDLNameUTCDay];
 }
 
-- (NSNumber<SDLInt> *)utcDay {
+- (nullable NSNumber<SDLInt> *)utcDay {
     return [store sdl_objectForName:SDLNameUTCDay];
 }
 
-- (void)setUtcHours:(NSNumber<SDLInt> *)utcHours {
+- (void)setUtcHours:(nullable NSNumber<SDLInt> *)utcHours {
     [store sdl_setObject:utcHours forName:SDLNameUTCHours];
 }
 
-- (NSNumber<SDLInt> *)utcHours {
+- (nullable NSNumber<SDLInt> *)utcHours {
     return [store sdl_objectForName:SDLNameUTCHours];
 }
 
-- (void)setUtcMinutes:(NSNumber<SDLInt> *)utcMinutes {
+- (void)setUtcMinutes:(nullable NSNumber<SDLInt> *)utcMinutes {
     [store sdl_setObject:utcMinutes forName:SDLNameUTCMinutes];
 }
 
-- (NSNumber<SDLInt> *)utcMinutes {
+- (nullable NSNumber<SDLInt> *)utcMinutes {
     return [store sdl_objectForName:SDLNameUTCMinutes];
 }
 
-- (void)setUtcSeconds:(NSNumber<SDLInt> *)utcSeconds {
+- (void)setUtcSeconds:(nullable NSNumber<SDLInt> *)utcSeconds {
     [store sdl_setObject:utcSeconds forName:SDLNameUTCSeconds];
 }
 
-- (NSNumber<SDLInt> *)utcSeconds {
+- (nullable NSNumber<SDLInt> *)utcSeconds {
     return [store sdl_objectForName:SDLNameUTCSeconds];
 }
 
-- (void)setCompassDirection:(SDLCompassDirection)compassDirection {
+- (void)setCompassDirection:(nullable SDLCompassDirection)compassDirection {
     [store sdl_setObject:compassDirection forName:SDLNameCompassDirection];
 }
 
-- (SDLCompassDirection)compassDirection {
+- (nullable SDLCompassDirection)compassDirection {
     return [store sdl_objectForName:SDLNameCompassDirection];
 }
 
-- (void)setPdop:(NSNumber<SDLFloat> *)pdop {
+- (void)setPdop:(nullable NSNumber<SDLFloat> *)pdop {
     [store sdl_setObject:pdop forName:SDLNamePDOP];
 }
 
-- (NSNumber<SDLFloat> *)pdop {
+- (nullable NSNumber<SDLFloat> *)pdop {
     return [store sdl_objectForName:SDLNamePDOP];
 }
 
-- (void)setHdop:(NSNumber<SDLFloat> *)hdop {
+- (void)setHdop:(nullable NSNumber<SDLFloat> *)hdop {
     [store sdl_setObject:hdop forName:SDLNameHDOP];
 }
 
-- (NSNumber<SDLFloat> *)hdop {
+- (nullable NSNumber<SDLFloat> *)hdop {
     return [store sdl_objectForName:SDLNameHDOP];
 }
 
-- (void)setVdop:(NSNumber<SDLFloat> *)vdop {
+- (void)setVdop:(nullable NSNumber<SDLFloat> *)vdop {
     [store sdl_setObject:vdop forName:SDLNameVDOP];
 }
 
-- (NSNumber<SDLFloat> *)vdop {
+- (nullable NSNumber<SDLFloat> *)vdop {
     return [store sdl_objectForName:SDLNameVDOP];
 }
 
-- (void)setActual:(NSNumber<SDLBool> *)actual {
+- (void)setActual:(nullable NSNumber<SDLBool> *)actual {
     [store sdl_setObject:actual forName:SDLNameActual];
 }
 
-- (NSNumber<SDLBool> *)actual {
+- (nullable NSNumber<SDLBool> *)actual {
     return [store sdl_objectForName:SDLNameActual];
 }
 
-- (void)setSatellites:(NSNumber<SDLInt> *)satellites {
+- (void)setSatellites:(nullable NSNumber<SDLInt> *)satellites {
     [store sdl_setObject:satellites forName:SDLNameSatellites];
 }
 
-- (NSNumber<SDLInt> *)satellites {
+- (nullable NSNumber<SDLInt> *)satellites {
     return [store sdl_objectForName:SDLNameSatellites];
 }
 
-- (void)setDimension:(SDLDimension)dimension {
+- (void)setDimension:(nullable SDLDimension)dimension {
     [store sdl_setObject:dimension forName:SDLNameDimension];
 }
 
-- (SDLDimension)dimension {
+- (nullable SDLDimension)dimension {
     return [store sdl_objectForName:SDLNameDimension];
 }
 
-- (void)setAltitude:(NSNumber<SDLFloat> *)altitude {
+- (void)setAltitude:(nullable NSNumber<SDLFloat> *)altitude {
     [store sdl_setObject:altitude forName:SDLNameAltitude];
 }
 
-- (NSNumber<SDLFloat> *)altitude {
+- (nullable NSNumber<SDLFloat> *)altitude {
     return [store sdl_objectForName:SDLNameAltitude];
 }
 
-- (void)setHeading:(NSNumber<SDLFloat> *)heading {
+- (void)setHeading:(nullable NSNumber<SDLFloat> *)heading {
     [store sdl_setObject:heading forName:SDLNameHeading];
 }
 
-- (NSNumber<SDLFloat> *)heading {
+- (nullable NSNumber<SDLFloat> *)heading {
     return [store sdl_objectForName:SDLNameHeading];
 }
 
-- (void)setSpeed:(NSNumber<SDLFloat> *)speed {
+- (void)setSpeed:(nullable NSNumber<SDLFloat> *)speed {
     [store sdl_setObject:speed forName:SDLNameSpeed];
 }
 
-- (NSNumber<SDLFloat> *)speed {
+- (nullable NSNumber<SDLFloat> *)speed {
     return [store sdl_objectForName:SDLNameSpeed];
+}
+
+- (void)setShifted:(nullable NSNumber<SDLBool> *)shifted {
+    [store sdl_setObject:shifted forName:SDLNameShifted];
+}
+
+- (nullable NSNumber<SDLBool> *)shifted {
+    return [store sdl_objectForName:SDLNameShifted];
 }
 
 @end

--- a/SmartDeviceLink/SDLNames.h
+++ b/SmartDeviceLink/SDLNames.h
@@ -469,6 +469,7 @@ extern SDLName const SDLNameSetDisplayLayout;
 extern SDLName const SDLNameSetGlobalProperties;
 extern SDLName const SDLNameSetInteriorVehicleData;
 extern SDLName const SDLNameSetMediaClockTimer;
+extern SDLName const SDLNameShifted;
 extern SDLName const SDLNameShortPress;
 extern SDLName const SDLNameShortPressAvailable;
 extern SDLName const SDLNameShow;

--- a/SmartDeviceLink/SDLNames.m
+++ b/SmartDeviceLink/SDLNames.m
@@ -463,6 +463,7 @@ SDLName const SDLNameSetDisplayLayout = @"SetDisplayLayout";
 SDLName const SDLNameDisplayName = @"displayName";
 SDLName const SDLNameSetGlobalProperties = @"SetGlobalProperties";
 SDLName const SDLNameSetMediaClockTimer = @"SetMediaClockTimer";
+SDLName const SDLNameShifted = @"shifted";
 SDLName const SDLNameShortPress = @"shortPress";
 SDLName const SDLNameShortPressAvailable = @"shortPressAvailable";
 SDLName const SDLNameShow = @"Show";

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLGPSDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLGPSDataSpec.m
@@ -38,6 +38,7 @@ describe(@"Getter/Setter Tests", ^ {
         testStruct.altitude = @3000;
         testStruct.heading = @96;
         testStruct.speed = @64;
+        testStruct.shifted = @YES;
         
         expect(testStruct.longitudeDegrees).to(equal(@31.41592653589793));
         expect(testStruct.latitudeDegrees).to(equal(@45));
@@ -57,27 +58,29 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testStruct.altitude).to(equal(@3000));
         expect(testStruct.heading).to(equal(@96));
         expect(testStruct.speed).to(equal(@64));
+        expect(testStruct.shifted).to(beTrue());
     });
     
     it(@"Should get correctly when initialized", ^ {
-        NSMutableDictionary* dict = [@{SDLNameLongitudeDegrees:@31.41592653589793,
-                                       SDLNameLatitudeDegrees:@45,
-                                       SDLNameUTCYear:@2015,
-                                       SDLNameUTCMonth:@1,
-                                       SDLNameUTCDay:@26,
-                                       SDLNameUTCHours:@23,
-                                       SDLNameUTCMinutes:@59,
-                                       SDLNameUTCSeconds:@59,
-                                       SDLNameCompassDirection:SDLCompassDirectionSoutheast,
-                                       SDLNamePDOP:@3.4,
-                                       SDLNameHDOP:@9.9,
-                                       SDLNameVDOP:@0,
-                                       SDLNameActual:@NO,
-                                       SDLNameSatellites:@12,
-                                       SDLNameDimension:SDLDimension3D,
-                                       SDLNameAltitude:@3000,
-                                       SDLNameHeading:@96,
-                                       SDLNameSpeed:@64} mutableCopy];
+        NSDictionary* dict = @{SDLNameLongitudeDegrees:@31.41592653589793,
+                               SDLNameLatitudeDegrees:@45,
+                               SDLNameUTCYear:@2015,
+                               SDLNameUTCMonth:@1,
+                               SDLNameUTCDay:@26,
+                               SDLNameUTCHours:@23,
+                               SDLNameUTCMinutes:@59,
+                               SDLNameUTCSeconds:@59,
+                               SDLNameCompassDirection:SDLCompassDirectionSoutheast,
+                               SDLNamePDOP:@3.4,
+                               SDLNameHDOP:@9.9,
+                               SDLNameVDOP:@0,
+                               SDLNameActual:@NO,
+                               SDLNameSatellites:@12,
+                               SDLNameDimension:SDLDimension3D,
+                               SDLNameAltitude:@3000,
+                               SDLNameHeading:@96,
+                               SDLNameSpeed:@64,
+                               SDLNameShifted:@YES};
         SDLGPSData* testStruct = [[SDLGPSData alloc] initWithDictionary:dict];
         
         expect(testStruct.longitudeDegrees).to(equal(@31.41592653589793));
@@ -98,6 +101,7 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testStruct.altitude).to(equal(@3000));
         expect(testStruct.heading).to(equal(@96));
         expect(testStruct.speed).to(equal(@64));
+        expect(testStruct.shifted).to(beTrue());
     });
     
     it(@"Should return nil if not set", ^ {
@@ -121,6 +125,7 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testStruct.altitude).to(beNil());
         expect(testStruct.heading).to(beNil());
         expect(testStruct.speed).to(beNil());
+        expect(testStruct.shifted).to(beNil());
     });
 });
 


### PR DESCRIPTION
Fixes #1003 

This PR is **not ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Unit tests and testing against Core 5.0

### Summary
Implement SDL-0175 - make a number of properties of `GPSData` optional, add a `shifted` property, and increase the value range of DOP values.

### Changelog
##### Enhancements
* Implement SDL-0175 - update `GPSData` struct by making a number of properties of `GPSData` optional, add a `shifted` property, and increase the value range of DOP values.

### Tasks Remaining:
- [ ] Test against Core 5.0

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
