### PR TITLE
Fix/shutdown video session in suspended state in sdl_ios v6.0.1

### DIFF
--- a/SmartDeviceLink/SDLStreamingMediaLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingMediaLifecycleManager.m
@@ -244,6 +244,10 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
     return [self.videoStreamStateMachine isCurrentState:SDLVideoStreamStateReady];
 }
 
+- (BOOL)isVideoSuspended {
+    return [self.videoStreamStateMachine isCurrentState:SDLVideoStreamStateSuspended];
+}
+
 - (BOOL)isVideoStreamingPaused {
     return !(self.isVideoConnected && self.isHmiStateVideoStreamCapable && self.isAppStateVideoStreamCapable);
 }
@@ -290,7 +294,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
     [self sdl_sendBackgroundFrames];
     [self.touchManager cancelPendingTouches];
 
-    if ([self.videoStreamStateMachine.currentState isEqualToString:SDLVideoStreamStateReady]) {
+    if (self.isVideoConnected) {
         [self.videoStreamStateMachine transitionToState:SDLVideoStreamStateSuspended];
     } else {
         [self sdl_stopVideoSession];
@@ -305,7 +309,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
     SDLLogD(@"App became active");
     if (!self.protocol) { return; }
 
-    if ([self.videoStreamStateMachine.currentState isEqualToString:SDLVideoStreamStateSuspended]) {
+    if (self.isVideoSuspended) {
         [self.videoStreamStateMachine transitionToState:SDLVideoStreamStateReady];
     } else {
         [self sdl_startVideoSession];
@@ -726,7 +730,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
         return;
     }
 
-    if (self.isVideoConnected) {
+    if (self.isVideoConnected || self.isVideoSuspended) {
         [self.videoStreamStateMachine transitionToState:SDLVideoStreamStateShuttingDown];
     }
 }

--- a/SmartDeviceLinkTests/SDLStreamingMediaLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/SDLStreamingMediaLifecycleManagerSpec.m
@@ -311,6 +311,17 @@ describe(@"the streaming media manager", ^{
                             expect(streamingLifecycleManager.currentVideoStreamState).to(equal(SDLVideoStreamStateReady));
                         });
                     });
+
+                    context(@"and hmi state changes to background after app becomes inactive", ^{
+                        beforeEach(^{
+                            [streamingLifecycleManager.appStateMachine setToState:SDLAppStateInactive fromOldState:nil callEnterTransition:YES];
+                            sendNotificationForHMILevel(SDLHMILevelBackground);
+                        });
+
+                        it(@"should close the stream", ^{
+                            expect(streamingLifecycleManager.currentVideoStreamState).to(equal(SDLVideoStreamStateShuttingDown));
+                        });
+                    });
                 });
             });
 


### PR DESCRIPTION
Fixes #1047 

This is a fix for v6.0.1. #1048 is for v6.1.0

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Test cases is also updated.

### Summary
Fix to transit to SDLVideoStreamManagerStateShuttingDown state from Supended state when sdl_stopVideoSession is called.

### Changelog
##### Bug Fixes
* Fix to close video session in suspended state.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
