### PR TITLE
Fix presenting a keyboard shows the test cell

### DIFF
--- a/SmartDeviceLink/SDLPresentKeyboardOperation.m
+++ b/SmartDeviceLink/SDLPresentKeyboardOperation.m
@@ -114,7 +114,7 @@ NS_ASSUME_NONNULL_BEGIN
     SDLPerformInteraction *performInteraction = [[SDLPerformInteraction alloc] init];
     performInteraction.initialText = self.initialText;
     performInteraction.interactionMode = SDLInteractionModeManualOnly;
-    performInteraction.interactionChoiceSetIDList = @[@0];
+    performInteraction.interactionChoiceSetIDList = @[];
     performInteraction.interactionLayout = SDLLayoutModeKeyboard;
 
     return performInteraction;

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLPresentKeyboardOperationSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLPresentKeyboardOperationSpec.m
@@ -73,7 +73,7 @@ describe(@"present keyboard operation", ^{
                 SDLPerformInteraction *request = testConnectionManager.receivedRequests.lastObject;
                 expect(request.initialText).to(equal(testInitialText));
                 expect(request.interactionMode).to(equal(SDLInteractionModeManualOnly));
-                expect(request.interactionChoiceSetIDList).to(equal(@[@0]));
+                expect(request.interactionChoiceSetIDList).to(beEmpty());
                 expect(request.interactionLayout).to(equal(SDLLayoutModeKeyboard));
             });
 


### PR DESCRIPTION
Fixes #1050 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Smoke tests

### Summary
Removes the test cell from being presented in a keyboard only interaction

### Changelog
This is an intra-release change, so no changelog is needed

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
