### PR TITLE
Updated SyncMsgVersion to v5.0.0

### DIFF
--- a/SmartDeviceLink/SDLRegisterAppInterface.m
+++ b/SmartDeviceLink/SDLRegisterAppInterface.m
@@ -53,7 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
     self.languageDesired = languageDesired;
     self.hmiDisplayLanguageDesired = languageDesired;
     
-    self.syncMsgVersion = [[SDLSyncMsgVersion alloc] initWithMajorVersion:1 minorVersion:0 patchVersion:0];
+    self.syncMsgVersion = [[SDLSyncMsgVersion alloc] initWithMajorVersion:5 minorVersion:0 patchVersion:0];
     self.appInfo = [SDLAppInfo currentAppInfo];
     self.deviceInfo = [SDLDeviceInfo currentDevice];
     self.correlationID = @1;

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLRegisterAppInterfaceSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLRegisterAppInterfaceSpec.m
@@ -48,7 +48,7 @@ describe(@"RegisterAppInterface Tests", ^{
     });
 
     describe(@"initializers", ^{
-        it(@"should initialize with initWithLifecycleConfiguration:", ^{
+        it(@"initWithLifecycleConfiguration:", ^{
             SDLLifecycleConfiguration *testConfiguration = [SDLLifecycleConfiguration defaultConfigurationWithAppName:appName appId:appId];
             testConfiguration.resumeHash = resumeHash;
             testConfiguration.appType = appType;
@@ -76,10 +76,10 @@ describe(@"RegisterAppInterface Tests", ^{
             expect(testRequest.nightColorScheme).to(equal(colorScheme));
         });
 
-        it(@"should initialize with initWithAppName:appId:languageDesired:isMediaApp:appTypes:shortAppName:", ^{
+        it(@"initWithAppName:appId:languageDesired:isMediaApp:appTypes:shortAppName:", ^{
             SDLRegisterAppInterface *testRequest = [[SDLRegisterAppInterface alloc] initWithAppName:appName appId:appId languageDesired:language];
 
-            expect(testRequest.syncMsgVersion).toNot(beNil());
+            expect(testRequest.syncMsgVersion).to(equal([[SDLSyncMsgVersion alloc] initWithMajorVersion:5 minorVersion:0 patchVersion:0]));
             expect(testRequest.appName).to(equal(appName));
             expect(testRequest.ttsName).to(beNil());
             expect(testRequest.ngnMediaScreenAppName).to(beNil());
@@ -95,7 +95,7 @@ describe(@"RegisterAppInterface Tests", ^{
             expect(testRequest.nightColorScheme).to(beNil());
         });
 
-        it(@"should initialize with initWithAppName:appId:languageDesired:isMediaApp:appTypes:shortAppName:", ^{
+        it(@"initWithAppName:appId:languageDesired:isMediaApp:appTypes:shortAppName:", ^{
             SDLRegisterAppInterface *testRequest = [[SDLRegisterAppInterface alloc] initWithAppName:appName appId:appId languageDesired:language isMediaApp:isMediaApp appTypes:@[appType] shortAppName:shortAppName];
 
             expect(testRequest.syncMsgVersion).toNot(beNil());
@@ -114,7 +114,7 @@ describe(@"RegisterAppInterface Tests", ^{
             expect(testRequest.nightColorScheme).to(beNil());
         });
 
-        it(@"should initialize with initWithAppName:appId:languageDesired:isMediaApp:appTypes:shortAppName:ttsName:vrSynonyms:hmiDisplayLanguageDesired:resumeHash:dayColorScheme:nightColorScheme:", ^{
+        it(@"initWithAppName:appId:languageDesired:isMediaApp:appTypes:shortAppName:ttsName:vrSynonyms:hmiDisplayLanguageDesired:resumeHash:dayColorScheme:nightColorScheme:", ^{
             SDLRegisterAppInterface *testRequest = [[SDLRegisterAppInterface alloc] initWithAppName:appName appId:appId languageDesired:language isMediaApp:isMediaApp appTypes:@[appType] shortAppName:shortAppName ttsName:@[chunk] vrSynonyms:@[vrSynonyms] hmiDisplayLanguageDesired:hmiDisplayLanguage resumeHash:resumeHash dayColorScheme:colorScheme nightColorScheme:colorScheme];
 
             expect(testRequest.syncMsgVersion).toNot(beNil());
@@ -133,8 +133,8 @@ describe(@"RegisterAppInterface Tests", ^{
             expect(testRequest.nightColorScheme).to(equal(colorScheme));
         });
 
-        it(@"should initialize with a dictionary", ^ {
-            NSMutableDictionary* dict = [@{SDLNameRequest:
+        it(@"init with a dictionary", ^ {
+            NSDictionary* dict = @{SDLNameRequest:
                                                @{SDLNameParameters:
                                                      @{SDLNameSyncMessageVersion:version,
                                                        SDLNameAppName:@"app56",
@@ -152,7 +152,7 @@ describe(@"RegisterAppInterface Tests", ^{
                                                        SDLNameDayColorScheme: colorScheme,
                                                        SDLNameNightColorScheme: colorScheme,
                                                        },
-                                                 SDLNameOperationName:SDLNameRegisterAppInterface}} mutableCopy];
+                                                 SDLNameOperationName:SDLNameRegisterAppInterface}};
             SDLRegisterAppInterface* testRequest = [[SDLRegisterAppInterface alloc] initWithDictionary:dict];
 
             expect(testRequest.syncMsgVersion).to(equal(version));
@@ -172,7 +172,7 @@ describe(@"RegisterAppInterface Tests", ^{
             expect(testRequest.nightColorScheme).to(equal(colorScheme));
         });
 
-        it(@"should initialize with nil", ^ {
+        it(@"init", ^ {
             SDLRegisterAppInterface* testRequest = [[SDLRegisterAppInterface alloc] init];
 
             expect(testRequest.syncMsgVersion).to(beNil());


### PR DESCRIPTION
Fixes #1052

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Test case added to _SDLRegisterAppInterfaceSpec_

### Summary
Updated the `syncMsgVersion` sent by the `RegisterAppInterface` RPC to 5.0.0 from 1.0.0. With the addition of [SDL-0089](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0089-mobile-api-versioning.md) in Core 5.0.0, this parameter becomes relevant, as Core now alters behavior based on the negotiated parameter.

### Changelog
##### Enhancements
* Updated the `syncMsgVersion` sent by the `RegisterAppInterface` RPC to 5.0.0.

### Tasks Remaining:
- [x] Test with Core 5.0.0
- [x] Test with Manticore

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)