### PR TITLE
Fix assets not being available via Cocoapods Swift subspec

### DIFF
--- a/SmartDeviceLink.podspec
+++ b/SmartDeviceLink.podspec
@@ -10,12 +10,12 @@ s.platform     = :ios, "8.0"
 s.dependency     'BiSON', '~> 1.1.1'
 s.source       = { :git => "https://github.com/smartdevicelink/sdl_ios.git", :tag => s.version.to_s }
 s.requires_arc = true
-s.resource_bundles = { 'SmartDeviceLink' => ['SmartDeviceLink/Assets/**/*'] }
 
 s.default_subspec = 'Default'
 
 s.subspec 'Default' do |sdefault|
 sdefault.source_files = 'SmartDeviceLink/*.{h,m}'
+sdefault.resource_bundles = { 'SmartDeviceLink' => ['SmartDeviceLink/Assets/**/*'] }
 
 sdefault.public_header_files = [
 'SmartDeviceLink/NSNumber+NumberType.h',
@@ -382,7 +382,6 @@ end
 
 s.subspec 'Swift' do |sswift|
 sswift.dependency 'SmartDeviceLink/Default'
-sswift.resource_bundles = { 'SmartDeviceLink' => ['SmartDeviceLink/Assets/**/*'] }
 sswift.source_files = 'SmartDeviceLinkSwift/*.swift'
 end
 

--- a/SmartDeviceLink.podspec
+++ b/SmartDeviceLink.podspec
@@ -14,10 +14,10 @@ s.resource_bundles = { 'SmartDeviceLink' => ['SmartDeviceLink/Assets/**/*'] }
 
 s.default_subspec = 'Default'
 
-s.subspec 'Default' do |ss|
-ss.source_files = 'SmartDeviceLink/*.{h,m}'
+s.subspec 'Default' do |sdefault|
+sdefault.source_files = 'SmartDeviceLink/*.{h,m}'
 
-ss.public_header_files = [
+sdefault.public_header_files = [
 'SmartDeviceLink/NSNumber+NumberType.h',
 'SmartDeviceLink/SDLAddCommand.h',
 'SmartDeviceLink/SDLAddCommandResponse.h',
@@ -380,9 +380,9 @@ ss.public_header_files = [
 ]
 end
 
-s.subspec 'Swift' do |ss|
-ss.dependency 'SmartDeviceLink/Default'
-ss.source_files = 'SmartDeviceLinkSwift/*.swift'
+s.subspec 'Swift' do |sswift|
+sswift.dependency 'SmartDeviceLink/Default'
+sswift.source_files = 'SmartDeviceLinkSwift/*.swift'
 end
 
 end

--- a/SmartDeviceLink.podspec
+++ b/SmartDeviceLink.podspec
@@ -382,6 +382,7 @@ end
 
 s.subspec 'Swift' do |sswift|
 sswift.dependency 'SmartDeviceLink/Default'
+sswift.resource_bundles = { 'SmartDeviceLink' => ['SmartDeviceLink/Assets/**/*'] }
 sswift.source_files = 'SmartDeviceLinkSwift/*.swift'
 end
 


### PR DESCRIPTION
Fixes #1026 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Smoke testing with an example application

### Summary
Fixed cocoapods assets would not download using `SmartDeviceLink/Swift` in Cocoapods.

### Changelog
##### Bug Fixes
* Fixed cocoapods assets would not download using `SmartDeviceLink/Swift` in Cocoapods.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)