### PR TITLE
Fixed the lock screen configuration's show in optional state

### DIFF
--- a/SmartDeviceLink/SDLLockScreenConfiguration.h
+++ b/SmartDeviceLink/SDLLockScreenConfiguration.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  Whether or not the lock screen should be shown in the "lock screen optional" state. Defaults to false.
  *
  *  @discussion In order for the "lock screen optional" state to occur, the following must be true:
- *  1. The app should have received at least 1 driver distraction notification (i.e. a `OnDriverDistraction` notification) from SDL Core.
+ *  1. The app should have received at least 1 driver distraction notification (i.e. a `OnDriverDistraction` notification) from SDL Core. Older versions of Core did not send a notification immediately on connection.
  *  2. The driver is not distracted (i.e. the last `OnDriverDistraction` notification received was for a driver distraction state off).
  *  3. The `hmiLevel` can not be `NONE`.
  *  4. If the `hmiLevel` is currently `BACKGROUND` then the previous `hmiLevel` should have been `FULL` or `LIMITED` (i.e. the user should have interacted with app before it was backgrounded).

--- a/SmartDeviceLink/SDLLockScreenConfiguration.h
+++ b/SmartDeviceLink/SDLLockScreenConfiguration.h
@@ -14,7 +14,13 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SDLLockScreenConfiguration : NSObject <NSCopying>
 
 /**
- *  Whether or not the lock screen should be shown in the "lock screen optional" state. Defaults to 'NO'.
+ *  Whether or not the lock screen should be shown in the "lock screen optional" state. Defaults to false.
+ *
+ *  @discussion In order for the "lock screen optional" state to occur, the following must be true:
+ *  1. The app should have received at least 1 driver distraction notification (i.e. a `OnDriverDistraction` notification) from SDL Core.
+ *  2. The driver is not distracted (i.e. the last `OnDriverDistraction` notification received was for a driver distraction state off).
+ *  3. The `hmiLevel` can not be `NONE`.
+ *  4. If the `hmiLevel` is currently `BACKGROUND` then the previous `hmiLevel` should have been `FULL` or `LIMITED` (i.e. the user should have interacted with app before it was backgrounded).
  */
 @property (assign, nonatomic) BOOL showInOptionalState;
 

--- a/SmartDeviceLink/SDLLockScreenManager.m
+++ b/SmartDeviceLink/SDLLockScreenManager.m
@@ -140,7 +140,7 @@ NS_ASSUME_NONNULL_BEGIN
     } else if ([self.lastLockNotification.lockScreenStatus isEqualToEnum:SDLLockScreenStatusOptional]) {
         if (self.config.showInOptionalState && !self.presenter.presented && self.canPresent) {
             [self.presenter present];
-        } else if (self.presenter.presented && [self.class sdl_canDismissLockScreenWithLockScreenStatus:self.lastLockNotification previousHMILevel:self.previousHMILevel showInOptionalState:self.config.showInOptionalState]) {
+        } else if (!self.config.showInOptionalState && self.presenter.presented) {
             [self.presenter dismiss];
         }
     } else if ([self.lastLockNotification.lockScreenStatus isEqualToEnum:SDLLockScreenStatusOff]) {
@@ -148,53 +148,6 @@ NS_ASSUME_NONNULL_BEGIN
             [self.presenter dismiss];
         }
     }
-}
-
-/**
- *  Checks if the lock screen can be dismissed. If the the app is currently in the "lock screen optional" state and the `showInOptionalState` has been set to true, then the lock screen should not be dismissed.
- *
- *  @param lockScreenStatus    The most recent lock screen status received from SDL Core
- *  @param previousHMILevel    The previous `hmiLevel`
- *  @param showInOptionalState Whether or not the lock screen should be shown in the "lock screen optional" state
- *  @return                    True if the lock screen can be dismissed; false if not
- */
-+ (BOOL)sdl_canDismissLockScreenWithLockScreenStatus:(nullable SDLOnLockScreenStatus *)lockScreenStatus previousHMILevel:(nullable SDLHMILevel)previousHMILevel showInOptionalState:(BOOL)showInOptionalState {
-    BOOL currentlyInShowInOptionalState = [self sdl_inLockScreenOptionalStateForLockScreenStatus:lockScreenStatus previousHMILevel:previousHMILevel];
-
-    if (currentlyInShowInOptionalState && showInOptionalState) {
-        return false;
-    }
-
-    return true;
-}
-
-/**
- *  Checks if the app is currently in the "lock screen optional" state.
- *
- *  @discussion In order for the "lock screen optional" state to occur, the following must be true:
- *  1. The app should have received at least 1 driver distraction notification (i.e. a `OnDriverDistraction` notification) from SDL Core. Older versions of Core did not send a notification immediately on connection.
- *  2. The driver is not distracted (i.e. the last `OnDriverDistraction` notification received was for a driver distraction state off).
- *  3. The `hmiLevel` can not be `NONE`.
- *  4. If the `hmiLevel` is currently `BACKGROUND` then the previous `hmiLevel` should have been `FULL` or `LIMITED` (i.e. the user should have interacted with app before it was backgrounded).
- *
- *  @param lockScreenStatus The most recent lock screen status received from SDL Core
- *  @param previousHMILevel The previous `hmiLevel`
- *  @return                 True if currently if the "lock screen optional" state; false if not
- */
-+ (BOOL)sdl_inLockScreenOptionalStateForLockScreenStatus:(nullable SDLOnLockScreenStatus *)lockScreenStatus previousHMILevel:(nullable SDLHMILevel)previousHMILevel {
-    if (lockScreenStatus == nil ||
-        lockScreenStatus.driverDistractionStatus.boolValue ||
-        [lockScreenStatus.hmiLevel isEqualToEnum:SDLHMILevelNone]) {
-        return false;
-    }
-
-    if ([lockScreenStatus.hmiLevel isEqualToEnum:SDLHMILevelFull] || [lockScreenStatus.hmiLevel isEqualToEnum:SDLHMILevelLimited]) {
-        return true;
-    } else if ([lockScreenStatus.hmiLevel isEqualToEnum:SDLHMILevelBackground] && ([previousHMILevel isEqualToEnum:SDLHMILevelLimited] || [previousHMILevel isEqualToEnum:SDLHMILevelFull])) {
-        return true;
-    }
-
-    return false;
 }
 
 @end

--- a/SmartDeviceLink/SDLLockScreenManager.m
+++ b/SmartDeviceLink/SDLLockScreenManager.m
@@ -28,7 +28,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic, readwrite) SDLLockScreenConfiguration *config;
 @property (strong, nonatomic) id<SDLViewControllerPresentable> presenter;
 @property (strong, nonatomic, nullable) SDLOnLockScreenStatus *lastLockNotification;
-@property (strong, nonatomic, nullable) SDLHMILevel previousHMILevel;
 
 @end
 
@@ -44,7 +43,6 @@ NS_ASSUME_NONNULL_BEGIN
     _canPresent = NO;
     _config = config;
     _presenter = presenter;
-    _previousHMILevel = nil;
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_lockScreenStatusDidChange:) name:SDLDidChangeLockScreenStatusNotification object:dispatcher];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_lockScreenIconReceived:) name:SDLDidReceiveLockScreenIcon object:dispatcher];
@@ -101,7 +99,6 @@ NS_ASSUME_NONNULL_BEGIN
         return;
     }
 
-    self.previousHMILevel = self.lastLockNotification.hmiLevel;
     self.lastLockNotification = notification.notification;
     [self sdl_checkLockScreen];
 }

--- a/SmartDeviceLink/SDLLockScreenManager.m
+++ b/SmartDeviceLink/SDLLockScreenManager.m
@@ -142,8 +142,6 @@ NS_ASSUME_NONNULL_BEGIN
             [self.presenter present];
         } else if (self.presenter.presented && [self.class sdl_canDismissLockScreenWithLockScreenStatus:self.lastLockNotification previousHMILevel:self.previousHMILevel showInOptionalState:self.config.showInOptionalState]) {
             [self.presenter dismiss];
-        } else {
-            NSLog(@"boo");
         }
     } else if ([self.lastLockNotification.lockScreenStatus isEqualToEnum:SDLLockScreenStatusOff]) {
         if (self.presenter.presented) {
@@ -153,7 +151,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 /**
- * Checks if the lock screen can be dismissed. If the the app is currently in the "lock screen optional" state and the `showInOptionalState` has been set to true, then the lock screen should not be dismissed.
+ *  Checks if the lock screen can be dismissed. If the the app is currently in the "lock screen optional" state and the `showInOptionalState` has been set to true, then the lock screen should not be dismissed.
  *
  *  @param lockScreenStatus    The most recent lock screen status received from SDL Core
  *  @param previousHMILevel    The previous `hmiLevel`

--- a/SmartDeviceLink/SDLLockScreenManager.m
+++ b/SmartDeviceLink/SDLLockScreenManager.m
@@ -28,6 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic, readwrite) SDLLockScreenConfiguration *config;
 @property (strong, nonatomic) id<SDLViewControllerPresentable> presenter;
 @property (strong, nonatomic, nullable) SDLOnLockScreenStatus *lastLockNotification;
+@property (strong, nonatomic, nullable) SDLHMILevel previousHMILevel;
 
 @end
 
@@ -43,6 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
     _canPresent = NO;
     _config = config;
     _presenter = presenter;
+    _previousHMILevel = nil;
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_lockScreenStatusDidChange:) name:SDLDidChangeLockScreenStatusNotification object:dispatcher];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_lockScreenIconReceived:) name:SDLDidReceiveLockScreenIcon object:dispatcher];
@@ -99,6 +101,7 @@ NS_ASSUME_NONNULL_BEGIN
         return;
     }
 
+    self.previousHMILevel = self.lastLockNotification.hmiLevel;
     self.lastLockNotification = notification.notification;
     [self sdl_checkLockScreen];
 }
@@ -137,14 +140,63 @@ NS_ASSUME_NONNULL_BEGIN
     } else if ([self.lastLockNotification.lockScreenStatus isEqualToEnum:SDLLockScreenStatusOptional]) {
         if (self.config.showInOptionalState && !self.presenter.presented && self.canPresent) {
             [self.presenter present];
-        } else if (self.presenter.presented) {
+        } else if (self.presenter.presented && [self.class sdl_canDismissLockScreenWithLockScreenStatus:self.lastLockNotification previousHMILevel:self.previousHMILevel showInOptionalState:self.config.showInOptionalState]) {
             [self.presenter dismiss];
+        } else {
+            NSLog(@"boo");
         }
     } else if ([self.lastLockNotification.lockScreenStatus isEqualToEnum:SDLLockScreenStatusOff]) {
         if (self.presenter.presented) {
             [self.presenter dismiss];
         }
     }
+}
+
+/**
+ * Checks if the lock screen can be dismissed. If the the app is currently in the "lock screen optional" state and the `showInOptionalState` has been set to true, then the lock screen should not be dismissed.
+ *
+ *  @param lockScreenStatus    The most recent lock screen status received from SDL Core
+ *  @param previousHMILevel    The previous `hmiLevel`
+ *  @param showInOptionalState Whether or not the lock screen should be shown in the "lock screen optional" state
+ *  @return                    True if the lock screen can be dismissed; false if not
+ */
++ (BOOL)sdl_canDismissLockScreenWithLockScreenStatus:(nullable SDLOnLockScreenStatus *)lockScreenStatus previousHMILevel:(nullable SDLHMILevel)previousHMILevel showInOptionalState:(BOOL)showInOptionalState {
+    BOOL currentlyInShowInOptionalState = [self sdl_inLockScreenOptionalStateForLockScreenStatus:lockScreenStatus previousHMILevel:previousHMILevel];
+
+    if (currentlyInShowInOptionalState && showInOptionalState) {
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ *  Checks if the app is currently in the "lock screen optional" state.
+ *
+ *  @discussion In order for the "lock screen optional" state to occur, the following must be true:
+ *  1. The app should have received at least 1 driver distraction notification (i.e. a `OnDriverDistraction` notification) from SDL Core. Older versions of Core did not send a notification immediately on connection.
+ *  2. The driver is not distracted (i.e. the last `OnDriverDistraction` notification received was for a driver distraction state off).
+ *  3. The `hmiLevel` can not be `NONE`.
+ *  4. If the `hmiLevel` is currently `BACKGROUND` then the previous `hmiLevel` should have been `FULL` or `LIMITED` (i.e. the user should have interacted with app before it was backgrounded).
+ *
+ *  @param lockScreenStatus The most recent lock screen status received from SDL Core
+ *  @param previousHMILevel The previous `hmiLevel`
+ *  @return                 True if currently if the "lock screen optional" state; false if not
+ */
++ (BOOL)sdl_inLockScreenOptionalStateForLockScreenStatus:(nullable SDLOnLockScreenStatus *)lockScreenStatus previousHMILevel:(nullable SDLHMILevel)previousHMILevel {
+    if (lockScreenStatus == nil ||
+        lockScreenStatus.driverDistractionStatus.boolValue ||
+        [lockScreenStatus.hmiLevel isEqualToEnum:SDLHMILevelNone]) {
+        return false;
+    }
+
+    if ([lockScreenStatus.hmiLevel isEqualToEnum:SDLHMILevelFull] || [lockScreenStatus.hmiLevel isEqualToEnum:SDLHMILevelLimited]) {
+        return true;
+    } else if ([lockScreenStatus.hmiLevel isEqualToEnum:SDLHMILevelBackground] && ([previousHMILevel isEqualToEnum:SDLHMILevelLimited] || [previousHMILevel isEqualToEnum:SDLHMILevelFull])) {
+        return true;
+    }
+
+    return false;
 }
 
 @end

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLLockScreenManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLLockScreenManagerSpec.m
@@ -202,64 +202,59 @@ describe(@"a lock screen manager", ^{
             });
         });
     });
-});
 
-describe(@"A lock screen status of OPTIONAL", ^{
-    __block SDLLockScreenManager *testLockScreenManager = nil;
-    __block SDLLockScreenConfiguration *testLockScreenConfig = nil;
-    __block id mockViewControllerPresenter = nil;
-    __block SDLOnLockScreenStatus *testOptionalStatus = nil;
+    describe(@"A lock screen status of OPTIONAL", ^{
+        __block SDLLockScreenManager *testLockScreenManager = nil;
+        __block SDLLockScreenConfiguration *testLockScreenConfig = nil;
+        __block id mockViewControllerPresenter = nil;
+        __block SDLRPCNotificationNotification *testLockStatusNotification = nil;
 
-    beforeEach(^{
-        mockViewControllerPresenter = OCMClassMock([SDLFakeViewControllerPresenter class]);
-    });
-
-    context(@"showInOptionalState is true", ^{
         beforeEach(^{
-            testLockScreenConfig = [SDLLockScreenConfiguration enabledConfiguration];
-            testLockScreenConfig.showInOptionalState = true;
+            mockViewControllerPresenter = OCMClassMock([SDLFakeViewControllerPresenter class]);
 
-            testLockScreenManager = [[SDLLockScreenManager alloc] initWithConfiguration:testLockScreenConfig notificationDispatcher:nil presenter:mockViewControllerPresenter];
-
-            [testLockScreenManager start];
-        });
-
-
-        it(@"should present the lock screen if not already presented", ^{
-            OCMStub([mockViewControllerPresenter lockViewController]).andReturn([OCMArg any]);
-            OCMStub([mockViewControllerPresenter presented]).andReturn(false);
-
-            testOptionalStatus = [[SDLOnLockScreenStatus alloc] init];
+            SDLOnLockScreenStatus *testOptionalStatus = [[SDLOnLockScreenStatus alloc] init];
             testOptionalStatus.lockScreenStatus = SDLLockScreenStatusOptional;
+            testLockStatusNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidChangeLockScreenStatusNotification object:nil rpcNotification:testOptionalStatus];
 
-            SDLRPCNotificationNotification *testLockStatusNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidChangeLockScreenStatusNotification object:nil rpcNotification:testOptionalStatus];
-            [[NSNotificationCenter defaultCenter] postNotification:testLockStatusNotification];
-
-            OCMVerify([mockViewControllerPresenter present]);
-        });
-    });
-
-    context(@"showInOptionalState is false", ^{
-        beforeEach(^{
             testLockScreenConfig = [SDLLockScreenConfiguration enabledConfiguration];
-            testLockScreenConfig.showInOptionalState = false;
-
-            testLockScreenManager = [[SDLLockScreenManager alloc] initWithConfiguration:testLockScreenConfig notificationDispatcher:nil presenter:mockViewControllerPresenter];
-
-            [testLockScreenManager start]; // Sets `canPresent` to `true`
         });
 
-        it(@"should dismiss the lock screen if already presented", ^{
-            OCMStub([mockViewControllerPresenter lockViewController]).andReturn([OCMArg any]);
-            OCMStub([mockViewControllerPresenter presented]).andReturn(true);
+        context(@"showInOptionalState is true", ^{
+            beforeEach(^{
+                testLockScreenConfig.showInOptionalState = true;
 
-            testOptionalStatus = [[SDLOnLockScreenStatus alloc] init];
-            testOptionalStatus.lockScreenStatus = SDLLockScreenStatusOptional;
+                testLockScreenManager = [[SDLLockScreenManager alloc] initWithConfiguration:testLockScreenConfig notificationDispatcher:nil presenter:mockViewControllerPresenter];
 
-            SDLRPCNotificationNotification *testLockStatusNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidChangeLockScreenStatusNotification object:nil rpcNotification:testOptionalStatus];
-            [[NSNotificationCenter defaultCenter] postNotification:testLockStatusNotification];
+                [testLockScreenManager start]; // Sets `canPresent` to `true`
+            });
 
-            OCMVerify([mockViewControllerPresenter dismiss]);
+            it(@"should present the lock screen if not already presented", ^{
+                OCMStub([mockViewControllerPresenter lockViewController]).andReturn([OCMArg any]);
+                OCMStub([mockViewControllerPresenter presented]).andReturn(false);
+
+                [[NSNotificationCenter defaultCenter] postNotification:testLockStatusNotification];
+
+                OCMVerify([mockViewControllerPresenter present]);
+            });
+        });
+
+        context(@"showInOptionalState is false", ^{
+            beforeEach(^{
+                testLockScreenConfig.showInOptionalState = false;
+
+                testLockScreenManager = [[SDLLockScreenManager alloc] initWithConfiguration:testLockScreenConfig notificationDispatcher:nil presenter:mockViewControllerPresenter];
+
+                [testLockScreenManager start]; // Sets `canPresent` to `true`
+            });
+
+            it(@"should dismiss the lock screen if already presented", ^{
+                OCMStub([mockViewControllerPresenter lockViewController]).andReturn([OCMArg any]);
+                OCMStub([mockViewControllerPresenter presented]).andReturn(true);
+
+                [[NSNotificationCenter defaultCenter] postNotification:testLockStatusNotification];
+
+                OCMVerify([mockViewControllerPresenter dismiss]);
+            });
         });
     });
 });

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLLockScreenManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLLockScreenManagerSpec.m
@@ -1,5 +1,6 @@
 #import <Quick/Quick.h>
 #import <Nimble/Nimble.h>
+#import <OCMock/OCMock.h>
 
 #import "SDLFakeViewControllerPresenter.h"
 #import "SDLLockScreenConfiguration.h"
@@ -11,6 +12,13 @@
 #import "SDLOnLockScreenStatus.h"
 #import "SDLRPCNotificationNotification.h"
 
+
+@interface SDLLockScreenManager ()
+
++ (BOOL)sdl_canDismissLockScreenWithLockScreenStatus:(SDLOnLockScreenStatus *)lockScreenStatus previousHMILevel:(SDLHMILevel)previousHMILevel showInOptionalState:(BOOL)showInOptionalState;
++ (BOOL)sdl_inLockScreenOptionalStateForLockScreenStatus:(nullable SDLOnLockScreenStatus *)lockScreenStatus previousHMILevel:(nullable SDLHMILevel)previousHMILevel;
+
+@end
 
 QuickSpecBegin(SDLLockScreenManagerSpec)
 
@@ -199,6 +207,128 @@ describe(@"a lock screen manager", ^{
                 expect(testManager.lockScreenViewController).toNot(beAnInstanceOf([SDLLockScreenViewController class]));
                 expect(testManager.lockScreenViewController).to(equal(testViewController));
             });
+        });
+    });
+});
+
+describe(@"The lock screen's show in optional state configuration", ^{
+    __block id mockLockScreenManager = nil;
+    __block SDLOnLockScreenStatus *testLockScreenStatus = nil;
+    __block SDLHMILevel testPreviousHMILevel = nil;
+
+    beforeEach(^{
+        mockLockScreenManager = OCMClassMock([SDLLockScreenManager class]);
+
+        testLockScreenStatus = [[SDLOnLockScreenStatus alloc] init];
+        testLockScreenStatus.userSelected = @NO;
+        testLockScreenStatus.lockScreenStatus = SDLLockScreenStatusOptional;
+
+        testPreviousHMILevel = nil;
+    });
+
+    context(@"Check if app in the lock screen optional state", ^{
+        it(@"is not in the lock screen optional state if the lock screen status is nil", ^{
+            BOOL inLockScreenOptionalState = [SDLLockScreenManager sdl_inLockScreenOptionalStateForLockScreenStatus:nil previousHMILevel:nil];
+
+            expect(inLockScreenOptionalState).to(beFalse());
+        });
+
+        it(@"is not in the lock screen optional state if the driver is distracted", ^{
+            testLockScreenStatus.driverDistractionStatus = @YES;
+            testLockScreenStatus.hmiLevel = SDLHMILevelFull;
+
+            BOOL inLockScreenOptionalState = [SDLLockScreenManager sdl_inLockScreenOptionalStateForLockScreenStatus:testLockScreenStatus previousHMILevel:nil];
+
+            expect(inLockScreenOptionalState).to(beFalse());
+        });
+
+        context(@"When the driver is not distracted", ^{
+            beforeEach(^{
+                testLockScreenStatus.driverDistractionStatus = @NO;
+            });
+
+            it(@"is in the lock screen optional state if the hmi level is FULL", ^{
+                testLockScreenStatus.hmiLevel = SDLHMILevelFull;
+
+                BOOL inLockScreenOptionalState = [SDLLockScreenManager sdl_inLockScreenOptionalStateForLockScreenStatus:testLockScreenStatus previousHMILevel:nil];
+
+                expect(inLockScreenOptionalState).to(beTrue());
+            });
+
+            it(@"is in the lock screen optional state if the hmi level is LIMITED", ^{
+                testLockScreenStatus.hmiLevel = SDLHMILevelLimited;
+
+                BOOL inLockScreenOptionalState = [SDLLockScreenManager sdl_inLockScreenOptionalStateForLockScreenStatus:testLockScreenStatus previousHMILevel:nil];
+
+                expect(inLockScreenOptionalState).to(beTrue());
+            });
+
+            it(@"is not in the lock screen optional state if the hmi level is NONE", ^{
+                testLockScreenStatus.hmiLevel = SDLHMILevelNone;
+
+                BOOL inLockScreenOptionalState = [SDLLockScreenManager sdl_inLockScreenOptionalStateForLockScreenStatus:testLockScreenStatus previousHMILevel:nil];
+
+                expect(inLockScreenOptionalState).to(beFalse());
+            });
+
+            context(@"When the current hmi level is BACKGROUND", ^{
+                beforeEach(^{
+                    testLockScreenStatus.hmiLevel = SDLHMILevelBackground;
+                });
+
+                it(@"is in the lock screen optional state if the hmi level is BACKGROUND and the previous hmi level was LIMITED", ^{
+                    BOOL inLockScreenOptionalState = [SDLLockScreenManager sdl_inLockScreenOptionalStateForLockScreenStatus:testLockScreenStatus previousHMILevel:SDLHMILevelLimited];
+
+                    expect(inLockScreenOptionalState).to(beTrue());
+                });
+
+                it(@"is in the lock screen optional state if the hmi level is BACKGROUND and the previous hmi level was FULL", ^{
+                    BOOL inLockScreenOptionalState = [SDLLockScreenManager sdl_inLockScreenOptionalStateForLockScreenStatus:testLockScreenStatus previousHMILevel:SDLHMILevelFull];
+
+                    expect(inLockScreenOptionalState).to(beTrue());
+                });
+
+                it(@"is not in the lock screen optional state if the hmi level is BACKGROUND and the previous hmi level was NONE", ^{
+                    BOOL inLockScreenOptionalState = [SDLLockScreenManager sdl_inLockScreenOptionalStateForLockScreenStatus:testLockScreenStatus previousHMILevel:SDLHMILevelNone];
+
+                    expect(inLockScreenOptionalState).to(beFalse());
+                });
+            });
+        });
+    });
+
+    context(@"Check if the lock screen can be dismissed", ^{
+        beforeEach(^{
+            testLockScreenStatus.userSelected = @NO;
+            testLockScreenStatus.lockScreenStatus = SDLLockScreenStatusOptional;
+            testLockScreenStatus.hmiLevel = SDLHMILevelLimited;
+            testLockScreenStatus.driverDistractionStatus = @NO;
+
+            testPreviousHMILevel = SDLHMILevelLimited;
+        });
+
+        it(@"can be dismissed if the show in optional state has been set to false", ^{
+            OCMStub([mockLockScreenManager sdl_inLockScreenOptionalStateForLockScreenStatus:[OCMArg any] previousHMILevel:[OCMArg any]]).andReturn(YES);
+
+            BOOL canDismissLockScreen = [SDLLockScreenManager sdl_canDismissLockScreenWithLockScreenStatus:testLockScreenStatus previousHMILevel:testPreviousHMILevel showInOptionalState:false];
+
+            expect(canDismissLockScreen).to(beTrue());
+        });
+
+        it(@"can be dismissed the SDL app is not in the lock screen optional state", ^{
+            OCMStub([mockLockScreenManager sdl_inLockScreenOptionalStateForLockScreenStatus:[OCMArg any] previousHMILevel:[OCMArg any]]).andReturn(NO);
+
+            BOOL canDismissLockScreen = [SDLLockScreenManager sdl_canDismissLockScreenWithLockScreenStatus:testLockScreenStatus previousHMILevel:testPreviousHMILevel showInOptionalState:true];
+
+            expect(canDismissLockScreen).to(beTrue());
+        });
+
+        it(@"can not be dismissed if the show in optional state has been set to true and the SDL app is in the lock screen optional state", ^{
+            OCMStub([mockLockScreenManager sdl_inLockScreenOptionalStateForLockScreenStatus:[OCMArg any] previousHMILevel:[OCMArg any]]).andReturn(YES);
+
+            BOOL canDismissLockScreen = [SDLLockScreenManager sdl_canDismissLockScreenWithLockScreenStatus:testLockScreenStatus previousHMILevel:testPreviousHMILevel showInOptionalState:true];
+
+            expect(canDismissLockScreen).to(beFalse());
         });
     });
 });


### PR DESCRIPTION
Fixes #1070

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Test cases added to _SDLLockScreenManagerSpec_ to test the `SDLLockScreenStatusOptional` state.

### Summary
If the lock screen configuration's `showInOptionalState` is set to true, the lock screen is now not dismissed when the app is in the "lock screen optional" state.

### Changelog
##### Enhancements
* The lock screen configuration's `showInOptionalState` now works as expected.

### Tasks Remaining:
- [x] Test enabled state with `showInOptionalState` set to true with Manticore and SYNC3
- [x] Test enabled state with `showInOptionalState` set to false with Manticore and SYNC3

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)