### PR TITLE
Implement SDL-0163 - Make spaceAvailable field non-mandatory

### DIFF
--- a/SmartDeviceLink/SDLDeleteFileOperation.m
+++ b/SmartDeviceLink/SDLDeleteFileOperation.m
@@ -48,20 +48,21 @@ NS_ASSUME_NONNULL_BEGIN
     SDLDeleteFile *deleteFile = [[SDLDeleteFile alloc] initWithFileName:self.fileName];
 
     typeof(self) weakself = self;
-    [self.connectionManager sendConnectionManagerRequest:deleteFile
-                           withResponseHandler:^(__kindof SDLRPCRequest *request, __kindof SDLRPCResponse *response, NSError *error) {
-                               // Pull out the parameters
-                               SDLDeleteFileResponse *deleteFileResponse = (SDLDeleteFileResponse *)response;
-                               BOOL success = [deleteFileResponse.success boolValue];
-                               NSUInteger bytesAvailable = [deleteFileResponse.spaceAvailable unsignedIntegerValue];
+    [self.connectionManager sendConnectionManagerRequest:deleteFile withResponseHandler:^(__kindof SDLRPCRequest *request, __kindof SDLRPCResponse *response, NSError *error) {
+        // Pull out the parameters
+        SDLDeleteFileResponse *deleteFileResponse = (SDLDeleteFileResponse *)response;
+        BOOL success = [deleteFileResponse.success boolValue];
 
-                               // Callback
-                               if (weakself.completionHandler != nil) {
-                                   weakself.completionHandler(success, bytesAvailable, error);
-                               }
+        // If spaceAvailable is nil, set it to the max value
+        NSUInteger bytesAvailable = deleteFileResponse.spaceAvailable != nil ? deleteFileResponse.spaceAvailable.unsignedIntegerValue : 2000000000;
 
-                               [weakself finishOperation];
-                           }];
+        // Callback
+        if (weakself.completionHandler != nil) {
+            weakself.completionHandler(success, bytesAvailable, error);
+        }
+
+        [weakself finishOperation];
+    }];
 }
 
 

--- a/SmartDeviceLink/SDLDeleteFileResponse.h
+++ b/SmartDeviceLink/SDLDeleteFileResponse.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The remaining available space for your application to store data on the remote system.
  */
-@property (strong, nonatomic) NSNumber<SDLInt> *spaceAvailable;
+@property (nullable, strong, nonatomic) NSNumber<SDLInt> *spaceAvailable;
 
 @end
 

--- a/SmartDeviceLink/SDLDeleteFileResponse.m
+++ b/SmartDeviceLink/SDLDeleteFileResponse.m
@@ -17,11 +17,11 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (void)setSpaceAvailable:(NSNumber<SDLInt> *)spaceAvailable {
+- (void)setSpaceAvailable:(nullable NSNumber<SDLInt> *)spaceAvailable {
     [parameters sdl_setObject:spaceAvailable forName:SDLNameSpaceAvailable];
 }
 
-- (NSNumber<SDLInt> *)spaceAvailable {
+- (nullable NSNumber<SDLInt> *)spaceAvailable {
     return [parameters sdl_objectForName:SDLNameSpaceAvailable];
 }
 

--- a/SmartDeviceLink/SDLFileManager.m
+++ b/SmartDeviceLink/SDLFileManager.m
@@ -228,13 +228,13 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
         __strong typeof(weakSelf) strongSelf = weakSelf;
 
         // Mutate self based on the changes
-        strongSelf.bytesAvailable = bytesAvailable;
         if (success) {
+            strongSelf.bytesAvailable = bytesAvailable;
             [strongSelf.mutableRemoteFileNames removeObject:name];
         }
 
         if (handler != nil) {
-            handler(success, self.bytesAvailable, error);
+            handler(success, bytesAvailable, error);
         }
     }];
 
@@ -385,11 +385,9 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
         if (self.uploadsInProgress[file.name]) {
             [self.uploadsInProgress removeObjectForKey:file.name];
         }
-
-        if (bytesAvailable != 0) {
-            weakSelf.bytesAvailable = bytesAvailable;
-        }
+        
         if (success) {
+            weakSelf.bytesAvailable = bytesAvailable;
             [weakSelf.mutableRemoteFileNames addObject:fileName];
             [weakSelf.uploadedEphemeralFileNames addObject:fileName];
         } else {

--- a/SmartDeviceLink/SDLListFilesOperation.m
+++ b/SmartDeviceLink/SDLListFilesOperation.m
@@ -47,19 +47,20 @@ NS_ASSUME_NONNULL_BEGIN
     SDLListFiles *listFiles = [[SDLListFiles alloc] init];
 
     __weak typeof(self) weakSelf = self;
-    [self.connectionManager sendConnectionManagerRequest:listFiles
-                                     withResponseHandler:^(__kindof SDLRPCRequest *request, __kindof SDLRPCResponse *response, NSError *error) {
-                                         SDLListFilesResponse *listFilesResponse = (SDLListFilesResponse *)response;
-                                         BOOL success = [listFilesResponse.success boolValue];
-                                         NSUInteger bytesAvailable = [listFilesResponse.spaceAvailable unsignedIntegerValue];
-                                         NSArray<NSString *> *fileNames = [NSArray arrayWithArray:listFilesResponse.filenames];
+    [self.connectionManager sendConnectionManagerRequest:listFiles withResponseHandler:^(__kindof SDLRPCRequest *request, __kindof SDLRPCResponse *response, NSError *error) {
+        SDLListFilesResponse *listFilesResponse = (SDLListFilesResponse *)response;
+        BOOL success = [listFilesResponse.success boolValue];
+        NSArray<NSString *> *fileNames = [NSArray arrayWithArray:listFilesResponse.filenames];
 
-                                         if (weakSelf.completionHandler != nil) {
-                                             weakSelf.completionHandler(success, bytesAvailable, fileNames, error);
-                                         }
+        // If spaceAvailable is nil, set it to the max value
+        NSUInteger bytesAvailable = listFilesResponse.spaceAvailable != nil ? listFilesResponse.spaceAvailable.unsignedIntegerValue : 2000000000;
 
-                                         [weakSelf finishOperation];
-                                     }];
+        if (weakSelf.completionHandler != nil) {
+            weakSelf.completionHandler(success, bytesAvailable, fileNames, error);
+        }
+
+        [weakSelf finishOperation];
+    }];
 }
 
 

--- a/SmartDeviceLink/SDLListFilesResponse.h
+++ b/SmartDeviceLink/SDLListFilesResponse.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Provides the total local space available on the module for the registered app.
  */
-@property (strong, nonatomic) NSNumber<SDLInt> *spaceAvailable;
+@property (nullable, strong, nonatomic) NSNumber<SDLInt> *spaceAvailable;
 
 @end
 

--- a/SmartDeviceLink/SDLListFilesResponse.m
+++ b/SmartDeviceLink/SDLListFilesResponse.m
@@ -25,11 +25,11 @@ NS_ASSUME_NONNULL_BEGIN
     return [parameters sdl_objectForName:SDLNameFilenames];
 }
 
-- (void)setSpaceAvailable:(NSNumber<SDLInt> *)spaceAvailable {
+- (void)setSpaceAvailable:(nullable NSNumber<SDLInt> *)spaceAvailable {
     [parameters sdl_setObject:spaceAvailable forName:SDLNameSpaceAvailable];
 }
 
-- (NSNumber<SDLInt> *)spaceAvailable {
+- (nullable NSNumber<SDLInt> *)spaceAvailable {
     return [parameters sdl_objectForName:SDLNameSpaceAvailable];
 }
 

--- a/SmartDeviceLink/SDLPutFileResponse.h
+++ b/SmartDeviceLink/SDLPutFileResponse.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Provides the total local space available in SDL Core for the registered app. If the transfer has systemFile enabled, then the value will be set to 0 automatically.
  */
-@property (strong, nonatomic) NSNumber<SDLInt> *spaceAvailable;
+@property (nullable, strong, nonatomic) NSNumber<SDLInt> *spaceAvailable;
 
 @end
 

--- a/SmartDeviceLink/SDLPutFileResponse.m
+++ b/SmartDeviceLink/SDLPutFileResponse.m
@@ -17,11 +17,11 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (void)setSpaceAvailable:(NSNumber<SDLInt> *)spaceAvailable {
+- (void)setSpaceAvailable:(nullable NSNumber<SDLInt> *)spaceAvailable {
     [parameters sdl_setObject:spaceAvailable forName:SDLNameSpaceAvailable];
 }
 
-- (NSNumber<SDLInt> *)spaceAvailable {
+- (nullable NSNumber<SDLInt> *)spaceAvailable {
     return [parameters sdl_objectForName:SDLNameSpaceAvailable];
 }
 

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingVideoLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingVideoLifecycleManagerSpec.m
@@ -319,11 +319,11 @@ describe(@"the streaming video manager", ^{
                     context(@"and hmi state changes to background after app becomes inactive", ^{
                         beforeEach(^{
                             [streamingLifecycleManager.appStateMachine setToState:SDLAppStateInactive fromOldState:nil callEnterTransition:YES];
-                            sendNotificationForHMILevel(SDLHMILevelBackground);
+                            sendNotificationForHMILevel(SDLHMILevelBackground, SDLVideoStreamingStateNotStreamable);
                         });
 
                         it(@"should close the stream", ^{
-                            expect(streamingLifecycleManager.currentVideoStreamState).to(equal(SDLVideoStreamStateShuttingDown));
+                            expect(streamingLifecycleManager.currentVideoStreamState).to(equal(SDLVideoStreamManagerStateShuttingDown));
                         });
                     });
                 });


### PR DESCRIPTION
Fixes #1072 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Unit tests have been added

### Summary
Update `ListFiles`, `PutFile`, and `DeleteFile` to have `spaceAvailable` non-mandatory, as it will not be there in error cases.

### Changelog
##### Enhancements
* Update `ListFiles`, `PutFile`, and `DeleteFile` to have `spaceAvailable` non-mandatory, as it will not be there in error cases.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)