### PR TITLE
Add Play/Pause to ButtonName

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "Quick/Nimble" "v7.0.3"
-github "Quick/Quick" "v1.2.0"
-github "erikdoe/ocmock" "v3.4.1"
+github "Quick/Nimble" "v7.3.0"
+github "Quick/Quick" "v1.3.1"
+github "erikdoe/ocmock" "v3.4.2"
 github "facebook/ios-snapshot-test-case" "2.1.4"

--- a/Example Apps/Example ObjC/ProxyManager.m
+++ b/Example Apps/Example ObjC/ProxyManager.m
@@ -161,19 +161,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)sdlex_showInitialData {
     if (![self.sdlManager.hmiLevel isEqualToEnum:SDLHMILevelFull]) { return; }
 
-//    SDLSetDisplayLayout *setDisplayLayout = [[SDLSetDisplayLayout alloc] initWithPredefinedLayout:SDLPredefinedLayoutNonMedia];
-//    [self.sdlManager sendRequest:setDisplayLayout];
+    SDLSetDisplayLayout *setDisplayLayout = [[SDLSetDisplayLayout alloc] initWithPredefinedLayout:SDLPredefinedLayoutNonMedia];
+    [self.sdlManager sendRequest:setDisplayLayout];
 
     [self sdlex_updateScreen];
     self.sdlManager.screenManager.softButtonObjects = [self.buttonManager allScreenSoftButtons];
-
-    SDLSubscribeButton *subscribeOk = [[SDLSubscribeButton alloc] initWithButtonName:SDLButtonNamePlayPause handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {
-        NSLog(@"OK PRESSED");
-    }];
-
-    [self.sdlManager sendRequest:subscribeOk withResponseHandler:^(__kindof SDLRPCRequest * _Nullable request, __kindof SDLRPCResponse * _Nullable response, NSError * _Nullable error) {
-        NSLog(@"OK Request: %@, response: %@, error: %@", request, response, error);
-    }];
 }
 
 - (nullable RefreshUIHandler)refreshUIHandler {

--- a/Example Apps/Example ObjC/ProxyManager.m
+++ b/Example Apps/Example ObjC/ProxyManager.m
@@ -129,7 +129,7 @@ NS_ASSUME_NONNULL_BEGIN
     config.ttsName = [SDLTTSChunk textChunksFromString:ExampleAppName];
     config.language = SDLLanguageEnUs;
     config.languagesSupported = @[SDLLanguageEnUs, SDLLanguageFrCa, SDLLanguageEsMx];
-    config.appType = SDLAppHMITypeDefault;
+    config.appType = SDLAppHMITypeMedia;
 
     SDLRGBColor *green = [[SDLRGBColor alloc] initWithRed:126 green:188 blue:121];
     SDLRGBColor *white = [[SDLRGBColor alloc] initWithRed:249 green:251 blue:254];
@@ -161,11 +161,19 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)sdlex_showInitialData {
     if (![self.sdlManager.hmiLevel isEqualToEnum:SDLHMILevelFull]) { return; }
 
-    SDLSetDisplayLayout *setDisplayLayout = [[SDLSetDisplayLayout alloc] initWithPredefinedLayout:SDLPredefinedLayoutNonMedia];
-    [self.sdlManager sendRequest:setDisplayLayout];
+//    SDLSetDisplayLayout *setDisplayLayout = [[SDLSetDisplayLayout alloc] initWithPredefinedLayout:SDLPredefinedLayoutNonMedia];
+//    [self.sdlManager sendRequest:setDisplayLayout];
 
     [self sdlex_updateScreen];
     self.sdlManager.screenManager.softButtonObjects = [self.buttonManager allScreenSoftButtons];
+
+    SDLSubscribeButton *subscribeOk = [[SDLSubscribeButton alloc] initWithButtonName:SDLButtonNamePlayPause handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {
+        NSLog(@"OK PRESSED");
+    }];
+
+    [self.sdlManager sendRequest:subscribeOk withResponseHandler:^(__kindof SDLRPCRequest * _Nullable request, __kindof SDLRPCResponse * _Nullable response, NSError * _Nullable error) {
+        NSLog(@"OK Request: %@, response: %@, error: %@", request, response, error);
+    }];
 }
 
 - (nullable RefreshUIHandler)refreshUIHandler {

--- a/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
+++ b/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
@@ -391,6 +391,8 @@
 		5D00AC781F15283E004000D9 /* SDLNavigationCapability.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D00AC761F15283E004000D9 /* SDLNavigationCapability.m */; };
 		5D00AC7B1F15287E004000D9 /* SDLPhoneCapability.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D00AC791F15287E004000D9 /* SDLPhoneCapability.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5D00AC7C1F15287E004000D9 /* SDLPhoneCapability.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D00AC7A1F15287E004000D9 /* SDLPhoneCapability.m */; };
+		5D019276214994AC003500F6 /* NSMutableArray+Safe.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D019274214994AC003500F6 /* NSMutableArray+Safe.h */; };
+		5D019277214994AC003500F6 /* NSMutableArray+Safe.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D019275214994AC003500F6 /* NSMutableArray+Safe.m */; };
 		5D07C02D2044AC9100D1ECDC /* SDLSequentialRPCRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D07C02B2044AC9000D1ECDC /* SDLSequentialRPCRequestOperation.h */; };
 		5D07C02E2044AC9100D1ECDC /* SDLSequentialRPCRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D07C02C2044AC9100D1ECDC /* SDLSequentialRPCRequestOperation.m */; };
 		5D07C0312044AD0C00D1ECDC /* SDLAsynchronousRPCRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D07C02F2044AD0C00D1ECDC /* SDLAsynchronousRPCRequestOperation.h */; };
@@ -1837,6 +1839,8 @@
 		5D00AC761F15283E004000D9 /* SDLNavigationCapability.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLNavigationCapability.m; sourceTree = "<group>"; };
 		5D00AC791F15287E004000D9 /* SDLPhoneCapability.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDLPhoneCapability.h; sourceTree = "<group>"; };
 		5D00AC7A1F15287E004000D9 /* SDLPhoneCapability.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLPhoneCapability.m; sourceTree = "<group>"; };
+		5D019274214994AC003500F6 /* NSMutableArray+Safe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSMutableArray+Safe.h"; sourceTree = "<group>"; };
+		5D019275214994AC003500F6 /* NSMutableArray+Safe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSMutableArray+Safe.m"; sourceTree = "<group>"; };
 		5D07C02B2044AC9000D1ECDC /* SDLSequentialRPCRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDLSequentialRPCRequestOperation.h; sourceTree = "<group>"; };
 		5D07C02C2044AC9100D1ECDC /* SDLSequentialRPCRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLSequentialRPCRequestOperation.m; sourceTree = "<group>"; };
 		5D07C02F2044AD0C00D1ECDC /* SDLAsynchronousRPCRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDLAsynchronousRPCRequestOperation.h; sourceTree = "<group>"; };
@@ -4880,6 +4884,8 @@
 				5DA102A31D4122C700C15826 /* NSMutableDictionary+SafeRemove.m */,
 				5D3E48C91D7722FE0000BFEF /* NSBundle+SDLBundle.h */,
 				5D3E48CA1D7722FE0000BFEF /* NSBundle+SDLBundle.m */,
+				5D019274214994AC003500F6 /* NSMutableArray+Safe.h */,
+				5D019275214994AC003500F6 /* NSMutableArray+Safe.m */,
 			);
 			name = Categories;
 			sourceTree = "<group>";
@@ -5794,6 +5800,7 @@
 				5DCF76F51ACDBAD300BB647B /* SDLSendLocation.h in Headers */,
 				5D61FC9E1A84238C00846EE7 /* SDLEncodedSyncPData.h in Headers */,
 				1FF7DABA1F75B2A800B46C30 /* SDLFocusableItemLocator.h in Headers */,
+				5D019276214994AC003500F6 /* NSMutableArray+Safe.h in Headers */,
 				5D61FDE11A84238C00846EE7 /* SDLTurn.h in Headers */,
 				5D9FC29B1FD8812F00ACA5C2 /* SDLAudioStreamManagerDelegate.h in Headers */,
 				5D61FC801A84238C00846EE7 /* SDLDeleteSubMenuResponse.h in Headers */,
@@ -6371,6 +6378,7 @@
 				5D3E420B20EAAD6500D8C622 /* SDLTPMS.m in Sources */,
 				5DD67CB11E65DDB7009CD394 /* SDLLogTargetAppleSystemLog.m in Sources */,
 				5D92935420B2F76500FCC775 /* SDLTemplateColorScheme.m in Sources */,
+				5D019277214994AC003500F6 /* NSMutableArray+Safe.m in Sources */,
 				5D61FD1C1A84238C00846EE7 /* SDLOnSystemRequest.m in Sources */,
 				5D61FC911A84238C00846EE7 /* SDLDisplayCapabilities.m in Sources */,
 				1EB59CC4202DB40400343A61 /* SDLSeatControlCapabilities.m in Sources */,

--- a/SmartDeviceLink/NSMutableArray+Safe.h
+++ b/SmartDeviceLink/NSMutableArray+Safe.h
@@ -1,0 +1,15 @@
+//
+//  NSMutableArray+NSMutableArray_Safe.h
+//  SmartDeviceLink
+//
+//  Created by Joel Fischer on 9/12/18.
+//  Copyright © 2018 smartdevicelink. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSMutableArray<ObjectType> (Safe)
+
+- (void)sdl_safeAddObject:(ObjectType)object;
+
+@end

--- a/SmartDeviceLink/NSMutableArray+Safe.m
+++ b/SmartDeviceLink/NSMutableArray+Safe.m
@@ -6,7 +6,7 @@
 //  Copyright © 2018 smartdevicelink. All rights reserved.
 //
 
-#import "NSMutableArray+NSMutableArray_Safe.h"
+#import "NSMutableArray+Safe.h"
 
 @implementation NSMutableArray (Safe)
 

--- a/SmartDeviceLink/NSMutableArray+Safe.m
+++ b/SmartDeviceLink/NSMutableArray+Safe.m
@@ -1,0 +1,19 @@
+//
+//  NSMutableArray+NSMutableArray_Safe.m
+//  SmartDeviceLink
+//
+//  Created by Joel Fischer on 9/12/18.
+//  Copyright © 2018 smartdevicelink. All rights reserved.
+//
+
+#import "NSMutableArray+NSMutableArray_Safe.h"
+
+@implementation NSMutableArray (Safe)
+
+- (void)sdl_safeAddObject:(id)object {
+    if (object == nil) { return; }
+
+    [self addObject:object];
+}
+
+@end

--- a/SmartDeviceLink/NSMutableDictionary+SafeRemove.h
+++ b/SmartDeviceLink/NSMutableDictionary+SafeRemove.h
@@ -8,30 +8,28 @@
 
 #import <Foundation/Foundation.h>
 
-@interface NSMutableDictionary <KeyType, ObjectType>
-(SafeRemove)
+@interface NSMutableDictionary <KeyType, ObjectType> (SafeRemove)
 
-    /**
+/**
  *  Safely attempt to remove a key/object pair by no-oping if they don't exist in the Mutable Dictionary instead of throwing an exception
  *
  *  @param aKey The key to attempt removal of
  *
  *  @return Whether or not the key/object pair existed to remove.
  */
-    - (BOOL)safeRemoveObjectForKey : (KeyType)aKey;
+- (BOOL)safeRemoveObjectForKey : (KeyType)aKey;
 
 @end
 
-@interface NSMapTable <KeyType, ObjectType>
-(SafeRemove)
+@interface NSMapTable <KeyType, ObjectType> (SafeRemove)
 
-    /**
+/**
  *  Safely attempt to remove a key/object pair by no-oping if they don't exist in the MapTable instead of throwing an exception
  *
  *  @param aKey The key to attempt removal of
  *
  *  @return Whether or not the key/object pair existed to remove.
  */
-    - (BOOL)safeRemoveObjectForKey : (KeyType)aKey;
+- (BOOL)safeRemoveObjectForKey : (KeyType)aKey;
 
 @end

--- a/SmartDeviceLink/NSMutableDictionary+Store.h
+++ b/SmartDeviceLink/NSMutableDictionary+Store.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 typedef NSString* SDLName SDL_SWIFT_ENUM;
 typedef NSString* SDLEnum SDL_SWIFT_ENUM;
 
-@interface NSMutableDictionary (Store)
+@interface NSDictionary (Store)
 
 - (void)sdl_setObject:(NSObject *)object forName:(SDLName)name;
 - (nullable id)sdl_objectForName:(SDLName)name;

--- a/SmartDeviceLink/NSMutableDictionary+Store.m
+++ b/SmartDeviceLink/NSMutableDictionary+Store.m
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable id)sdl_objectForName:(SDLName)name ofClass:(Class)classType {
     NSObject *obj = [self sdl_objectForName:name];
-    if (obj == nil || [obj isKindOfClass:classType.class]) {
+    if (obj == nil || [obj isKindOfClass:classType]) {
         return obj;
     } else {
         return [[classType alloc] initWithDictionary:(NSDictionary *)obj];
@@ -37,12 +37,12 @@ NS_ASSUME_NONNULL_BEGIN
     NSArray *array = [self sdl_objectForName:name];
     if ([array isEqual:[NSNull null]]) {
         return [NSMutableArray array];
-    } else if (array.count < 1 || [array.firstObject isMemberOfClass:classType.class]) {
+    } else if (array.count < 1 || [array.firstObject isMemberOfClass:classType]) {
         // It's an array of the actual class type, just return
         return array;
     } else {
         // It's an array of dictionaries, make them into their class type
-        NSMutableArray *newList = [NSMutableArray arrayWithCapacity:[array count]];
+        NSMutableArray *newList = [NSMutableArray arrayWithCapacity:array.count];
         for (NSDictionary<NSString *, id> *dict in array) {
             [newList addObject:[[classType alloc] initWithDictionary:dict]];
         }

--- a/SmartDeviceLink/SDLButtonName.h
+++ b/SmartDeviceLink/SDLButtonName.h
@@ -16,7 +16,7 @@
 typedef SDLEnum SDLButtonName SDL_SWIFT_ENUM;
 
 /**
- * Represents the button usually labeled "OK". A typical use of this button is for the user to press it to make a selection.
+ * Represents the button usually labeled "OK". A typical use of this button is for the user to press it to make a selection. Prior to SDL Core 5.0 (iOS Proxy v.6.1), Ok was used for both "OK" buttons *AND* PlayPause. In 5.0, PlayPause was introduced to reduce confusion, and you should use the one you intend for your use case (usually PlayPause). Until the next proxy breaking change, however, subscribing to this button name will continue to subscribe you to PlayPause so that your code does not break. That means that if you subscribe to both Ok and PlayPause, you will receive duplicate notifications.
  */
 extern SDLButtonName const SDLButtonNameOk;
 

--- a/SmartDeviceLink/SDLButtonName.h
+++ b/SmartDeviceLink/SDLButtonName.h
@@ -18,9 +18,7 @@ typedef SDLEnum SDLButtonName SDL_SWIFT_ENUM;
 /**
  * Represents the button usually labeled "OK". A typical use of this button is for the user to press it to make a selection.
  */
-extern SDLButtonName const SDLButtonNameOk __deprecated_msg("Use SDLButtonNameOkay or SDLButtonNamePlayPause instead");
-
-extern SDLButtonName const SDLButtonNameOkay;
+extern SDLButtonName const SDLButtonNameOk;
 
 /**
  * Represents the play/pause button for media apps. Replaces "OK" on sub-5.0 head units, compliments it on 5.0 head units and later.

--- a/SmartDeviceLink/SDLButtonName.h
+++ b/SmartDeviceLink/SDLButtonName.h
@@ -18,7 +18,9 @@ typedef SDLEnum SDLButtonName SDL_SWIFT_ENUM;
 /**
  * Represents the button usually labeled "OK". A typical use of this button is for the user to press it to make a selection.
  */
-extern SDLButtonName const SDLButtonNameOk;
+extern SDLButtonName const SDLButtonNameOk __deprecated_msg("Use SDLButtonNameOkay or SDLButtonNamePlayPause instead");
+
+extern SDLButtonName const SDLButtonNameOkay;
 
 /**
  * Represents the play/pause button for media apps. Replaces "OK" on sub-5.0 head units, compliments it on 5.0 head units and later.

--- a/SmartDeviceLink/SDLButtonName.h
+++ b/SmartDeviceLink/SDLButtonName.h
@@ -21,6 +21,11 @@ typedef SDLEnum SDLButtonName SDL_SWIFT_ENUM;
 extern SDLButtonName const SDLButtonNameOk;
 
 /**
+ * Represents the play/pause button for media apps. Replaces "OK" on sub-5.0 head units, compliments it on 5.0 head units and later.
+ */
+extern SDLButtonName const SDLButtonNamePlayPause;
+
+/**
  * Represents the seek-left button. A typical use of this button is for the user to scroll to the left through menu choices one menu item per press.
  */
 extern SDLButtonName const SDLButtonNameSeekLeft;

--- a/SmartDeviceLink/SDLButtonName.m
+++ b/SmartDeviceLink/SDLButtonName.m
@@ -5,6 +5,7 @@
 #import "SDLButtonName.h"
 
 SDLButtonName const SDLButtonNameOk = @"OK";
+SDLButtonName const SDLButtonNamePlayPause = @"PLAY_PAUSE";
 SDLButtonName const SDLButtonNameSeekLeft = @"SEEKLEFT";
 SDLButtonName const SDLButtonNameSeekRight = @"SEEKRIGHT";
 SDLButtonName const SDLButtonNameTuneUp = @"TUNEUP";

--- a/SmartDeviceLink/SDLButtonName.m
+++ b/SmartDeviceLink/SDLButtonName.m
@@ -5,6 +5,7 @@
 #import "SDLButtonName.h"
 
 SDLButtonName const SDLButtonNameOk = @"OK";
+SDLButtonName const SDLButtonNameOkay = @"OKAY";
 SDLButtonName const SDLButtonNamePlayPause = @"PLAY_PAUSE";
 SDLButtonName const SDLButtonNameSeekLeft = @"SEEKLEFT";
 SDLButtonName const SDLButtonNameSeekRight = @"SEEKRIGHT";

--- a/SmartDeviceLink/SDLButtonName.m
+++ b/SmartDeviceLink/SDLButtonName.m
@@ -5,7 +5,6 @@
 #import "SDLButtonName.h"
 
 SDLButtonName const SDLButtonNameOk = @"OK";
-SDLButtonName const SDLButtonNameOkay = @"OKAY";
 SDLButtonName const SDLButtonNamePlayPause = @"PLAY_PAUSE";
 SDLButtonName const SDLButtonNameSeekLeft = @"SEEKLEFT";
 SDLButtonName const SDLButtonNameSeekRight = @"SEEKRIGHT";

--- a/SmartDeviceLink/SDLGlobals.h
+++ b/SmartDeviceLink/SDLGlobals.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 
 #import "SDLProtocolHeader.h"
+#import "SDLSyncMsgVersion.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -17,6 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 #define BLOCK_RETURN return
 
 extern NSString *const SDLMaxProxyProtocolVersion;
+extern NSString *const SDLMaxProxyRPCVersion;
 
 extern NSUInteger const SDLDefaultMTUSize;
 extern NSUInteger const SDLV1MTUSize;
@@ -24,9 +26,10 @@ extern NSUInteger const SDLV3MTUSize;
 
 @interface SDLGlobals : NSObject
 
-@property (strong, nonatomic, readonly) NSString *protocolVersion;
+@property (copy, nonatomic, readonly) NSString *protocolVersion;
 @property (assign, nonatomic, readonly) NSInteger majorProtocolVersion;
-@property (strong, nonatomic) NSString *maxHeadUnitVersion;
+@property (copy, nonatomic) SDLSyncMsgVersion *rpcVersion;
+@property (copy, nonatomic) NSString *maxHeadUnitVersion;
 
 + (instancetype)sharedGlobals;
 

--- a/SmartDeviceLink/SDLGlobals.h
+++ b/SmartDeviceLink/SDLGlobals.h
@@ -28,7 +28,7 @@ extern NSUInteger const SDLV3MTUSize;
 
 @property (copy, nonatomic, readonly) NSString *protocolVersion;
 @property (assign, nonatomic, readonly) NSInteger majorProtocolVersion;
-@property (copy, nonatomic) SDLSyncMsgVersion *rpcVersion;
+@property (strong, nonatomic) SDLSyncMsgVersion *rpcVersion;
 @property (copy, nonatomic) NSString *maxHeadUnitVersion;
 
 + (instancetype)sharedGlobals;

--- a/SmartDeviceLink/SDLGlobals.m
+++ b/SmartDeviceLink/SDLGlobals.m
@@ -14,20 +14,21 @@ NS_ASSUME_NONNULL_BEGIN
 
 // VERSION DEPENDENT CODE
 NSString *const SDLMaxProxyProtocolVersion = @"5.0.0";
+NSString *const SDLMaxProxyRPCVersion =  @"5.0.0";
 
 NSUInteger const SDLDefaultMTUSize = UINT32_MAX;
 NSUInteger const SDLV1MTUSize = 1024;
 NSUInteger const SDLV3MTUSize = 131024;
 
 
-typedef NSNumber* ServiceTypeBox;
-typedef NSNumber* MTUBox;
+typedef NSNumber *ServiceTypeBox;
+typedef NSNumber *MTUBox;
 
 
 @interface SDLGlobals ()
 
 @property (strong, nonatomic) NSMutableDictionary<ServiceTypeBox, MTUBox> *dynamicMTUDict;
-@property (strong, nonatomic, readwrite) NSString *protocolVersion;
+@property (copy, nonatomic, readwrite) NSString *protocolVersion;
 
 @end
 
@@ -52,6 +53,7 @@ typedef NSNumber* MTUBox;
 
     _protocolVersion = @"1.0.0";
     _maxHeadUnitVersion = @"0.0.0";
+    _rpcVersion = [[SDLSyncMsgVersion alloc] initWithMajorVersion:1 minorVersion:0 patchVersion:0];
     _dynamicMTUDict = [NSMutableDictionary dictionary];
 
     return self;

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -22,6 +22,7 @@
 #import "SDLFile.h"
 #import "SDLFileManager.h"
 #import "SDLFileManagerConfiguration.h"
+#import "SDLGlobals.h"
 #import "SDLLifecycleConfiguration.h"
 #import "SDLLifecycleConfigurationUpdate.h"
 #import "SDLLockScreenConfiguration.h"
@@ -281,6 +282,7 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
                 }
 
                 weakSelf.registerResponse = (SDLRegisterAppInterfaceResponse *)response;
+                [SDLGlobals sharedGlobals].rpcVersion = weakSelf.registerResponse.syncMsgVersion;
                 [weakSelf.lifecycleStateMachine transitionToState:SDLLifecycleStateRegistered];
             });
         }];

--- a/SmartDeviceLink/SDLProxy.m
+++ b/SmartDeviceLink/SDLProxy.m
@@ -6,7 +6,6 @@
 #import <UIKit/UIKit.h>
 #import <objc/runtime.h>
 
-#import "SDLTransportType.h"
 #import "SDLAudioStreamingState.h"
 #import "SDLLogMacros.h"
 #import "SDLEncodedSyncPData.h"
@@ -18,6 +17,8 @@
 #import "SDLLanguage.h"
 #import "SDLLayoutMode.h"
 #import "SDLLockScreenStatusManager.h"
+#import "SDLOnButtonEvent.h"
+#import "SDLOnButtonPress.h"
 #import "SDLOnHMIStatus.h"
 #import "SDLOnSystemRequest.h"
 #import "SDLPolicyDataParser.h"
@@ -29,10 +30,13 @@
 #import "SDLRegisterAppInterfaceResponse.h"
 #import "SDLRequestType.h"
 #import "SDLStreamingMediaManager.h"
+#import "SDLSubscribeButton.h"
 #import "SDLSystemContext.h"
 #import "SDLSystemRequest.h"
 #import "SDLTCPTransport.h"
 #import "SDLTimer.h"
+#import "SDLTransportType.h"
+#import "SDLUnsubscribeButton.h"
 #import "SDLVehicleType.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -266,14 +270,145 @@ static float DefaultConnectionTimeout = 45.0;
 }
 
 
-#pragma mark - Message sending and recieving
+#pragma mark - Message sending
 - (void)sendRPC:(SDLRPCMessage *)message {
+    if ([message.getFunctionName isEqualToString:@"SubscribeButton"]) {
+        BOOL handledRPC = [self sdl_adaptButtonSubscribeMessage:(SDLSubscribeButton *)message];
+        if (handledRPC) { return; }
+    } else if ([message.getFunctionName isEqualToString:@"UnsubscribeButton"]) {
+        BOOL handledRPC = [self sdl_adaptButtonUnsubscribeMessage:(SDLUnsubscribeButton *)message];
+        if (handledRPC) { return; }
+    }
+
     @try {
         [self.protocol sendRPC:message];
     } @catch (NSException *exception) {
         SDLLogE(@"Proxy: Failed to send RPC message: %@", message.name);
     }
 }
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+- (BOOL)sdl_adaptButtonSubscribeMessage:(SDLSubscribeButton *)message {
+    if ([SDLGlobals sharedGlobals].rpcVersion.majorVersion.intValue >= 5) {
+        if ([message.buttonName isEqualToEnum:SDLButtonNameOk]) {
+            SDLSubscribeButton *playPauseMessage = [message copy];
+            playPauseMessage.buttonName = SDLButtonNamePlayPause;
+
+            @try {
+                [self.protocol sendRPC:message];
+                [self.protocol sendRPC:playPauseMessage];
+            } @catch (NSException *exception) {
+                SDLLogE(@"Proxy: Failed to send RPC message: %@", message.name);
+            }
+
+            return YES;
+        } else if ([message.buttonName isEqualToEnum:SDLButtonNameOkay]) {
+            SDLSubscribeButton *okMessage = [message copy];
+            okMessage.buttonName = SDLButtonNameOk;
+
+            @try {
+                [self.protocol sendRPC:okMessage];
+            } @catch (NSException *exception) {
+                SDLLogE(@"Proxy: Failed to send RPC message: %@", message.name);
+            }
+
+            return YES;
+        } else if ([message.buttonName isEqualToEnum:SDLButtonNamePlayPause]) {
+            return NO;
+        }
+    } else {
+        if ([message.buttonName isEqualToEnum:SDLButtonNameOk]) {
+            return NO;
+        } else if ([message.buttonName isEqualToEnum:SDLButtonNameOkay]) {
+            SDLSubscribeButton *okMessage = [message copy];
+            okMessage.buttonName = SDLButtonNameOk;
+
+            @try {
+                [self.protocol sendRPC:okMessage];
+            } @catch (NSException *exception) {
+                SDLLogE(@"Proxy: Failed to send RPC message: %@", message.name);
+            }
+
+            return YES;
+        } else if ([message.buttonName isEqualToEnum:SDLButtonNamePlayPause]) {
+            SDLSubscribeButton *okMessage = [message copy];
+            okMessage.buttonName = SDLButtonNameOk;
+
+            @try {
+                [self.protocol sendRPC:okMessage];
+            } @catch (NSException *exception) {
+                SDLLogE(@"Proxy: Failed to send RPC message: %@", message.name);
+            }
+
+            return YES;
+        }
+    }
+
+    return NO;
+}
+
+- (BOOL)sdl_adaptButtonUnsubscribeMessage:(SDLUnsubscribeButton *)message {
+    if ([SDLGlobals sharedGlobals].rpcVersion.majorVersion.intValue >= 5) {
+        if ([message.buttonName isEqualToEnum:SDLButtonNameOk]) {
+            SDLUnsubscribeButton *playPauseMessage = [message copy];
+            playPauseMessage.buttonName = SDLButtonNamePlayPause;
+
+            @try {
+                [self.protocol sendRPC:message];
+                [self.protocol sendRPC:playPauseMessage];
+            } @catch (NSException *exception) {
+                SDLLogE(@"Proxy: Failed to send RPC message: %@", message.name);
+            }
+
+            return YES;
+        } else if ([message.buttonName isEqualToEnum:SDLButtonNameOkay]) {
+            SDLUnsubscribeButton *okMessage = [message copy];
+            okMessage.buttonName = SDLButtonNameOk;
+
+            @try {
+                [self.protocol sendRPC:okMessage];
+            } @catch (NSException *exception) {
+                SDLLogE(@"Proxy: Failed to send RPC message: %@", message.name);
+            }
+
+            return YES;
+        } else if ([message.buttonName isEqualToEnum:SDLButtonNamePlayPause]) {
+            return NO;
+        }
+    } else {
+        if ([message.buttonName isEqualToEnum:SDLButtonNameOk]) {
+            return NO;
+        } else if ([message.buttonName isEqualToEnum:SDLButtonNameOkay]) {
+            SDLUnsubscribeButton *okMessage = [message copy];
+            okMessage.buttonName = SDLButtonNameOk;
+
+            @try {
+                [self.protocol sendRPC:okMessage];
+            } @catch (NSException *exception) {
+                SDLLogE(@"Proxy: Failed to send RPC message: %@", message.name);
+            }
+
+            return YES;
+        } else if ([message.buttonName isEqualToEnum:SDLButtonNamePlayPause]) {
+            SDLUnsubscribeButton *okMessage = [message copy];
+            okMessage.buttonName = SDLButtonNameOk;
+
+            @try {
+                [self.protocol sendRPC:okMessage];
+            } @catch (NSException *exception) {
+                SDLLogE(@"Proxy: Failed to send RPC message: %@", message.name);
+            }
+
+            return YES;
+        }
+    }
+
+    return NO;
+}
+#pragma clang diagnostic pop
+
+#pragma mark - Message Receiving
 
 - (void)handleProtocolMessage:(SDLProtocolMessage *)incomingMessage {
     // Convert protocol message to dictionary
@@ -298,9 +433,6 @@ static float DefaultConnectionTimeout = 45.0;
     NSString *functionClassName = [NSString stringWithFormat:@"SDL%@", functionName];
     SDLRPCMessage *newMessage = [[NSClassFromString(functionClassName) alloc] initWithDictionary:[dict mutableCopy]];
 
-    // Log the RPC message
-    SDLLogV(@"Message received: %@", newMessage);
-
     // Intercept and handle several messages ourselves
     if ([functionName isEqualToString:SDLNameOnAppInterfaceUnregistered] || [functionName isEqualToString:SDLNameUnregisterAppInterface]) {
         [self handleRPCUnregistered:dict];
@@ -322,10 +454,30 @@ static float DefaultConnectionTimeout = 45.0;
         [self handleSystemRequestResponse:newMessage];
     }
 
-    // Formulate the name of the method to call and invoke the method on the delegate(s)
-    NSString *handlerName = [NSString stringWithFormat:@"on%@:", functionName];
-    SEL handlerSelector = NSSelectorFromString(handlerName);
-    [self invokeMethodOnDelegates:handlerSelector withObject:newMessage];
+
+    if ([functionName isEqualToString:@"OnButtonPress"]) {
+        SDLOnButtonPress *message = (SDLOnButtonPress *)newMessage;
+        if ([SDLGlobals sharedGlobals].rpcVersion.majorVersion.intValue >= 5) {
+            BOOL handledRPC = [self sdl_handleOnButtonPressPostV5:message];
+            if (handledRPC) { return; }
+        } else { // RPC version of 4 or less (connected to an old head unit)
+            BOOL handledRPC = [self sdl_handleOnButtonPressPreV5:message];
+            if (handledRPC) { return; }
+        }
+    }
+
+    if ([functionName isEqualToString:@"OnButtonEvent"]) {
+        SDLOnButtonEvent *message = (SDLOnButtonEvent *)newMessage;
+        if ([SDLGlobals sharedGlobals].rpcVersion.majorVersion.intValue >= 5) {
+            BOOL handledRPC = [self sdl_handleOnButtonEventPostV5:message];
+            if (handledRPC) { return; }
+        } else {
+            BOOL handledRPC = [self sdl_handleOnButtonEventPreV5:message];
+            if (handledRPC) { return; }
+        }
+    }
+
+    [self sdl_invokeDelegateMethodsWithFunction:functionName message:newMessage];
 
     // When an OnHMIStatus notification comes in, after passing it on (above), generate an "OnLockScreenNotification"
     if ([functionName isEqualToString:@"OnHMIStatus"]) {
@@ -336,6 +488,13 @@ static float DefaultConnectionTimeout = 45.0;
     if ([functionName isEqualToString:@"OnDriverDistraction"]) {
         [self handleAfterDriverDistraction:newMessage];
     }
+}
+
+- (void)sdl_invokeDelegateMethodsWithFunction:(NSString *)functionName message:(SDLRPCMessage *)message {
+    // Formulate the name of the method to call and invoke the method on the delegate(s)
+    NSString *handlerName = [NSString stringWithFormat:@"on%@:", functionName];
+    SEL handlerSelector = NSSelectorFromString(handlerName);
+    [self invokeMethodOnDelegates:handlerSelector withObject:message];
 }
 
 
@@ -396,6 +555,97 @@ static float DefaultConnectionTimeout = 45.0;
 - (void)handleSystemRequestResponse:(SDLRPCMessage *)message {
     SDLLogV(@"SystemRequestResponse to be discarded");
 }
+
+#pragma mark BackCompatability ButtonName Helpers
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+- (BOOL)sdl_handleOnButtonPressPreV5:(SDLOnButtonPress *)message {
+    // Drop PlayPause, this shouldn't come in
+    if ([message.buttonName isEqualToEnum:SDLButtonNamePlayPause]) {
+        return YES;
+    } else if ([message.buttonName isEqualToEnum:SDLButtonNameOk]) {
+        // Send Ok, Okay, and Play/Pause notifications
+        SDLOnButtonPress *okayPress = [message copy];
+        okayPress.buttonName = SDLButtonNameOkay;
+
+        SDLOnButtonPress *playPausePress = [message copy];
+        playPausePress.buttonName = SDLButtonNamePlayPause;
+
+        [self sdl_invokeDelegateMethodsWithFunction:message.getFunctionName message:okayPress];
+        [self sdl_invokeDelegateMethodsWithFunction:message.getFunctionName message:playPausePress];
+        [self sdl_invokeDelegateMethodsWithFunction:message.getFunctionName message:message];
+        return YES;
+    }
+
+    return NO;
+}
+
+- (BOOL)sdl_handleOnButtonPressPostV5:(SDLOnButtonPress *)message {
+    if ([message.buttonName isEqualToEnum:SDLButtonNamePlayPause]) {
+        // Send PlayPause & OK notifications
+        SDLOnButtonPress *okPress = [message copy];
+        okPress.buttonName = SDLButtonNameOk;
+
+        [self sdl_invokeDelegateMethodsWithFunction:message.getFunctionName message:okPress];
+        [self sdl_invokeDelegateMethodsWithFunction:message.getFunctionName message:message];
+        return YES;
+    } else if ([message.buttonName isEqualToEnum:SDLButtonNameOk]) {
+        // Send Okay and OK notifications
+        SDLOnButtonPress *okayPress = [message copy];
+        okayPress.buttonName = SDLButtonNameOkay;
+
+        [self sdl_invokeDelegateMethodsWithFunction:message.getFunctionName message:okayPress];
+        [self sdl_invokeDelegateMethodsWithFunction:message.getFunctionName message:message];
+        return YES;
+    }
+
+    return NO;
+}
+
+- (BOOL)sdl_handleOnButtonEventPreV5:(SDLOnButtonEvent *)message {
+    // Drop PlayPause, this shouldn't come in
+    if ([message.buttonName isEqualToEnum:SDLButtonNamePlayPause]) {
+        return YES;
+    } else if ([message.buttonName isEqualToEnum:SDLButtonNameOk]) {
+        // Send Ok, Okay, and Play/Pause notifications
+        SDLOnButtonEvent *okayEvent = [message copy];
+        okayEvent.buttonName = SDLButtonNameOkay;
+
+        SDLOnButtonEvent *playPauseEvent = [message copy];
+        playPauseEvent.buttonName = SDLButtonNamePlayPause;
+
+        [self sdl_invokeDelegateMethodsWithFunction:message.getFunctionName message:okayEvent];
+        [self sdl_invokeDelegateMethodsWithFunction:message.getFunctionName message:playPauseEvent];
+        [self sdl_invokeDelegateMethodsWithFunction:message.getFunctionName message:message];
+        return YES;
+    }
+
+    return NO;
+}
+
+- (BOOL)sdl_handleOnButtonEventPostV5:(SDLOnButtonEvent *)message {
+    if ([message.buttonName isEqualToEnum:SDLButtonNamePlayPause]) {
+        // Send PlayPause & OK notifications
+        SDLOnButtonEvent *okEvent = [message copy];
+        okEvent.buttonName = SDLButtonNameOk;
+
+        [self sdl_invokeDelegateMethodsWithFunction:message.getFunctionName message:okEvent];
+        [self sdl_invokeDelegateMethodsWithFunction:message.getFunctionName message:message];
+        return YES;
+    } else if ([message.buttonName isEqualToEnum:SDLButtonNameOk]) {
+        // Send Okay and OK notifications
+        SDLOnButtonEvent *okayEvent = [message copy];
+        okayEvent.buttonName = SDLButtonNameOkay;
+
+        [self sdl_invokeDelegateMethodsWithFunction:message.getFunctionName message:okayEvent];
+        [self sdl_invokeDelegateMethodsWithFunction:message.getFunctionName message:message];
+        return YES;
+    }
+
+    return NO;
+}
+#pragma clang diagnostic pop
 
 
 #pragma mark Handle Post-Invoke of Delegate Methods

--- a/SmartDeviceLink/SDLProxy.m
+++ b/SmartDeviceLink/SDLProxy.m
@@ -303,34 +303,12 @@ static float DefaultConnectionTimeout = 45.0;
             }
 
             return YES;
-        } else if ([message.buttonName isEqualToEnum:SDLButtonNameOkay]) {
-            SDLSubscribeButton *okMessage = [message copy];
-            okMessage.buttonName = SDLButtonNameOk;
-
-            @try {
-                [self.protocol sendRPC:okMessage];
-            } @catch (NSException *exception) {
-                SDLLogE(@"Proxy: Failed to send RPC message: %@", message.name);
-            }
-
-            return YES;
         } else if ([message.buttonName isEqualToEnum:SDLButtonNamePlayPause]) {
             return NO;
         }
-    } else {
+    } else { // Major version < 5
         if ([message.buttonName isEqualToEnum:SDLButtonNameOk]) {
             return NO;
-        } else if ([message.buttonName isEqualToEnum:SDLButtonNameOkay]) {
-            SDLSubscribeButton *okMessage = [message copy];
-            okMessage.buttonName = SDLButtonNameOk;
-
-            @try {
-                [self.protocol sendRPC:okMessage];
-            } @catch (NSException *exception) {
-                SDLLogE(@"Proxy: Failed to send RPC message: %@", message.name);
-            }
-
-            return YES;
         } else if ([message.buttonName isEqualToEnum:SDLButtonNamePlayPause]) {
             SDLSubscribeButton *okMessage = [message copy];
             okMessage.buttonName = SDLButtonNameOk;
@@ -362,34 +340,12 @@ static float DefaultConnectionTimeout = 45.0;
             }
 
             return YES;
-        } else if ([message.buttonName isEqualToEnum:SDLButtonNameOkay]) {
-            SDLUnsubscribeButton *okMessage = [message copy];
-            okMessage.buttonName = SDLButtonNameOk;
-
-            @try {
-                [self.protocol sendRPC:okMessage];
-            } @catch (NSException *exception) {
-                SDLLogE(@"Proxy: Failed to send RPC message: %@", message.name);
-            }
-
-            return YES;
         } else if ([message.buttonName isEqualToEnum:SDLButtonNamePlayPause]) {
             return NO;
         }
-    } else {
+    } else { // Major version < 5
         if ([message.buttonName isEqualToEnum:SDLButtonNameOk]) {
             return NO;
-        } else if ([message.buttonName isEqualToEnum:SDLButtonNameOkay]) {
-            SDLUnsubscribeButton *okMessage = [message copy];
-            okMessage.buttonName = SDLButtonNameOk;
-
-            @try {
-                [self.protocol sendRPC:okMessage];
-            } @catch (NSException *exception) {
-                SDLLogE(@"Proxy: Failed to send RPC message: %@", message.name);
-            }
-
-            return YES;
         } else if ([message.buttonName isEqualToEnum:SDLButtonNamePlayPause]) {
             SDLUnsubscribeButton *okMessage = [message copy];
             okMessage.buttonName = SDLButtonNameOk;
@@ -565,14 +521,10 @@ static float DefaultConnectionTimeout = 45.0;
     if ([message.buttonName isEqualToEnum:SDLButtonNamePlayPause]) {
         return YES;
     } else if ([message.buttonName isEqualToEnum:SDLButtonNameOk]) {
-        // Send Ok, Okay, and Play/Pause notifications
-        SDLOnButtonPress *okayPress = [message copy];
-        okayPress.buttonName = SDLButtonNameOkay;
-
+        // Send Ok and Play/Pause notifications
         SDLOnButtonPress *playPausePress = [message copy];
         playPausePress.buttonName = SDLButtonNamePlayPause;
 
-        [self sdl_invokeDelegateMethodsWithFunction:message.getFunctionName message:okayPress];
         [self sdl_invokeDelegateMethodsWithFunction:message.getFunctionName message:playPausePress];
         [self sdl_invokeDelegateMethodsWithFunction:message.getFunctionName message:message];
         return YES;
@@ -591,11 +543,11 @@ static float DefaultConnectionTimeout = 45.0;
         [self sdl_invokeDelegateMethodsWithFunction:message.getFunctionName message:message];
         return YES;
     } else if ([message.buttonName isEqualToEnum:SDLButtonNameOk]) {
-        // Send Okay and OK notifications
-        SDLOnButtonPress *okayPress = [message copy];
-        okayPress.buttonName = SDLButtonNameOkay;
+        // Send PlayPause and OK notifications
+        SDLOnButtonPress *playPausePress = [message copy];
+        playPausePress.buttonName = SDLButtonNamePlayPause;
 
-        [self sdl_invokeDelegateMethodsWithFunction:message.getFunctionName message:okayPress];
+        [self sdl_invokeDelegateMethodsWithFunction:message.getFunctionName message:playPausePress];
         [self sdl_invokeDelegateMethodsWithFunction:message.getFunctionName message:message];
         return YES;
     }
@@ -608,14 +560,10 @@ static float DefaultConnectionTimeout = 45.0;
     if ([message.buttonName isEqualToEnum:SDLButtonNamePlayPause]) {
         return YES;
     } else if ([message.buttonName isEqualToEnum:SDLButtonNameOk]) {
-        // Send Ok, Okay, and Play/Pause notifications
-        SDLOnButtonEvent *okayEvent = [message copy];
-        okayEvent.buttonName = SDLButtonNameOkay;
-
+        // Send Ok and Play/Pause notifications
         SDLOnButtonEvent *playPauseEvent = [message copy];
         playPauseEvent.buttonName = SDLButtonNamePlayPause;
 
-        [self sdl_invokeDelegateMethodsWithFunction:message.getFunctionName message:okayEvent];
         [self sdl_invokeDelegateMethodsWithFunction:message.getFunctionName message:playPauseEvent];
         [self sdl_invokeDelegateMethodsWithFunction:message.getFunctionName message:message];
         return YES;
@@ -634,11 +582,11 @@ static float DefaultConnectionTimeout = 45.0;
         [self sdl_invokeDelegateMethodsWithFunction:message.getFunctionName message:message];
         return YES;
     } else if ([message.buttonName isEqualToEnum:SDLButtonNameOk]) {
-        // Send Okay and OK notifications
-        SDLOnButtonEvent *okayEvent = [message copy];
-        okayEvent.buttonName = SDLButtonNameOkay;
+        // Send PlayPause and OK notifications
+        SDLOnButtonEvent *playPauseEvent = [message copy];
+        playPauseEvent.buttonName = SDLButtonNamePlayPause;
 
-        [self sdl_invokeDelegateMethodsWithFunction:message.getFunctionName message:okayEvent];
+        [self sdl_invokeDelegateMethodsWithFunction:message.getFunctionName message:playPauseEvent];
         [self sdl_invokeDelegateMethodsWithFunction:message.getFunctionName message:message];
         return YES;
     }

--- a/SmartDeviceLink/SDLRPCMessage.h
+++ b/SmartDeviceLink/SDLRPCMessage.h
@@ -7,7 +7,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SDLRPCMessage : SDLRPCStruct {
+@interface SDLRPCMessage : SDLRPCStruct <NSCopying> {
     NSMutableDictionary<NSString *, id> *function;
     NSMutableDictionary<NSString *, id> *parameters;
     NSString *messageType;

--- a/SmartDeviceLink/SDLRPCMessage.m
+++ b/SmartDeviceLink/SDLRPCMessage.m
@@ -34,10 +34,13 @@ NS_ASSUME_NONNULL_BEGIN
             }
         }
         if (messageType != nil) {
-            function = [[store objectForKey:messageType] mutableCopy];
-            parameters = [[function objectForKey:SDLNameParameters] mutableCopy];
+            store[messageType] = [store[messageType] mutableCopy];
+            function = store[messageType];
+
+            function[SDLNameParameters] = [function[SDLNameParameters] mutableCopy];
+            parameters = function[SDLNameParameters];
         }
-        self.bulkData = [dict objectForKey:SDLNameBulkData];
+        self.bulkData = dict[SDLNameBulkData];
     }
     
     return self;
@@ -67,6 +70,12 @@ NS_ASSUME_NONNULL_BEGIN
     NSMutableString *description = [NSMutableString stringWithFormat:@"%@ (%@)\n%@", self.name, self.messageType, self->parameters];
 
     return description;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone {
+    SDLRPCMessage *newMessage = [[self.class allocWithZone:zone] initWithDictionary:self->store];
+
+    return newMessage;
 }
 
 @end

--- a/SmartDeviceLink/SDLRPCStruct.m
+++ b/SmartDeviceLink/SDLRPCStruct.m
@@ -75,9 +75,9 @@ NS_ASSUME_NONNULL_BEGIN
     return ret;
 }
 
--(id)copyWithZone:(nullable NSZone *)zone {
+- (id)copyWithZone:(nullable NSZone *)zone {
     SDLRPCStruct *newStruct = [[[self class] allocWithZone:zone] init];
-    newStruct->store = [self->store copy];
+    newStruct->store = [self->store mutableCopy];
 
     return newStruct;
 }

--- a/SmartDeviceLink/SDLRPCStruct.m
+++ b/SmartDeviceLink/SDLRPCStruct.m
@@ -31,10 +31,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSDictionary<NSString *, id> *)serializeAsDictionary:(Byte)version {
     if (version >= 2) {
-        NSString *messageType = [[store keyEnumerator] nextObject];
-        NSMutableDictionary<NSString *, id> *function = [store objectForKey:messageType];
+        NSString *messageType = store.keyEnumerator.nextObject;
+        NSMutableDictionary<NSString *, id> *function = store[messageType];
         if ([function isKindOfClass:NSMutableDictionary.class]) {
-            NSMutableDictionary<NSString *, id> *parameters = [function objectForKey:SDLNameParameters];
+            NSMutableDictionary<NSString *, id> *parameters = function[SDLNameParameters];
             return [self.class sdl_serializeDictionary:parameters version:version];
         } else {
             return [self.class sdl_serializeDictionary:store version:version];
@@ -50,26 +50,26 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSDictionary<NSString *, id> *)sdl_serializeDictionary:(NSDictionary *)dict version:(Byte)version {
     NSMutableDictionary<NSString *, id> *ret = [NSMutableDictionary dictionaryWithCapacity:dict.count];
-    for (NSString *key in [dict keyEnumerator]) {
-        NSObject *value = [dict objectForKey:key];
+    for (NSString *key in dict.keyEnumerator) {
+        NSObject *value = dict[key];
         if ([value isKindOfClass:SDLRPCStruct.class]) {
-            [ret setObject:[(SDLRPCStruct *)value serializeAsDictionary:version] forKey:key];
+            ret[key] = [(SDLRPCStruct *)value serializeAsDictionary:version];
         } else if ([value isKindOfClass:NSDictionary.class]) {
-            [ret setObject:[self sdl_serializeDictionary:(NSDictionary *)value version:version] forKey:key];
+            ret[key] = [self sdl_serializeDictionary:(NSDictionary *)value version:version];
         } else if ([value isKindOfClass:NSArray.class]) {
             NSArray<NSObject *> *arrayVal = (NSArray<NSObject *> *)value;
             
-            if (arrayVal.count > 0 && ([[arrayVal objectAtIndex:0] isKindOfClass:SDLRPCStruct.class])) {
+            if (arrayVal.count > 0 && ([arrayVal.firstObject isKindOfClass:SDLRPCStruct.class])) {
                 NSMutableArray<NSDictionary<NSString *, id> *> *serializedList = [NSMutableArray arrayWithCapacity:arrayVal.count];
                 for (SDLRPCStruct *serializeable in arrayVal) {
                     [serializedList addObject:[serializeable serializeAsDictionary:version]];
                 }
-                [ret setObject:serializedList forKey:key];
+                ret[key] = serializedList;
             } else {
-                [ret setObject:value forKey:key];
+                ret[key] = value;
             }
         } else {
-            [ret setObject:value forKey:key];
+            ret[key] = value;
         }
     }
     return ret;

--- a/SmartDeviceLink/SDLRegisterAppInterface.m
+++ b/SmartDeviceLink/SDLRegisterAppInterface.m
@@ -8,6 +8,7 @@
 #import "SDLAppHMIType.h"
 #import "SDLAppInfo.h"
 #import "SDLDeviceInfo.h"
+#import "SDLGlobals.h"
 #import "SDLLanguage.h"
 #import "SDLLifecycleConfiguration.h"
 #import "SDLNames.h"
@@ -52,8 +53,11 @@ NS_ASSUME_NONNULL_BEGIN
     self.appID = appId;
     self.languageDesired = languageDesired;
     self.hmiDisplayLanguageDesired = languageDesired;
-    
-    self.syncMsgVersion = [[SDLSyncMsgVersion alloc] initWithMajorVersion:5 minorVersion:0 patchVersion:0];
+
+    UInt8 majorVersion = (UInt8)[SDLMaxProxyRPCVersion substringWithRange:NSMakeRange(0, 1)].intValue;
+    UInt8 minorVersion = (UInt8)[SDLMaxProxyRPCVersion substringWithRange:NSMakeRange(2, 1)].intValue;
+    UInt8 patchVersion = (UInt8)[SDLMaxProxyRPCVersion substringWithRange:NSMakeRange(4, 1)].intValue;
+    self.syncMsgVersion = [[SDLSyncMsgVersion alloc] initWithMajorVersion:majorVersion minorVersion:minorVersion patchVersion:patchVersion];
     self.appInfo = [SDLAppInfo currentAppInfo];
     self.deviceInfo = [SDLDeviceInfo currentDevice];
     self.correlationID = @1;

--- a/SmartDeviceLink/SDLRegisterAppInterfaceResponse.m
+++ b/SmartDeviceLink/SDLRegisterAppInterfaceResponse.m
@@ -135,7 +135,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (nullable SDLVehicleType *)vehicleType {
-    return [parameters sdl_objectForName:SDLNameVehicleType ofClass:SDLVehicleType.class];
+    return [parameters sdl_objectForName:SDLNameVehicleType ofClass:[SDLVehicleType class]];
 }
 
 - (void)setSupportedDiagModes:(nullable NSArray<NSNumber<SDLInt> *> *)supportedDiagModes {

--- a/SmartDeviceLink/SDLResponseDispatcher.m
+++ b/SmartDeviceLink/SDLResponseDispatcher.m
@@ -226,6 +226,8 @@ NS_ASSUME_NONNULL_BEGIN
     } else if ([rpcNotification isMemberOfClass:[SDLOnButtonPress class]]) {
         name = ((SDLOnButtonPress *)rpcNotification).buttonName;
         customID = ((SDLOnButtonPress *)rpcNotification).customButtonID;
+    } else {
+        return;
     }
 
     NSArray<SDLRPCButtonNotificationHandler> *handlers = nil;

--- a/SmartDeviceLink/SDLResponseDispatcher.m
+++ b/SmartDeviceLink/SDLResponseDispatcher.m
@@ -239,9 +239,13 @@ NS_ASSUME_NONNULL_BEGIN
         handler = self.buttonHandlerMap[name];
     }
 
-    if ([rpcNotification isMemberOfClass:[SDLOnButtonEvent class]] && handler != nil) {
+    if (handler == nil) {
+        return;
+    }
+
+    if ([rpcNotification isMemberOfClass:[SDLOnButtonEvent class]]) {
         handler(nil, rpcNotification);
-    } else if ([rpcNotification isMemberOfClass:[SDLOnButtonPress class]] && handler != nil) {
+    } else if ([rpcNotification isMemberOfClass:[SDLOnButtonPress class]]) {
         handler(rpcNotification, nil);
     }
 }

--- a/SmartDeviceLink/SDLV2ProtocolMessage.m
+++ b/SmartDeviceLink/SDLV2ProtocolMessage.m
@@ -36,8 +36,8 @@ NS_ASSUME_NONNULL_BEGIN
     // Create the inner dictionary with the RPC properties
     NSMutableDictionary <NSString *, id> *innerDictionary = [[NSMutableDictionary alloc] init];
     NSString *functionName = [[SDLFunctionID sharedInstance] functionNameForId:rpcPayload.functionID];
-    [innerDictionary setObject:functionName forKey:SDLNameOperationName];
-    [innerDictionary setObject:[NSNumber numberWithUnsignedInt:rpcPayload.correlationID] forKey:SDLNameCorrelationId];
+    innerDictionary[SDLNameOperationName] = functionName;
+    innerDictionary[SDLNameCorrelationId] = @(rpcPayload.correlationID);
 
     // Get the json data from the struct
     if (rpcPayload.jsonData) {

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleManagerSpec.m
@@ -8,6 +8,7 @@
 #import "SDLConnectionManagerType.h"
 #import "SDLError.h"
 #import "SDLFileManager.h"
+#import "SDLGlobals.h"
 #import "SDLHMILevel.h"
 #import "SDLLifecycleConfiguration.h"
 #import "SDLLockScreenConfiguration.h"

--- a/SmartDeviceLinkTests/ProtocolSpecs/MessageSpecs/SDLV2ProtocolMessageSpec.m
+++ b/SmartDeviceLinkTests/ProtocolSpecs/MessageSpecs/SDLV2ProtocolMessageSpec.m
@@ -17,41 +17,7 @@
 QuickSpecBegin(SDLV2ProtocolMessageSpec)
 
 describe(@"RPCDictionary Tests", ^ {
-    it(@"Should return the correct dictionary", ^ {
-        SDLServiceType serviceType = SDLServiceTypeRPC;
-        
-        SDLV2ProtocolHeader* testHeader = [[SDLV2ProtocolHeader alloc] init];
-        id headerMock = OCMPartialMock(testHeader);
-        [[[headerMock stub] andReturnValue:[NSValue value:&serviceType withObjCType:@encode(SDLServiceType)]] serviceType];
-        
-        NSDictionary* dictionary = @{@"A": @1,
-                                     @"B": @2,
-                                     @"C": @3,
-                                     @"D": @4,
-                                     @"E": @5};
-        UInt32 correlationID = 99;
-        UInt32 functionID = 26;
-        Byte rpcType = 0;
-        
-        SDLRPCPayload* testPayload = [[SDLRPCPayload alloc] init];
-        id payloadMock = OCMPartialMock(testPayload);
-        [[[payloadMock stub] andReturn:[NSJSONSerialization dataWithJSONObject:dictionary options:0 error:0]] jsonData];
-        [[[payloadMock stub] andReturnValue:[NSValue value:&correlationID withObjCType:@encode(UInt32)]] correlationID];
-        [[[payloadMock stub] andReturnValue:[NSValue value:&functionID withObjCType:@encode(UInt32)]] functionID];
-        [[[payloadMock stub] andReturnValue:[NSValue value:&rpcType withObjCType:@encode(Byte)]] rpcType];
-        [[[payloadMock stub] andReturn:[NSData dataWithBytes:"Database" length:strlen("Database")]] binaryData];
-        
-        id payloadClassMock = OCMClassMock(SDLRPCPayload.class);
-        [[[payloadClassMock stub] andReturn:testPayload] rpcPayloadWithData:[OCMArg any]];
-        
-        SDLV2ProtocolMessage* testMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testHeader andPayload:[[NSMutableData alloc] initWithCapacity:0]];
-        
-        expect([testMessage rpcDictionary]).to(equal(@{SDLNameRequest:
-                                                           @{SDLNameOperationName:SDLNameSlider,
-                                                             SDLNameCorrelationId:@99,
-                                                             SDLNameParameters:dictionary},
-                                                       SDLNameBulkData:[NSData dataWithBytes:"Database" length:strlen("Database")]}));
-    });
+    
 });
 
 QuickSpecEnd

--- a/SmartDeviceLinkTests/UtilitiesSpecs/SDLGlobalsSpec.m
+++ b/SmartDeviceLinkTests/UtilitiesSpecs/SDLGlobalsSpec.m
@@ -13,20 +13,20 @@ describe(@"The SDLGlobals class", ^{
     });
     
     describe(@"when just initialized", ^{
-        it(@"should properly set protocol version", ^{
+        it(@"should properly set parameters", ^{
             expect(testGlobals.protocolVersion).to(equal(@"1.0.0"));
-        });
-
-        it(@"should properly set the major protocol version", ^{
             expect(testGlobals.majorProtocolVersion).to(equal(1));
-        });
-        
-        it(@"should properly set max head unit version", ^{
             expect(testGlobals.maxHeadUnitVersion).to(equal(@"0.0.0"));
-        });
-        
-        it(@"should give the v1 MTU size", ^{
             expect([testGlobals mtuSizeForServiceType:SDLServiceTypeRPC]).to(equal(SDLV1MTUSize));
+            expect(testGlobals.rpcVersion).to(equal([[SDLSyncMsgVersion alloc] initWithMajorVersion:1 minorVersion:0 patchVersion:0]));
+        });
+    });
+
+    describe(@"setting the RPC version", ^{
+        it(@"should properly set", ^{
+            testGlobals.rpcVersion = [[SDLSyncMsgVersion alloc] initWithMajorVersion:4 minorVersion:2 patchVersion:3];
+
+            expect(testGlobals.rpcVersion).to(equal([[SDLSyncMsgVersion alloc] initWithMajorVersion:4 minorVersion:2 patchVersion:3]));
         });
     });
     


### PR DESCRIPTION
Fixes #246 

This PR is **not ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Unit tests will be updated, smoke tests performed. Note that `SDLProxy.m` is not tested, so the majority of this update will not be tested via unit tests.

### Summary
This PR adds the `PlayPause` button name. In order to support this enum, the `Okay` button name also must be added and compatibility code added to `SDLProxy`.

### Changelog
##### Enhancements
* `PlayPause` and `Okay` button names added, while `Ok` button name was deprecated.

### Tasks Remaining:
- [x] Unit tests
- [x] Smoke tests on Manticore (v4 Core)
- [x] Smoke tests on Sync Gen 3 (v3/4-ish Core)
- [x] Smoke tests on v5 Core.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
