### PR TITLE
fix of crash NSRangeException

### DIFF
--- a/SmartDeviceLink/SDLAsynchronousRPCRequestOperation.m
+++ b/SmartDeviceLink/SDLAsynchronousRPCRequestOperation.m
@@ -122,7 +122,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (self.isFinished) { return; }
     self.requestFailed = YES;
 
-    for (NSUInteger i = self.requestsComplete; i <= self.requests.count; i++) {
+    for (NSUInteger i = self.requestsComplete; i < self.requests.count; i++) {
         if (self.progressHandler != NULL) {
             self.progressHandler(self.requests[i], nil, [NSError sdl_lifecycle_multipleRequestsCancelled], self.percentComplete);
         }

--- a/SmartDeviceLinkTests/TestUtilities/TestMultipleRequestsConnectionManager.h
+++ b/SmartDeviceLinkTests/TestUtilities/TestMultipleRequestsConnectionManager.h
@@ -13,6 +13,11 @@
 @interface TestMultipleRequestsConnectionManager : TestConnectionManager
 
 /**
+ *  While the flag is a true, completion will not be called
+ */
+@property (nonatomic, assign) BOOL isPendingCompletion;
+
+/**
  *  A response and error to pass into the last request's block
  */
 @property (copy, nonatomic) NSMutableDictionary *responses;


### PR DESCRIPTION

Fixes https://github.com/smartdevicelink/sdl_ios/issues/1076

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
Add unit test to handle the situation 

### Summary
PR fixed an issue when sdl_abortOperationWithRequest called when an operation is isCancelled but not is isFinished, and try to call progressHandler in a for-each cycle then try to get a request for the array by index is equal requests.count.
##### Bug Fixes
`<` instend of `<=`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)