### PR TITLE
Fix out of range exception and failure to cancel Asynchronous RPC Operation

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "Quick/Nimble" "v7.0.3"
-github "Quick/Quick" "v1.2.0"
-github "erikdoe/ocmock" "v3.4.1"
+github "Quick/Nimble" "v7.3.0"
+github "Quick/Quick" "v1.3.1"
+github "erikdoe/ocmock" "v3.4.2"
 github "facebook/ios-snapshot-test-case" "2.1.4"

--- a/SmartDeviceLink/SDLAsynchronousRPCRequestOperation.m
+++ b/SmartDeviceLink/SDLAsynchronousRPCRequestOperation.m
@@ -80,7 +80,7 @@ NS_ASSUME_NONNULL_BEGIN
     for (SDLRPCRequest *request in self.requests) {
         if (self.isCancelled) {
             [self sdl_abortOperationWithRequest:request];
-            break;
+            return;
         }
 
         [self sdl_sendRequest:request];
@@ -119,16 +119,19 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)sdl_abortOperationWithRequest:(SDLRPCRequest *)request {
-    if (self.isFinished) { return; }
     self.requestFailed = YES;
 
-    for (NSUInteger i = self.requestsComplete; i <= self.requests.count; i++) {
+    for (NSUInteger i = self.requestsComplete; i < self.requests.count; i++) {
         if (self.progressHandler != NULL) {
             self.progressHandler(self.requests[i], nil, [NSError sdl_lifecycle_multipleRequestsCancelled], self.percentComplete);
         }
 
         if (self.responseHandler != NULL) {
             self.responseHandler(request, nil, [NSError sdl_lifecycle_multipleRequestsCancelled]);
+        }
+
+        if (self.completionHandler != NULL) {
+            self.completionHandler(NO);
         }
     }
 

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLAsynchronousRPCRequestOperationSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLAsynchronousRPCRequestOperationSpec.m
@@ -74,7 +74,7 @@ describe(@"sending asynchronous requests", ^{
             }
         });
 
-        fit(@"should fail correctly", ^{
+        it(@"should fail correctly", ^{
             testOperation = [[SDLAsynchronousRPCRequestOperation alloc] initWithConnectionManager:testConnectionManager requests:[sendRequests copy] progressHandler:^(__kindof SDLRPCRequest * _Nonnull request, __kindof SDLRPCResponse * _Nullable response, NSError * _Nullable error, float percentComplete) {
                 expect(percentComplete).to(beCloseTo(0));
                 expect(response).to(beNil());

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLAsynchronousRPCRequestOperationSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLAsynchronousRPCRequestOperationSpec.m
@@ -17,7 +17,7 @@ describe(@"sending asynchronous requests", ^{
 
     __block NSMutableArray<SDLAddCommand *> *sendRequests = nil;
     __block NSMutableDictionary<NSNumber<SDLInt> *, TestRequestProgressResponse *> *testProgressResponses;
-    __block NSMutableArray<SDLRPCResponse *> *resultResponses = [NSMutableArray array];
+    __block NSMutableArray<SDLRPCResponse *> *resultResponses = nil;
 
     beforeEach(^{
         testOperation = nil;
@@ -25,6 +25,7 @@ describe(@"sending asynchronous requests", ^{
 
         sendRequests = [NSMutableArray array];
         testProgressResponses = [NSMutableDictionary dictionary];
+        resultResponses = [NSMutableArray array];
 
         testOperationQueue = [[NSOperationQueue alloc] init];
         testOperationQueue.name = @"com.sdl.asynchronousRPCOp.testqueue";
@@ -59,6 +60,32 @@ describe(@"sending asynchronous requests", ^{
 
             [testOperationQueue addOperation:testOperation];
             [NSThread sleepForTimeInterval:0.5];
+        });
+    });
+
+    context(@"when request are cancelled", ^{
+        beforeEach(^{
+            for (int i = 0; i < 3; i++) {
+                SDLAddCommand *addCommand = [[SDLAddCommand alloc] init];
+                addCommand.correlationID = @(i);
+                [sendRequests addObject:addCommand];
+
+                testProgressResponses[addCommand.correlationID] = [[TestRequestProgressResponse alloc] initWithCorrelationId:addCommand.correlationID percentComplete:((float)(i+1)/3.0) error:nil];
+            }
+        });
+
+        fit(@"should fail correctly", ^{
+            testOperation = [[SDLAsynchronousRPCRequestOperation alloc] initWithConnectionManager:testConnectionManager requests:[sendRequests copy] progressHandler:^(__kindof SDLRPCRequest * _Nonnull request, __kindof SDLRPCResponse * _Nullable response, NSError * _Nullable error, float percentComplete) {
+                expect(percentComplete).to(beCloseTo(0));
+                expect(response).to(beNil());
+                expect(error).toNot(beNil());
+                expect(error.code).to(equal(-8));
+            } completionHandler:^(BOOL success) {
+                expect(success).to(beFalsy());
+            }];
+
+            [testOperationQueue addOperation:testOperation];
+            [testOperationQueue cancelAllOperations];
         });
     });
 


### PR DESCRIPTION
Fixes #1076

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Unit tests have been added

### Summary
Fix possible crashes in SDLAsynchronousRPCOperation on cancellation of operations.

### Changelog
##### Bug Fixes
* Fix possible crashes in SDLAsynchronousRPCOperation on cancellation of operations.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)