### PR TITLE
Fix VRSessions blocking the execution of the choice set manager queue

### DIFF
--- a/SmartDeviceLink/SDLChoiceSetManager.m
+++ b/SmartDeviceLink/SDLChoiceSetManager.m
@@ -427,7 +427,6 @@ UInt16 const ChoiceCellIdMin = 1;
     }
 
     // We need to check for this to make sure we can currently present the dialog. If the current context is HMI_OBSCURED or ALERT, we have to wait for MAIN to present
-    SDLSystemContext oldSystemContext = self.currentSystemContext;
     self.currentSystemContext = hmiStatus.systemContext;
 
     if ([self.currentSystemContext isEqualToEnum:SDLSystemContextHMIObscured] || [self.currentSystemContext isEqualToEnum:SDLSystemContextAlert]) {

--- a/SmartDeviceLink/SDLChoiceSetManager.m
+++ b/SmartDeviceLink/SDLChoiceSetManager.m
@@ -434,9 +434,7 @@ UInt16 const ChoiceCellIdMin = 1;
         self.transactionQueue.suspended = YES;
     }
 
-    if (([oldSystemContext isEqualToEnum:SDLSystemContextHMIObscured] || [oldSystemContext isEqualToEnum:SDLSystemContextAlert])
-        && [self.currentSystemContext isEqualToEnum:SDLSystemContextMain]
-        && ![self.currentHMILevel isEqualToEnum:SDLHMILevelNone]) {
+    if ([self.currentSystemContext isEqualToEnum:SDLSystemContextMain] && ![self.currentHMILevel isEqualToEnum:SDLHMILevelNone]) {
         self.transactionQueue.suspended = NO;
     }
 }


### PR DESCRIPTION
Fixes #1081 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Smoke tested

### Summary
When a VR session would engage, the system would suspend the choice set queue without unsuspending it after completion in some cases.

### Changelog
No changes to previous versions of the library (all internal to 6.1 code)

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
