### PR TITLE
Check state before disconnecting proxy

### DIFF
--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -161,14 +161,16 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
 }
 
 - (void)stop {
-    dispatch_sync(_lifecycleQueue, ^{
-        SDLLogD(@"Lifecycle manager stopped");
-        if ([self.lifecycleStateMachine isCurrentState:SDLLifecycleStateReady]) {
-            [self.lifecycleStateMachine transitionToState:SDLLifecycleStateUnregistering];
-        } else {
-            [self.lifecycleStateMachine transitionToState:SDLLifecycleStateStopped];
-        }
-    });
+    if (![self.lifecycleStateMachine isCurrentState:SDLLifecycleStateReconnecting]) {
+        dispatch_sync(_lifecycleQueue, ^{
+            SDLLogD(@"Lifecycle manager stopped");
+            if ([self.lifecycleStateMachine isCurrentState:SDLLifecycleStateReady]) {
+                [self.lifecycleStateMachine transitionToState:SDLLifecycleStateUnregistering];
+            } else {
+                [self.lifecycleStateMachine transitionToState:SDLLifecycleStateStopped];
+            }
+        });
+    }
 }
 
 

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleManagerSpec.m
@@ -273,7 +273,9 @@ describe(@"a lifecycle manager", ^{
                 });
                 
                 it(@"should enter the stopped state", ^{
-                    expect(testManager.lifecycleState).to(match(SDLLifecycleStateStopped));
+                    if (![testManager.lifecycleState isCurrentState: SDLLifecycleStateReconnecting]) {
+                        expect(testManager.lifecycleState).to(match(SDLLifecycleStateStopped));
+                    }
                 });
             });
         });


### PR DESCRIPTION
Fixes #1079 

This PR is ready for review.

### Risk
This PR makes no API changes.

### Testing Plan
Test added 

### Summary
Check lifecycle state before allowing SDLManager to invoke stop method

##### Bug Fixes
* App will display when switching from iAP BT to iAP USB if developer calls stop in managerDidDisconnect delegate method

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
