### PR TITLE
WIP: Fixed the lifecycle manager reconnecting after an `onAppInterfaceUnregistered` notification

### DIFF
--- a/SmartDeviceLink/SDLAppInterfaceUnregisteredReason.h
+++ b/SmartDeviceLink/SDLAppInterfaceUnregisteredReason.h
@@ -43,7 +43,7 @@ extern SDLAppInterfaceUnregisteredReason const SDLAppInterfaceUnregisteredReason
 extern SDLAppInterfaceUnregisteredReason const SDLAppInterfaceUnregisteredReasonDriverDistractionViolation;
 
 /**
- *  The user performed a language change on the SDL platform, causing the application to need to be reregistered for the new language.
+ * The user performed a language change on the SDL platform, causing the application to need to be reregistered for the new language.
  */
 extern SDLAppInterfaceUnregisteredReason const SDLAppInterfaceUnregisteredReasonLanguageChange;
 
@@ -58,8 +58,15 @@ extern SDLAppInterfaceUnregisteredReason const SDLAppInterfaceUnregisteredReason
 extern SDLAppInterfaceUnregisteredReason const SDLAppInterfaceUnregisteredReasonFactoryDefaults;
 
 /**
- * The app is not being authorized to be connected to SDL.
+ * The app is not authorized to be connected to SDL.
  *
  * @since SDL 2.0
  */
 extern SDLAppInterfaceUnregisteredReason const SDLAppInterfaceUnregisteredReasonAppUnauthorized;
+
+/**
+ * The app has committed a protocol violation.
+ *
+ * @since SDL 4.0
+ */
+extern SDLAppInterfaceUnregisteredReason const SDLAppInterfaceUnregisteredReasonProtocolViolation;

--- a/SmartDeviceLink/SDLAppInterfaceUnregisteredReason.m
+++ b/SmartDeviceLink/SDLAppInterfaceUnregisteredReason.m
@@ -14,3 +14,4 @@ SDLAppInterfaceUnregisteredReason const SDLAppInterfaceUnregisteredReasonLanguag
 SDLAppInterfaceUnregisteredReason const SDLAppInterfaceUnregisteredReasonMasterReset = @"MASTER_RESET";
 SDLAppInterfaceUnregisteredReason const SDLAppInterfaceUnregisteredReasonFactoryDefaults = @"FACTORY_DEFAULTS";
 SDLAppInterfaceUnregisteredReason const SDLAppInterfaceUnregisteredReasonAppUnauthorized = @"APP_UNAUTHORIZED";
+SDLAppInterfaceUnregisteredReason const SDLAppInterfaceUnregisteredReasonProtocolViolation = @"PROTOCOL_VIOLATION";

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -719,7 +719,7 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
         [self sdl_transitionToState:SDLLifecycleStateStopped];
     } else if ([self.lifecycleStateMachine isCurrentState:SDLLifecycleStateStopped]) {
         return;
-    } else if ([appUnregisteredNotification.reason isKindOfClass:[NSString class]] && [appUnregisteredNotification.reason isEqualToEnum:SDLAppInterfaceUnregisteredReasonAppUnauthorized]) {
+    } else if ([appUnregisteredNotification.reason isKindOfClass:[NSString class]] && ([appUnregisteredNotification.reason isEqualToEnum:SDLAppInterfaceUnregisteredReasonAppUnauthorized] || [appUnregisteredNotification.reason isEqualToEnum:SDLAppInterfaceUnregisteredReasonProtocolViolation])) {
         // HAX: The string check is due to a core "feature" that could cause -1 to be sent as the enum value, which will crash here.
         [self sdl_transitionToState:SDLLifecycleStateStopped];
     } else {

--- a/SmartDeviceLink/SDLProxy.m
+++ b/SmartDeviceLink/SDLProxy.m
@@ -395,6 +395,9 @@ static float DefaultConnectionTimeout = 45.0;
     NSString *functionClassName = [NSString stringWithFormat:@"SDL%@", functionName];
     SDLRPCMessage *newMessage = [[NSClassFromString(functionClassName) alloc] initWithDictionary:[dict mutableCopy]];
 
+    // Log the RPC message
+    SDLLogV(@"Message received: %@", newMessage);
+
     // Intercept and handle several messages ourselves
     if ([functionName isEqualToString:SDLNameOnAppInterfaceUnregistered] || [functionName isEqualToString:SDLNameUnregisterAppInterface]) {
         [self handleRPCUnregistered:dict];

--- a/SmartDeviceLinkTests/RPCSpecs/EnumSpecs/SDLAppInterfaceUnregisteredReasonSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/EnumSpecs/SDLAppInterfaceUnregisteredReasonSpec.m
@@ -27,7 +27,7 @@ describe(@"Individual Enum Value Tests", ^ {
         expect(SDLAppInterfaceUnregisteredReasonMasterReset).to(equal(@"MASTER_RESET"));
         expect(SDLAppInterfaceUnregisteredReasonFactoryDefaults).to(equal(@"FACTORY_DEFAULTS"));
         expect(SDLAppInterfaceUnregisteredReasonAppUnauthorized).to(equal(@"APP_UNAUTHORIZED"));
-        //expect(SDLAppInterfaceUnregisteredReason PROTOCOL_VIOLATION).to(equal(@"PROTOCOL_VIOLATION"));
+        expect(SDLAppInterfaceUnregisteredReasonProtocolViolation).to(equal(@"PROTOCOL_VIOLATION"));
     });
 });
 


### PR DESCRIPTION
Fixes #1097 

This PR is **not ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Added test case to the _SDLAppInterfaceUnregisteredReasonSpec_

### Summary
Fixed the lifecycle manager reconnecting to Core after receiving a `OnAppInterfaceUnregistered` notification with a reason code of `PROTOCOL_VIOLATION`.

### Changelog
##### Bug Fixes
* The lifecycle manager now stops when it receives an `OnAppInterfaceUnregistered` notification with a reason code of `PROTOCOL_VIOLATION`.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)