### PR TITLE
[SDL-0196] Support Static Icon in Screen Manager

### DIFF
--- a/Example Apps/Example ObjC/ButtonManager.m
+++ b/Example Apps/Example ObjC/ButtonManager.m
@@ -73,7 +73,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (SDLSoftButtonObject *)sdlex_softButtonAlertWithManager:(SDLManager *)manager {
-    SDLSoftButtonState *alertImageAndTextState = [[SDLSoftButtonState alloc] initWithStateName:AlertSoftButtonImageState text:AlertSoftButtonText image:[[UIImage imageNamed:AlertBWIconName] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate]];
+    SDLSoftButtonState *alertImageAndTextState = [[SDLSoftButtonState alloc] initWithStateName:AlertSoftButtonImageState text:AlertSoftButtonText artwork:[SDLArtwork artworkWithImage:[[UIImage imageNamed:CarBWIconImageName] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate] asImageFormat:SDLArtworkImageFormatPNG]];
     SDLSoftButtonState *alertTextState = [[SDLSoftButtonState alloc] initWithStateName:AlertSoftButtonTextState text:AlertSoftButtonText image:nil];
 
     __weak typeof(self) weakself = self;

--- a/Example Apps/Example ObjC/PerformInteractionManager.m
+++ b/Example Apps/Example ObjC/PerformInteractionManager.m
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (NSArray<SDLChoiceCell *> *)cells {
-    SDLChoiceCell *firstChoice = [[SDLChoiceCell alloc] initWithText:PICSFirstChoice];
+    SDLChoiceCell *firstChoice = [[SDLChoiceCell alloc] initWithText:PICSFirstChoice artwork:[SDLArtwork artworkWithStaticIcon:SDLStaticIconNameKey] voiceCommands:nil];
     SDLChoiceCell *secondChoice = [[SDLChoiceCell alloc] initWithText:PICSSecondChoice];
     SDLChoiceCell *thirdChoice = [[SDLChoiceCell alloc] initWithText:PICSThirdChoice];
 

--- a/Example Apps/Example Swift/PerformInteractionManager.swift
+++ b/Example Apps/Example Swift/PerformInteractionManager.swift
@@ -30,9 +30,9 @@ class PerformInteractionManager: NSObject {
 private extension PerformInteractionManager {
     /// The PICS menu items
     var choiceCells: [SDLChoiceCell] {
-        let firstChoice = SDLChoiceCell(text: PICSFirstChoice, artwork: nil, voiceCommands: nil)
-        let secondChoice = SDLChoiceCell(text: PICSSecondChoice, artwork: nil, voiceCommands: nil)
-        let thirdChoice = SDLChoiceCell(text: PICSThirdChoice, artwork: nil, voiceCommands: nil)
+        let firstChoice = SDLChoiceCell(text: PICSFirstChoice, artwork: SDLArtwork(staticIcon: .key), voiceCommands: nil)
+        let secondChoice = SDLChoiceCell(text: PICSSecondChoice)
+        let thirdChoice = SDLChoiceCell(text: PICSThirdChoice)
         return [firstChoice, secondChoice, thirdChoice]
     }
 

--- a/SmartDeviceLink/SDLArtwork.h
+++ b/SmartDeviceLink/SDLArtwork.h
@@ -9,6 +9,7 @@
 #import <UIKit/UIKit.h>
 
 #import "SDLFile.h"
+#import "SDLStaticIconName.h"
 
 typedef NS_ENUM(NSUInteger, SDLArtworkImageFormat) {
     SDLArtworkImageFormatPNG,
@@ -58,6 +59,15 @@ NS_ASSUME_NONNULL_BEGIN
  *  @return An instance of this class to be passed to the file manager.
  */
 + (instancetype)artworkWithImage:(UIImage *)image asImageFormat:(SDLArtworkImageFormat)imageFormat NS_SWIFT_UNAVAILABLE("Use the standard initializer and set persistant to false");
+
+/**
+ Create an SDLArtwork that represents a static icon. This can only be passed to the screen manager; passing this directly to the file manager will fail.
+
+ @param staticIcon The static icon to be shown on the remote system.
+
+ @return An instance of this class to be passed to a screen manager.
+ */
++ (instancetype)artworkWithStaticIcon:(SDLStaticIconName)staticIcon NS_SWIFT_UNAVAILABLE("Use the standard initializer");
 
 /**
  *  Convenience helper to create a persistent artwork from an image.
@@ -114,6 +124,15 @@ NS_ASSUME_NONNULL_BEGIN
  *  @return An instance of this class to be passed to the file manager.
  */
 - (instancetype)initWithImage:(UIImage *)image persistent:(BOOL)persistent asImageFormat:(SDLArtworkImageFormat)imageFormat;
+
+/**
+ Create an SDLArtwork that represents a static icon. This can only be passed to the screen manager; passing this directly to the file manager will fail.
+
+ @param staticIcon The static icon to be shown on the remote system.
+
+ @return An instance of this class to be passed to a screen manager.
+ */
+- (instancetype)initWithStaticIcon:(SDLStaticIconName)staticIcon;
 
 @end
 

--- a/SmartDeviceLink/SDLArtwork.h
+++ b/SmartDeviceLink/SDLArtwork.h
@@ -11,6 +11,8 @@
 #import "SDLFile.h"
 #import "SDLStaticIconName.h"
 
+@class SDLImage;
+
 typedef NS_ENUM(NSUInteger, SDLArtworkImageFormat) {
     SDLArtworkImageFormatPNG,
     SDLArtworkImageFormatJPG
@@ -26,6 +28,11 @@ NS_ASSUME_NONNULL_BEGIN
  *  @discussion An image should be templated if it is intended to be used as an icon in a button or menu.
  */
 @property (assign, nonatomic, readonly) BOOL isTemplate;
+
+/**
+ The Image RPC representing this artwork. Generally for use internally, you should instead pass an artwork to a Screen Manager method.
+ */
+@property (strong, nonatomic, readonly) SDLImage *imageRPC;
 
 /**
  *  Convenience helper to create an ephemeral artwork from an image.

--- a/SmartDeviceLink/SDLArtwork.m
+++ b/SmartDeviceLink/SDLArtwork.m
@@ -16,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (strong, nonatomic) UIImage *image;
 @property (assign, nonatomic, readwrite) BOOL isTemplate;
+@property (assign, nonatomic, readwrite) BOOL isStaticIcon;
 
 @end
 
@@ -35,6 +36,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (instancetype)artworkWithImage:(UIImage *)image asImageFormat:(SDLArtworkImageFormat)imageFormat {
     return [[self alloc] initWithImage:image persistent:NO asImageFormat:imageFormat];
+}
+
++ (instancetype)artworkWithStaticIcon:(SDLStaticIconName)staticIcon {
+    return [[self alloc] initWithStaticIcon:staticIcon];
 }
 
 + (instancetype)persistentArtworkWithImage:(UIImage *)image name:(NSString *)name asImageFormat:(SDLArtworkImageFormat)imageFormat {
@@ -58,6 +63,13 @@ NS_ASSUME_NONNULL_BEGIN
     NSData *imageData = [self.class sdl_dataForUIImage:image imageFormat:imageFormat];
     NSString *imageName = [self.class sdl_md5HashFromNSData:imageData];
     return [super initWithData:[self.class sdl_dataForUIImage:image imageFormat:imageFormat] name:(imageName != nil ? imageName : @"") fileExtension:[self.class sdl_fileExtensionForImageFormat:imageFormat] persistent:persistent];
+}
+
+- (instancetype)initWithStaticIcon:(SDLStaticIconName)staticIcon {
+    self = [super initWithData:[staticIcon dataUsingEncoding:NSASCIIStringEncoding] name:staticIcon fileExtension:@"" persistent:NO];
+    self.isStaticIcon = true;
+
+    return self;
 }
 
 /**

--- a/SmartDeviceLink/SDLArtwork.m
+++ b/SmartDeviceLink/SDLArtwork.m
@@ -177,6 +177,10 @@ NS_ASSUME_NONNULL_BEGIN
     return haveEqualNames && haveEqualData && haveEqualFormats;
 }
 
+- (NSString *)description {
+    return [NSString stringWithFormat:@"SDLArtwork name: %@, image: %@, isTemplate: %@, isStaticIcon: %@", self.name, self.image, (self.isTemplate ? @"YES" : @"NO"), (self.isStaticIcon ? @"YES" : @"NO")];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLArtwork.m
+++ b/SmartDeviceLink/SDLArtwork.m
@@ -6,27 +6,29 @@
 //  Copyright © 2015 smartdevicelink. All rights reserved.
 //
 
-#import "SDLArtwork.h"
-#import "SDLFileType.h"
 #import <CommonCrypto/CommonDigest.h>
 
+#import "SDLArtwork.h"
+#import "SDLFileType.h"
+#import "SDLImage.h"
+
 NS_ASSUME_NONNULL_BEGIN
+
+@interface SDLFile ()
+
+@property (assign, nonatomic, readwrite) BOOL isStaticIcon;
+
+@end
 
 @interface SDLArtwork ()
 
 @property (strong, nonatomic) UIImage *image;
 @property (assign, nonatomic, readwrite) BOOL isTemplate;
-@property (assign, nonatomic, readwrite) BOOL isStaticIcon;
 
 @end
 
 
 @implementation SDLArtwork
-
-- (void)setImage:(UIImage *)image {
-    _image = image;
-    _isTemplate = (image.renderingMode == UIImageRenderingModeAlwaysTemplate);
-}
 
 #pragma mark - Lifecycle
 
@@ -71,6 +73,23 @@ NS_ASSUME_NONNULL_BEGIN
 
     return self;
 }
+
+#pragma mark - Setters and Getters
+
+- (void)setImage:(UIImage *)image {
+    _image = image;
+    _isTemplate = (image.renderingMode == UIImageRenderingModeAlwaysTemplate);
+}
+
+- (SDLImage *)imageRPC {
+    if (self.isStaticIcon) {
+        return [[SDLImage alloc] initWithStaticIconName:self.name];
+    } else {
+        return [[SDLImage alloc] initWithName:self.name isTemplate:self.isTemplate];
+    }
+}
+
+#pragma mark - Helper Methods
 
 /**
  * Returns the JPG or PNG image data for a UIImage.

--- a/SmartDeviceLink/SDLChoiceSet.m
+++ b/SmartDeviceLink/SDLChoiceSet.m
@@ -129,6 +129,10 @@ static SDLChoiceSetLayout _defaultLayout = SDLChoiceSetLayoutList;
     return [NSString stringWithFormat:@"SDLChoiceSet: \"%@\", layout: %@", _title, (_layout == SDLChoiceSetLayoutList ? @"List" : @"Tiles")];
 }
 
+- (NSString *)debugDescription {
+    return [NSString stringWithFormat:@"SDLChoiceSet: Title: \"%@\", layout: %@, timeout: %@, initial prompt: \"%@\", timeout prompt: \"%@\", help prompt: \"%@\", help list: %@, choices: %@", _title, (_layout == SDLChoiceSetLayoutList ? @"List" : @"Tiles"), @(_timeout), _initialPrompt, _timeoutPrompt, _helpPrompt, _helpList, _choices];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLChoiceSetManager.m
+++ b/SmartDeviceLink/SDLChoiceSetManager.m
@@ -22,7 +22,6 @@
 #import "SDLError.h"
 #import "SDLFileManager.h"
 #import "SDLHMILevel.h"
-#import "SDLImage.h"
 #import "SDLKeyboardProperties.h"
 #import "SDLLogMacros.h"
 #import "SDLOnHMIStatus.h"
@@ -280,7 +279,12 @@ UInt16 const ChoiceCellIdMin = 1;
     }
 
     self.pendingPresentationSet = choiceSet;
-    [self preloadChoices:self.pendingPresentationSet.choices withCompletionHandler:nil];
+    [self preloadChoices:self.pendingPresentationSet.choices withCompletionHandler:^(NSError * _Nullable error) {
+        if (error != nil) {
+            [choiceSet.delegate choiceSet:choiceSet didReceiveError:error];
+            return;
+        }
+    }];
 
     [self sdl_findIdsOnChoiceSet:self.pendingPresentationSet];
 

--- a/SmartDeviceLink/SDLChoiceSetManager.m
+++ b/SmartDeviceLink/SDLChoiceSetManager.m
@@ -404,11 +404,17 @@ UInt16 const ChoiceCellIdMin = 1;
 
 - (void)sdl_registerResponse:(SDLRPCResponseNotification *)notification {
     SDLRegisterAppInterfaceResponse *response = (SDLRegisterAppInterfaceResponse *)notification.response;
+
+    if (!response.success.boolValue) { return; }
+
     self.displayCapabilities = response.displayCapabilities;
 }
 
 - (void)sdl_displayLayoutResponse:(SDLRPCResponseNotification *)notification {
     SDLSetDisplayLayoutResponse *response = (SDLSetDisplayLayoutResponse *)notification.response;
+
+    if (!response.success.boolValue) { return; }
+
     self.displayCapabilities = response.displayCapabilities;
 }
 

--- a/SmartDeviceLink/SDLError.h
+++ b/SmartDeviceLink/SDLError.h
@@ -50,6 +50,7 @@ extern SDLErrorDomain *const SDLErrorDomainTransport;
 + (NSError *)sdl_fileManager_fileDoesNotExistError;
 + (NSError *)sdl_fileManager_fileUploadCanceled;
 + (NSError *)sdl_fileManager_dataMissingError;
++ (NSError *)sdl_fileManager_staticIconError;
 
 #pragma mark Show Managers
 

--- a/SmartDeviceLink/SDLError.m
+++ b/SmartDeviceLink/SDLError.m
@@ -177,6 +177,15 @@ SDLErrorDomain *const SDLErrorDomainTransport = @"com.sdl.transport.error";
     return [NSError errorWithDomain:SDLErrorDomainFileManager code:SDLFileManagerErrorFileDataMissing userInfo:userInfo];
 }
 
++ (NSError *)sdl_fileManager_staticIconError {
+    NSDictionary<NSString *, NSString *> *userInfo = @{
+                                                       NSLocalizedDescriptionKey: NSLocalizedString(@"The file upload was canceled", nil),
+                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"The file is a static icon, which cannot be uploaded", nil),
+                                                       NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"Stop trying to upload a static icon, set it via the screen manager or create an SDLImage instead", nil)
+                                                       };
+    return [NSError errorWithDomain:SDLErrorDomainFileManager code:SDLFileManagerErrorStaticIcon userInfo:userInfo];
+}
+
 #pragma mark SDLUploadFileOperation
 
 + (NSError *)sdl_fileManager_fileDoesNotExistError {

--- a/SmartDeviceLink/SDLErrorConstants.h
+++ b/SmartDeviceLink/SDLErrorConstants.h
@@ -86,6 +86,10 @@ typedef NS_ENUM(NSInteger, SDLFileManagerError) {
      *  The file data is nil or empty.
      */
     SDLFileManagerErrorFileDataMissing = -9,
+    /*
+     *  The file is a static icon, which cannot be uploaded
+     */
+    SDLFileManagerErrorStaticIcon = -10,
 };
 
 /**

--- a/SmartDeviceLink/SDLFile.h
+++ b/SmartDeviceLink/SDLFile.h
@@ -55,6 +55,15 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, readonly) NSInputStream *inputStream;
 
+/**
+ Describes whether or not this file is represented by static icon data. The head unit will present its representation of the static icon concept when sent this data.
+
+ A file that represents a static icon may not be uploaded via the File Manager. It must be set using the Screen Manager.
+
+ Support for this feature may vary by system, but it will generally be more supported in soft buttons and menus.
+ */
+@property (assign, nonatomic, readonly) BOOL isStaticIcon;
+
 - (instancetype)init NS_UNAVAILABLE;
 
 /**

--- a/SmartDeviceLink/SDLFile.m
+++ b/SmartDeviceLink/SDLFile.m
@@ -24,6 +24,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (copy, nonatomic, readwrite) NSString *name;
 
 @property (nonatomic, readwrite) NSInputStream *inputStream;
+
+@property (assign, nonatomic, readwrite) BOOL isStaticIcon;
+
 @end
 
 

--- a/SmartDeviceLink/SDLFileManager.m
+++ b/SmartDeviceLink/SDLFileManager.m
@@ -351,6 +351,13 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
         return;
     }
 
+    if (file.isStaticIcon) {
+        if (handler != nil) {
+            handler(NO, self.bytesAvailable, [NSError sdl_fileManager_staticIconError]);
+        }
+        return;
+    }
+
     // Make sure we are able to send files
     if (![self.currentState isEqualToString:SDLFileManagerStateReady]) {
         if (handler != nil) {

--- a/SmartDeviceLink/SDLMenuManager.m
+++ b/SmartDeviceLink/SDLMenuManager.m
@@ -283,7 +283,7 @@ UInt32 const MenuCellIdMin = 1;
 
     NSMutableSet<SDLArtwork *> *mutableArtworks = [NSMutableSet set];
     for (SDLMenuCell *cell in cells) {
-        if (cell.icon != nil && ![self.fileManager hasUploadedFile:cell.icon]) {
+        if ([self sdl_artworkNeedsUpload:cell.icon]) {
             [mutableArtworks addObject:cell.icon];
         }
 
@@ -293,6 +293,10 @@ UInt32 const MenuCellIdMin = 1;
     }
 
     return [mutableArtworks allObjects];
+}
+
+- (BOOL)sdl_artworkNeedsUpload:(SDLArtwork *)artwork {
+    return (artwork != nil && ![self.fileManager hasUploadedFile:artwork] && !artwork.isStaticIcon);
 }
 
 #pragma mark IDs
@@ -374,14 +378,14 @@ UInt32 const MenuCellIdMin = 1;
 
     command.menuParams = params;
     command.vrCommands = cell.voiceCommands;
-    command.cmdIcon = (cell.icon && shouldHaveArtwork) ? [[SDLImage alloc] initWithName:cell.icon.name isTemplate:cell.icon.isTemplate] : nil;
+    command.cmdIcon = (cell.icon && shouldHaveArtwork) ? cell.icon.imageRPC : nil;
     command.cmdID = @(cell.cellId);
 
     return command;
 }
 
 - (SDLAddSubMenu *)sdl_subMenuCommandForMenuCell:(SDLMenuCell *)cell withArtwork:(BOOL)shouldHaveArtwork position:(UInt16)position {
-    SDLImage *icon = (shouldHaveArtwork && (cell.icon.name != nil)) ? [[SDLImage alloc] initWithName:cell.icon.name isTemplate:cell.icon.isTemplate] : nil;
+    SDLImage *icon = (shouldHaveArtwork && (cell.icon.name != nil)) ? cell.icon.imageRPC : nil;
     return [[SDLAddSubMenu alloc] initWithId:cell.cellId menuName:cell.title menuIcon:icon position:(UInt8)position];
 }
 

--- a/SmartDeviceLink/SDLPreloadChoicesOperation.m
+++ b/SmartDeviceLink/SDLPreloadChoicesOperation.m
@@ -81,11 +81,13 @@ NS_ASSUME_NONNULL_BEGIN
 
     NSMutableArray<SDLArtwork *> *artworksToUpload = [NSMutableArray arrayWithCapacity:self.cellsToUpload.count];
     for (SDLChoiceCell *cell in self.cellsToUpload) {
-        if ([self.displayCapabilities hasImageFieldOfName:SDLImageFieldNameChoiceImage]) {
-            cell.artwork != nil ? [artworksToUpload addObject:cell.artwork] : nil;
+        if ([self.displayCapabilities hasImageFieldOfName:SDLImageFieldNameChoiceImage]
+            && ![self sdl_artworkNeedsUpload:cell.artwork]) {
+            [artworksToUpload addObject:cell.artwork];
         }
-        if ([self.displayCapabilities hasImageFieldOfName:SDLImageFieldNameChoiceSecondaryImage]) {
-            cell.secondaryArtwork != nil ? [artworksToUpload addObject:cell.secondaryArtwork] : nil;
+        if ([self.displayCapabilities hasImageFieldOfName:SDLImageFieldNameChoiceSecondaryImage]
+            && ![self sdl_artworkNeedsUpload:cell.artwork]) {
+            [artworksToUpload addObject:cell.secondaryArtwork];
         }
     }
 
@@ -107,6 +109,10 @@ NS_ASSUME_NONNULL_BEGIN
     }];
 }
 
+- (BOOL)sdl_artworkNeedsUpload:(SDLArtwork *)artwork {
+    return (!artwork || [self.fileManager hasUploadedFile:artwork] || artwork.isStaticIcon);
+}
+
 - (void)sdl_preloadCells {
     _currentState = SDLPreloadChoicesOperationStatePreloadingChoices;
 
@@ -123,7 +129,7 @@ NS_ASSUME_NONNULL_BEGIN
         }
     } completionHandler:^(BOOL success) {
         if (!success) {
-            SDLLogW(@"Error preloading choice cells: %@", errors);
+            SDLLogE(@"Error preloading choice cells: %@", errors);
             weakSelf.internalError = [NSError sdl_choiceSetManager_choiceUploadFailed:errors];
         }
 
@@ -147,8 +153,8 @@ NS_ASSUME_NONNULL_BEGIN
     NSString *secondaryText = [self.displayCapabilities hasTextFieldOfName:SDLTextFieldNameSecondaryText] ? cell.secondaryText : nil;
     NSString *tertiaryText = [self.displayCapabilities hasTextFieldOfName:SDLTextFieldNameTertiaryText] ? cell.tertiaryText : nil;
 
-    SDLImage *image = ([self.displayCapabilities hasImageFieldOfName:SDLImageFieldNameChoiceImage] && cell.artwork != nil) ? [[SDLImage alloc] initWithName:cell.artwork.name isTemplate:cell.artwork.isTemplate] : nil;
-    SDLImage *secondaryImage = ([self.displayCapabilities hasImageFieldOfName:SDLImageFieldNameChoiceSecondaryImage] && cell.secondaryArtwork != nil) ? [[SDLImage alloc] initWithName:cell.secondaryArtwork.name isTemplate:cell.secondaryArtwork.isTemplate] : nil;
+    SDLImage *image = ([self.displayCapabilities hasImageFieldOfName:SDLImageFieldNameChoiceImage] && cell.artwork != nil) ? cell.artwork.imageRPC : nil;
+    SDLImage *secondaryImage = ([self.displayCapabilities hasImageFieldOfName:SDLImageFieldNameChoiceSecondaryImage] && cell.secondaryArtwork != nil) ? cell.secondaryArtwork.imageRPC : nil;
 
     SDLChoice *choice = [[SDLChoice alloc] initWithId:cell.choiceId menuName:(NSString *_Nonnull)menuName vrCommands:(NSArray<NSString *> * _Nonnull)vrCommands image:image secondaryText:secondaryText secondaryImage:secondaryImage tertiaryText:tertiaryText];
 

--- a/SmartDeviceLink/SDLPreloadChoicesOperation.m
+++ b/SmartDeviceLink/SDLPreloadChoicesOperation.m
@@ -86,7 +86,7 @@ NS_ASSUME_NONNULL_BEGIN
             [artworksToUpload addObject:cell.artwork];
         }
         if ([self.displayCapabilities hasImageFieldOfName:SDLImageFieldNameChoiceSecondaryImage]
-            && [self sdl_artworkNeedsUpload:cell.artwork]) {
+            && [self sdl_artworkNeedsUpload:cell.secondaryArtwork]) {
             [artworksToUpload addObject:cell.secondaryArtwork];
         }
     }

--- a/SmartDeviceLink/SDLPreloadChoicesOperation.m
+++ b/SmartDeviceLink/SDLPreloadChoicesOperation.m
@@ -82,11 +82,11 @@ NS_ASSUME_NONNULL_BEGIN
     NSMutableArray<SDLArtwork *> *artworksToUpload = [NSMutableArray arrayWithCapacity:self.cellsToUpload.count];
     for (SDLChoiceCell *cell in self.cellsToUpload) {
         if ([self.displayCapabilities hasImageFieldOfName:SDLImageFieldNameChoiceImage]
-            && ![self sdl_artworkNeedsUpload:cell.artwork]) {
+            && [self sdl_artworkNeedsUpload:cell.artwork]) {
             [artworksToUpload addObject:cell.artwork];
         }
         if ([self.displayCapabilities hasImageFieldOfName:SDLImageFieldNameChoiceSecondaryImage]
-            && ![self sdl_artworkNeedsUpload:cell.artwork]) {
+            && [self sdl_artworkNeedsUpload:cell.artwork]) {
             [artworksToUpload addObject:cell.secondaryArtwork];
         }
     }
@@ -110,7 +110,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (BOOL)sdl_artworkNeedsUpload:(SDLArtwork *)artwork {
-    return (!artwork || [self.fileManager hasUploadedFile:artwork] || artwork.isStaticIcon);
+    return (artwork != nil && ![self.fileManager hasUploadedFile:artwork] && !artwork.isStaticIcon);
 }
 
 - (void)sdl_preloadCells {

--- a/SmartDeviceLink/SDLSoftButtonManager.m
+++ b/SmartDeviceLink/SDLSoftButtonManager.m
@@ -268,7 +268,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSMutableArray<SDLArtwork *> *initialStatesToBeUploaded = [NSMutableArray array];
     // Upload all soft button images, the initial state images first, then the other states. We need to send updates when the initial state is ready.
     for (SDLSoftButtonObject *object in self.softButtonObjects) {
-        if (![self sdl_artworkNeedsUpload:object.currentState.artwork]) {
+        if ([self sdl_artworkNeedsUpload:object.currentState.artwork]) {
             [initialStatesToBeUploaded addObject:object.currentState.artwork];
         }
     }
@@ -293,7 +293,7 @@ NS_ASSUME_NONNULL_BEGIN
     for (SDLSoftButtonObject *object in self.softButtonObjects) {
         for (SDLSoftButtonState *state in object.states) {
             if ([state.name isEqualToString:object.currentState.name]) { continue; }
-            if (![self sdl_artworkNeedsUpload:object.currentState.artwork]) {
+            if ([self sdl_artworkNeedsUpload:state.artwork]) {
                 [otherStatesToBeUploaded addObject:state.artwork];
             }
         }
@@ -314,7 +314,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (BOOL)sdl_artworkNeedsUpload:(SDLArtwork *)artwork {
-    return (!artwork || [self.fileManager hasUploadedFile:artwork] || artwork.isStaticIcon);
+    return (artwork != nil && ![self.fileManager hasUploadedFile:artwork] && !artwork.isStaticIcon);
 }
 
 #pragma mark - Creating Soft Buttons

--- a/SmartDeviceLink/SDLSoftButtonManager.m
+++ b/SmartDeviceLink/SDLSoftButtonManager.m
@@ -359,12 +359,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)sdl_registerResponse:(SDLRPCResponseNotification *)notification {
     SDLRegisterAppInterfaceResponse *response = (SDLRegisterAppInterfaceResponse *)notification.response;
+
+    if (!response.success.boolValue) { return; }
+
     self.softButtonCapabilities = response.softButtonCapabilities ? response.softButtonCapabilities.firstObject : nil;
     self.displayCapabilities = response.displayCapabilities;
 }
 
 - (void)sdl_displayLayoutResponse:(SDLRPCResponseNotification *)notification {
     SDLSetDisplayLayoutResponse *response = (SDLSetDisplayLayoutResponse *)notification.response;
+
+    if (!response.success.boolValue) { return; }
 
     self.softButtonCapabilities = response.softButtonCapabilities ? response.softButtonCapabilities.firstObject : nil;
     self.displayCapabilities = response.displayCapabilities;

--- a/SmartDeviceLink/SDLSoftButtonManager.m
+++ b/SmartDeviceLink/SDLSoftButtonManager.m
@@ -249,7 +249,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)sdl_allCurrentStateImagesAreUploaded {
     for (SDLSoftButtonObject *button in self.softButtonObjects) {
         SDLArtwork *artwork = button.currentState.artwork;
-        if (artwork != nil && ![self.fileManager hasUploadedFile:artwork]) {
+        if (artwork != nil && ![self.fileManager hasUploadedFile:artwork] && !artwork.isStaticIcon) {
             return NO;
         }
     }
@@ -268,7 +268,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSMutableArray<SDLArtwork *> *initialStatesToBeUploaded = [NSMutableArray array];
     // Upload all soft button images, the initial state images first, then the other states. We need to send updates when the initial state is ready.
     for (SDLSoftButtonObject *object in self.softButtonObjects) {
-        if (object.currentState.artwork != nil && ![self.fileManager hasUploadedFile:object.currentState.artwork]) {
+        if (![self sdl_isArtworkUploadedOrNonExistent:object.currentState.artwork]) {
             [initialStatesToBeUploaded addObject:object.currentState.artwork];
         }
     }
@@ -293,7 +293,7 @@ NS_ASSUME_NONNULL_BEGIN
     for (SDLSoftButtonObject *object in self.softButtonObjects) {
         for (SDLSoftButtonState *state in object.states) {
             if ([state.name isEqualToString:object.currentState.name]) { continue; }
-            if (state.artwork != nil && ![self.fileManager hasUploadedFile:state.artwork]) {
+            if (![self sdl_isArtworkUploadedOrNonExistent:object.currentState.artwork]) {
                 [otherStatesToBeUploaded addObject:state.artwork];
             }
         }
@@ -311,6 +311,10 @@ NS_ASSUME_NONNULL_BEGIN
             [self sdl_updateWithCompletionHandler:nil];
         }];
     }
+}
+
+- (BOOL)sdl_isArtworkUploadedOrNonExistent:(SDLArtwork *)artwork {
+    return (!artwork || [self.fileManager hasUploadedFile:artwork] || artwork.isStaticIcon);
 }
 
 #pragma mark - Creating Soft Buttons

--- a/SmartDeviceLink/SDLSoftButtonManager.m
+++ b/SmartDeviceLink/SDLSoftButtonManager.m
@@ -268,7 +268,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSMutableArray<SDLArtwork *> *initialStatesToBeUploaded = [NSMutableArray array];
     // Upload all soft button images, the initial state images first, then the other states. We need to send updates when the initial state is ready.
     for (SDLSoftButtonObject *object in self.softButtonObjects) {
-        if (![self sdl_isArtworkUploadedOrNonExistent:object.currentState.artwork]) {
+        if (![self sdl_artworkNeedsUpload:object.currentState.artwork]) {
             [initialStatesToBeUploaded addObject:object.currentState.artwork];
         }
     }
@@ -293,7 +293,7 @@ NS_ASSUME_NONNULL_BEGIN
     for (SDLSoftButtonObject *object in self.softButtonObjects) {
         for (SDLSoftButtonState *state in object.states) {
             if ([state.name isEqualToString:object.currentState.name]) { continue; }
-            if (![self sdl_isArtworkUploadedOrNonExistent:object.currentState.artwork]) {
+            if (![self sdl_artworkNeedsUpload:object.currentState.artwork]) {
                 [otherStatesToBeUploaded addObject:state.artwork];
             }
         }
@@ -313,7 +313,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
-- (BOOL)sdl_isArtworkUploadedOrNonExistent:(SDLArtwork *)artwork {
+- (BOOL)sdl_artworkNeedsUpload:(SDLArtwork *)artwork {
     return (!artwork || [self.fileManager hasUploadedFile:artwork] || artwork.isStaticIcon);
 }
 

--- a/SmartDeviceLink/SDLSoftButtonState.m
+++ b/SmartDeviceLink/SDLSoftButtonState.m
@@ -71,11 +71,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable SDLImage *)image {
     if (self.artwork == nil) { return nil; }
 
-    if (self.artwork.isStaticIcon) {
-        return [[SDLImage alloc] initWithStaticIconName:self.artwork.name];
-    } else {
-        return [[SDLImage alloc] initWithName:self.artwork.name ofType:SDLImageTypeDynamic isTemplate:self.artwork.isTemplate];
-    }
+    return self.artwork.imageRPC;
 }
 
 - (NSString *)description {

--- a/SmartDeviceLink/SDLSoftButtonState.m
+++ b/SmartDeviceLink/SDLSoftButtonState.m
@@ -71,7 +71,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable SDLImage *)image {
     if (self.artwork == nil) { return nil; }
 
-    return [[SDLImage alloc] initWithName:self.artwork.name ofType:SDLImageTypeDynamic isTemplate:self.artwork.isTemplate];
+    if (self.artwork.isStaticIcon) {
+        return [[SDLImage alloc] initWithStaticIconName:self.artwork.name];
+    } else {
+        return [[SDLImage alloc] initWithName:self.artwork.name ofType:SDLImageTypeDynamic isTemplate:self.artwork.isTemplate];
+    }
 }
 
 - (NSString *)description {

--- a/SmartDeviceLink/SDLTextAndGraphicManager.m
+++ b/SmartDeviceLink/SDLTextAndGraphicManager.m
@@ -175,7 +175,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         // Start uploading the images
         __block SDLShow *thisUpdate = fullShow;
-        [self sdl_uploadImagesWithCompletionHandler:^(NSError * _Nonnull error) {
+        [self sdl_uploadImagesWithCompletionHandler:^(NSError *_Nullable error) {
             __strong typeof(weakSelf) strongSelf = weakSelf;
 
             if (error != nil) {
@@ -463,8 +463,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable SDLShow *)sdl_createImageOnlyShowWithPrimaryArtwork:(nullable SDLArtwork *)primaryArtwork secondaryArtwork:(nullable SDLArtwork *)secondaryArtwork  {
     SDLShow *newShow = [[SDLShow alloc] init];
-    newShow.graphic = [self sdl_artworkNeedsUpload:primaryArtwork] ? [self sdl_imageFromArtwork:primaryArtwork] : nil;
-    newShow.secondaryGraphic = [self sdl_artworkNeedsUpload:secondaryArtwork] ? [self sdl_imageFromArtwork:secondaryArtwork] : nil;
+    newShow.graphic = [self sdl_artworkNeedsUpload:primaryArtwork] ? primaryArtwork.imageRPC : nil;
+    newShow.secondaryGraphic = [self sdl_artworkNeedsUpload:secondaryArtwork] ? secondaryArtwork.imageRPC : nil;
 
     if (newShow.graphic == nil && newShow.secondaryGraphic == nil) {
         SDLLogV(@"No graphics to upload");

--- a/SmartDeviceLink/SDLTextAndGraphicManager.m
+++ b/SmartDeviceLink/SDLTextAndGraphicManager.m
@@ -688,11 +688,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)sdl_registerResponse:(SDLRPCResponseNotification *)notification {
     SDLRegisterAppInterfaceResponse *response = (SDLRegisterAppInterfaceResponse *)notification.response;
+
+    if (!response.success.boolValue) { return; }
+
     self.displayCapabilities = response.displayCapabilities;
 }
 
 - (void)sdl_displayLayoutResponse:(SDLRPCResponseNotification *)notification {
     SDLSetDisplayLayoutResponse *response = (SDLSetDisplayLayoutResponse *)notification.response;
+
+    if (!response.success.boolValue) { return; }
+
     self.displayCapabilities = response.displayCapabilities;
 
     // Auto-send an updated show

--- a/SmartDeviceLink/SDLTextAndGraphicManager.m
+++ b/SmartDeviceLink/SDLTextAndGraphicManager.m
@@ -162,7 +162,7 @@ NS_ASSUME_NONNULL_BEGIN
         SDLLogV(@"No images to send, sending text");
         // If there are no images to update, just send the text
         self.inProgressUpdate = [self sdl_extractTextFromShow:fullShow];
-    } else if ([self sdl_isArtworkUploadedOrNonExistent:self.primaryGraphic] && [self sdl_isArtworkUploadedOrNonExistent:self.secondaryGraphic]) {
+    } else if ([self sdl_artworkNeedsUpload:self.primaryGraphic] && [self sdl_artworkNeedsUpload:self.secondaryGraphic]) {
         SDLLogV(@"Images already uploaded, sending full update");
         // The files to be updated are already uploaded, send the full show immediately
         self.inProgressUpdate = fullShow;
@@ -471,8 +471,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable SDLShow *)sdl_createImageOnlyShowWithPrimaryArtwork:(nullable SDLArtwork *)primaryArtwork secondaryArtwork:(nullable SDLArtwork *)secondaryArtwork  {
     SDLShow *newShow = [[SDLShow alloc] init];
-    newShow.graphic = [self sdl_isArtworkUploadedOrNonExistent:primaryArtwork] ? [self sdl_imageFromArtwork:primaryArtwork] : nil;
-    newShow.secondaryGraphic = [self sdl_isArtworkUploadedOrNonExistent:secondaryArtwork] ? [self sdl_imageFromArtwork:secondaryArtwork] : nil;
+    newShow.graphic = [self sdl_artworkNeedsUpload:primaryArtwork] ? [self sdl_imageFromArtwork:primaryArtwork] : nil;
+    newShow.secondaryGraphic = [self sdl_artworkNeedsUpload:secondaryArtwork] ? [self sdl_imageFromArtwork:secondaryArtwork] : nil;
 
     if (newShow.graphic == nil && newShow.secondaryGraphic == nil) {
         SDLLogV(@"No graphics to upload");
@@ -503,7 +503,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param artwork     The artwork to be uploaded to Core
  *  @return            True if the artwork does not need to be uploaded to Core; false if artwork stills needs to be sent to Core.
  */
-- (BOOL)sdl_isArtworkUploadedOrNonExistent:(SDLArtwork *)artwork {
+- (BOOL)sdl_artworkNeedsUpload:(SDLArtwork *)artwork {
     return (!artwork || [self.fileManager hasUploadedFile:artwork] || artwork.isStaticIcon);
 }
 

--- a/SmartDeviceLink/SDLTextAndGraphicManager.m
+++ b/SmartDeviceLink/SDLTextAndGraphicManager.m
@@ -263,21 +263,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     if ([self sdl_shouldUpdatePrimaryImage]) {
-        show.graphic = [self sdl_imageFromArtwork:self.primaryGraphic];
+        show.graphic = self.primaryGraphic.imageRPC;
     }
     if ([self sdl_shouldUpdateSecondaryImage]) {
-        show.secondaryGraphic = [self sdl_imageFromArtwork:self.secondaryGraphic];
+        show.secondaryGraphic = self.secondaryGraphic.imageRPC;
     }
 
     return show;
-}
-
-- (SDLImage *)sdl_imageFromArtwork:(SDLArtwork *)artwork {
-    if (artwork.isStaticIcon) {
-        return [[SDLImage alloc] initWithStaticIconName:artwork.name];
-    } else {
-        return [[SDLImage alloc] initWithName:self.primaryGraphic.name ofType:SDLImageTypeDynamic isTemplate:artwork.isTemplate];
-    }
 }
 
 #pragma mark Text

--- a/SmartDeviceLink/SDLTextAndGraphicManager.m
+++ b/SmartDeviceLink/SDLTextAndGraphicManager.m
@@ -162,7 +162,7 @@ NS_ASSUME_NONNULL_BEGIN
         SDLLogV(@"No images to send, sending text");
         // If there are no images to update, just send the text
         self.inProgressUpdate = [self sdl_extractTextFromShow:fullShow];
-    } else if ([self sdl_artworkNeedsUpload:self.primaryGraphic] && [self sdl_artworkNeedsUpload:self.secondaryGraphic]) {
+    } else if (![self sdl_artworkNeedsUpload:self.primaryGraphic] && ![self sdl_artworkNeedsUpload:self.secondaryGraphic]) {
         SDLLogV(@"Images already uploaded, sending full update");
         // The files to be updated are already uploaded, send the full show immediately
         self.inProgressUpdate = fullShow;
@@ -463,8 +463,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable SDLShow *)sdl_createImageOnlyShowWithPrimaryArtwork:(nullable SDLArtwork *)primaryArtwork secondaryArtwork:(nullable SDLArtwork *)secondaryArtwork  {
     SDLShow *newShow = [[SDLShow alloc] init];
-    newShow.graphic = [self sdl_artworkNeedsUpload:primaryArtwork] ? primaryArtwork.imageRPC : nil;
-    newShow.secondaryGraphic = [self sdl_artworkNeedsUpload:secondaryArtwork] ? secondaryArtwork.imageRPC : nil;
+    newShow.graphic = ![self sdl_artworkNeedsUpload:primaryArtwork] ? primaryArtwork.imageRPC : nil;
+    newShow.secondaryGraphic = ![self sdl_artworkNeedsUpload:secondaryArtwork] ? secondaryArtwork.imageRPC : nil;
 
     if (newShow.graphic == nil && newShow.secondaryGraphic == nil) {
         SDLLogV(@"No graphics to upload");
@@ -489,14 +489,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Helpers
 
-/**
- *  Checks if an artwork needs to be uploaded to Core.
- *
- *  @param artwork     The artwork to be uploaded to Core
- *  @return            True if the artwork does not need to be uploaded to Core; false if artwork stills needs to be sent to Core.
- */
 - (BOOL)sdl_artworkNeedsUpload:(SDLArtwork *)artwork {
-    return (!artwork || [self.fileManager hasUploadedFile:artwork] || artwork.isStaticIcon);
+    return (artwork != nil && ![self.fileManager hasUploadedFile:artwork] && !artwork.isStaticIcon);
 }
 
 - (BOOL)sdl_shouldUpdatePrimaryImage {

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLArtworkSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLArtworkSpec.m
@@ -12,7 +12,7 @@
 
 QuickSpecBegin(SDLArtworkSpec)
 
-fdescribe(@"SDLArtwork Tests", ^{
+describe(@"SDLArtwork Tests", ^{
     __block SDLArtwork *expectedArtwork = nil;
     __block SDLImage *expectedImage = nil;
     __block NSData *expectedImageData = nil;

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLArtworkSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLArtworkSpec.m
@@ -3,6 +3,8 @@
 
 #import "SDLArtwork.h"
 #import "SDLFileType.h"
+#import "SDLImage.h"
+#import "SDLStaticIconName.h"
 
 @interface SDLArtwork()
 + (NSString *)sdl_md5HashFromNSData:(NSData *)data;
@@ -10,14 +12,20 @@
 
 QuickSpecBegin(SDLArtworkSpec)
 
-describe(@"SDLArtwork", ^{
+fdescribe(@"SDLArtwork Tests", ^{
     __block SDLArtwork *expectedArtwork = nil;
+    __block SDLImage *expectedImage = nil;
+    __block NSData *expectedImageData = nil;
     __block UIImage *testImagePNG = nil;
     __block UIImage *testImagePNG2 = nil;
     __block UIImage *testImageJPG = nil;
     __block UIImage *testImagePNGTemplate = nil;
 
     beforeEach(^{
+        expectedArtwork = nil;
+        expectedImage = nil;
+        expectedImageData = nil;
+
         testImagePNG = [UIImage imageNamed:@"testImagePNG" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil];
         testImagePNG2 = [UIImage imageNamed:@"TestLockScreenAppIcon" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil];
         testImageJPG = [UIImage imageNamed:@"testImageJPG.jpg" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil];
@@ -25,21 +33,81 @@ describe(@"SDLArtwork", ^{
     });
 
     context(@"On creation", ^{
-        describe(@"When setting the image", ^{
-            __block NSData *expectedImageData = nil;
+        it(@"should init with artworkWithImage:name:asImageFormat:", ^{
+            NSString *artworkName = @"Test";
+            expectedArtwork = [SDLArtwork artworkWithImage:testImagePNG name:artworkName asImageFormat:SDLArtworkImageFormatPNG];
+            SDLArtwork *expected2  = [[SDLArtwork alloc] initWithImage:testImagePNG name:artworkName persistent:NO asImageFormat:SDLArtworkImageFormatPNG];
 
+            expect(expectedArtwork).to(equal(expected2));
+        });
+
+        it(@"should init with persistentArtworkWithImage:name:asImageFormat:", ^{
+            NSString *artworkName = @"Test";
+            expectedArtwork = [SDLArtwork persistentArtworkWithImage:testImagePNG name:artworkName asImageFormat:SDLArtworkImageFormatPNG];
+            SDLArtwork *expected2  = [[SDLArtwork alloc] initWithImage:testImagePNG name:artworkName persistent:YES asImageFormat:SDLArtworkImageFormatPNG];
+
+            expect(expectedArtwork).to(equal(expected2));
+        });
+
+        it(@"should init with artworkWithImage:asImageFormat:", ^{
+            expectedArtwork = [SDLArtwork artworkWithImage:testImagePNG asImageFormat:SDLArtworkImageFormatPNG];
+            SDLArtwork *expected2 = [[SDLArtwork alloc] initWithImage:testImagePNG persistent:NO asImageFormat:SDLArtworkImageFormatPNG];
+
+            expect(expectedArtwork).to(equal(expected2));
+        });
+
+        it(@"should init with persistentArtworkWithImage:asImageFormat:", ^{
+            expectedArtwork = [SDLArtwork persistentArtworkWithImage:testImagePNG asImageFormat:SDLArtworkImageFormatPNG];
+            SDLArtwork *expected2 = [[SDLArtwork alloc] initWithImage:testImagePNG persistent:NO asImageFormat:SDLArtworkImageFormatPNG];
+
+            expect(expectedArtwork).to(equal(expected2));
+        });
+
+        it(@"should init with artworkWithStaticIcon:", ^{
+            SDLStaticIconName icon = SDLStaticIconNameRSS;
+            expectedArtwork = [SDLArtwork artworkWithStaticIcon:icon];
+            SDLArtwork *expected2 = [[SDLArtwork alloc] initWithStaticIcon:icon];
+
+            expect(expectedArtwork).to(equal(expected2));
+        });
+
+        it(@"should init with initWithStaticIcon:", ^{
+            SDLStaticIconName icon = SDLStaticIconNameRSS;
+            expectedArtwork = [[SDLArtwork alloc] initWithStaticIcon:icon];
+            expectedImage = [[SDLImage alloc] initWithStaticIconName:icon];
+
+            expect(expectedArtwork.name).to(equal(icon));
+            expect(expectedArtwork.isStaticIcon).to(beTrue());
+            expect(expectedArtwork.imageRPC).to(equal(expectedImage));
+            expect(expectedArtwork.isTemplate).to(equal(NO));
+            expect(expectedArtwork.persistent).to(beFalse());
+        });
+
+        describe(@"When setting the image", ^{
             it(@"should set the image data successfully for an image with a name", ^ {
+                NSString *imageName = @"testImage";
                 expectedImageData = UIImagePNGRepresentation(testImagePNG);
-                expectedArtwork = [[SDLArtwork alloc] initWithImage:testImagePNG name:@"testImage" persistent:true asImageFormat:SDLArtworkImageFormatPNG];
+                expectedArtwork = [[SDLArtwork alloc] initWithImage:testImagePNG name:imageName persistent:true asImageFormat:SDLArtworkImageFormatPNG];
+                expectedImage = [[SDLImage alloc] initWithName:imageName isTemplate:NO];
 
                 expect(expectedImageData).to(equal(expectedArtwork.data));
+                expect(expectedArtwork.name).to(equal(imageName));
+                expect(expectedArtwork.imageRPC).to(equal(expectedImage));
+                expect(expectedArtwork.fileType).to(equal(SDLFileTypePNG));
+                expect(expectedArtwork.persistent).to(beTrue());
             });
 
             it(@"should set the image data successfully for an image without a name", ^ {
                 expectedImageData = UIImagePNGRepresentation(testImagePNG);
-                expectedArtwork = [[SDLArtwork alloc] initWithImage:testImagePNG persistent:true asImageFormat:SDLArtworkImageFormatPNG];
+                expectedArtwork = [[SDLArtwork alloc] initWithImage:testImagePNG persistent:false asImageFormat:SDLArtworkImageFormatPNG];
+                expectedImage = [[SDLImage alloc] initWithName:[SDLArtwork sdl_md5HashFromNSData:expectedImageData] isTemplate:NO];
 
                 expect(expectedImageData).to(equal(expectedArtwork.data));
+                expect(expectedArtwork.name).to(equal([SDLArtwork sdl_md5HashFromNSData:expectedImageData]));
+                expect(expectedArtwork.imageRPC).to(equal(expectedImage));
+                expect(expectedArtwork.fileType).to(equal(SDLFileTypePNG));
+                expect(expectedArtwork.persistent).to(beFalse());
+                expect(expectedArtwork.name.length).to(equal(16));
             });
 
             it(@"should not set the image data if the image is nil", ^{
@@ -47,7 +115,12 @@ describe(@"SDLArtwork", ^{
                 expectedImageData = UIImagePNGRepresentation(testImage);
                 expectedArtwork = [[SDLArtwork alloc] initWithImage:testImage persistent:true asImageFormat:SDLArtworkImageFormatPNG];
 
+                expect(expectedArtwork).to(beNil());
                 expect(expectedArtwork.data).to(beNil());
+                expect(expectedArtwork.name).to(beNil());
+                expect(expectedArtwork.imageRPC).to(beNil());
+                expect(expectedArtwork.fileType).to(beNil());
+                expect(expectedArtwork.persistent).to(beFalse());
             });
 
             describe(@"Setting the image data should also set whether or not the image is a template", ^{
@@ -64,80 +137,6 @@ describe(@"SDLArtwork", ^{
 
                     expect(expectedArtwork.isTemplate).to(beFalse());
                 });
-            });
-        });
-
-        describe(@"When setting the name", ^{
-            __block NSString *expectedName = nil;
-
-            it(@"should set the passed name correctly", ^{
-                NSString *imageName = @"TestImageName";
-                expectedName = imageName;
-                expectedArtwork = [[SDLArtwork alloc] initWithImage:testImagePNG name:imageName persistent:true asImageFormat:SDLArtworkImageFormatPNG];
-            });
-
-            context(@"When no name is provided", ^{
-                it(@"should create a unique name based on the hash of the image", ^{
-                    expectedName = [SDLArtwork sdl_md5HashFromNSData:UIImagePNGRepresentation(testImagePNG)];
-                    expectedArtwork = [[SDLArtwork alloc] initWithImage:testImagePNG persistent:true asImageFormat:SDLArtworkImageFormatPNG];
-                });
-
-                it(@"should create an empty string if the image is nil", ^{
-                    UIImage *testNilImage = nil;
-                    expectedName = @"";
-                    expectedArtwork = [[SDLArtwork alloc] initWithImage:testNilImage persistent:true asImageFormat:SDLArtworkImageFormatPNG];
-                });
-            });
-
-            afterEach(^{
-                if (expectedName.length == 0) {
-                    expect(expectedArtwork.name).to(beNil());
-                } else {
-                    expect(expectedName).to(equal(expectedArtwork.name));
-                }
-            });
-        });
-
-        describe(@"When setting the image format", ^{
-            __block SDLFileType expectedImageFormat = nil;
-            __block NSData *expectedImageData = nil;
-
-            it(@"should create a PNG image successfully", ^{
-                expectedImageFormat = SDLFileTypePNG;
-                expectedImageData = UIImagePNGRepresentation(testImagePNG);
-
-                expectedArtwork = [[SDLArtwork alloc] initWithImage:testImagePNG name:@"testImagePNG" persistent:true asImageFormat:SDLArtworkImageFormatPNG];
-            });
-
-            it(@"should create a JPG image successfully", ^{
-                expectedImageFormat = SDLFileTypeJPEG;
-                expectedImageData = UIImageJPEGRepresentation(testImageJPG, 0.85);
-                expectedArtwork = [[SDLArtwork alloc] initWithImage:testImageJPG name:@"testImageJPG" persistent:true asImageFormat:SDLArtworkImageFormatJPG];
-            });
-
-            afterEach(^{
-                expect(expectedImageFormat).to(equal(expectedArtwork.fileType));
-                expect(expectedImageData).to(equal(expectedArtwork.data));
-            });
-        });
-
-        describe(@"When setting the image persistence", ^{
-            __block Boolean expectedPersistance = false;
-
-            it(@"should set the image persistence to ephemeral successfully", ^{
-                Boolean persistance = false;
-                expectedPersistance = persistance;
-                expectedArtwork = [[SDLArtwork alloc] initWithImage:testImagePNG name:@"testImagePNG" persistent:persistance asImageFormat:SDLArtworkImageFormatPNG];
-            });
-
-            it(@"should set the image persistence to permanent successfully", ^{
-                Boolean persistance = true;
-                expectedPersistance = persistance;
-                expectedArtwork = [[SDLArtwork alloc] initWithImage:testImagePNG name:@"testImagePNG" persistent:persistance asImageFormat:SDLArtworkImageFormatPNG];
-            });
-
-            afterEach(^{
-                expect(expectedPersistance).to(equal(expectedArtwork.persistent));
             });
         });
     });
@@ -161,19 +160,6 @@ describe(@"SDLArtwork", ^{
             expectedName1 = [SDLArtwork sdl_md5HashFromNSData:UIImagePNGRepresentation(testImagePNG)];
             expectedName2 = [SDLArtwork sdl_md5HashFromNSData:UIImagePNGRepresentation(testImagePNG2)];
             expect(expectedName1).toNot(equal(expectedName2));
-        });
-    });
-
-    context(@"If generating a name for the artwork using the md5 hash", ^{
-        __block NSString *expectedName = nil;
-
-        beforeEach(^{
-            expectedName = nil;
-        });
-
-        it(@"should be truncated to 16 characters", ^{
-            expectedName = [SDLArtwork sdl_md5HashFromNSData:UIImagePNGRepresentation(testImagePNG)];
-            expect(expectedName.length).to(equal(16));
         });
     });
 });

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLPreloadChoicesOperationSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLPreloadChoicesOperationSpec.m
@@ -52,6 +52,7 @@ describe(@"a preload choices operation", ^{
 
         context(@"with artworks", ^{
             __block NSSet<SDLChoiceCell *> *cellsWithArtwork = nil;
+            __block NSSet<SDLChoiceCell *> *cellsWithStaticIcon = nil;
             __block NSString *art1Name = @"Art1Name";
             __block NSString *art2Name = @"Art2Name";
 
@@ -62,7 +63,11 @@ describe(@"a preload choices operation", ^{
                 SDLArtwork *cell2Art = [[SDLArtwork alloc] initWithData:cellArtData name:art2Name fileExtension:@"png" persistent:NO];
                 SDLChoiceCell *cell2WithArtAndSecondary = [[SDLChoiceCell alloc] initWithText:@"Cell2" secondaryText:nil tertiaryText:nil voiceCommands:nil artwork:cell2Art secondaryArtwork:cell2Art];
 
+                SDLArtwork *staticIconArt = [SDLArtwork artworkWithStaticIcon:SDLStaticIconNameDate];
+                SDLChoiceCell *cellWithStaticIcon = [[SDLChoiceCell alloc] initWithText:@"Static Icon" secondaryText:nil tertiaryText:nil voiceCommands:nil artwork:staticIconArt secondaryArtwork:nil];
+
                 cellsWithArtwork = [NSSet setWithArray:@[cell1WithArt, cell2WithArtAndSecondary]];
+                cellsWithStaticIcon = [NSSet setWithArray:@[cellWithStaticIcon]];
             });
 
             context(@"disallowed display capabilities", ^{
@@ -120,6 +125,17 @@ describe(@"a preload choices operation", ^{
                             return (artworks.count == 2);
                         }] completionHandler:[OCMArg any]]);
                         expect(@(testOp.currentState)).to(equal(SDLPreloadChoicesOperationStatePreloadingChoices));
+                    });
+                });
+
+                context(@"when artworks are static icons", ^{
+                    beforeEach(^{
+                        testOp = [[SDLPreloadChoicesOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager displayCapabilities:displayCapabilities isVROptional:NO cellsToPreload:cellsWithStaticIcon];
+                        [testOp start];
+                    });
+
+                    it(@"should skip uploading artwork", ^{
+                        OCMReject([testFileManager uploadArtwork:[OCMArg any] completionHandler:[OCMArg any]]);
                     });
                 });
 

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLSoftButtonManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLSoftButtonManagerSpec.m
@@ -71,6 +71,9 @@ describe(@"a soft button manager", ^{
     __block SDLSoftButtonState *object2State1 = [[SDLSoftButtonState alloc] initWithStateName:object2State1Name text:object2State1Text artwork:object2State1Art];
     __block SDLSoftButtonState *object2State2 = [[SDLSoftButtonState alloc] initWithStateName:object2State2Name text:object2State2Text image:nil];
 
+    __block SDLArtwork *staticIconArt = [SDLArtwork artworkWithStaticIcon:SDLStaticIconNameDate];
+    __block SDLSoftButtonState *staticIconState = [[SDLSoftButtonState alloc] initWithStateName:@"Static State" text:nil artwork:staticIconArt];
+
     beforeEach(^{
         testFileManager = OCMClassMock([SDLFileManager class]);
         testConnectionManager = [[TestConnectionManager alloc] init];
@@ -181,6 +184,17 @@ describe(@"a soft button manager", ^{
             SDLSoftButtonCapabilities *softButtonImagesSupported = [[SDLSoftButtonCapabilities alloc] init];
             softButtonImagesSupported.imageSupported = @YES;
             testManager.softButtonCapabilities = softButtonImagesSupported;
+        });
+
+        context(@"when button artworks are static icons", ^{
+            beforeEach(^{
+                testObject1 = [[SDLSoftButtonObject alloc] initWithName:object1Name state:staticIconState handler:nil];
+                testManager.softButtonObjects = @[testObject1];
+            });
+
+            it(@"should not have attempted to upload any artworks", ^{
+                OCMReject([testFileManager uploadArtwork:[OCMArg any] completionHandler:[OCMArg any]]);
+            });
         });
 
         context(@"when button artworks are already on the file system", ^{

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicManagerSpec.m
@@ -47,6 +47,7 @@ describe(@"text and graphic manager", ^{
     __block NSString *testString = @"some string";
     __block NSString *testArtworkName = @"some artwork name";
     __block SDLArtwork *testArtwork = [[SDLArtwork alloc] initWithData:[@"Test data" dataUsingEncoding:NSUTF8StringEncoding] name:testArtworkName fileExtension:@"png" persistent:NO];
+    __block SDLArtwork *testStaticIcon = [SDLArtwork artworkWithStaticIcon:SDLStaticIconNameDate];
 
     beforeEach(^{
         mockFileManager = OCMClassMock([SDLFileManager class]);
@@ -762,6 +763,20 @@ describe(@"text and graphic manager", ^{
                     expect(testManager.inProgressUpdate.graphic.value).to(equal(testArtworkName));
                     expect(testManager.inProgressUpdate.secondaryGraphic.value).to(equal(testArtworkName));
                     expect(testManager.inProgressUpdate.mainField1).to(equal(testTextFieldText));
+                });
+            });
+
+            context(@"when the image is a static icon", ^{
+                beforeEach(^{
+                    testManager.primaryGraphic = testStaticIcon;
+                    testManager.batchUpdates = NO;
+                    [testManager updateWithCompletionHandler:nil];
+                });
+
+                it(@"should immediately update without uploading the images", ^{
+                    OCMReject([mockFileManager uploadArtwork:[OCMArg any] completionHandler:[OCMArg any]]);
+                    expect(testManager.inProgressUpdate.mainField1).to(equal(testTextFieldText));
+                    expect(testManager.inProgressUpdate.graphic.value).toNot(beNil());
                 });
             });
 


### PR DESCRIPTION
Fixes #1062 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Unit tests and smoke tests

### Summary
`SDLArtwork` and screen manager updated to support static icons and the `SDLStaticIconName` enum.

### Changelog
##### Enhancements
* `SDLArtwork` can now be created with a static icon. Such artworks can be passed to the `SDLScreenManager` for use in various image slots such as soft buttons and choices.

##### Bug Fixes
* Fixed failed `SetDisplayLayout` causing `SDLScreenManager` to break.

### Tasks Remaining:
- [x] Unit Tests

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
