### PR TITLE
SDL 0118  Video Streaming Backgrounded String

### DIFF
--- a/SmartDeviceLink/CVPixelBufferRef+SDLUtil.m
+++ b/SmartDeviceLink/CVPixelBufferRef+SDLUtil.m
@@ -10,23 +10,27 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+// Video stream string message padding is 5% of the screen size. Padding is added to the message so the text is not flush with the edge of the screen.
+CGFloat const SDLVideoStringMessagePadding = .05;
+
 UIFont * _Nullable sdl_findFontSizeToFitText(CGSize size, NSString *text) {
-    CGFloat fontSize = 100;
-    
+    CGFloat fontSize = 300;
+
     do {
-        CGSize textSize = [text boundingRectWithSize:CGSizeMake(size.width, CGFLOAT_MAX)
+        CGFloat padding = SDLVideoStringMessagePadding * size.width * 2;
+        CGSize textSize = [text boundingRectWithSize:CGSizeMake((size.width - padding), CGFLOAT_MAX)
                                              options:NSStringDrawingUsesLineFragmentOrigin
-                                          attributes:@{NSFontAttributeName : [UIFont boldSystemFontOfSize:fontSize]}
+                                          attributes:@{NSFontAttributeName : [UIFont systemFontOfSize:fontSize]}
                                              context:nil].size;
-        
-        if (textSize.height <= size.height) {
+
+        if (textSize.height <= (size.height - padding)) {
             break;
         }
         
-        fontSize -= 30.0;
+        fontSize -= 10.0;
     } while (fontSize > 0.0);
 
-    return (fontSize > 0) ? [UIFont boldSystemFontOfSize:fontSize] : nil;
+    return (fontSize > 0) ? [UIFont systemFontOfSize:fontSize] : nil;
 }
 
 UIImage * _Nullable sdl_createTextImage(NSString *text, CGSize size) {
@@ -58,11 +62,11 @@ UIImage * _Nullable sdl_createTextImage(NSString *text, CGSize size) {
                                        attributes:textAttributes
                                           context:nil];
 
-    CGFloat padding = 50;
+    CGFloat padding = SDLVideoStringMessagePadding * size.width;
     CGRect textInset = CGRectMake(0 + padding,
                                   (frame.size.height - CGRectGetHeight(textFrame)) / 2.0,
-                                  frame.size.width - (2 * padding),
-                                  frame.size.height);
+                                  frame.size.width - (padding * 2),
+                                  frame.size.height - (padding * 2));
     
     [text drawInRect:textInset
       withAttributes:textAttributes];

--- a/SmartDeviceLink/CVPixelBufferRef+SDLUtil.m
+++ b/SmartDeviceLink/CVPixelBufferRef+SDLUtil.m
@@ -23,7 +23,7 @@ UIFont * _Nullable sdl_findFontSizeToFitText(CGSize size, NSString *text) {
             break;
         }
         
-        fontSize -= 10.0;
+        fontSize -= 30.0;
     } while (fontSize > 0.0);
 
     return (fontSize > 0) ? [UIFont boldSystemFontOfSize:fontSize] : nil;
@@ -46,7 +46,7 @@ UIImage * _Nullable sdl_createTextImage(NSString *text, CGSize size) {
     CGContextSaveGState(context);
     
     NSMutableParagraphStyle* textStyle = NSMutableParagraphStyle.defaultParagraphStyle.mutableCopy;
-    textStyle.alignment = NSTextAlignmentCenter;
+    textStyle.alignment = NSTextAlignmentLeft;
     
     NSDictionary* textAttributes = @{
                                      NSFontAttributeName: font,
@@ -57,10 +57,11 @@ UIImage * _Nullable sdl_createTextImage(NSString *text, CGSize size) {
                                           options:NSStringDrawingUsesLineFragmentOrigin
                                        attributes:textAttributes
                                           context:nil];
-    
-    CGRect textInset = CGRectMake(0,
+
+    CGFloat padding = 50;
+    CGRect textInset = CGRectMake(0 + padding,
                                   (frame.size.height - CGRectGetHeight(textFrame)) / 2.0,
-                                  frame.size.width,
+                                  frame.size.width - (2 * padding),
                                   frame.size.height);
     
     [text drawInRect:textInset

--- a/SmartDeviceLink/CVPixelBufferRef+SDLUtil.m
+++ b/SmartDeviceLink/CVPixelBufferRef+SDLUtil.m
@@ -7,6 +7,7 @@
 //
 
 #import "CVPixelBufferRef+SDLUtil.h"
+#import "SDLLogMacros.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -37,7 +38,7 @@ UIImage * _Nullable sdl_createTextImage(NSString *text, CGSize size) {
     UIFont *font = sdl_findFontSizeToFitText(size, text);
     
     if (!font) {
-        NSLog(@"Text cannot fit inside frame");
+        SDLLogW(@"Text cannot fit inside frame");
         return nil;
     }
 
@@ -83,7 +84,7 @@ Boolean CVPixelBufferAddText(CVPixelBufferRef CV_NONNULL pixelBuffer, NSString *
     
     UIImage *image = sdl_createTextImage(text, CGSizeMake(width, height));
     if (!image) {
-        NSLog(@"Could not create text image.");
+        SDLLogE(@"Could not create text image.");
         return false;
     }
     

--- a/SmartDeviceLink/CVPixelBufferRef+SDLUtil.m
+++ b/SmartDeviceLink/CVPixelBufferRef+SDLUtil.m
@@ -27,7 +27,7 @@ UIFont * _Nullable sdl_findFontSizeToFitText(CGSize size, NSString *text) {
             break;
         }
         
-        fontSize -= 10.0;
+        fontSize -= 1.0;
     } while (fontSize > 0.0);
 
     return (fontSize > 0) ? [UIFont systemFontOfSize:fontSize] : nil;

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -134,7 +134,7 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
         [configuration.lifecycleConfig.appType isEqualToEnum:SDLAppHMITypeProjection] ||
         [configuration.lifecycleConfig.additionalAppTypes containsObject:SDLAppHMITypeNavigation] ||
         [configuration.lifecycleConfig.additionalAppTypes containsObject:SDLAppHMITypeProjection]) {
-        _streamManager = [[SDLStreamingMediaManager alloc] initWithConnectionManager:self streamingMediaConfiguration:configuration.streamingMediaConfig lifecycleConfiguration:configuration.lifecycleConfig];
+        _streamManager = [[SDLStreamingMediaManager alloc] initWithConnectionManager:self config:configuration];
     } else {
         SDLLogV(@"Skipping StreamingMediaManager setup due to app type");
     }

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -134,7 +134,7 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
         [configuration.lifecycleConfig.appType isEqualToEnum:SDLAppHMITypeProjection] ||
         [configuration.lifecycleConfig.additionalAppTypes containsObject:SDLAppHMITypeNavigation] ||
         [configuration.lifecycleConfig.additionalAppTypes containsObject:SDLAppHMITypeProjection]) {
-        _streamManager = [[SDLStreamingMediaManager alloc] initWithConnectionManager:self config:configuration];
+        _streamManager = [[SDLStreamingMediaManager alloc] initWithConnectionManager:self configuration:configuration];
     } else {
         SDLLogV(@"Skipping StreamingMediaManager setup due to app type");
     }

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -134,7 +134,7 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
         [configuration.lifecycleConfig.appType isEqualToEnum:SDLAppHMITypeProjection] ||
         [configuration.lifecycleConfig.additionalAppTypes containsObject:SDLAppHMITypeNavigation] ||
         [configuration.lifecycleConfig.additionalAppTypes containsObject:SDLAppHMITypeProjection]) {
-        _streamManager = [[SDLStreamingMediaManager alloc] initWithConnectionManager:self configuration:configuration.streamingMediaConfig];
+        _streamManager = [[SDLStreamingMediaManager alloc] initWithConnectionManager:self streamingMediaConfiguration:configuration.streamingMediaConfig lifecycleConfiguration:configuration.lifecycleConfig];
     } else {
         SDLLogV(@"Skipping StreamingMediaManager setup due to app type");
     }

--- a/SmartDeviceLink/SDLStreamingMediaManager.h
+++ b/SmartDeviceLink/SDLStreamingMediaManager.h
@@ -15,7 +15,6 @@
 @class SDLAudioStreamManager;
 @class SDLConfiguration;
 @class SDLProtocol;
-@class SDLStreamingMediaConfiguration;
 @class SDLTouchManager;
 @class SDLVideoStreamingFormat;
 
@@ -119,7 +118,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param configuration This session's configuration
  @return A new streaming manager
  */
-- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager config:(SDLConfiguration *)configuration NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager configuration:(SDLConfiguration *)configuration NS_DESIGNATED_INITIALIZER;
 
 /**
  *  Start the manager with a completion block that will be called when startup completes. This is used internally. To use an SDLStreamingMediaManager, you should use the manager found on `SDLManager`.

--- a/SmartDeviceLink/SDLStreamingMediaManager.h
+++ b/SmartDeviceLink/SDLStreamingMediaManager.h
@@ -13,6 +13,7 @@
 #import "SDLStreamingMediaManagerConstants.h"
 
 @class SDLAudioStreamManager;
+@class SDLLifecycleConfiguration;
 @class SDLProtocol;
 @class SDLStreamingMediaConfiguration;
 @class SDLTouchManager;
@@ -118,7 +119,17 @@ NS_ASSUME_NONNULL_BEGIN
  @param configuration The configuration of this streaming media session
  @return A new streaming manager
  */
-- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager configuration:(SDLStreamingMediaConfiguration *)configuration NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager configuration:(SDLStreamingMediaConfiguration *)configuration;
+
+/**
+ Create a new streaming media manager for navigation and VPM apps with a specified configuration
+
+ @param connectionManager The pass-through for RPCs
+ @param streamingMediaConfiguration The configuration of this streaming media session
+ @param lifecycleConfiguration The lifecycle configuration of the app
+ @return A new streaming manager
+ */
+- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager streamingMediaConfiguration:(SDLStreamingMediaConfiguration *)streamingMediaConfiguration lifecycleConfiguration:(SDLLifecycleConfiguration *)lifecycleConfiguration NS_DESIGNATED_INITIALIZER;
 
 /**
  *  Start the manager with a completion block that will be called when startup completes. This is used internally. To use an SDLStreamingMediaManager, you should use the manager found on `SDLManager`.

--- a/SmartDeviceLink/SDLStreamingMediaManager.h
+++ b/SmartDeviceLink/SDLStreamingMediaManager.h
@@ -128,7 +128,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param configuration This session's configuration
  @return A new streaming manager
  */
-- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager config:(SDLConfiguration *)configuration;
+- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager config:(SDLConfiguration *)configuration NS_DESIGNATED_INITIALIZER;
 
 /**
  *  Start the manager with a completion block that will be called when startup completes. This is used internally. To use an SDLStreamingMediaManager, you should use the manager found on `SDLManager`.

--- a/SmartDeviceLink/SDLStreamingMediaManager.h
+++ b/SmartDeviceLink/SDLStreamingMediaManager.h
@@ -116,15 +116,6 @@ NS_ASSUME_NONNULL_BEGIN
  Create a new streaming media manager for navigation and VPM apps with a specified configuration
 
  @param connectionManager The pass-through for RPCs
- @param configuration The configuration of this streaming media session
- @return A new streaming manager
- */
-- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager configuration:(SDLStreamingMediaConfiguration *)configuration __deprecated_msg("Use initWithConnectionManager:config: instead");
-
-/**
- Create a new streaming media manager for navigation and VPM apps with a specified configuration
-
- @param connectionManager The pass-through for RPCs
  @param configuration This session's configuration
  @return A new streaming manager
  */

--- a/SmartDeviceLink/SDLStreamingMediaManager.h
+++ b/SmartDeviceLink/SDLStreamingMediaManager.h
@@ -119,7 +119,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param configuration The configuration of this streaming media session
  @return A new streaming manager
  */
-- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager configuration:(SDLStreamingMediaConfiguration *)configuration;
+- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager configuration:(SDLStreamingMediaConfiguration *)configuration __deprecated_msg("Use initWithConnectionManager:streamingMediaConfiguration:lifecycleConfiguration: instead");
 
 /**
  Create a new streaming media manager for navigation and VPM apps with a specified configuration

--- a/SmartDeviceLink/SDLStreamingMediaManager.h
+++ b/SmartDeviceLink/SDLStreamingMediaManager.h
@@ -13,7 +13,7 @@
 #import "SDLStreamingMediaManagerConstants.h"
 
 @class SDLAudioStreamManager;
-@class SDLLifecycleConfiguration;
+@class SDLConfiguration;
 @class SDLProtocol;
 @class SDLStreamingMediaConfiguration;
 @class SDLTouchManager;
@@ -119,17 +119,16 @@ NS_ASSUME_NONNULL_BEGIN
  @param configuration The configuration of this streaming media session
  @return A new streaming manager
  */
-- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager configuration:(SDLStreamingMediaConfiguration *)configuration __deprecated_msg("Use initWithConnectionManager:streamingMediaConfiguration:lifecycleConfiguration: instead");
+- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager configuration:(SDLStreamingMediaConfiguration *)configuration __deprecated_msg("Use initWithConnectionManager:config: instead");
 
 /**
  Create a new streaming media manager for navigation and VPM apps with a specified configuration
 
  @param connectionManager The pass-through for RPCs
- @param streamingMediaConfiguration The configuration of this streaming media session
- @param lifecycleConfiguration The lifecycle configuration of the app
+ @param configuration This session's configuration
  @return A new streaming manager
  */
-- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager streamingMediaConfiguration:(SDLStreamingMediaConfiguration *)streamingMediaConfiguration lifecycleConfiguration:(SDLLifecycleConfiguration *)lifecycleConfiguration NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager config:(SDLConfiguration *)configuration;
 
 /**
  *  Start the manager with a completion block that will be called when startup completes. This is used internally. To use an SDLStreamingMediaManager, you should use the manager found on `SDLManager`.

--- a/SmartDeviceLink/SDLStreamingMediaManager.m
+++ b/SmartDeviceLink/SDLStreamingMediaManager.m
@@ -39,11 +39,6 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Public
 #pragma mark Lifecycle
 
-- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager configuration:(SDLStreamingMediaConfiguration *)configuration {
-    SDLConfiguration *defaultConfig = [SDLConfiguration configurationWithLifecycle:[SDLLifecycleConfiguration defaultConfigurationWithAppName:@"" fullAppId:@""] lockScreen:SDLLockScreenConfiguration.enabledConfiguration logging:SDLLogConfiguration.debugConfiguration streamingMedia:configuration fileManager:SDLFileManagerConfiguration.defaultConfiguration];
-    return [self initWithConnectionManager:connectionManager config:defaultConfig];
-}
-
 - (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager config:(SDLConfiguration *)configuration {
     self = [super init];
     if (!self) {

--- a/SmartDeviceLink/SDLStreamingMediaManager.m
+++ b/SmartDeviceLink/SDLStreamingMediaManager.m
@@ -10,6 +10,7 @@
 
 #import "SDLAudioStreamManager.h"
 #import "SDLConnectionManagerType.h"
+#import "SDLLifecycleConfiguration.h"
 #import "SDLStreamingMediaConfiguration.h"
 #import "SDLStreamingMediaManagerDataSource.h"
 #import "SDLStreamingAudioLifecycleManager.h"
@@ -42,6 +43,18 @@ NS_ASSUME_NONNULL_BEGIN
     
     _audioLifecycleManager = [[SDLStreamingAudioLifecycleManager alloc] initWithConnectionManager:connectionManager configuration:configuration];
     _videoLifecycleManager = [[SDLStreamingVideoLifecycleManager alloc] initWithConnectionManager:connectionManager configuration:configuration];
+
+    return self;
+}
+
+- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager streamingMediaConfiguration:(SDLStreamingMediaConfiguration *)streamingMediaConfiguration lifecycleConfiguration:(SDLLifecycleConfiguration *)lifecycleConfiguration {
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+
+    _audioLifecycleManager = [[SDLStreamingAudioLifecycleManager alloc] initWithConnectionManager:connectionManager configuration:streamingMediaConfiguration];
+    _videoLifecycleManager = [[SDLStreamingVideoLifecycleManager alloc] initWithConnectionManager:connectionManager streamingMediaConfiguration:streamingMediaConfiguration lifecycleConfiguration:lifecycleConfiguration];
 
     return self;
 }

--- a/SmartDeviceLink/SDLStreamingMediaManager.m
+++ b/SmartDeviceLink/SDLStreamingMediaManager.m
@@ -11,7 +11,10 @@
 #import "SDLAudioStreamManager.h"
 #import "SDLConfiguration.h"
 #import "SDLConnectionManagerType.h"
+#import "SDLFileManagerConfiguration.h"
 #import "SDLLifecycleConfiguration.h"
+#import "SDLLockScreenConfiguration.h"
+#import "SDLLogConfiguration.h"
 #import "SDLStreamingMediaConfiguration.h"
 #import "SDLStreamingMediaManagerDataSource.h"
 #import "SDLStreamingAudioLifecycleManager.h"
@@ -37,15 +40,8 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark Lifecycle
 
 - (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager configuration:(SDLStreamingMediaConfiguration *)configuration {
-    self = [super init];
-    if (!self) {
-        return nil;
-    }
-
-    _audioLifecycleManager = [[SDLStreamingAudioLifecycleManager alloc] initWithConnectionManager:connectionManager configuration:configuration];
-    _videoLifecycleManager = [[SDLStreamingVideoLifecycleManager alloc] initWithConnectionManager:connectionManager streamingMediaConfiguration:configuration lifecycleConfiguration:[SDLLifecycleConfiguration defaultConfigurationWithAppName:@"" fullAppId:@""]];
-
-    return self;
+    SDLConfiguration *defaultConfig = [SDLConfiguration configurationWithLifecycle:[SDLLifecycleConfiguration defaultConfigurationWithAppName:@"" fullAppId:@""] lockScreen:SDLLockScreenConfiguration.enabledConfiguration logging:SDLLogConfiguration.debugConfiguration streamingMedia:configuration fileManager:SDLFileManagerConfiguration.defaultConfiguration];
+    return [self initWithConnectionManager:connectionManager config:defaultConfig];
 }
 
 - (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager config:(SDLConfiguration *)configuration {
@@ -55,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     _audioLifecycleManager = [[SDLStreamingAudioLifecycleManager alloc] initWithConnectionManager:connectionManager configuration:configuration.streamingMediaConfig];
-    _videoLifecycleManager = [[SDLStreamingVideoLifecycleManager alloc] initWithConnectionManager:connectionManager streamingMediaConfiguration:configuration.streamingMediaConfig lifecycleConfiguration:configuration.lifecycleConfig];
+    _videoLifecycleManager = [[SDLStreamingVideoLifecycleManager alloc] initWithConnectionManager:connectionManager config:configuration];
 
     return self;
 }

--- a/SmartDeviceLink/SDLStreamingMediaManager.m
+++ b/SmartDeviceLink/SDLStreamingMediaManager.m
@@ -36,12 +36,11 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark Lifecycle
 
 - (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager configuration:(SDLStreamingMediaConfiguration *)configuration {
-    self = [super init];
+    self = [self initWithConnectionManager:connectionManager streamingMediaConfiguration:configuration lifecycleConfiguration:[SDLLifecycleConfiguration defaultConfigurationWithAppName:@"" fullAppId:@""]];
     if (!self) {
         return nil;
     }
     
-    _audioLifecycleManager = [[SDLStreamingAudioLifecycleManager alloc] initWithConnectionManager:connectionManager configuration:configuration];
     _videoLifecycleManager = [[SDLStreamingVideoLifecycleManager alloc] initWithConnectionManager:connectionManager configuration:configuration];
 
     return self;

--- a/SmartDeviceLink/SDLStreamingMediaManager.m
+++ b/SmartDeviceLink/SDLStreamingMediaManager.m
@@ -9,6 +9,7 @@
 #import "SDLStreamingMediaManager.h"
 
 #import "SDLAudioStreamManager.h"
+#import "SDLConfiguration.h"
 #import "SDLConnectionManagerType.h"
 #import "SDLLifecycleConfiguration.h"
 #import "SDLStreamingMediaConfiguration.h"
@@ -36,17 +37,25 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark Lifecycle
 
 - (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager configuration:(SDLStreamingMediaConfiguration *)configuration {
-    return [self initWithConnectionManager:connectionManager streamingMediaConfiguration:configuration lifecycleConfiguration:[SDLLifecycleConfiguration defaultConfigurationWithAppName:@"" fullAppId:@""]];
-}
-
-- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager streamingMediaConfiguration:(SDLStreamingMediaConfiguration *)streamingMediaConfiguration lifecycleConfiguration:(SDLLifecycleConfiguration *)lifecycleConfiguration {
     self = [super init];
     if (!self) {
         return nil;
     }
 
-    _audioLifecycleManager = [[SDLStreamingAudioLifecycleManager alloc] initWithConnectionManager:connectionManager configuration:streamingMediaConfiguration];
-    _videoLifecycleManager = [[SDLStreamingVideoLifecycleManager alloc] initWithConnectionManager:connectionManager streamingMediaConfiguration:streamingMediaConfiguration lifecycleConfiguration:lifecycleConfiguration];
+    _audioLifecycleManager = [[SDLStreamingAudioLifecycleManager alloc] initWithConnectionManager:connectionManager configuration:configuration];
+    _videoLifecycleManager = [[SDLStreamingVideoLifecycleManager alloc] initWithConnectionManager:connectionManager streamingMediaConfiguration:configuration lifecycleConfiguration:[SDLLifecycleConfiguration defaultConfigurationWithAppName:@"" fullAppId:@""]];
+
+    return self;
+}
+
+- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager config:(SDLConfiguration *)configuration {
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+
+    _audioLifecycleManager = [[SDLStreamingAudioLifecycleManager alloc] initWithConnectionManager:connectionManager configuration:configuration.streamingMediaConfig];
+    _videoLifecycleManager = [[SDLStreamingVideoLifecycleManager alloc] initWithConnectionManager:connectionManager streamingMediaConfiguration:configuration.streamingMediaConfig lifecycleConfiguration:configuration.lifecycleConfig];
 
     return self;
 }

--- a/SmartDeviceLink/SDLStreamingMediaManager.m
+++ b/SmartDeviceLink/SDLStreamingMediaManager.m
@@ -11,12 +11,6 @@
 #import "SDLAudioStreamManager.h"
 #import "SDLConfiguration.h"
 #import "SDLConnectionManagerType.h"
-#import "SDLFileManagerConfiguration.h"
-#import "SDLLifecycleConfiguration.h"
-#import "SDLLockScreenConfiguration.h"
-#import "SDLLogConfiguration.h"
-#import "SDLStreamingMediaConfiguration.h"
-#import "SDLStreamingMediaManagerDataSource.h"
 #import "SDLStreamingAudioLifecycleManager.h"
 #import "SDLStreamingVideoLifecycleManager.h"
 #import "SDLTouchManager.h"
@@ -39,14 +33,14 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Public
 #pragma mark Lifecycle
 
-- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager config:(SDLConfiguration *)configuration {
+- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager configuration:(SDLConfiguration *)configuration {
     self = [super init];
     if (!self) {
         return nil;
     }
 
     _audioLifecycleManager = [[SDLStreamingAudioLifecycleManager alloc] initWithConnectionManager:connectionManager configuration:configuration.streamingMediaConfig];
-    _videoLifecycleManager = [[SDLStreamingVideoLifecycleManager alloc] initWithConnectionManager:connectionManager config:configuration];
+    _videoLifecycleManager = [[SDLStreamingVideoLifecycleManager alloc] initWithConnectionManager:connectionManager configuration:configuration];
 
     return self;
 }

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.h
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.h
@@ -16,8 +16,8 @@
 #import "SDLVideoStreamingState.h"
 
 @class SDLCarWindow;
+@class SDLConfiguration;
 @class SDLImageResolution;
-@class SDLLifecycleConfiguration;
 @class SDLProtocol;
 @class SDLStateMachine;
 @class SDLStreamingMediaConfiguration;
@@ -145,11 +145,10 @@ NS_ASSUME_NONNULL_BEGIN
  Create a new streaming media manager for navigation and VPM apps with a specified configuration
 
  @param connectionManager The pass-through for RPCs
- @param streamingMediaConfiguration The configuration of this streaming media session
- @param lifecycleConfiguration The lifecycle configuration of the app
+ @param configuration This session's configuration
  @return A new streaming manager
  */
-- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager streamingMediaConfiguration:(SDLStreamingMediaConfiguration *)streamingMediaConfiguration lifecycleConfiguration:(SDLLifecycleConfiguration *)lifecycleConfiguration NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager config:(SDLConfiguration *)configuration;
 
 /**
  *  Start the manager with a completion block that will be called when startup completes. This is used internally. To use an SDLStreamingMediaManager, you should use the manager found on `SDLManager`.

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.h
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.h
@@ -136,15 +136,6 @@ NS_ASSUME_NONNULL_BEGIN
  Create a new streaming media manager for navigation and VPM apps with a specified configuration
 
  @param connectionManager The pass-through for RPCs
- @param configuration The configuration of this streaming media session
- @return A new streaming manager
- */
-- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager configuration:(SDLStreamingMediaConfiguration *)configuration __deprecated_msg("Use initWithConnectionManager:streamingMediaConfiguration:lifecycleConfiguration: instead");
-
-/**
- Create a new streaming media manager for navigation and VPM apps with a specified configuration
-
- @param connectionManager The pass-through for RPCs
  @param configuration This session's configuration
  @return A new streaming manager
  */

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.h
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.h
@@ -139,7 +139,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param configuration This session's configuration
  @return A new streaming manager
  */
-- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager config:(SDLConfiguration *)configuration;
+- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager configuration:(SDLConfiguration *)configuration;
 
 /**
  *  Start the manager with a completion block that will be called when startup completes. This is used internally. To use an SDLStreamingMediaManager, you should use the manager found on `SDLManager`.

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.h
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.h
@@ -139,7 +139,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param configuration The configuration of this streaming media session
  @return A new streaming manager
  */
-- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager configuration:(SDLStreamingMediaConfiguration *)configuration;
+- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager configuration:(SDLStreamingMediaConfiguration *)configuration __deprecated_msg("Use initWithConnectionManager:streamingMediaConfiguration:lifecycleConfiguration: instead");
 
 /**
  Create a new streaming media manager for navigation and VPM apps with a specified configuration
@@ -149,7 +149,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param lifecycleConfiguration The lifecycle configuration of the app
  @return A new streaming manager
  */
-- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager streamingMediaConfiguration:(SDLStreamingMediaConfiguration *)streamingMediaConfiguration lifecycleConfiguration:(SDLLifecycleConfiguration *)lifecycleConfiguration;
+- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager streamingMediaConfiguration:(SDLStreamingMediaConfiguration *)streamingMediaConfiguration lifecycleConfiguration:(SDLLifecycleConfiguration *)lifecycleConfiguration NS_DESIGNATED_INITIALIZER;
 
 /**
  *  Start the manager with a completion block that will be called when startup completes. This is used internally. To use an SDLStreamingMediaManager, you should use the manager found on `SDLManager`.

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.h
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.h
@@ -17,6 +17,7 @@
 
 @class SDLCarWindow;
 @class SDLImageResolution;
+@class SDLLifecycleConfiguration;
 @class SDLProtocol;
 @class SDLStateMachine;
 @class SDLStreamingMediaConfiguration;
@@ -138,7 +139,17 @@ NS_ASSUME_NONNULL_BEGIN
  @param configuration The configuration of this streaming media session
  @return A new streaming manager
  */
-- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager configuration:(SDLStreamingMediaConfiguration *)configuration NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager configuration:(SDLStreamingMediaConfiguration *)configuration;
+
+/**
+ Create a new streaming media manager for navigation and VPM apps with a specified configuration
+
+ @param connectionManager The pass-through for RPCs
+ @param streamingMediaConfiguration The configuration of this streaming media session
+ @param lifecycleConfiguration The lifecycle configuration of the app
+ @return A new streaming manager
+ */
+- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager streamingMediaConfiguration:(SDLStreamingMediaConfiguration *)streamingMediaConfiguration lifecycleConfiguration:(SDLLifecycleConfiguration *)lifecycleConfiguration;
 
 /**
  *  Start the manager with a completion block that will be called when startup completes. This is used internally. To use an SDLStreamingMediaManager, you should use the manager found on `SDLManager`.

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -75,6 +75,8 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
 
 @property (assign, nonatomic) CMTime lastPresentationTimestamp;
 
+@property (copy, nonatomic, getter=getVideoStreamBackgroundString) NSString *videoStreamBackgroundString;
+
 @end
 
 @implementation SDLStreamingVideoLifecycleManager
@@ -391,7 +393,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
 
         if (!self.backgroundingPixelBuffer) {
             CVPixelBufferRef backgroundingPixelBuffer = [self.videoEncoder newPixelBuffer];
-            if (CVPixelBufferAddText(backgroundingPixelBuffer, [self videoStreamBackgroundString]) == NO) {
+            if (CVPixelBufferAddText(backgroundingPixelBuffer, self.videoStreamBackgroundString) == NO) {
                 SDLLogE(@"Could not create a backgrounding frame");
                 [self.videoStreamStateMachine transitionToState:SDLVideoStreamManagerStateStopped];
                 return;
@@ -781,7 +783,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
     return @[h264raw, h264rtp];
 }
 
-- (NSString *)videoStreamBackgroundString {
+- (NSString *)getVideoStreamBackgroundString {
     return [NSString stringWithFormat:@"When it is safe to do so, open %@ on your phone", self.appName];
 }
 

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -66,8 +66,8 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
 @property (copy, nonatomic) NSDictionary<NSString *, id> *videoEncoderSettings;
 @property (copy, nonatomic) NSArray<NSString *> *secureMakes;
 @property (copy, nonatomic) NSString *connectedVehicleMake;
-@property (copy, nonatomic) NSString *appName;
 
+@property (copy, nonatomic) NSString *appName;
 @property (assign, nonatomic) CV_NULLABLE CVPixelBufferRef backgroundingPixelBuffer;
 
 @property (strong, nonatomic, nullable) CADisplayLink *displayLink;
@@ -383,8 +383,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
 
         if (!self.backgroundingPixelBuffer) {
             CVPixelBufferRef backgroundingPixelBuffer = [self.videoEncoder newPixelBuffer];
-            NSString *videoStreamBackgroundedString = [NSString stringWithFormat:@"When it is safe to do so, open %@ on phone", self.appName];
-            if (CVPixelBufferAddText(backgroundingPixelBuffer, videoStreamBackgroundedString) == NO) {
+            if (CVPixelBufferAddText(backgroundingPixelBuffer, [self videoStreamBackgroundString]) == NO) {
                 SDLLogE(@"Could not create a backgrounding frame");
                 [self.videoStreamStateMachine transitionToState:SDLVideoStreamManagerStateStopped];
                 return;
@@ -774,6 +773,10 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
     SDLVideoStreamingFormat *h264rtp = [[SDLVideoStreamingFormat alloc] initWithCodec:SDLVideoStreamingCodecH264 protocol:SDLVideoStreamingProtocolRTP];
 
     return @[h264raw, h264rtp];
+}
+
+- (NSString *)videoStreamBackgroundString {
+    return [NSString stringWithFormat:@"When it is safe to do so, open %@ on phone", self.appName];
 }
 
 @end

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -85,11 +85,6 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
 
 @implementation SDLStreamingVideoLifecycleManager
 
-- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager configuration:(SDLStreamingMediaConfiguration *)configuration {
-    SDLConfiguration *defaultConfig = [SDLConfiguration configurationWithLifecycle:[SDLLifecycleConfiguration defaultConfigurationWithAppName:@"" fullAppId:@""] lockScreen:SDLLockScreenConfiguration.enabledConfiguration logging:SDLLogConfiguration.debugConfiguration streamingMedia:configuration fileManager:SDLFileManagerConfiguration.defaultConfiguration];
-    return [self initWithConnectionManager:connectionManager config:defaultConfig];
-}
-
 - (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager config:(SDLConfiguration *)configuration {
     self = [super init];
     if (!self) {

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -782,7 +782,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
 }
 
 - (NSString *)videoStreamBackgroundString {
-    return [NSString stringWithFormat:@"When it is safe to do so, open %@ on phone", self.appName];
+    return [NSString stringWithFormat:@"When it is safe to do so, open %@ on your phone", self.appName];
 }
 
 @end

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -383,7 +383,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
 
         if (!self.backgroundingPixelBuffer) {
             CVPixelBufferRef backgroundingPixelBuffer = [self.videoEncoder newPixelBuffer];
-            NSString *videoStreamBackgroundedString = [NSString stringWithFormat:@"%@ must be open on the phone in order to work. When it is safe to do so, open %@ on phone", self.appName, self.appName];
+            NSString *videoStreamBackgroundedString = [NSString stringWithFormat:@"When it is safe to do so, open %@ on phone", self.appName];
             if (CVPixelBufferAddText(backgroundingPixelBuffer, videoStreamBackgroundedString) == NO) {
                 SDLLogE(@"Could not create a backgrounding frame");
                 [self.videoStreamStateMachine transitionToState:SDLVideoStreamManagerStateStopped];

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -68,7 +68,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
 @property (copy, nonatomic) NSArray<NSString *> *secureMakes;
 @property (copy, nonatomic) NSString *connectedVehicleMake;
 
-@property (copy, nonatomic) NSString *appName;
+@property (copy, nonatomic, readonly) NSString *appName;
 @property (assign, nonatomic) CV_NULLABLE CVPixelBufferRef backgroundingPixelBuffer;
 
 @property (strong, nonatomic, nullable) CADisplayLink *displayLink;
@@ -76,7 +76,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
 
 @property (assign, nonatomic) CMTime lastPresentationTimestamp;
 
-@property (copy, nonatomic) NSString *videoStreamBackgroundString;
+@property (copy, nonatomic, readonly) NSString *videoStreamBackgroundString;
 
 @end
 

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -17,7 +17,6 @@
 #import "SDLControlFramePayloadVideoStartService.h"
 #import "SDLControlFramePayloadVideoStartServiceAck.h"
 #import "SDLDisplayCapabilities.h"
-#import "SDLFileManagerConfiguration.h"
 #import "SDLFocusableItemLocator.h"
 #import "SDLGenericResponse.h"
 #import "SDLGetSystemCapability.h"
@@ -28,8 +27,6 @@
 #import "SDLHMILevel.h"
 #import "SDLImageResolution.h"
 #import "SDLLifecycleConfiguration.h"
-#import "SDLLockScreenConfiguration.h"
-#import "SDLLogConfiguration.h"
 #import "SDLLogMacros.h"
 #import "SDLOnHMIStatus.h"
 #import "SDLProtocol.h"
@@ -79,13 +76,13 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
 
 @property (assign, nonatomic) CMTime lastPresentationTimestamp;
 
-@property (copy, nonatomic, getter=getVideoStreamBackgroundString) NSString *videoStreamBackgroundString;
+@property (copy, nonatomic) NSString *videoStreamBackgroundString;
 
 @end
 
 @implementation SDLStreamingVideoLifecycleManager
 
-- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager config:(SDLConfiguration *)configuration {
+- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager configuration:(SDLConfiguration *)configuration {
     self = [super init];
     if (!self) {
         return nil;
@@ -783,7 +780,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
     return @[h264raw, h264rtp];
 }
 
-- (NSString *)getVideoStreamBackgroundString {
+- (NSString *)videoStreamBackgroundString {
     return [NSString stringWithFormat:@"When it is safe to do so, open %@ on your phone", self.appName];
 }
 

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingVideoLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingVideoLifecycleManagerSpec.m
@@ -38,8 +38,8 @@
 #import "TestConnectionManager.h"
 
 @interface SDLStreamingVideoLifecycleManager ()
-@property (copy, nonatomic) NSString *appName;
-- (NSString *)videoStreamBackgroundString;
+@property (copy, nonatomic, readonly) NSString *appName;
+@property (copy, nonatomic, readonly) NSString *videoStreamBackgroundString;
 @end
 
 QuickSpecBegin(SDLStreamingVideoLifecycleManagerSpec)

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingVideoLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingVideoLifecycleManagerSpec.m
@@ -33,6 +33,11 @@
 #import "SDLVideoStreamingState.h"
 #import "TestConnectionManager.h"
 
+@interface SDLStreamingVideoLifecycleManager ()
+@property (copy, nonatomic) NSString *appName;
+- (NSString *)videoStreamBackgroundString;
+@end
+
 QuickSpecBegin(SDLStreamingVideoLifecycleManagerSpec)
 
 describe(@"the streaming video manager", ^{
@@ -650,6 +655,14 @@ describe(@"the streaming video manager", ^{
                     expect(streamingLifecycleManager.currentVideoStreamState).to(equal(SDLVideoStreamManagerStateStopped));
                 });
             });
+        });
+    });
+
+    describe(@"Creating a background video stream string", ^{
+        __block NSString *expectedVideoStreamBackgroundString = [NSString stringWithFormat:@"When it is safe to do so, open %@ on phone", testAppName];
+
+        it(@"Should return the correct video stream background string for the screen size", ^{
+            expect([streamingLifecycleManager videoStreamBackgroundString]).to(match(expectedVideoStreamBackgroundString));
         });
     });
 });

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingVideoLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingVideoLifecycleManagerSpec.m
@@ -3,12 +3,14 @@
 #import <OCMock/OCMock.h>
 
 #import "SDLCarWindowViewController.h"
+#import "SDLConfiguration.h"
 #import "SDLControlFramePayloadConstants.h"
 #import "SDLControlFramePayloadNak.h"
 #import "SDLControlFramePayloadVideoStartService.h"
 #import "SDLControlFramePayloadVideoStartServiceAck.h"
 #import "SDLDisplayCapabilities.h"
 #import "SDLFakeStreamingManagerDataSource.h"
+#import "SDLFileManagerConfiguration.h"
 #import "SDLFocusableItemLocator.h"
 #import "SDLGetSystemCapability.h"
 #import "SDLGetSystemCapabilityResponse.h"
@@ -17,6 +19,8 @@
 #import "SDLHMILevel.h"
 #import "SDLImageResolution.h"
 #import "SDLLifecycleConfiguration.h"
+#import "SDLLockScreenConfiguration.h"
+#import "SDLLogConfiguration.h"
 #import "SDLOnHMIStatus.h"
 #import "SDLProtocol.h"
 #import "SDLRegisterAppInterfaceResponse.h"
@@ -49,6 +53,8 @@ describe(@"the streaming video manager", ^{
     __block NSString *testAppName = @"Test App";
     __block SDLLifecycleConfiguration * testLifecycleConfiguration = [SDLLifecycleConfiguration defaultConfigurationWithAppName:testAppName fullAppId:@""];
 
+    __block SDLConfiguration *testConfig = nil;
+
     __block void (^sendNotificationForHMILevel)(SDLHMILevel hmiLevel, SDLVideoStreamingState streamState) = ^(SDLHMILevel hmiLevel, SDLVideoStreamingState streamState) {
         SDLOnHMIStatus *hmiStatus = [[SDLOnHMIStatus alloc] init];
         hmiStatus.hmiLevel = hmiLevel;
@@ -67,7 +73,11 @@ describe(@"the streaming video manager", ^{
         testConfiguration.rootViewController = testViewController;
         testConnectionManager = [[TestConnectionManager alloc] init];
 
-        streamingLifecycleManager = [[SDLStreamingVideoLifecycleManager alloc] initWithConnectionManager:testConnectionManager streamingMediaConfiguration:testConfiguration lifecycleConfiguration:testLifecycleConfiguration];
+        testLifecycleConfiguration.appType = SDLAppHMITypeNavigation;
+
+        testConfig = [SDLConfiguration configurationWithLifecycle:testLifecycleConfiguration lockScreen:SDLLockScreenConfiguration.enabledConfiguration logging:SDLLogConfiguration.debugConfiguration streamingMedia:testConfiguration fileManager:SDLFileManagerConfiguration.defaultConfiguration];
+
+        streamingLifecycleManager = [[SDLStreamingVideoLifecycleManager alloc] initWithConnectionManager:testConnectionManager configuration:testConfig];
     });
 
     it(@"should initialize properties", ^{
@@ -659,10 +669,10 @@ describe(@"the streaming video manager", ^{
     });
 
     describe(@"Creating a background video stream string", ^{
-        __block NSString *expectedVideoStreamBackgroundString = [NSString stringWithFormat:@"When it is safe to do so, open %@ on phone", testAppName];
+        __block NSString *expectedVideoStreamBackgroundString = [NSString stringWithFormat:@"When it is safe to do so, open %@ on your phone", testAppName];
 
         it(@"Should return the correct video stream background string for the screen size", ^{
-            expect([streamingLifecycleManager videoStreamBackgroundString]).to(match(expectedVideoStreamBackgroundString));
+            expect(streamingLifecycleManager.videoStreamBackgroundString).to(match(expectedVideoStreamBackgroundString));
         });
     });
 });

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingVideoLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingVideoLifecycleManagerSpec.m
@@ -16,6 +16,7 @@
 #import "SDLGlobals.h"
 #import "SDLHMILevel.h"
 #import "SDLImageResolution.h"
+#import "SDLLifecycleConfiguration.h"
 #import "SDLOnHMIStatus.h"
 #import "SDLProtocol.h"
 #import "SDLRegisterAppInterfaceResponse.h"
@@ -39,8 +40,9 @@ describe(@"the streaming video manager", ^{
     __block SDLStreamingMediaConfiguration *testConfiguration = [SDLStreamingMediaConfiguration insecureConfiguration];
     __block SDLCarWindowViewController *testViewController = [[SDLCarWindowViewController alloc] init];
     __block SDLFakeStreamingManagerDataSource *testDataSource = [[SDLFakeStreamingManagerDataSource alloc] init];
-    __block NSString *someBackgroundTitleString = nil;
     __block TestConnectionManager *testConnectionManager = nil;
+    __block NSString *testAppName = @"Test App";
+    __block SDLLifecycleConfiguration * testLifecycleConfiguration = [SDLLifecycleConfiguration defaultConfigurationWithAppName:testAppName fullAppId:@""];
 
     __block void (^sendNotificationForHMILevel)(SDLHMILevel hmiLevel, SDLVideoStreamingState streamState) = ^(SDLHMILevel hmiLevel, SDLVideoStreamingState streamState) {
         SDLOnHMIStatus *hmiStatus = [[SDLOnHMIStatus alloc] init];
@@ -58,9 +60,9 @@ describe(@"the streaming video manager", ^{
                                                          };
         testConfiguration.dataSource = testDataSource;
         testConfiguration.rootViewController = testViewController;
-        someBackgroundTitleString = @"Open Test App";
         testConnectionManager = [[TestConnectionManager alloc] init];
-        streamingLifecycleManager = [[SDLStreamingVideoLifecycleManager alloc] initWithConnectionManager:testConnectionManager configuration:testConfiguration];
+
+        streamingLifecycleManager = [[SDLStreamingVideoLifecycleManager alloc] initWithConnectionManager:testConnectionManager streamingMediaConfiguration:testConfiguration lifecycleConfiguration:testLifecycleConfiguration];
     });
 
     it(@"should initialize properties", ^{


### PR DESCRIPTION
Fixes #1058 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Test cases added to the _SDLStreamingVideoLifecycleManagerSpec_

### Summary
The `SDLStreamingVideoLifecycleManager` now displays a string of text on the head unit screen when the app leaves the foreground.

### Changelog
##### Enhancements
* When a video streaming `NAVIGATION` or `PROJECTION` app enters the background on the phone, the video stream stops sending data due to background limitations. On iOS devices as the device is entering the background, a few frames of pure black are sent. Now we send a black screen with some white text telling the driver why their stream stopped.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)