### PR TITLE
Fix screen sub-managers failing if Register or SetDisplayLayout responses are failures

### DIFF
--- a/SmartDeviceLink/SDLChoiceSetManager.m
+++ b/SmartDeviceLink/SDLChoiceSetManager.m
@@ -407,7 +407,7 @@ UInt16 const ChoiceCellIdMin = 1;
 
     if (!response.success.boolValue) { return; }
     if (response.displayCapabilities == nil) {
-        SDLLogW(@"RegisterAppInterface succeeded but didn't send a display capabilities. A lot of things will probably break.");
+        SDLLogE(@"RegisterAppInterface succeeded but didn't send a display capabilities. A lot of things will probably break.");
         return;
     }
 
@@ -419,7 +419,7 @@ UInt16 const ChoiceCellIdMin = 1;
 
     if (!response.success.boolValue) { return; }
     if (response.displayCapabilities == nil) {
-        SDLLogW(@"SetDisplayLayout succeeded but didn't send a display capabilities. A lot of things will probably break.");
+        SDLLogE(@"SetDisplayLayout succeeded but didn't send a display capabilities. A lot of things will probably break.");
         return;
     }
 

--- a/SmartDeviceLink/SDLChoiceSetManager.m
+++ b/SmartDeviceLink/SDLChoiceSetManager.m
@@ -406,6 +406,10 @@ UInt16 const ChoiceCellIdMin = 1;
     SDLRegisterAppInterfaceResponse *response = (SDLRegisterAppInterfaceResponse *)notification.response;
 
     if (!response.success.boolValue) { return; }
+    if (response.displayCapabilities == nil) {
+        SDLLogW(@"RegisterAppInterface succeeded but didn't send a display capabilities. A lot of things will probably break.");
+        return;
+    }
 
     self.displayCapabilities = response.displayCapabilities;
 }
@@ -414,6 +418,10 @@ UInt16 const ChoiceCellIdMin = 1;
     SDLSetDisplayLayoutResponse *response = (SDLSetDisplayLayoutResponse *)notification.response;
 
     if (!response.success.boolValue) { return; }
+    if (response.displayCapabilities == nil) {
+        SDLLogW(@"SetDisplayLayout succeeded but didn't send a display capabilities. A lot of things will probably break.");
+        return;
+    }
 
     self.displayCapabilities = response.displayCapabilities;
 }

--- a/SmartDeviceLink/SDLChoiceSetManager.m
+++ b/SmartDeviceLink/SDLChoiceSetManager.m
@@ -404,11 +404,17 @@ UInt16 const ChoiceCellIdMin = 1;
 
 - (void)sdl_registerResponse:(SDLRPCResponseNotification *)notification {
     SDLRegisterAppInterfaceResponse *response = (SDLRegisterAppInterfaceResponse *)notification.response;
+
+    if (!response.success.boolValue) { return; }
+
     self.displayCapabilities = response.displayCapabilities;
 }
 
 - (void)sdl_displayLayoutResponse:(SDLRPCResponseNotification *)notification {
     SDLSetDisplayLayoutResponse *response = (SDLSetDisplayLayoutResponse *)notification.response;
+
+    if (!response.success.boolValue) { return; }
+
     self.displayCapabilities = response.displayCapabilities;
 }
 

--- a/SmartDeviceLink/SDLMenuManager.m
+++ b/SmartDeviceLink/SDLMenuManager.m
@@ -413,11 +413,25 @@ UInt32 const MenuCellIdMin = 1;
 
 - (void)sdl_registerResponse:(SDLRPCResponseNotification *)notification {
     SDLRegisterAppInterfaceResponse *response = (SDLRegisterAppInterfaceResponse *)notification.response;
+
+    if (!response.success.boolValue) { return; }
+    if (response.displayCapabilities == nil) {
+        SDLLogE(@"RegisterAppInterface succeeded but didn't send a display capabilities. A lot of things will probably break.");
+        return;
+    }
+
     self.displayCapabilities = response.displayCapabilities;
 }
 
 - (void)sdl_displayLayoutResponse:(SDLRPCResponseNotification *)notification {
     SDLSetDisplayLayoutResponse *response = (SDLSetDisplayLayoutResponse *)notification.response;
+
+    if (!response.success.boolValue) { return; }
+    if (response.displayCapabilities == nil) {
+        SDLLogE(@"SetDisplayLayout succeeded but didn't send a display capabilities. A lot of things will probably break.");
+        return;
+    }
+
     self.displayCapabilities = response.displayCapabilities;
 }
 

--- a/SmartDeviceLink/SDLSoftButtonManager.m
+++ b/SmartDeviceLink/SDLSoftButtonManager.m
@@ -355,12 +355,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)sdl_registerResponse:(SDLRPCResponseNotification *)notification {
     SDLRegisterAppInterfaceResponse *response = (SDLRegisterAppInterfaceResponse *)notification.response;
+
+    if (!response.success.boolValue) { return; }
+
     self.softButtonCapabilities = response.softButtonCapabilities ? response.softButtonCapabilities.firstObject : nil;
     self.displayCapabilities = response.displayCapabilities;
 }
 
 - (void)sdl_displayLayoutResponse:(SDLRPCResponseNotification *)notification {
     SDLSetDisplayLayoutResponse *response = (SDLSetDisplayLayoutResponse *)notification.response;
+
+    if (!response.success.boolValue) { return; }
 
     self.softButtonCapabilities = response.softButtonCapabilities ? response.softButtonCapabilities.firstObject : nil;
     self.displayCapabilities = response.displayCapabilities;

--- a/SmartDeviceLink/SDLSoftButtonManager.m
+++ b/SmartDeviceLink/SDLSoftButtonManager.m
@@ -358,7 +358,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     if (!response.success.boolValue) { return; }
     if (response.displayCapabilities == nil) {
-        SDLLogW(@"RegisterAppInterface succeeded but didn't send a display capabilities. A lot of things will probably break.");
+        SDLLogE(@"RegisterAppInterface succeeded but didn't send a display capabilities. A lot of things will probably break.");
         return;
     }
 
@@ -371,7 +371,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     if (!response.success.boolValue) { return; }
     if (response.displayCapabilities == nil) {
-        SDLLogW(@"SetDisplayLayout succeeded but didn't send a display capabilities. A lot of things will probably break.");
+        SDLLogE(@"SetDisplayLayout succeeded but didn't send a display capabilities. A lot of things will probably break.");
         return;
     }
 

--- a/SmartDeviceLink/SDLSoftButtonManager.m
+++ b/SmartDeviceLink/SDLSoftButtonManager.m
@@ -357,6 +357,10 @@ NS_ASSUME_NONNULL_BEGIN
     SDLRegisterAppInterfaceResponse *response = (SDLRegisterAppInterfaceResponse *)notification.response;
 
     if (!response.success.boolValue) { return; }
+    if (response.displayCapabilities == nil) {
+        SDLLogW(@"RegisterAppInterface succeeded but didn't send a display capabilities. A lot of things will probably break.");
+        return;
+    }
 
     self.softButtonCapabilities = response.softButtonCapabilities ? response.softButtonCapabilities.firstObject : nil;
     self.displayCapabilities = response.displayCapabilities;
@@ -366,6 +370,10 @@ NS_ASSUME_NONNULL_BEGIN
     SDLSetDisplayLayoutResponse *response = (SDLSetDisplayLayoutResponse *)notification.response;
 
     if (!response.success.boolValue) { return; }
+    if (response.displayCapabilities == nil) {
+        SDLLogW(@"SetDisplayLayout succeeded but didn't send a display capabilities. A lot of things will probably break.");
+        return;
+    }
 
     self.softButtonCapabilities = response.softButtonCapabilities ? response.softButtonCapabilities.firstObject : nil;
     self.displayCapabilities = response.displayCapabilities;

--- a/SmartDeviceLink/SDLTextAndGraphicManager.m
+++ b/SmartDeviceLink/SDLTextAndGraphicManager.m
@@ -674,11 +674,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)sdl_registerResponse:(SDLRPCResponseNotification *)notification {
     SDLRegisterAppInterfaceResponse *response = (SDLRegisterAppInterfaceResponse *)notification.response;
+
+    if (!response.success.boolValue) { return; }
+
     self.displayCapabilities = response.displayCapabilities;
 }
 
 - (void)sdl_displayLayoutResponse:(SDLRPCResponseNotification *)notification {
     SDLSetDisplayLayoutResponse *response = (SDLSetDisplayLayoutResponse *)notification.response;
+
+    if (!response.success.boolValue) { return; }
+
     self.displayCapabilities = response.displayCapabilities;
 
     // Auto-send an updated show

--- a/SmartDeviceLink/SDLTextAndGraphicManager.m
+++ b/SmartDeviceLink/SDLTextAndGraphicManager.m
@@ -676,6 +676,10 @@ NS_ASSUME_NONNULL_BEGIN
     SDLRegisterAppInterfaceResponse *response = (SDLRegisterAppInterfaceResponse *)notification.response;
 
     if (!response.success.boolValue) { return; }
+    if (response.displayCapabilities == nil) {
+        SDLLogW(@"RegisterAppInterface succeeded but didn't send a display capabilities. A lot of things will probably break.");
+        return;
+    }
 
     self.displayCapabilities = response.displayCapabilities;
 }
@@ -684,6 +688,11 @@ NS_ASSUME_NONNULL_BEGIN
     SDLSetDisplayLayoutResponse *response = (SDLSetDisplayLayoutResponse *)notification.response;
 
     if (!response.success.boolValue) { return; }
+    if (!response.success.boolValue) { return; }
+    if (response.displayCapabilities == nil) {
+        SDLLogW(@"SetDisplayLayout succeeded but didn't send a display capabilities. A lot of things will probably break.");
+        return;
+    }
 
     self.displayCapabilities = response.displayCapabilities;
 

--- a/SmartDeviceLink/SDLTextAndGraphicManager.m
+++ b/SmartDeviceLink/SDLTextAndGraphicManager.m
@@ -677,7 +677,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     if (!response.success.boolValue) { return; }
     if (response.displayCapabilities == nil) {
-        SDLLogW(@"RegisterAppInterface succeeded but didn't send a display capabilities. A lot of things will probably break.");
+        SDLLogE(@"RegisterAppInterface succeeded but didn't send a display capabilities. A lot of things will probably break.");
         return;
     }
 
@@ -690,7 +690,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (!response.success.boolValue) { return; }
     if (!response.success.boolValue) { return; }
     if (response.displayCapabilities == nil) {
-        SDLLogW(@"SetDisplayLayout succeeded but didn't send a display capabilities. A lot of things will probably break.");
+        SDLLogE(@"SetDisplayLayout succeeded but didn't send a display capabilities. A lot of things will probably break.");
         return;
     }
 


### PR DESCRIPTION
Fixes #1108 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Smoke tests

### Summary
If a `RegisterAppInterface` or `SetDisplayLayout` fail, don't set `displayCapabilities` to nil in the screen manager.

### Changelog
##### Bug Fixes
* If a `RegisterAppInterface` or `SetDisplayLayout` fail, don't set `displayCapabilities` to nil in the screen manager.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)