### PR TITLE
[SDL 0197] Implement updated SetMediaClockTimer initializers

### DIFF
--- a/SmartDeviceLink/SDLSetMediaClockTimer.h
+++ b/SmartDeviceLink/SDLSetMediaClockTimer.h
@@ -23,11 +23,114 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SDLSetMediaClockTimer : SDLRPCRequest
 
-- (instancetype)initWithUpdateMode:(SDLUpdateMode)updateMode hours:(UInt8)hours minutes:(UInt8)minutes seconds:(UInt8)seconds audioStreamingIndicator:(SDLAudioStreamingIndicator)audioStreamingIndicator;
+/**
+ Create a media clock timer that counts up, e.g from 0:00 to 4:18.
 
-- (instancetype)initWithUpdateMode:(SDLUpdateMode)updateMode hours:(UInt8)hours minutes:(UInt8)minutes seconds:(UInt8)seconds;
+ This will fail if startTime is greater than endTime
 
-- (instancetype)initWithUpdateMode:(SDLUpdateMode)updateMode;
+ @param startTime The start time interval, e.g. (0) 0:00
+ @param endTime The end time interval, e.g. (258) 4:18
+ @param playPauseIndicator An optional audio indicator to change the play/pause button
+ @return An object of SetMediaClockTimer
+ */
++ (instancetype)countUpFromStartTimeInterval:(NSTimeInterval)startTime toEndTimeInterval:(NSTimeInterval)endTime playPauseIndicator:(nullable SDLAudioStreamingIndicator)playPauseIndicator NS_SWIFT_NAME(countUp(from:to:playPauseIndicator:));
+
+/**
+ Create a media clock timer that counts up, e.g from 0:00 to 4:18.
+
+ This will fail if startTime is greater than endTime
+
+ @param startTime The start time interval, e.g. 0:00
+ @param endTime The end time interval, e.g. 4:18
+ @param playPauseIndicator An optional audio indicator to change the play/pause button
+ @return An object of SetMediaClockTimer
+ */
++ (instancetype)countUpFromStartTime:(SDLStartTime *)startTime toEndTime:(SDLStartTime *)endTime playPauseIndicator:(nullable SDLAudioStreamingIndicator)playPauseIndicator NS_SWIFT_NAME(countUp(from:to:playPauseIndicator:));
+
+/**
+ Create a media clock timer that counts down, e.g. from 4:18 to 0:00
+
+ This will fail if endTime is greater than startTime
+
+ @param startTime The start time interval, e.g. (258) 4:18
+ @param endTime The end time interval, e.g. (0) 0:00
+ @param playPauseIndicator An optional audio indicator to change the play/pause button
+ @return An object of SetMediaClockTimer
+ */
++ (instancetype)countDownFromStartTimeInterval:(NSTimeInterval)startTime toEndTimeInterval:(NSTimeInterval)endTime playPauseIndicator:(nullable SDLAudioStreamingIndicator)playPauseIndicator NS_SWIFT_NAME(countDown(from:to:playPauseIndicator:));
+
+/**
+ Create a media clock timer that counts down, e.g. from 4:18 to 0:00
+
+ This will fail if endTime is greater than startTime
+
+ @param startTime The start time interval, e.g. 4:18
+ @param endTime The end time interval, e.g. 0:00
+ @param playPauseIndicator An optional audio indicator to change the play/pause button
+ @return An object of SetMediaClockTimer
+ */
++ (instancetype)countDownFromStartTime:(SDLStartTime *)startTime toEndTime:(SDLStartTime *)endTime playPauseIndicator:(nullable SDLAudioStreamingIndicator)playPauseIndicator NS_SWIFT_NAME(countDown(from:to:playPauseIndicator:));
+
+/**
+ Pause an existing (counting up / down) media clock timer
+
+ @param playPauseIndicator An optional audio indicator to change the play/pause button
+ @return An object of SetMediaClockTimer
+ */
++ (instancetype)pauseWithPlayPauseIndicator:(nullable SDLAudioStreamingIndicator)playPauseIndicator NS_SWIFT_NAME(pause(playPauseIndicator:));
+
+/**
+ Update a pause time (or pause and update the time) on a media clock timer
+
+ @param startTime The new start time interval
+ @param endTime The new end time interval
+ @param playPauseIndicator An optional audio indicator to change the play/pause button
+ @return An object of SetMediaClockTimer
+ */
++ (instancetype)updatePauseWithNewStartTimeInterval:(NSTimeInterval)startTime endTimeInterval:(NSTimeInterval)endTime playPauseIndicator:(nullable SDLAudioStreamingIndicator)playPauseIndicator NS_SWIFT_NAME(pause(newStart:newEnd:playPauseIndicator:));
+
+/**
+ Update a pause time (or pause and update the time) on a media clock timer
+
+ @param startTime The new start time
+ @param endTime The new end time
+ @param playPauseIndicator An optional audio indicator to change the play/pause button
+ @return An object of SetMediaClockTimer
+ */
++ (instancetype)updatePauseWithNewStartTime:(SDLStartTime *)startTime endTime:(SDLStartTime *)endTime playPauseIndicator:(nullable SDLAudioStreamingIndicator)playPauseIndicator NS_SWIFT_NAME(pause(newStart:newEnd:playPauseIndicator:));
+
+/**
+ Resume a paused media clock timer. It resumes at the same time at which it was paused.
+
+ @param playPauseIndicator An optional audio indicator to change the play/pause button
+ @return An object of SetMediaClockTimer
+ */
++ (instancetype)resumeWithPlayPauseIndicator:(nullable SDLAudioStreamingIndicator)playPauseIndicator NS_SWIFT_NAME(resume(playPauseIndicator:));
+
+/**
+ Remove a media clock timer from the screen
+
+ @param playPauseIndicator An optional audio indicator to change the play/pause button
+ @return An object of SetMediaClockTimer
+ */
++ (instancetype)clearWithPlayPauseIndicator:(nullable SDLAudioStreamingIndicator)playPauseIndicator NS_SWIFT_NAME(clear(playPauseIndicator:));
+
+- (instancetype)initWithUpdateMode:(SDLUpdateMode)updateMode hours:(UInt8)hours minutes:(UInt8)minutes seconds:(UInt8)seconds audioStreamingIndicator:(SDLAudioStreamingIndicator)audioStreamingIndicator __deprecated_msg("Use a specific initializer");
+
+- (instancetype)initWithUpdateMode:(SDLUpdateMode)updateMode hours:(UInt8)hours minutes:(UInt8)minutes seconds:(UInt8)seconds __deprecated_msg("Use a specific initializer");
+
+- (instancetype)initWithUpdateMode:(SDLUpdateMode)updateMode __deprecated_msg("Use a specific initializer");
+
+/**
+ Create a SetMediaClockTimer RPC with all available parameters. It's recommended to use the specific initializers above.
+
+ @param updateMode The type of SetMediaClockTimer RPC
+ @param startTime The start time. Only valid in some updateModes.
+ @param endTime The end time. Only valid in some updateModes.
+ @param playPauseIndicator The display of the play/pause button
+ @return An object of SetMediaClockTimer
+ */
+- (instancetype)initWithUpdateMode:(SDLUpdateMode)updateMode startTime:(nullable SDLStartTime *)startTime endTime:(nullable SDLStartTime *)endTime playPauseIndicator:(nullable SDLAudioStreamingIndicator)playPauseIndicator NS_SWIFT_NAME(init(updateMode:startTime:endTime:playPauseIndicator:));
 
 /**
  * A Start Time with specifying hour, minute, second values
@@ -71,7 +174,6 @@ NS_ASSUME_NONNULL_BEGIN
  * will not change.
  */
 @property (strong, nonatomic, nullable) SDLAudioStreamingIndicator audioStreamingIndicator;
-
 
 @end
 

--- a/SmartDeviceLink/SDLSetMediaClockTimer.m
+++ b/SmartDeviceLink/SDLSetMediaClockTimer.m
@@ -18,6 +18,63 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (instancetype)initWithUpdateMode:(SDLUpdateMode)updateMode startTime:(nullable SDLStartTime *)startTime endTime:(nullable SDLStartTime *)endTime playPauseIndicator:(nullable SDLAudioStreamingIndicator)playPauseIndicator {
+    self = [self init];
+    if (!self) { return nil; }
+
+    self.updateMode = updateMode;
+    self.startTime = startTime;
+    self.endTime = endTime;
+    self.audioStreamingIndicator = playPauseIndicator;
+
+    return self;
+}
+
++ (instancetype)countUpFromStartTimeInterval:(NSTimeInterval)startTime toEndTimeInterval:(NSTimeInterval)endTime playPauseIndicator:(nullable SDLAudioStreamingIndicator)playPauseIndicator {
+    SDLStartTime *startTimeRPC = [[SDLStartTime alloc] initWithTimeInterval:startTime];
+    SDLStartTime *endTimeRPC = [[SDLStartTime alloc] initWithTimeInterval:endTime];
+
+    return [[self alloc] initWithUpdateMode:SDLUpdateModeCountUp startTime:startTimeRPC endTime:endTimeRPC playPauseIndicator:playPauseIndicator];
+}
+
++ (instancetype)countUpFromStartTime:(SDLStartTime *)startTime toEndTime:(SDLStartTime *)endTime playPauseIndicator:(nullable SDLAudioStreamingIndicator)playPauseIndicator {
+    return [[self alloc] initWithUpdateMode:SDLUpdateModeCountUp startTime:startTime endTime:endTime playPauseIndicator:playPauseIndicator];
+}
+
++ (instancetype)countDownFromStartTimeInterval:(NSTimeInterval)startTime toEndTimeInterval:(NSTimeInterval)endTime playPauseIndicator:(nullable SDLAudioStreamingIndicator)playPauseIndicator {
+    SDLStartTime *startTimeRPC = [[SDLStartTime alloc] initWithTimeInterval:startTime];
+    SDLStartTime *endTimeRPC = [[SDLStartTime alloc] initWithTimeInterval:endTime];
+
+    return [[self alloc] initWithUpdateMode:SDLUpdateModeCountDown startTime:startTimeRPC endTime:endTimeRPC playPauseIndicator:playPauseIndicator];
+}
+
++ (instancetype)countDownFromStartTime:(SDLStartTime *)startTime toEndTime:(SDLStartTime *)endTime playPauseIndicator:(nullable SDLAudioStreamingIndicator)playPauseIndicator {
+    return [[self alloc] initWithUpdateMode:SDLUpdateModeCountDown startTime:startTime endTime:endTime playPauseIndicator:playPauseIndicator];
+}
+
++ (instancetype)pauseWithPlayPauseIndicator:(nullable SDLAudioStreamingIndicator)playPauseIndicator {
+    return [[self alloc] initWithUpdateMode:SDLUpdateModePause startTime:nil endTime:nil playPauseIndicator:playPauseIndicator];
+}
+
++ (instancetype)updatePauseWithNewStartTimeInterval:(NSTimeInterval)startTime endTimeInterval:(NSTimeInterval)endTime playPauseIndicator:(nullable SDLAudioStreamingIndicator)playPauseIndicator {
+    SDLStartTime *startTimeRPC = [[SDLStartTime alloc] initWithTimeInterval:startTime];
+    SDLStartTime *endTimeRPC = [[SDLStartTime alloc] initWithTimeInterval:endTime];
+
+    return [[self alloc] initWithUpdateMode:SDLUpdateModePause startTime:startTimeRPC endTime:endTimeRPC playPauseIndicator:playPauseIndicator];
+}
+
++ (instancetype)updatePauseWithNewStartTime:(SDLStartTime *)startTime endTime:(SDLStartTime *)endTime playPauseIndicator:(nullable SDLAudioStreamingIndicator)playPauseIndicator {
+    return [[self alloc] initWithUpdateMode:SDLUpdateModePause startTime:startTime endTime:endTime playPauseIndicator:playPauseIndicator];
+}
+
++ (instancetype)resumeWithPlayPauseIndicator:(nullable SDLAudioStreamingIndicator)playPauseIndicator {
+    return [[self alloc] initWithUpdateMode:SDLUpdateModeResume startTime:nil endTime:nil playPauseIndicator:playPauseIndicator];
+}
+
++ (instancetype)clearWithPlayPauseIndicator:(nullable SDLAudioStreamingIndicator)playPauseIndicator {
+    return [[self alloc] initWithUpdateMode:SDLUpdateModeClear startTime:nil endTime:nil playPauseIndicator:playPauseIndicator];
+}
+
 - (instancetype)initWithUpdateMode:(SDLUpdateMode)updateMode hours:(UInt8)hours minutes:(UInt8)minutes seconds:(UInt8)seconds audioStreamingIndicator:(SDLAudioStreamingIndicator)audioStreamingIndicator {
     self = [self initWithUpdateMode:updateMode hours:hours minutes:minutes seconds:seconds];
     if (!self) {

--- a/SmartDeviceLink/SDLStartTime.h
+++ b/SmartDeviceLink/SDLStartTime.h
@@ -13,6 +13,22 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface SDLStartTime : SDLRPCStruct
 
+/**
+ Create a time struct with a time interval (time in seconds). Fractions of the second will be eliminated and rounded down.
+
+ @param timeInterval The time interval to transform into hours, minutes, seconds
+ @return The object
+ */
+- (instancetype)initWithTimeInterval:(NSTimeInterval)timeInterval;
+
+/**
+ Create a time struct with hours, minutes, and seconds
+
+ @param hours The number of hours
+ @param minutes The number of minutes
+ @param seconds The number of seconds
+ @return The object
+ */
 - (instancetype)initWithHours:(UInt8)hours minutes:(UInt8)minutes seconds:(UInt8)seconds;
 
 /**

--- a/SmartDeviceLink/SDLStartTime.m
+++ b/SmartDeviceLink/SDLStartTime.m
@@ -11,6 +11,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLStartTime
 
+- (instancetype)initWithTimeInterval:(NSTimeInterval)timeInterval {
+    self = [self init];
+    if (!self) { return nil; }
+
+    // https://stackoverflow.com/a/15304826/1221798
+    long seconds = lround(timeInterval);
+    self.hours = @(seconds / 3600);
+    self.minutes = @((seconds % 3600) / 60);
+    self.seconds = @(seconds % 60);
+
+    return self;
+}
+
 - (instancetype)initWithHours:(UInt8)hours minutes:(UInt8)minutes seconds:(UInt8)seconds {
     self = [self init];
     if (!self) {

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSetMediaClockTimerSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSetMediaClockTimerSpec.m
@@ -16,10 +16,132 @@
 
 QuickSpecBegin(SDLSetMediaClockTimerSpec)
 
-SDLStartTime* time1 = [[SDLStartTime alloc] init];
-SDLStartTime* time2 = [[SDLStartTime alloc] init];
+describe(@"SetMediaClocktimer Spec", ^ {
+    __block NSTimeInterval testTime1Interval = 32887;
+    __block NSTimeInterval testTime2Interval = 3723;
+    __block SDLStartTime *time1 = [[SDLStartTime alloc] initWithHours:9 minutes:8 seconds:7];
+    __block SDLStartTime *time2 = [[SDLStartTime alloc] initWithHours:1 minutes:2 seconds:3];
+    __block SDLUpdateMode testUpdateMode = SDLUpdateModeCountUp;
+    __block SDLAudioStreamingIndicator testIndicator = SDLAudioStreamingIndicatorPlayPause;
 
-describe(@"Getter/Setter Tests", ^ {
+    describe(@"when initialized", ^{
+        it(@"should properly initialize with initWithDictionary:", ^{
+            NSMutableDictionary* dict = [@{SDLNameRequest:
+                                               @{SDLNameParameters:
+                                                     @{SDLNameStartTime:time1,
+                                                       SDLNameEndTime:time2,
+                                                       SDLNameUpdateMode:testUpdateMode,
+                                                       SDLNameAudioStreamingIndicator:testIndicator
+                                                       },
+                                                 SDLNameOperationName:SDLNameSetMediaClockTimer}} mutableCopy];
+            SDLSetMediaClockTimer* testRequest = [[SDLSetMediaClockTimer alloc] initWithDictionary:dict];
+
+            expect(testRequest.startTime).to(equal(time1));
+            expect(testRequest.endTime).to(equal(time2));
+            expect(testRequest.updateMode).to(equal(testUpdateMode));
+            expect(testRequest.audioStreamingIndicator).to(equal(testIndicator));
+        });
+
+        it(@"should properly initialize with init", ^{
+            SDLSetMediaClockTimer* testRequest = [[SDLSetMediaClockTimer alloc] init];
+
+            expect(testRequest.startTime).to(beNil());
+            expect(testRequest.endTime).to(beNil());
+            expect(testRequest.updateMode).to(beNil());
+            expect(testRequest.audioStreamingIndicator).to(beNil());
+        });
+
+        it(@"should properly initialize with countUpWithStartTimeInterval:endTimeInterval:playPauseIndicator:", ^{
+            SDLSetMediaClockTimer *testRequest = [SDLSetMediaClockTimer countUpFromStartTimeInterval:testTime1Interval toEndTimeInterval:testTime2Interval playPauseIndicator:testIndicator];
+
+            expect(testRequest.startTime).to(equal(time1));
+            expect(testRequest.endTime).to(equal(time2));
+            expect(testRequest.updateMode).to(equal(SDLUpdateModeCountUp));
+            expect(testRequest.audioStreamingIndicator).to(equal(testIndicator));
+        });
+
+        it(@"should properly initialize with countUpWithStartTime:endTime:playPauseIndicator:", ^{
+            SDLSetMediaClockTimer *testRequest = [SDLSetMediaClockTimer countUpFromStartTime:time1 toEndTime:time2 playPauseIndicator:testIndicator];
+
+            expect(testRequest.startTime).to(equal(time1));
+            expect(testRequest.endTime).to(equal(time2));
+            expect(testRequest.updateMode).to(equal(SDLUpdateModeCountUp));
+            expect(testRequest.audioStreamingIndicator).to(equal(testIndicator));
+        });
+
+        it(@"should properly initialize with countUpWithStartTimeInterval:endTimeInterval:playPauseIndicator:", ^{
+            SDLSetMediaClockTimer *testRequest = [SDLSetMediaClockTimer countDownFromStartTimeInterval:testTime1Interval toEndTimeInterval:testTime2Interval playPauseIndicator:testIndicator];
+
+            expect(testRequest.startTime).to(equal(time1));
+            expect(testRequest.endTime).to(equal(time2));
+            expect(testRequest.updateMode).to(equal(SDLUpdateModeCountDown));
+            expect(testRequest.audioStreamingIndicator).to(equal(testIndicator));
+        });
+
+        it(@"should properly initialize with countDownWithStartTime:endTime:playPauseIndicator:", ^{
+            SDLSetMediaClockTimer *testRequest = [SDLSetMediaClockTimer countDownFromStartTime:time1 toEndTime:time2 playPauseIndicator:testIndicator];
+
+            expect(testRequest.startTime).to(equal(time1));
+            expect(testRequest.endTime).to(equal(time2));
+            expect(testRequest.updateMode).to(equal(SDLUpdateModeCountDown));
+            expect(testRequest.audioStreamingIndicator).to(equal(testIndicator));
+        });
+
+        it(@"should properly initialize with pauseWithPlayPauseIndicator", ^{
+            SDLSetMediaClockTimer *testRequest = [SDLSetMediaClockTimer pauseWithPlayPauseIndicator:testIndicator];
+
+            expect(testRequest.startTime).to(beNil());
+            expect(testRequest.endTime).to(beNil());
+            expect(testRequest.updateMode).to(equal(SDLUpdateModePause));
+            expect(testRequest.audioStreamingIndicator).to(equal(testIndicator));
+        });
+
+        it(@"should properly initialize with updatePauseWithNewStartTimeInterval:endTimeInterval:playPauseIndicator:", ^{
+            SDLSetMediaClockTimer *testRequest = [SDLSetMediaClockTimer updatePauseWithNewStartTimeInterval:testTime1Interval endTimeInterval:testTime2Interval playPauseIndicator:testIndicator];
+
+            expect(testRequest.startTime).to(equal(time1));
+            expect(testRequest.endTime).to(equal(time2));
+            expect(testRequest.updateMode).to(equal(SDLUpdateModePause));
+            expect(testRequest.audioStreamingIndicator).to(equal(testIndicator));
+        });
+
+        it(@"should properly initialize with updatePauseWithNewStartTime:endTime:playPauseIndicator:", ^{
+            SDLSetMediaClockTimer *testRequest = [SDLSetMediaClockTimer updatePauseWithNewStartTime:time1 endTime:time2 playPauseIndicator:testIndicator];
+
+            expect(testRequest.startTime).to(equal(time1));
+            expect(testRequest.endTime).to(equal(time2));
+            expect(testRequest.updateMode).to(equal(SDLUpdateModePause));
+            expect(testRequest.audioStreamingIndicator).to(equal(testIndicator));
+        });
+
+        it(@"should properly initialize with resumeWithPlayPauseIndicator:", ^{
+            SDLSetMediaClockTimer *testRequest = [SDLSetMediaClockTimer resumeWithPlayPauseIndicator:testIndicator];
+
+            expect(testRequest.startTime).to(beNil());
+            expect(testRequest.endTime).to(beNil());
+            expect(testRequest.updateMode).to(equal(SDLUpdateModeResume));
+            expect(testRequest.audioStreamingIndicator).to(equal(testIndicator));
+        });
+
+        it(@"should properly initialize with clearWithPlayPauseIndicator:", ^{
+            SDLSetMediaClockTimer *testRequest = [SDLSetMediaClockTimer clearWithPlayPauseIndicator:testIndicator];
+
+            expect(testRequest.startTime).to(beNil());
+            expect(testRequest.endTime).to(beNil());
+            expect(testRequest.updateMode).to(equal(SDLUpdateModeClear));
+            expect(testRequest.audioStreamingIndicator).to(equal(testIndicator));
+        });
+
+        it(@"should properly initialize with initWithUpdateMode:startTime:endTime:playPauseIndicator:", ^{
+            SDLSetMediaClockTimer *testRequest = [[SDLSetMediaClockTimer alloc] initWithUpdateMode:testUpdateMode startTime:time1 endTime:time2 playPauseIndicator:testIndicator];
+
+            expect(testRequest.startTime).to(equal(time1));
+            expect(testRequest.endTime).to(equal(time2));
+            expect(testRequest.updateMode).to(equal(testUpdateMode));
+            expect(testRequest.audioStreamingIndicator).to(equal(testIndicator));
+        });
+    });
+
     it(@"Should set and get correctly", ^ {
         SDLSetMediaClockTimer* testRequest = [[SDLSetMediaClockTimer alloc] init];
         
@@ -32,32 +154,6 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testRequest.endTime).to(equal(time2));
         expect(testRequest.updateMode).to(equal(SDLUpdateModeCountUp));
         expect(testRequest.audioStreamingIndicator).to(equal(SDLAudioStreamingIndicatorPlayPause));
-    });
-    
-    it(@"Should get correctly when initialized", ^ {
-        NSMutableDictionary* dict = [@{SDLNameRequest:
-                                           @{SDLNameParameters:
-                                                 @{SDLNameStartTime:time1,
-                                                   SDLNameEndTime:time2,
-                                                   SDLNameUpdateMode:SDLUpdateModeCountUp,
-                                                   SDLNameAudioStreamingIndicator:SDLAudioStreamingIndicatorPlayPause
-                                                   },
-                                             SDLNameOperationName:SDLNameSetMediaClockTimer}} mutableCopy];
-        SDLSetMediaClockTimer* testRequest = [[SDLSetMediaClockTimer alloc] initWithDictionary:dict];
-        
-        expect(testRequest.startTime).to(equal(time1));
-        expect(testRequest.endTime).to(equal(time2));
-        expect(testRequest.updateMode).to(equal(SDLUpdateModeCountUp));
-        expect(testRequest.audioStreamingIndicator).to(equal(SDLAudioStreamingIndicatorPlayPause));
-    });
-    
-    it(@"Should return nil if not set", ^ {
-        SDLSetMediaClockTimer* testRequest = [[SDLSetMediaClockTimer alloc] init];
-        
-        expect(testRequest.startTime).to(beNil());
-        expect(testRequest.endTime).to(beNil());
-        expect(testRequest.updateMode).to(beNil());
-        expect(testRequest.audioStreamingIndicator).to(beNil());
     });
 });
 

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLStartTimeSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLStartTimeSpec.m
@@ -13,7 +13,50 @@
 
 QuickSpecBegin(SDLStartTimeSpec)
 
-describe(@"Getter/Setter Tests", ^ {
+describe(@"StartTime Spec", ^ {
+    describe(@"when initialized", ^{
+        __block UInt8 testHours = 22;
+        __block UInt8 testMinutes = 39;
+        __block UInt8 testSeconds = 11;
+
+        __block NSTimeInterval testTimeInterval = 81551;
+
+        it(@"should properly initialize with init", ^{
+            SDLStartTime *testStruct = [[SDLStartTime alloc] init];
+
+            expect(testStruct.hours).to(beNil());
+            expect(testStruct.minutes).to(beNil());
+            expect(testStruct.seconds).to(beNil());
+        });
+
+        it(@"should properly initialize with initWithDictionary:", ^{
+            NSDictionary<NSString *, id> *dict = @{SDLNameHours:@(testHours),
+                                                   SDLNameMinutes:@(testMinutes),
+                                                   SDLNameSeconds:@(testSeconds)};
+            SDLStartTime *testStruct = [[SDLStartTime alloc] initWithDictionary:dict];
+
+            expect(testStruct.hours).to(equal(@(testHours)));
+            expect(testStruct.minutes).to(equal(@(testMinutes)));
+            expect(testStruct.seconds).to(equal(@(testSeconds)));
+        });
+
+        it(@"should properly initialize with initWithTimeInterval:", ^{
+            SDLStartTime *testStruct = [[SDLStartTime alloc] initWithTimeInterval:testTimeInterval];
+
+            expect(testStruct.hours).to(equal(@(testHours)));
+            expect(testStruct.minutes).to(equal(@(testMinutes)));
+            expect(testStruct.seconds).to(equal(@(testSeconds)));
+        });
+
+        it(@"should properly initialize with initWithHours:minutes:seconds:", ^{
+            SDLStartTime *testStruct = [[SDLStartTime alloc] initWithHours:testHours minutes:testMinutes seconds:testSeconds];
+
+            expect(testStruct.hours).to(equal(@(testHours)));
+            expect(testStruct.minutes).to(equal(@(testMinutes)));
+            expect(testStruct.seconds).to(equal(@(testSeconds)));
+        });
+    });
+
     it(@"Should set and get correctly", ^ {
         SDLStartTime* testStruct = [[SDLStartTime alloc] init];
         
@@ -24,25 +67,6 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testStruct.hours).to(equal(@22));
         expect(testStruct.minutes).to(equal(@39));
         expect(testStruct.seconds).to(equal(@11));
-    });
-    
-    it(@"Should get correctly when initialized", ^ {
-        NSMutableDictionary<NSString *, id> *dict = [@{SDLNameHours:@22,
-                                                       SDLNameMinutes:@39,
-                                                       SDLNameSeconds:@11} mutableCopy];
-        SDLStartTime* testStruct = [[SDLStartTime alloc] initWithDictionary:dict];
-        
-        expect(testStruct.hours).to(equal(@22));
-        expect(testStruct.minutes).to(equal(@39));
-        expect(testStruct.seconds).to(equal(@11));
-    });
-    
-    it(@"Should return nil if not set", ^ {
-        SDLStartTime* testStruct = [[SDLStartTime alloc] init];
-        
-        expect(testStruct.hours).to(beNil());
-        expect(testStruct.minutes).to(beNil());
-        expect(testStruct.seconds).to(beNil());
     });
 });
 


### PR DESCRIPTION
Fixes #1071 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Unit tests are added

### Summary
This PR updates initializers for `SetMediaClockTimer` and `StartTime` RPCs.

### Changelog
##### Enhancements
* Updated initializers for `SetMediaClockTimer` and `StartTime` RPCs.

### Tasks Remaining:
n/a

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)