### PR TITLE
fix to call sdl_retryEstablishSession after data sesion is closed

### DIFF
--- a/SmartDeviceLink/SDLIAPTransport.m
+++ b/SmartDeviceLink/SDLIAPTransport.m
@@ -564,7 +564,7 @@ int const ProtocolIndexTimeoutSeconds = 10;
             strongSelf.session.streamDelegate = nil;
             strongSelf.session = nil;
             
-            // We don't call sdl_retryEstablishSession here because the stream end event usually fires when the accessory is disconnected
+            [strongSelf sdl_retryEstablishSession];
         });
         
         // To prevent deadlocks the handler must return to the runloop and not block the thread


### PR DESCRIPTION
Fixes #1113

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
I tested with our customer's HU

### Summary
Call sdl_retryEstablishSession  after HU closed EA sessions.

### Changelog
##### Breaking Changes
* [Breaking change info]

##### Enhancements
* Proxy starts reconnection sequence after HU closes EA session

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
