### PR TITLE
Check class type to take care of the case textField.name has "long" type

### DIFF
--- a/SmartDeviceLink/SDLDisplayCapabilities+ShowManagerExtensions.m
+++ b/SmartDeviceLink/SDLDisplayCapabilities+ShowManagerExtensions.m
@@ -25,6 +25,7 @@
 - (NSUInteger)maxNumberOfMainFieldLines {
     NSInteger highestFound = 0;
     for (SDLTextField *textField in self.textFields) {
+        if (![textField.name isKindOfClass:[NSString class]]) { continue; }
         if ([textField.name isEqualToString:SDLTextFieldNameMainField1]
             || [textField.name isEqualToString:SDLTextFieldNameMainField2]
             || [textField.name isEqualToString:SDLTextFieldNameMainField3]


### PR DESCRIPTION
Fixes #1122 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
I tested with my devboard HU.

### Summary
Add a type check in SDLDisplayCapabilities+ShowManagerExtensions#maxNumberOfMainFieldLines.

### Changelog
##### Bug Fixes
* Avoid crash by adding type check at SDLDisplayCapabilities+ShowManagerExtensions#maxNumberOfMainFieldLines.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
