### PR TITLE
check class type to take care of language enum being “-1”

### DIFF
--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -313,7 +313,7 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
     BOOL delegateCanUpdateLifecycle = [self.delegate respondsToSelector:@selector(managerShouldUpdateLifecycleToLanguage:)];
     
     // language mismatch? but actual language is a supported language? and delegate has implemented method?
-    if (![actualLanguage isEqualToEnum:desiredLanguage] && [supportedLanguages containsObject:actualLanguage] && delegateCanUpdateLifecycle) {
+    if ([actualLanguage isKindOfClass:[NSString class]] && ![actualLanguage isEqualToEnum:desiredLanguage] && [supportedLanguages containsObject:actualLanguage] && delegateCanUpdateLifecycle) {
         [self sdl_transitionToState:SDLLifecycleStateUpdatingConfiguration];
     } else {
         [self sdl_transitionToState:SDLLifecycleStateSettingUpManagers];
@@ -324,30 +324,32 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
     // we can expect that the delegate has implemented the update method and the actual language is a supported language
     SDLLanguage actualLanguage = self.registerResponse.language;
 
-    SDLLifecycleConfigurationUpdate *configUpdate = [self.delegate managerShouldUpdateLifecycleToLanguage:actualLanguage];
-    
-    if (configUpdate) {
-        self.configuration.lifecycleConfig.language = actualLanguage;
-        if (configUpdate.appName) {
-            self.configuration.lifecycleConfig.appName = configUpdate.appName;
-        }
-        if (configUpdate.shortAppName) {
-            self.configuration.lifecycleConfig.shortAppName = configUpdate.shortAppName;
-        }
-        if (configUpdate.ttsName) {
-            self.configuration.lifecycleConfig.ttsName = configUpdate.ttsName;
-        }
-        if (configUpdate.voiceRecognitionCommandNames) {
-            self.configuration.lifecycleConfig.voiceRecognitionCommandNames = configUpdate.voiceRecognitionCommandNames;
-        }
-        
-        SDLChangeRegistration *changeRegistration = [[SDLChangeRegistration alloc] initWithLanguage:actualLanguage hmiDisplayLanguage:actualLanguage];
-        changeRegistration.appName = configUpdate.appName;
-        changeRegistration.ngnMediaScreenAppName = configUpdate.shortAppName;
-        changeRegistration.ttsName = configUpdate.ttsName;
-        changeRegistration.vrSynonyms = configUpdate.voiceRecognitionCommandNames;
+    if ([actualLanguage isKindOfClass:[NSString class]]) {
+        SDLLifecycleConfigurationUpdate *configUpdate = [self.delegate managerShouldUpdateLifecycleToLanguage:actualLanguage];
 
-        [self sendConnectionManagerRequest:changeRegistration withResponseHandler:nil];
+        if (configUpdate) {
+            self.configuration.lifecycleConfig.language = actualLanguage;
+            if (configUpdate.appName) {
+                self.configuration.lifecycleConfig.appName = configUpdate.appName;
+            }
+            if (configUpdate.shortAppName) {
+                self.configuration.lifecycleConfig.shortAppName = configUpdate.shortAppName;
+            }
+            if (configUpdate.ttsName) {
+                self.configuration.lifecycleConfig.ttsName = configUpdate.ttsName;
+            }
+            if (configUpdate.voiceRecognitionCommandNames) {
+                self.configuration.lifecycleConfig.voiceRecognitionCommandNames = configUpdate.voiceRecognitionCommandNames;
+            }
+
+            SDLChangeRegistration *changeRegistration = [[SDLChangeRegistration alloc] initWithLanguage:actualLanguage hmiDisplayLanguage:actualLanguage];
+            changeRegistration.appName = configUpdate.appName;
+            changeRegistration.ngnMediaScreenAppName = configUpdate.shortAppName;
+            changeRegistration.ttsName = configUpdate.ttsName;
+            changeRegistration.vrSynonyms = configUpdate.voiceRecognitionCommandNames;
+
+            [self sendConnectionManagerRequest:changeRegistration withResponseHandler:nil];
+        }
     }
     
     [self sdl_transitionToState:SDLLifecycleStateSettingUpManagers];


### PR DESCRIPTION
Fixes #1127

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
I tested with our internal HU devboard which has invalid language settings.

### Summary
Check class type of `language` in RAI response before accessing it.

### Changelog

##### Bug Fixes
* [Bug Fix Info]
Check class type of `language` in RAI response before accessing it.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
