### PR TITLE
Add an explicit crash if an invalid soft button state is created

### DIFF
--- a/SmartDeviceLink/SDLSoftButtonState.m
+++ b/SmartDeviceLink/SDLSoftButtonState.m
@@ -32,6 +32,8 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation SDLSoftButtonState
 
 - (instancetype)initWithStateName:(NSString *)stateName text:(nullable NSString *)text image:(nullable UIImage *)image {
+    NSParameterAssert((text != nil) || (image != nil));
+
     SDLArtwork *artwork = [[SDLArtwork alloc] initWithImage:image persistent:YES asImageFormat:SDLArtworkImageFormatPNG];
     return [self initWithStateName:stateName text:text artwork:artwork];
 }
@@ -40,10 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
     self = [super init];
     if (!self) { return nil; }
 
-    if (artwork == nil && text == nil) {
-        SDLLogE(@"Attempted to create an invalid soft button state: text and artwork are both nil");
-        return nil;
-    }
+    NSParameterAssert((text != nil) || (artwork != nil));
 
     _name = stateName;
     _text = text;

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLSoftButtonStateSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLSoftButtonStateSpec.m
@@ -60,6 +60,17 @@ describe(@"soft button state", ^{
             expect(testSoftButton.image.value).to(equal(testArtworkName));
         });
     });
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-value"
+    context(@"when created invalid", ^{
+        it(@"should assert", ^{
+            expectAction(^{
+                [[SDLSoftButtonState alloc] initWithStateName:testStateName text:nil image:nil];
+            }).to(raiseException());
+        });
+    });
+#pragma clang diagnostic pop
 });
 
 QuickSpecEnd


### PR DESCRIPTION
Fixes #1126 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Unit tests have been added

### Summary
Add an explicit crash if an `SDLSoftButtonState` is created without either text or image.

### Changelog
##### Bug Fixes
* Add an explicit crash if an `SDLSoftButtonState` is created without either text or image.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)