### PR TITLE
Remove test ChoiceSet after it's no longer needed in ChoiceSetManager

### DIFF
--- a/SmartDeviceLink/SDLCheckChoiceVROptionalOperation.m
+++ b/SmartDeviceLink/SDLCheckChoiceVROptionalOperation.m
@@ -11,6 +11,7 @@
 #import "SDLChoice.h"
 #import "SDLCreateInteractionChoiceSet.h"
 #import "SDLConnectionManagerType.h"
+#import "SDLDeleteInteractionChoiceSet.h"
 #import "SDLLogMacros.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -47,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 
             weakself.vrOptional = YES;
             weakself.internalError = nil;
-            [weakself finishOperation];
+            [weakself sdl_deleteTestChoices];
             return;
         }
 
@@ -58,7 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
 
                 weakself.vrOptional = NO;
                 weakself.internalError = nil;
-                [weakself finishOperation];
+                [weakself sdl_deleteTestChoices];
                 return;
             }
 
@@ -67,6 +68,15 @@ NS_ASSUME_NONNULL_BEGIN
             weakself.internalError = error;
             [weakself finishOperation];
         }];
+    }];
+}
+
+- (void)sdl_deleteTestChoices {
+    SDLDeleteInteractionChoiceSet *deleteChoiceSet = [[SDLDeleteInteractionChoiceSet alloc] initWithId:0];
+
+    __weak typeof(self) weakself = self;
+    [self.connectionManager sendConnectionManagerRequest:deleteChoiceSet withResponseHandler:^(__kindof SDLRPCRequest * _Nullable request, __kindof SDLRPCResponse * _Nullable response, NSError * _Nullable error) {
+        [weakself finishOperation];
     }];
 }
 

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLCheckChoiceVROptionalOperationSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLCheckChoiceVROptionalOperationSpec.m
@@ -6,6 +6,8 @@
 #import "SDLChoice.h"
 #import "SDLCreateInteractionChoiceSet.h"
 #import "SDLCreateInteractionChoiceSetResponse.h"
+#import "SDLDeleteInteractionChoiceSet.h"
+#import "SDLDeleteInteractionChoiceSetResponse.h"
 #import "TestConnectionManager.h"
 
 QuickSpecBegin(SDLCheckChoiceVROptionalOperationSpec)
@@ -64,15 +66,26 @@ describe(@"check choice VR optional operation", ^{
                 [testConnectionManager respondToLastRequestWithResponse:testResponse];
             });
 
-            it(@"should have called the completion handler with proper data", ^{
-                expect(hasCalledOperationCompletionHandler).toEventually(beTrue());
-                expect(resultVROptional).to(beTrue());
-                expect(resultError).to(beNil());
+            it(@"should have sent a DeleteChoiceSet request", ^{
+                expect(testConnectionManager.receivedRequests.lastObject).to(beAnInstanceOf([SDLDeleteInteractionChoiceSet class]));
             });
 
-            it(@"should be set to finished", ^{
-                expect(@(testOp.finished)).to(equal(@YES));
-                expect(@(testOp.executing)).to(equal(@NO));
+            describe(@"after the DeleteChoiceSet response", ^{
+                beforeEach(^{
+                    SDLDeleteInteractionChoiceSetResponse *testDeleteResponse = [[SDLDeleteInteractionChoiceSetResponse alloc] init];
+                    testDeleteResponse.success = @YES;
+                    testDeleteResponse.resultCode = SDLResultSuccess;
+
+                    [testConnectionManager respondToLastRequestWithResponse:testDeleteResponse];
+                });
+
+                it(@"should have called the completion handler with proper data and finish", ^{
+                    expect(hasCalledOperationCompletionHandler).toEventually(beTrue());
+                    expect(resultVROptional).to(beTrue());
+                    expect(resultError).to(beNil());
+                    expect(@(testOp.finished)).to(equal(@YES));
+                    expect(@(testOp.executing)).to(equal(@NO));
+                });
             });
         });
 
@@ -109,15 +122,22 @@ describe(@"check choice VR optional operation", ^{
                     [testConnectionManager respondToLastRequestWithResponse:testResponse];
                 });
 
-                it(@"should have called the completion handler with proper data", ^{
-                    expect(hasCalledOperationCompletionHandler).toEventually(beTrue());
-                    expect(resultVROptional).toEventually(beFalse());
-                    expect(resultError).toEventually(beNil());
-                });
+                describe(@"after the DeleteChoiceSet response", ^{
+                    beforeEach(^{
+                        SDLDeleteInteractionChoiceSetResponse *testDeleteResponse = [[SDLDeleteInteractionChoiceSetResponse alloc] init];
+                        testDeleteResponse.success = @YES;
+                        testDeleteResponse.resultCode = SDLResultSuccess;
 
-                it(@"should be set to finished", ^{
-                    expect(@(testOp.finished)).to(equal(@YES));
-                    expect(@(testOp.executing)).to(equal(@NO));
+                        [testConnectionManager respondToLastRequestWithResponse:testDeleteResponse];
+                    });
+
+                    it(@"should have called the completion handler with proper data and finish", ^{
+                        expect(hasCalledOperationCompletionHandler).toEventually(beTrue());
+                        expect(resultVROptional).to(beTrue());
+                        expect(resultError).to(beNil());
+                        expect(@(testOp.finished)).to(equal(@YES));
+                        expect(@(testOp.executing)).to(equal(@NO));
+                    });
                 });
             });
 


### PR DESCRIPTION
Fixes #1129 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Unit tests have been added

### Summary
Delete the test `CreateInteractionChoiceSet` used by the `SDLChoiceSetManager` after it is no longer needed.

### Changelog
##### Bug Fixes
* Delete the test `CreateInteractionChoiceSet` used by the `SDLChoiceSetManager` after it is no longer needed.

### Tasks Remaining:
- [ ] [Task 1]
- [ ] [Task 2]

### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)