### PR TITLE
Support generating the RTP video stream SSRC once at a higher level

### DIFF
--- a/Example Apps/Example ObjC/ProxyManager.m
+++ b/Example Apps/Example ObjC/ProxyManager.m
@@ -113,7 +113,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)sdlex_setupConfigurationWithLifecycleConfiguration:(SDLLifecycleConfiguration *)lifecycleConfiguration {
-    SDLConfiguration *config = [SDLConfiguration configurationWithLifecycle:lifecycleConfiguration lockScreen:[SDLLockScreenConfiguration enabledConfigurationWithAppIcon:[UIImage imageNamed:ExampleAppLogoName] backgroundColor:nil] logging:[self.class sdlex_logConfiguration] streamingMedia:[SDLStreamingMediaConfiguration autostreamingInsecureConfigurationWithInitialViewController:[UIApplication sharedApplication].keyWindow.rootViewController] fileManager:[SDLFileManagerConfiguration defaultConfiguration]];
+    SDLConfiguration *config = [SDLConfiguration configurationWithLifecycle:lifecycleConfiguration lockScreen:[SDLLockScreenConfiguration enabledConfigurationWithAppIcon:[UIImage imageNamed:ExampleAppLogoName] backgroundColor:nil] logging:[self.class sdlex_logConfiguration] fileManager:[SDLFileManagerConfiguration defaultConfiguration]];
     self.sdlManager = [[SDLManager alloc] initWithConfiguration:config delegate:self];
 
     [self startManager];
@@ -129,7 +129,7 @@ NS_ASSUME_NONNULL_BEGIN
     config.ttsName = [SDLTTSChunk textChunksFromString:ExampleAppName];
     config.language = SDLLanguageEnUs;
     config.languagesSupported = @[SDLLanguageEnUs, SDLLanguageFrCa, SDLLanguageEsMx];
-    config.appType = SDLAppHMITypeNavigation;
+    config.appType = SDLAppHMITypeDefault;
 
     SDLRGBColor *green = [[SDLRGBColor alloc] initWithRed:126 green:188 blue:121];
     SDLRGBColor *white = [[SDLRGBColor alloc] initWithRed:249 green:251 blue:254];

--- a/Example Apps/Example ObjC/ProxyManager.m
+++ b/Example Apps/Example ObjC/ProxyManager.m
@@ -113,7 +113,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)sdlex_setupConfigurationWithLifecycleConfiguration:(SDLLifecycleConfiguration *)lifecycleConfiguration {
-    SDLConfiguration *config = [SDLConfiguration configurationWithLifecycle:lifecycleConfiguration lockScreen:[SDLLockScreenConfiguration enabledConfigurationWithAppIcon:[UIImage imageNamed:ExampleAppLogoName] backgroundColor:nil] logging:[self.class sdlex_logConfiguration] fileManager:[SDLFileManagerConfiguration defaultConfiguration]];
+    SDLConfiguration *config = [SDLConfiguration configurationWithLifecycle:lifecycleConfiguration lockScreen:[SDLLockScreenConfiguration enabledConfigurationWithAppIcon:[UIImage imageNamed:ExampleAppLogoName] backgroundColor:nil] logging:[self.class sdlex_logConfiguration] streamingMedia:[SDLStreamingMediaConfiguration autostreamingInsecureConfigurationWithInitialViewController:[UIApplication sharedApplication].keyWindow.rootViewController] fileManager:[SDLFileManagerConfiguration defaultConfiguration]];
     self.sdlManager = [[SDLManager alloc] initWithConfiguration:config delegate:self];
 
     [self startManager];
@@ -129,7 +129,7 @@ NS_ASSUME_NONNULL_BEGIN
     config.ttsName = [SDLTTSChunk textChunksFromString:ExampleAppName];
     config.language = SDLLanguageEnUs;
     config.languagesSupported = @[SDLLanguageEnUs, SDLLanguageFrCa, SDLLanguageEsMx];
-    config.appType = SDLAppHMITypeMedia;
+    config.appType = SDLAppHMITypeNavigation;
 
     SDLRGBColor *green = [[SDLRGBColor alloc] initWithRed:126 green:188 blue:121];
     SDLRGBColor *white = [[SDLRGBColor alloc] initWithRed:249 green:251 blue:254];

--- a/SmartDeviceLink/SDLH264VideoEncoder.h
+++ b/SmartDeviceLink/SDLH264VideoEncoder.h
@@ -58,7 +58,7 @@ extern NSString *const SDLErrorDomainVideoEncoder;
 
 - (instancetype)init NS_UNAVAILABLE;
 
-- (instancetype)initWithProtocol:(SDLVideoStreamingProtocol)protocol dimensions:(CGSize)dimensions properties:(NSDictionary<NSString *, id> *)properties delegate:(id<SDLVideoEncoderDelegate> __nullable)delegate error:(NSError **)error NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithProtocol:(SDLVideoStreamingProtocol)protocol dimensions:(CGSize)dimensions ssrc:(UInt32)ssrc properties:(NSDictionary<NSString *, id> *)properties delegate:(id<SDLVideoEncoderDelegate> __nullable)delegate error:(NSError **)error NS_DESIGNATED_INITIALIZER;
 
 - (void)stop;
 

--- a/SmartDeviceLink/SDLH264VideoEncoder.m
+++ b/SmartDeviceLink/SDLH264VideoEncoder.m
@@ -45,7 +45,7 @@ static NSDictionary<NSString *, id>* _defaultVideoEncoderSettings;
                                      };
 }
 
-- (instancetype)initWithProtocol:(SDLVideoStreamingProtocol)protocol dimensions:(CGSize)dimensions properties:(NSDictionary<NSString *, id> *)properties delegate:(id<SDLVideoEncoderDelegate> __nullable)delegate error:(NSError **)error {
+- (instancetype)initWithProtocol:(SDLVideoStreamingProtocol)protocol dimensions:(CGSize)dimensions ssrc:(UInt32)ssrc properties:(NSDictionary<NSString *, id> *)properties delegate:(id<SDLVideoEncoderDelegate> __nullable)delegate error:(NSError **)error {
     self = [super init];
     if (!self) {
         return nil;
@@ -115,7 +115,7 @@ static NSDictionary<NSString *, id>* _defaultVideoEncoderSettings;
     if ([protocol isEqualToEnum:SDLVideoStreamingProtocolRAW]) {
         _packetizer = [[SDLRAWH264Packetizer alloc] init];
     } else if ([protocol isEqualToEnum:SDLVideoStreamingProtocolRTP]) {
-        _packetizer = [[SDLRTPH264Packetizer alloc] init];
+        _packetizer = [[SDLRTPH264Packetizer alloc] initWithSSRC:ssrc];
     } else {
         if (!*error) {
             *error = [NSError errorWithDomain:SDLErrorDomainVideoEncoder code:SDLVideoEncoderErrorProtocolUnknown userInfo:@{ @"encoder": protocol}];

--- a/SmartDeviceLink/SDLRTPH264Packetizer.h
+++ b/SmartDeviceLink/SDLRTPH264Packetizer.h
@@ -28,15 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (assign, nonatomic) UInt8 payloadType;
 
-/**
- * SSRC of RTP header field.
- *
- * SSRC field identifies the source of a stream and it should be
- * chosen randomly (see section 3 and 5.1 in RFC 3550).
- *
- * @note A random value is generated and used as default.
- */
-@property (assign, nonatomic) UInt32 ssrc;
+- (instancetype)initWithSSRC:(UInt32)ssrc;
 
 @end
 

--- a/SmartDeviceLink/SDLRTPH264Packetizer.m
+++ b/SmartDeviceLink/SDLRTPH264Packetizer.m
@@ -55,11 +55,21 @@ static inline void sdl_writeLongInNetworkByteOrder(UInt8 *buffer, UInt32 value) 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface SDLRTPH264Packetizer ()
+
 @property (assign, nonatomic) UInt32 initialTimestamp;
 @property (assign, nonatomic) UInt16 sequenceNum;
+@property (assign, nonatomic) UInt32 ssrc;
+
 @end
 
 @implementation SDLRTPH264Packetizer
+
+- (instancetype)initWithSSRC:(UInt32)ssrc {
+    self = [self init];
+    _ssrc = ssrc;
+
+    return self;
+}
 
 - (instancetype)init {
     self = [super init];
@@ -71,7 +81,6 @@ NS_ASSUME_NONNULL_BEGIN
     // initial value of the sequence number and timestamp should be random ([5.1] in RFC3550)
     _initialTimestamp = arc4random_uniform(UINT32_MAX);
     _sequenceNum = (UInt16)arc4random_uniform(UINT16_MAX);
-    _ssrc = arc4random_uniform(UINT32_MAX);
 
     return self;
 }

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -71,6 +71,15 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
 @property (strong, nonatomic, nullable) CADisplayLink *displayLink;
 @property (assign, nonatomic) BOOL useDisplayLink;
 
+/**
+ * SSRC of RTP header field.
+ *
+ * SSRC field identifies the source of a stream and it should be
+ * chosen randomly (see section 3 and 5.1 in RFC 3550).
+ *
+ * @note A random value is generated and used as default.
+ */
+@property (assign, nonatomic) UInt32 ssrc;
 @property (assign, nonatomic) CMTime lastPresentationTimestamp;
 
 @end
@@ -140,6 +149,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_appStateDidUpdate:) name:UIApplicationDidBecomeActiveNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_appStateDidUpdate:) name:UIApplicationWillResignActiveNotification object:nil];
 
+    _ssrc = arc4random_uniform(UINT32_MAX);
     _lastPresentationTimestamp = kCMTimeInvalid;
 
     return self;
@@ -374,7 +384,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
         NSAssert(self.videoFormat != nil, @"No video format is known, but it must be if we got a protocol start service response");
 
         SDLLogD(@"Attempting to create video encoder");
-        self.videoEncoder = [[SDLH264VideoEncoder alloc] initWithProtocol:self.videoFormat.protocol dimensions:self.screenSize properties:self.videoEncoderSettings delegate:self error:&error];
+        self.videoEncoder = [[SDLH264VideoEncoder alloc] initWithProtocol:self.videoFormat.protocol dimensions:self.screenSize ssrc:self.ssrc properties:self.videoEncoderSettings delegate:self error:&error];
 
         if (error || self.videoEncoder == nil) {
             SDLLogE(@"Could not create a video encoder: %@", error);

--- a/SmartDeviceLinkTests/SDLH264VideoEncoderSpec.m
+++ b/SmartDeviceLinkTests/SDLH264VideoEncoderSpec.m
@@ -23,6 +23,7 @@ QuickSpecBegin(SDLH264VideoEncoderSpec)
 describe(@"a video encoder", ^{
     __block SDLH264VideoEncoder *testVideoEncoder = nil;
     __block CGSize testSize = CGSizeZero;
+    __block UInt32 testSSRC = 234;
     __block id videoEncoderDelegateMock = OCMProtocolMock(@protocol(SDLVideoEncoderDelegate));
     __block NSError *testError = nil;
     __block SDLVideoStreamingProtocol testProtocol = nil;
@@ -35,7 +36,7 @@ describe(@"a video encoder", ^{
     
     context(@"if using default video encoder settings", ^{
         beforeEach(^{
-            testVideoEncoder = [[SDLH264VideoEncoder alloc] initWithProtocol:testProtocol dimensions:testSize properties:SDLH264VideoEncoder.defaultVideoEncoderSettings delegate:videoEncoderDelegateMock error:&testError];
+            testVideoEncoder = [[SDLH264VideoEncoder alloc] initWithProtocol:testProtocol dimensions:testSize ssrc:testSSRC properties:SDLH264VideoEncoder.defaultVideoEncoderSettings delegate:videoEncoderDelegateMock error:&testError];
         });
         
         it(@"should initialize properties", ^{
@@ -70,7 +71,7 @@ describe(@"a video encoder", ^{
                                  (__bridge NSString *)kVTCompressionPropertyKey_ExpectedFrameRate : @1
                                  };
 
-                testVideoEncoder = [[SDLH264VideoEncoder alloc] initWithProtocol:testProtocol dimensions:testSize properties:testSettings delegate:videoEncoderDelegateMock error:&testError];
+                testVideoEncoder = [[SDLH264VideoEncoder alloc] initWithProtocol:testProtocol dimensions:testSize ssrc:testSSRC properties:testSettings delegate:videoEncoderDelegateMock error:&testError];
             });
             
             it(@"should initialize properties", ^{
@@ -90,7 +91,7 @@ describe(@"a video encoder", ^{
                 testSettings = @{
                                  @"Bad" : @"Property"
                                  };
-                testVideoEncoder = [[SDLH264VideoEncoder alloc] initWithProtocol:testProtocol dimensions:testSize properties:testSettings delegate:videoEncoderDelegateMock error:&testError];
+                testVideoEncoder = [[SDLH264VideoEncoder alloc] initWithProtocol:testProtocol dimensions:testSize ssrc:testSSRC properties:testSettings delegate:videoEncoderDelegateMock error:&testError];
             });
             
             it(@"should not be initialized", ^{
@@ -103,7 +104,7 @@ describe(@"a video encoder", ^{
     context(@"using an unknown protocol", ^{
         beforeEach(^{
             testProtocol = SDLVideoStreamingProtocolRTSP;
-            testVideoEncoder = [[SDLH264VideoEncoder alloc] initWithProtocol:testProtocol dimensions:testSize properties:SDLH264VideoEncoder.defaultVideoEncoderSettings delegate:videoEncoderDelegateMock error:&testError];
+            testVideoEncoder = [[SDLH264VideoEncoder alloc] initWithProtocol:testProtocol dimensions:testSize ssrc:testSSRC properties:SDLH264VideoEncoder.defaultVideoEncoderSettings delegate:videoEncoderDelegateMock error:&testError];
         });
 
         it(@"should not be initialized", ^{
@@ -116,7 +117,7 @@ describe(@"a video encoder", ^{
     context(@"creating with RTP H264 Protocol", ^{
         beforeEach(^{
             testProtocol = SDLVideoStreamingProtocolRTP;
-            testVideoEncoder = [[SDLH264VideoEncoder alloc] initWithProtocol:testProtocol dimensions:testSize properties:SDLH264VideoEncoder.defaultVideoEncoderSettings delegate:videoEncoderDelegateMock error:&testError];
+            testVideoEncoder = [[SDLH264VideoEncoder alloc] initWithProtocol:testProtocol dimensions:testSize ssrc:testSSRC properties:SDLH264VideoEncoder.defaultVideoEncoderSettings delegate:videoEncoderDelegateMock error:&testError];
         });
 
         it(@"should create an RTP packetizer", ^{


### PR DESCRIPTION
Fixes #1132

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Unit tests are added

### Summary
The RTP packetizer SSRC is now generated by the `SDLStreamingVideoLifecycleManager` and kept constant across suspensions.

### Changelog
##### Bug Fixes
* RTP video stream SSRC will no longer be different after video stream is suspended and resumed

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
