### PR TITLE
Return nil instead of NSNull

### DIFF
--- a/SmartDeviceLink/NSMutableDictionary+Store.m
+++ b/SmartDeviceLink/NSMutableDictionary+Store.m
@@ -21,7 +21,11 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (nullable id)sdl_objectForName:(SDLName)name {
-    return self[name];
+    id object = self[name];
+    if ([object isKindOfClass:NSNull.class]) {
+        return nil;
+    }
+    return object;
 }
 
 - (nullable id)sdl_objectForName:(SDLName)name ofClass:(Class)classType {

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLRegisterAppInterfaceResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLRegisterAppInterfaceResponseSpec.m
@@ -138,6 +138,54 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testResponse.systemSoftwareVersion).to(beNil());
         expect(testResponse.iconResumed).to(beNil());
     });
+
+    it(@"Should get correctly when initialized from NSNull", ^ {
+        NSDictionary *dict = @{SDLNameRequest:
+                                   @{SDLNameParameters:
+                                         @{SDLNameSyncMessageVersion:NSNull.null,
+                                           SDLNameLanguage:NSNull.null,
+                                           SDLNameHMIDisplayLanguage:NSNull.null,
+                                           SDLNameDisplayCapabilities:NSNull.null,
+                                           SDLNameButtonCapabilities:NSNull.null,
+                                           SDLNameSoftButtonCapabilities:NSNull.null,
+                                           SDLNamePresetBankCapabilities:NSNull.null,
+                                           SDLNameHMIZoneCapabilities:NSNull.null,
+                                           SDLNameSpeechCapabilities:NSNull.null,
+                                           SDLNameVRCapabilities:NSNull.null,
+                                           SDLNameAudioPassThruCapabilities:NSNull.null,
+                                           SDLNamePCMStreamCapabilities:NSNull.null,
+                                           SDLNameVehicleType:NSNull.null,
+                                           SDLNamePrerecordedSpeech:NSNull.null,
+                                           SDLNameSupportedDiagnosticModes:NSNull.null,
+                                           SDLNameHMICapabilities: NSNull.null,
+                                           SDLNameSDLVersion: NSNull.null,
+                                           SDLNameSystemSoftwareVersion: NSNull.null,
+                                           SDLNameIconResumed: NSNull.null,
+                                           },
+                                     SDLNameOperationName:SDLNameRegisterAppInterface}};
+        SDLRegisterAppInterfaceResponse* testResponse = [[SDLRegisterAppInterfaceResponse alloc] initWithDictionary:dict];
+
+        expect(testResponse.syncMsgVersion).to(beNil());
+        expect(testResponse.language).to(beNil());
+        expect(testResponse.hmiDisplayLanguage).to(beNil());
+        expect(testResponse.displayCapabilities).to(beNil());
+        expect(testResponse.buttonCapabilities).to(beNil());
+        expect(testResponse.softButtonCapabilities).to(beNil());
+        expect(testResponse.presetBankCapabilities).to(beNil());
+        expect(testResponse.hmiZoneCapabilities).to(beNil());
+        expect(testResponse.speechCapabilities).to(beNil());
+        expect(testResponse.vrCapabilities).to(beNil());
+        expect(testResponse.audioPassThruCapabilities).to(beNil());
+        expect(testResponse.pcmStreamCapabilities).to(beNil());
+        expect(testResponse.vehicleType).to(beNil());
+        expect(testResponse.prerecordedSpeech).to(beNil());
+        expect(testResponse.supportedDiagModes).to(beNil());
+        expect(testResponse.hmiCapabilities).to(beNil());
+        expect(testResponse.sdlVersion).to(beNil());
+        expect(testResponse.systemSoftwareVersion).to(beNil());
+        expect(testResponse.iconResumed).to(beNil());
+    });
+
 });
 
 QuickSpecEnd


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_ios/issues/1153

This PR is **[ready]** for review.

### Risk
This PR makes **[minor]** API changes.

### Testing Plan
1) Create SDLRegisterAppInterfaceResponse with dictionary that contains NSNull values.
2) Validate values they should be nil

### Summary
The main idea the decrease number of crash unrecognized selector sent to instance.
In top level, we don't want to validate every value on NSNull. For example, if you send message 'count' to array then it mustn't crash. 

### Changelog
##### Breaking Changes
* If anyone expects NSNull and build any logic on it then it would be broken

##### Enhancements
* Where we expect nullable value, we can get nil or value but not NSNull

##### Bug Fixes
* NSNull unrecognized selector sent to instance

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
