### PR TITLE
check block on nil before call

### DIFF
--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -290,7 +290,9 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
                 // If the success BOOL is NO or we received an error at this point, we failed. Call the ready handler and transition to the DISCONNECTED state.
                 if (error != nil || ![response.success boolValue]) {
                     SDLLogE(@"Failed to register the app. Error: %@, Response: %@", error, response);
-                    weakSelf.readyHandler(NO, error);
+                    if (weakSelf.readyHandler) {
+                        weakSelf.readyHandler(NO, error);
+                    }
 
                     if (weakSelf.lifecycleState != SDLLifecycleStateReconnecting) {
                         [weakSelf sdl_transitionToState:SDLLifecycleStateStopped];


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_ios/issues/1155

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan

### Summary
as we use weakSelf then self can be dealloced here, and we need check block before call.

### Changelog
##### Breaking Changes

##### Enhancements

##### Bug Fixes
* No crash when we try to call nil block

### Tasks Remaining:

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
