### PR TITLE
Hotfix 1159 verifies return type for language params

### DIFF
--- a/SmartDeviceLink/SDLRegisterAppInterfaceResponse.m
+++ b/SmartDeviceLink/SDLRegisterAppInterfaceResponse.m
@@ -39,7 +39,11 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (nullable SDLLanguage)language {
-    return [parameters sdl_objectForName:SDLNameLanguage];
+    id value = [parameters sdl_objectForName:SDLNameLanguage];
+    if (![value isKindOfClass:SDLLanguageEnUs.class]) {
+        return nil;
+    }
+    return value;
 }
 
 - (void)setHmiDisplayLanguage:(nullable SDLLanguage)hmiDisplayLanguage {
@@ -47,7 +51,11 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (nullable SDLLanguage)hmiDisplayLanguage {
-    return [parameters sdl_objectForName:SDLNameHMIDisplayLanguage];
+    id value = [parameters sdl_objectForName:SDLNameHMIDisplayLanguage];
+    if (![value isKindOfClass:SDLLanguageEnUs.class]) {
+        return nil;
+    }
+    return value;
 }
 
 - (void)setDisplayCapabilities:(nullable SDLDisplayCapabilities *)displayCapabilities {


### PR DESCRIPTION
Fixes #1159

This PR is **ready** for review.

### Risk
This PR makes **[no]** API changes.

### Summary
Whenever the type returned by language parameters is not kind of class of SDLLangaugeEnUs, nil is expected to be returned. `nil` can be returned in these cases as the parameters are not mandatory. 

##### Bug Fixes
* Avoids @(-1) returned to apps as language. 

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
