### PR TITLE
Hotfix 1161 wraps objects into an array if needed

### DIFF
--- a/SmartDeviceLink/NSMutableDictionary+Store.m
+++ b/SmartDeviceLink/NSMutableDictionary+Store.m
@@ -38,11 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (![array isKindOfClass:NSArray.class]) {
         // as of objc nature array can contain dict objects without crashing.
         // the hotfix wraps the dict object into an array as the car missed to do it in the first place.
-        if ([array isKindOfClass:NSDictionary.class]) {
-            array = @[array];
-        } else {
-            return nil;
-        }
+        array = @[array];
     }
     if (array.count < 1 || [array.firstObject isMemberOfClass:classType]) {
         // It's an array of the actual class type, just return

--- a/SmartDeviceLink/NSMutableDictionary+Store.m
+++ b/SmartDeviceLink/NSMutableDictionary+Store.m
@@ -35,9 +35,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSArray *)sdl_objectsForName:(SDLName)name ofClass:(Class)classType {
     NSArray *array = [self sdl_objectForName:name];
-    if ([array isEqual:[NSNull null]]) {
-        return [NSMutableArray array];
-    } else if (array.count < 1 || [array.firstObject isMemberOfClass:classType]) {
+    if (![array isKindOfClass:NSArray.class]) {
+        // as of objc nature array can contain dict objects without crashing.
+        // the hotfix wraps the dict object into an array as the car missed to do it in the first place.
+        if ([array isKindOfClass:NSDictionary.class]) {
+            array = @[array];
+        } else {
+            return nil;
+        }
+    }
+    if (array.count < 1 || [array.firstObject isMemberOfClass:classType]) {
         // It's an array of the actual class type, just return
         return array;
     } else {


### PR DESCRIPTION
Fixes #1161 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
For array parameters, it can happen that cars don't send data with an array of objects, not even an array with a single object. Instead they send the actual object... not wrapped in an array.

##### Bug Fixes
* Wraps objects into an array if an array of objects is expected.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
