### PR TITLE
Added a convenience init to `GetAppServiceData` struct

### DIFF
--- a/SmartDeviceLink/SDLGetAppServiceData.h
+++ b/SmartDeviceLink/SDLGetAppServiceData.h
@@ -35,6 +35,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithAppServiceType:(SDLAppServiceType)serviceType;
 
 /**
+ *  Convenience init for subscribing to a service type.
+ *
+ *  @param serviceType      The app service type
+ *  @return                 A SDLGetAppServiceData object
+ */
+- (instancetype)initAndSubscribeToAppServiceType:(SDLAppServiceType)serviceType;
+
+/**
  *  Convenience init for all parameters.
  *
  *  @param serviceType      The app service type

--- a/SmartDeviceLink/SDLGetAppServiceData.m
+++ b/SmartDeviceLink/SDLGetAppServiceData.m
@@ -37,6 +37,10 @@ NS_ASSUME_NONNULL_BEGIN
     return [self initWithServiceType:serviceType];
 }
 
+- (instancetype)initAndSubscribeToAppServiceType:(SDLAppServiceType)serviceType {
+    return [self initWithServiceType:serviceType subscribe:YES];
+}
+
 - (instancetype)initWithServiceType:(NSString *)serviceType subscribe:(BOOL)subscribe {
     self = [self initWithServiceType:serviceType];
     if (!self) {

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetAppServiceDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetAppServiceDataSpec.m
@@ -63,6 +63,13 @@ describe(@"Getter/Setter Tests", ^{
         expect(testRequest.subscribe).to(beNil());
     });
 
+    it(@"Should initialize correctly with initAndSubscribeToAppServiceType:", ^{
+        SDLGetAppServiceData *testRequest = [[SDLGetAppServiceData alloc] initAndSubscribeToAppServiceType:testAppServiceType];
+
+        expect(testRequest.serviceType).to(equal(testAppServiceType));
+        expect(testRequest.subscribe).to(beTrue());
+    });
+
     it(@"Should initialize correctly with initWithServiceType:subscribe:", ^{
         SDLGetAppServiceData *testRequest = [[SDLGetAppServiceData alloc] initWithServiceType:testServiceType subscribe:testSubscribe];
 


### PR DESCRIPTION
Fixes #1188

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Added test case to _SDLGetAppServiceDataSpec_ test cases 

### Summary
Added a convenience init to the `GetAppServiceData` struct that takes a `SDLAppServiceType` and subscribes to updates.

### Changelog
##### Enhancements
* Added a convenience init to the `GetAppServiceData` struct that takes a `SDLAppServiceType` and subscribes to updates.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
