### PR TITLE
Made service data param nullable

### DIFF
--- a/SmartDeviceLink/SDLGetAppServiceDataResponse.h
+++ b/SmartDeviceLink/SDLGetAppServiceDataResponse.h
@@ -28,9 +28,9 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Contains all the current data of the app service.
  *
- *  SDLAppServiceData, Required
+ *  SDLAppServiceData, Optional
  */
-@property (strong, nonatomic) SDLAppServiceData *serviceData;
+@property (nullable, strong, nonatomic) SDLAppServiceData *serviceData;
 
 @end
 

--- a/SmartDeviceLink/SDLGetAppServiceDataResponse.m
+++ b/SmartDeviceLink/SDLGetAppServiceDataResponse.m
@@ -34,11 +34,11 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (void)setServiceData:(SDLAppServiceData *)serviceData {
+- (void)setServiceData:(nullable SDLAppServiceData *)serviceData {
     [parameters sdl_setObject:serviceData forName:SDLRPCParameterNameServiceData];
 }
 
-- (SDLAppServiceData *)serviceData {
+- (nullable SDLAppServiceData *)serviceData {
     return [parameters sdl_objectForName:SDLRPCParameterNameServiceData ofClass:SDLAppServiceData.class];
 }
 


### PR DESCRIPTION
Fixes #1191

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Test cases already exist for `SDLGetAppServiceDataResponse`

### Summary
Made the `serviceData` param in `SDLGetAppServiceDataResponse` nullable to match rpc_spec v.5.1.

### Changelog
##### Enhancements
* Made the `serviceData` param in `SDLGetAppServiceDataResponse` nullable to match rpc_spec v.5.1.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
