### PR TITLE
Clear appServicesCapability in systemCapabilityManager on stop

### DIFF
--- a/SmartDeviceLink/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.m
@@ -80,6 +80,7 @@ NS_ASSUME_NONNULL_BEGIN
     _phoneCapability = nil;
     _videoStreamingCapability = nil;
     _remoteControlCapability = nil;
+    _appServicesCapabilities = nil;
 }
 
 


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Tests caught this error

### Summary
Fix `systemCapabilityManager` not clearing the `appServicesCapability`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
