### PR TITLE
Update test dependencies for Xcode 10.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode10
+osx_image: xcode10.2
 xcode_project: SmartDeviceLink-iOS.xcodeproj
 xcode_scheme: SmartDeviceLink
 xcode_sdk: iphonesimulator12.0

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,4 +1,4 @@
-github "Quick/Quick" ~> 1.2
-github "Quick/Nimble" ~> 7.0
+github "Quick/Quick" ~> 2.0
+github "Quick/Nimble" ~> 8.0
 github "erikdoe/ocmock" ~> 3.4
-github "facebook/ios-snapshot-test-case" ~> 2.1
+github "uber/ios-snapshot-test-case" ~> 6.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "Quick/Nimble" "v7.3.0"
-github "Quick/Quick" "v1.3.1"
-github "erikdoe/ocmock" "v3.4.2"
-github "facebook/ios-snapshot-test-case" "2.1.4"
+github "Quick/Nimble" "v7.3.4"
+github "Quick/Quick" "v1.3.4"
+github "erikdoe/ocmock" "v3.4.3"
+github "uber/ios-snapshot-test-case" "6.0.3"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "Quick/Nimble" "v7.3.4"
-github "Quick/Quick" "v1.3.4"
+github "Quick/Nimble" "v8.0.1"
+github "Quick/Quick" "v2.0.0"
 github "erikdoe/ocmock" "v3.4.3"
 github "uber/ios-snapshot-test-case" "6.0.3"

--- a/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
+++ b/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
@@ -1303,6 +1303,8 @@
 		88802FF420853BED00E9EBC6 /* SmartDeviceLinkSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D4346631E6F38E600B639C6 /* SmartDeviceLinkSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		88802FF520853CD500E9EBC6 /* SmartDeviceLinkSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 88802FEF20853AE600E9EBC6 /* SmartDeviceLinkSwift.framework */; };
 		88802FF620853CD500E9EBC6 /* SmartDeviceLinkSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 88802FEF20853AE600E9EBC6 /* SmartDeviceLinkSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8880D24722205B1B00964F6A /* SDLNavigationInstruction.h in Headers */ = {isa = PBXBuildFile; fileRef = 8880D24522205B1B00964F6A /* SDLNavigationInstruction.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8880D24822205B1B00964F6A /* SDLNavigationInstruction.m in Sources */ = {isa = PBXBuildFile; fileRef = 8880D24622205B1B00964F6A /* SDLNavigationInstruction.m */; };
 		8881AFAC2225D61900EA870B /* SDLSetCloudAppProperties.h in Headers */ = {isa = PBXBuildFile; fileRef = 8881AFAA2225D61900EA870B /* SDLSetCloudAppProperties.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8881AFAD2225D61900EA870B /* SDLSetCloudAppProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = 8881AFAB2225D61900EA870B /* SDLSetCloudAppProperties.m */; };
 		8881AFAF2225D8EB00EA870B /* SDLSetCloudAppPropertiesSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 8881AFAE2225D8EB00EA870B /* SDLSetCloudAppPropertiesSpec.m */; };
@@ -1315,8 +1317,6 @@
 		8881AFBE2225E9BB00EA870B /* SDLGetCloudAppPropertiesResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 8881AFBC2225E9BB00EA870B /* SDLGetCloudAppPropertiesResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8881AFBF2225E9BB00EA870B /* SDLGetCloudAppPropertiesResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 8881AFBD2225E9BB00EA870B /* SDLGetCloudAppPropertiesResponse.m */; };
 		8881AFC12225EB9300EA870B /* SDLGetCloudAppPropertiesResponseSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 8881AFC02225EB9300EA870B /* SDLGetCloudAppPropertiesResponseSpec.m */; };
-		8880D24722205B1B00964F6A /* SDLNavigationInstruction.h in Headers */ = {isa = PBXBuildFile; fileRef = 8880D24522205B1B00964F6A /* SDLNavigationInstruction.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8880D24822205B1B00964F6A /* SDLNavigationInstruction.m in Sources */ = {isa = PBXBuildFile; fileRef = 8880D24622205B1B00964F6A /* SDLNavigationInstruction.m */; };
 		8886EB982111F4FA008294A5 /* SDLFileManagerConfigurationSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 8886EB972111F4FA008294A5 /* SDLFileManagerConfigurationSpec.m */; };
 		888F86FE221DEE200052FE4C /* SDLAsynchronousRPCOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 888F86FD221DEE1F0052FE4C /* SDLAsynchronousRPCOperation.m */; };
 		888F8700221DF4880052FE4C /* SDLAsynchronousRPCOperationSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 888F86FF221DF4880052FE4C /* SDLAsynchronousRPCOperationSpec.m */; };
@@ -2922,6 +2922,8 @@
 		8877F5F01F34AA2D00DC128A /* SDLSendHapticDataResponseSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLSendHapticDataResponseSpec.m; sourceTree = "<group>"; };
 		887BE4D322272B2200B397C2 /* SDLControlFramePayloadConstantsSpec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLControlFramePayloadConstantsSpec.m; sourceTree = "<group>"; };
 		88802FEF20853AE600E9EBC6 /* SmartDeviceLinkSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SmartDeviceLinkSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8880D24522205B1B00964F6A /* SDLNavigationInstruction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDLNavigationInstruction.h; sourceTree = "<group>"; };
+		8880D24622205B1B00964F6A /* SDLNavigationInstruction.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLNavigationInstruction.m; sourceTree = "<group>"; };
 		8881AFAA2225D61900EA870B /* SDLSetCloudAppProperties.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDLSetCloudAppProperties.h; sourceTree = "<group>"; };
 		8881AFAB2225D61900EA870B /* SDLSetCloudAppProperties.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLSetCloudAppProperties.m; sourceTree = "<group>"; };
 		8881AFAE2225D8EB00EA870B /* SDLSetCloudAppPropertiesSpec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLSetCloudAppPropertiesSpec.m; sourceTree = "<group>"; };
@@ -2934,8 +2936,6 @@
 		8881AFBC2225E9BB00EA870B /* SDLGetCloudAppPropertiesResponse.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDLGetCloudAppPropertiesResponse.h; sourceTree = "<group>"; };
 		8881AFBD2225E9BB00EA870B /* SDLGetCloudAppPropertiesResponse.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLGetCloudAppPropertiesResponse.m; sourceTree = "<group>"; };
 		8881AFC02225EB9300EA870B /* SDLGetCloudAppPropertiesResponseSpec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLGetCloudAppPropertiesResponseSpec.m; sourceTree = "<group>"; };
-		8880D24522205B1B00964F6A /* SDLNavigationInstruction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDLNavigationInstruction.h; sourceTree = "<group>"; };
-		8880D24622205B1B00964F6A /* SDLNavigationInstruction.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLNavigationInstruction.m; sourceTree = "<group>"; };
 		8886EB972111F4FA008294A5 /* SDLFileManagerConfigurationSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLFileManagerConfigurationSpec.m; sourceTree = "<group>"; };
 		888F86FD221DEE1F0052FE4C /* SDLAsynchronousRPCOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLAsynchronousRPCOperation.m; sourceTree = "<group>"; };
 		888F86FF221DF4880052FE4C /* SDLAsynchronousRPCOperationSpec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLAsynchronousRPCOperationSpec.m; sourceTree = "<group>"; };
@@ -6699,8 +6699,14 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
+				fr,
+				de,
+				ja,
+				"zh-Hans",
+				es,
 			);
 			mainGroup = 5D4019A61A76EC350006B0C2;
 			productRefGroup = 5D4019B01A76EC350006B0C2 /* Products */;

--- a/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
+++ b/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
@@ -452,7 +452,6 @@
 		5D1FF2C7213045F2000EB9B4 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5D1FF2C5213045F1000EB9B4 /* Images.xcassets */; };
 		5D1FF2CA2130463F000EB9B4 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D1FF2C92130463F000EB9B4 /* AppDelegate.m */; };
 		5D1FF2CC2130464E000EB9B4 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D1FF2CB2130464D000EB9B4 /* main.m */; };
-		5D1FF2CE21304654000EB9B4 /* SmartDeviceLink-Example-ObjC-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 5D1FF2CD21304654000EB9B4 /* SmartDeviceLink-Example-ObjC-Info.plist */; };
 		5D1FF2D12130466D000EB9B4 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5D1FF2CF2130466D000EB9B4 /* LaunchScreen.xib */; };
 		5D1FF2DA21304746000EB9B4 /* ButtonManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D1FF2D221304745000EB9B4 /* ButtonManager.swift */; };
 		5D1FF2DB21304746000EB9B4 /* ProxyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D1FF2D321304745000EB9B4 /* ProxyManager.swift */; };
@@ -473,7 +472,6 @@
 		5D1FF2F3213047AB000EB9B4 /* ConnectionTCPTableViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5D1FF2F0213047AB000EB9B4 /* ConnectionTCPTableViewController.storyboard */; };
 		5D1FF2F5213047B3000EB9B4 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5D1FF2F4213047B2000EB9B4 /* LaunchScreen.xib */; };
 		5D1FF2F8213047C1000EB9B4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D1FF2F7213047C1000EB9B4 /* AppDelegate.swift */; };
-		5D1FF2FA2130480C000EB9B4 /* SmartDeviceLink-Example-Swift-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 5D1FF2F92130480C000EB9B4 /* SmartDeviceLink-Example-Swift-Info.plist */; };
 		5D293AFE1FE078A9000CBD7E /* SDLCarWindowViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D293AFC1FE078A9000CBD7E /* SDLCarWindowViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5D293AFF1FE078A9000CBD7E /* SDLCarWindowViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D293AFD1FE078A9000CBD7E /* SDLCarWindowViewController.m */; };
 		5D2F58081D0717D5001085CE /* SDLManagerDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D2F58071D0717D5001085CE /* SDLManagerDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -6696,10 +6694,9 @@
 			};
 			buildConfigurationList = 5D4019AA1A76EC350006B0C2 /* Build configuration list for PBXProject "SmartDeviceLink-iOS" */;
 			compatibilityVersion = "Xcode 8.0";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
 				Base,
 				fr,
@@ -6732,7 +6729,6 @@
 				5D1FF2C6213045F2000EB9B4 /* Images.xcassets in Resources */,
 				5D1FF2B021304568000EB9B4 /* Main.storyboard in Resources */,
 				5D1FF2D12130466D000EB9B4 /* LaunchScreen.xib in Resources */,
-				5D1FF2CE21304654000EB9B4 /* SmartDeviceLink-Example-ObjC-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6768,7 +6764,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				5D1FF2F1213047AB000EB9B4 /* Main.storyboard in Resources */,
-				5D1FF2FA2130480C000EB9B4 /* SmartDeviceLink-Example-Swift-Info.plist in Resources */,
 				5D1FF2F3213047AB000EB9B4 /* ConnectionTCPTableViewController.storyboard in Resources */,
 				5D1FF2C7213045F2000EB9B4 /* Images.xcassets in Resources */,
 				5D1FF2F5213047B3000EB9B4 /* LaunchScreen.xib in Resources */,

--- a/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
+++ b/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
@@ -6685,7 +6685,7 @@
 					};
 					5D61FA251A84237100846EE7 = {
 						CreatedOnToolsVersion = 6.1.1;
-						LastSwiftMigration = 0920;
+						LastSwiftMigration = 1020;
 					};
 					8829567D207CF68800EF056C = {
 						LastSwiftMigration = 0930;
@@ -8115,7 +8115,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.smartdevicelink.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -8146,8 +8146,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.smartdevicelink.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/SmartDeviceLinkTests/ProtocolSpecs/MessageSpecs/SDLV1ProtocolMessageSpec.m
+++ b/SmartDeviceLinkTests/ProtocolSpecs/MessageSpecs/SDLV1ProtocolMessageSpec.m
@@ -24,7 +24,7 @@ describe(@"RPCDictionary Tests", ^ {
                                          @"Floor": @"Wax",
                                          @"Wax": @"Museum"};
         SDLV1ProtocolMessage* testMessage = [[SDLV1ProtocolMessage alloc] initWithHeader:testHeader andPayload:[NSJSONSerialization dataWithJSONObject:testDictionary options:0 error:0]];
-        
+
         expect([testMessage rpcDictionary]).to(equal(testDictionary));
     });
 });


### PR DESCRIPTION
Fixes #1208

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
This PR updates testing dependencies. This will be verified by the maintainers.

### Summary
With Xcode 10.2, Swift 3 support is dropped. This PR updates testing dependencies for Swift 4/5 support, and updates Travis-CI to run Xcode 10.2.

### Changelog
##### Enhancements
* Update testing dependencies and Travis-CI for Xcode 10.2.

### Tasks Remaining:
- [x] Tests are failing to compile (https://github.com/Quick/Nimble/issues/642)
- [x] Ensure Travis-CI still works.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
