### PR TITLE
Update documentation to warn the devs to wrap a `stop` call in `start:withReadyHandler:`

### DIFF
--- a/SmartDeviceLink/SDLLifecycleManager.h
+++ b/SmartDeviceLink/SDLLifecycleManager.h
@@ -107,6 +107,7 @@ typedef void (^SDLManagerReadyBlock)(BOOL success, NSError *_Nullable error);
  *  Start the manager, which will tell it to start looking for a connection. Once one does, it will automatically run the setup process and call the readyBlock when done.
  *
  *  @warning If you call this method from SDLManager's `startWithReadyHandler` be sure to wrap the `stop` call inside a dispatch_async and send it to the main queue or a global queue, otherwise calling `stop` may cause a deadlock.
+ *
  *  @param readyHandler The block called when the manager is ready to be used or an error occurs while attempting to become ready.
  */
 - (void)startWithReadyHandler:(SDLManagerReadyBlock)readyHandler;

--- a/SmartDeviceLink/SDLLifecycleManager.h
+++ b/SmartDeviceLink/SDLLifecycleManager.h
@@ -105,16 +105,14 @@ typedef void (^SDLManagerReadyBlock)(BOOL success, NSError *_Nullable error);
 
 /**
  *  Start the manager, which will tell it to start looking for a connection. Once one does, it will automatically run the setup process and call the readyBlock when done.
- *
+*   @warning If you call this method from SDLManager's `startWithReadyHandler` be sure to wrap the `stop` call inside a dispatch_async and send it to the main queue or a global queuee, otherwise calling `stop` may cause a deadlock.
  *  @param readyHandler The block called when the manager is ready to be used or an error occurs while attempting to become ready.
- 
- *  @warning If you call this method from SDLManager's startWithReadyHandler be sure to wrap the stop call inside a dispatch_async and call it from the main queue or a global queue and call stop from there, otherwise calling stop may crete a deadlock.
  */
 - (void)startWithReadyHandler:(SDLManagerReadyBlock)readyHandler;
 
 /**
  *  Stop the manager, it will disconnect if needed and no longer look for a connection. You probably don't need to call this method ever.
- *  @warning If you call this method from SDLManager's startWithReadyHandler be sure to wrap the stop call inside a dispatch_async and call it from the main queue or a global queue and call stop from there, otherwise calling stop may crete a deadlock.
+ *   @warning If you call this method from SDLManager's `startWithReadyHandler` be sure to wrap the `stop` call inside a dispatch_async and send it to the main queue or a global queuee, otherwise calling `stop` may cause a deadlock.
  */
 - (void)stop;
 

--- a/SmartDeviceLink/SDLLifecycleManager.h
+++ b/SmartDeviceLink/SDLLifecycleManager.h
@@ -115,7 +115,7 @@ typedef void (^SDLManagerReadyBlock)(BOOL success, NSError *_Nullable error);
 /**
  *  Stop the manager, it will disconnect if needed and no longer look for a connection. You probably don't need to call this method ever.
  *
- *   @warning If you call this method from SDLManager's `startWithReadyHandler` be sure to wrap the `stop` call inside a dispatch_async and send it to the main queue or a global queue, otherwise calling `stop` may cause a deadlock.
+ *  @warning If you call this method from SDLManager's `startWithReadyHandler` be sure to wrap the `stop` call inside a dispatch_async and send it to the main queue or a global queue, otherwise calling `stop` may cause a deadlock.
  */
 - (void)stop;
 

--- a/SmartDeviceLink/SDLLifecycleManager.h
+++ b/SmartDeviceLink/SDLLifecycleManager.h
@@ -105,14 +105,16 @@ typedef void (^SDLManagerReadyBlock)(BOOL success, NSError *_Nullable error);
 
 /**
  *  Start the manager, which will tell it to start looking for a connection. Once one does, it will automatically run the setup process and call the readyBlock when done.
-*   @warning If you call this method from SDLManager's `startWithReadyHandler` be sure to wrap the `stop` call inside a dispatch_async and send it to the main queue or a global queuee, otherwise calling `stop` may cause a deadlock.
+ *
+ *  @warning If you call this method from SDLManager's `startWithReadyHandler` be sure to wrap the `stop` call inside a dispatch_async and send it to the main queue or a global queue, otherwise calling `stop` may cause a deadlock.
  *  @param readyHandler The block called when the manager is ready to be used or an error occurs while attempting to become ready.
  */
 - (void)startWithReadyHandler:(SDLManagerReadyBlock)readyHandler;
 
 /**
  *  Stop the manager, it will disconnect if needed and no longer look for a connection. You probably don't need to call this method ever.
- *   @warning If you call this method from SDLManager's `startWithReadyHandler` be sure to wrap the `stop` call inside a dispatch_async and send it to the main queue or a global queuee, otherwise calling `stop` may cause a deadlock.
+ *
+ *   @warning If you call this method from SDLManager's `startWithReadyHandler` be sure to wrap the `stop` call inside a dispatch_async and send it to the main queue or a global queue, otherwise calling `stop` may cause a deadlock.
  */
 - (void)stop;
 

--- a/SmartDeviceLink/SDLLifecycleManager.h
+++ b/SmartDeviceLink/SDLLifecycleManager.h
@@ -107,11 +107,14 @@ typedef void (^SDLManagerReadyBlock)(BOOL success, NSError *_Nullable error);
  *  Start the manager, which will tell it to start looking for a connection. Once one does, it will automatically run the setup process and call the readyBlock when done.
  *
  *  @param readyHandler The block called when the manager is ready to be used or an error occurs while attempting to become ready.
+ 
+ *  @warning If you call this method from SDLManager's startWithReadyHandler be sure to wrap the stop call inside a dispatch_async and call it from the main queue or a global queue and call stop from there, otherwise calling stop may crete a deadlock.
  */
 - (void)startWithReadyHandler:(SDLManagerReadyBlock)readyHandler;
 
 /**
  *  Stop the manager, it will disconnect if needed and no longer look for a connection. You probably don't need to call this method ever.
+ *  @warning If you call this method from SDLManager's startWithReadyHandler be sure to wrap the stop call inside a dispatch_async and call it from the main queue or a global queue and call stop from there, otherwise calling stop may crete a deadlock.
  */
 - (void)stop;
 


### PR DESCRIPTION
Fixes #1203 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
No tests needed

### Summary
Updated documentation to warn the devs to wrap the stop call within a async or global thread 

##### Bug Fixes
* Update documentation to mention a potential deadlock issue with calling `stop` within the `readyHandler`.

- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)