### PR TITLE
Update System Capability Manager to auto-cache`OnSystemCapability`

### DIFF
--- a/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
+++ b/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
@@ -1303,6 +1303,8 @@
 		88802FF420853BED00E9EBC6 /* SmartDeviceLinkSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D4346631E6F38E600B639C6 /* SmartDeviceLinkSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		88802FF520853CD500E9EBC6 /* SmartDeviceLinkSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 88802FEF20853AE600E9EBC6 /* SmartDeviceLinkSwift.framework */; };
 		88802FF620853CD500E9EBC6 /* SmartDeviceLinkSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 88802FEF20853AE600E9EBC6 /* SmartDeviceLinkSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8880D24722205B1B00964F6A /* SDLNavigationInstruction.h in Headers */ = {isa = PBXBuildFile; fileRef = 8880D24522205B1B00964F6A /* SDLNavigationInstruction.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8880D24822205B1B00964F6A /* SDLNavigationInstruction.m in Sources */ = {isa = PBXBuildFile; fileRef = 8880D24622205B1B00964F6A /* SDLNavigationInstruction.m */; };
 		8881AFAC2225D61900EA870B /* SDLSetCloudAppProperties.h in Headers */ = {isa = PBXBuildFile; fileRef = 8881AFAA2225D61900EA870B /* SDLSetCloudAppProperties.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8881AFAD2225D61900EA870B /* SDLSetCloudAppProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = 8881AFAB2225D61900EA870B /* SDLSetCloudAppProperties.m */; };
 		8881AFAF2225D8EB00EA870B /* SDLSetCloudAppPropertiesSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 8881AFAE2225D8EB00EA870B /* SDLSetCloudAppPropertiesSpec.m */; };
@@ -1315,8 +1317,6 @@
 		8881AFBE2225E9BB00EA870B /* SDLGetCloudAppPropertiesResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 8881AFBC2225E9BB00EA870B /* SDLGetCloudAppPropertiesResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8881AFBF2225E9BB00EA870B /* SDLGetCloudAppPropertiesResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 8881AFBD2225E9BB00EA870B /* SDLGetCloudAppPropertiesResponse.m */; };
 		8881AFC12225EB9300EA870B /* SDLGetCloudAppPropertiesResponseSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 8881AFC02225EB9300EA870B /* SDLGetCloudAppPropertiesResponseSpec.m */; };
-		8880D24722205B1B00964F6A /* SDLNavigationInstruction.h in Headers */ = {isa = PBXBuildFile; fileRef = 8880D24522205B1B00964F6A /* SDLNavigationInstruction.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8880D24822205B1B00964F6A /* SDLNavigationInstruction.m in Sources */ = {isa = PBXBuildFile; fileRef = 8880D24622205B1B00964F6A /* SDLNavigationInstruction.m */; };
 		8886EB982111F4FA008294A5 /* SDLFileManagerConfigurationSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 8886EB972111F4FA008294A5 /* SDLFileManagerConfigurationSpec.m */; };
 		888F86FE221DEE200052FE4C /* SDLAsynchronousRPCOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 888F86FD221DEE1F0052FE4C /* SDLAsynchronousRPCOperation.m */; };
 		888F8700221DF4880052FE4C /* SDLAsynchronousRPCOperationSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 888F86FF221DF4880052FE4C /* SDLAsynchronousRPCOperationSpec.m */; };
@@ -2922,6 +2922,8 @@
 		8877F5F01F34AA2D00DC128A /* SDLSendHapticDataResponseSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLSendHapticDataResponseSpec.m; sourceTree = "<group>"; };
 		887BE4D322272B2200B397C2 /* SDLControlFramePayloadConstantsSpec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLControlFramePayloadConstantsSpec.m; sourceTree = "<group>"; };
 		88802FEF20853AE600E9EBC6 /* SmartDeviceLinkSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SmartDeviceLinkSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8880D24522205B1B00964F6A /* SDLNavigationInstruction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDLNavigationInstruction.h; sourceTree = "<group>"; };
+		8880D24622205B1B00964F6A /* SDLNavigationInstruction.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLNavigationInstruction.m; sourceTree = "<group>"; };
 		8881AFAA2225D61900EA870B /* SDLSetCloudAppProperties.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDLSetCloudAppProperties.h; sourceTree = "<group>"; };
 		8881AFAB2225D61900EA870B /* SDLSetCloudAppProperties.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLSetCloudAppProperties.m; sourceTree = "<group>"; };
 		8881AFAE2225D8EB00EA870B /* SDLSetCloudAppPropertiesSpec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLSetCloudAppPropertiesSpec.m; sourceTree = "<group>"; };
@@ -2934,8 +2936,6 @@
 		8881AFBC2225E9BB00EA870B /* SDLGetCloudAppPropertiesResponse.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDLGetCloudAppPropertiesResponse.h; sourceTree = "<group>"; };
 		8881AFBD2225E9BB00EA870B /* SDLGetCloudAppPropertiesResponse.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLGetCloudAppPropertiesResponse.m; sourceTree = "<group>"; };
 		8881AFC02225EB9300EA870B /* SDLGetCloudAppPropertiesResponseSpec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLGetCloudAppPropertiesResponseSpec.m; sourceTree = "<group>"; };
-		8880D24522205B1B00964F6A /* SDLNavigationInstruction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDLNavigationInstruction.h; sourceTree = "<group>"; };
-		8880D24622205B1B00964F6A /* SDLNavigationInstruction.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLNavigationInstruction.m; sourceTree = "<group>"; };
 		8886EB972111F4FA008294A5 /* SDLFileManagerConfigurationSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLFileManagerConfigurationSpec.m; sourceTree = "<group>"; };
 		888F86FD221DEE1F0052FE4C /* SDLAsynchronousRPCOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLAsynchronousRPCOperation.m; sourceTree = "<group>"; };
 		888F86FF221DF4880052FE4C /* SDLAsynchronousRPCOperationSpec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLAsynchronousRPCOperationSpec.m; sourceTree = "<group>"; };
@@ -6699,8 +6699,14 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
+				fr,
+				de,
+				ja,
+				"zh-Hans",
+				es,
 			);
 			mainGroup = 5D4019A61A76EC350006B0C2;
 			productRefGroup = 5D4019B01A76EC350006B0C2 /* Products */;

--- a/SmartDeviceLink/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.m
@@ -214,7 +214,13 @@ typedef NSString * SDLServiceID;
  */
 - (void)sdl_subscribeToSystemCapabilityUpdates {
     for (SDLSystemCapabilityType type in [self.class sdl_systemCapabilityTypes]) {
-        SDLGetSystemCapability *getSystemCapability = [[SDLGetSystemCapability alloc] initWithType:type subscribe:YES];
+        SDLGetSystemCapability *getSystemCapability = [[SDLGetSystemCapability alloc] initWithType:type];
+        SDLVersion *onSystemCapabilityNotificationRPCVersion = [SDLVersion versionWithString:@"5.1.0"];
+        SDLVersion *headUnitRPCVersion = SDLGlobals.sharedGlobals.rpcVersion;
+        if ([headUnitRPCVersion isGreaterThanOrEqualToVersion:onSystemCapabilityNotificationRPCVersion]) {
+            getSystemCapability.subscribe = @YES;
+        }
+
         [self sdl_sendGetSystemCapability:getSystemCapability completionHandler:nil];
     }
 }

--- a/SmartDeviceLink/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.m
@@ -160,13 +160,6 @@ typedef NSString * SDLServiceID;
     self.presetBankCapabilities = response.presetBankCapabilities;
 }
 
-- (void)sdl_getSystemCapabilityResponse:(SDLRPCResponseNotification *)notification {
-    SDLGetSystemCapabilityResponse *response = (SDLGetSystemCapabilityResponse *)notification.response;
-    if (!response.success.boolValue) { return; }
-
-    [self sdl_saveSystemCapability:response.systemCapability completionHandler:nil];
-}
-
 /**
  *  Called when an `OnSystemCapabilityUpdated` notification is received from Core. The updated system capabilty is saved.
  *
@@ -221,7 +214,7 @@ typedef NSString * SDLServiceID;
  */
 - (void)sdl_subscribeToSystemCapabilityUpdates {
     for (SDLSystemCapabilityType type in [self.class sdl_systemCapabilityTypes]) {
-        SDLGetSystemCapability *getSystemCapability = [[SDLGetSystemCapability alloc] initWithType:type subscribe:true];
+        SDLGetSystemCapability *getSystemCapability = [[SDLGetSystemCapability alloc] initWithType:type subscribe:YES];
         [self sdl_sendGetSystemCapability:getSystemCapability completionHandler:nil];
     }
 }
@@ -240,7 +233,6 @@ typedef NSString * SDLServiceID;
             return;
         }
 
-        // TODO: Still do this even though we do it in `sdl_getSystemCapabilityResponse`? Will the handler be called before the changes are applied if we don't?
         SDLGetSystemCapabilityResponse *getSystemCapabilityResponse = (SDLGetSystemCapabilityResponse *)response;
         if (!getSystemCapabilityResponse.success.boolValue) { return; }
         [self sdl_saveSystemCapability:getSystemCapabilityResponse.systemCapability completionHandler:handler];
@@ -269,6 +261,8 @@ typedef NSString * SDLServiceID;
         SDLLogW(@"Received response for unknown System Capability Type: %@", systemCapabilityType);
         return;
     }
+
+    SDLLogD(@"Updated system capability manager with new data: %@", systemCapability);
 
     if (handler == nil) { return; }
     handler(nil, self);

--- a/SmartDeviceLink/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.m
@@ -106,6 +106,8 @@ typedef NSString * SDLServiceID;
 #pragma mark - Getters
 
 - (nullable SDLAppServicesCapabilities *)appServicesCapabilities {
+    if (self.appServicesCapabilitiesDictionary.count == 0) { return nil; }
+    
     return [[SDLAppServicesCapabilities alloc] initWithAppServices:self.appServicesCapabilitiesDictionary.allValues];
 }
 

--- a/SmartDeviceLink/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.m
@@ -107,7 +107,7 @@ typedef NSString * SDLServiceID;
 
 - (nullable SDLAppServicesCapabilities *)appServicesCapabilities {
     if (self.appServicesCapabilitiesDictionary.count == 0) { return nil; }
-    
+
     return [[SDLAppServicesCapabilities alloc] initWithAppServices:self.appServicesCapabilitiesDictionary.allValues];
 }
 
@@ -234,7 +234,7 @@ typedef NSString * SDLServiceID;
         }
 
         SDLGetSystemCapabilityResponse *getSystemCapabilityResponse = (SDLGetSystemCapabilityResponse *)response;
-        if (!getSystemCapabilityResponse.resultCode.boolValue) { return; }
+        if (!getSystemCapabilityResponse.success.boolValue) { return; }
         [self sdl_saveSystemCapability:getSystemCapabilityResponse.systemCapability completionHandler:handler];
     }];
 }

--- a/SmartDeviceLink/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.m
@@ -160,6 +160,13 @@ typedef NSString * SDLServiceID;
     self.presetBankCapabilities = response.presetBankCapabilities;
 }
 
+- (void)sdl_getSystemCapabilityResponse:(SDLRPCResponseNotification *)notification {
+    SDLGetSystemCapabilityResponse *response = (SDLGetSystemCapabilityResponse *)notification.response;
+    if (!response.success.boolValue) { return; }
+
+    [self sdl_saveSystemCapability:response.systemCapability completionHandler:nil];
+}
+
 /**
  *  Called when an `OnSystemCapabilityUpdated` notification is received from Core. The updated system capabilty is saved.
  *
@@ -233,6 +240,7 @@ typedef NSString * SDLServiceID;
             return;
         }
 
+        // TODO: Still do this even though we do it in `sdl_getSystemCapabilityResponse`? Will the handler be called before the changes are applied if we don't?
         SDLGetSystemCapabilityResponse *getSystemCapabilityResponse = (SDLGetSystemCapabilityResponse *)response;
         if (!getSystemCapabilityResponse.success.boolValue) { return; }
         [self sdl_saveSystemCapability:getSystemCapabilityResponse.systemCapability completionHandler:handler];

--- a/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
+++ b/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
@@ -335,93 +335,26 @@ describe(@"System capability manager", ^{
 
     context(@"When the system capability manager is stopped after being started", ^{
         beforeEach(^{
-            SDLRegisterAppInterfaceResponse *testRegisterAppInterfaceResponse = [[SDLRegisterAppInterfaceResponse alloc] init];
-            testRegisterAppInterfaceResponse.displayCapabilities = [[SDLDisplayCapabilities alloc] init];
-            testRegisterAppInterfaceResponse.hmiCapabilities = [[SDLHMICapabilities alloc] init];
-            testRegisterAppInterfaceResponse.softButtonCapabilities = @[[[SDLSoftButtonCapabilities alloc] init]];
-            testRegisterAppInterfaceResponse.buttonCapabilities = @[[[SDLButtonCapabilities alloc] init]];
-            testRegisterAppInterfaceResponse.presetBankCapabilities = [[SDLPresetBankCapabilities alloc] init];
-            testRegisterAppInterfaceResponse.hmiZoneCapabilities = @[SDLHMIZoneCapabilitiesFront];
-            testRegisterAppInterfaceResponse.speechCapabilities = @[SDLSpeechCapabilitiesPrerecorded];
-            testRegisterAppInterfaceResponse.prerecordedSpeech = @[SDLPrerecordedSpeechHelp];
-            testRegisterAppInterfaceResponse.vrCapabilities = @[SDLVRCapabilitiesText];
-            testRegisterAppInterfaceResponse.audioPassThruCapabilities = @[[[SDLAudioPassThruCapabilities alloc] init]];
-            testRegisterAppInterfaceResponse.pcmStreamCapabilities = [[SDLAudioPassThruCapabilities alloc] init];
-            testRegisterAppInterfaceResponse.success = @YES;
-            SDLRPCResponseNotification *registerAppInterfaceNotification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveRegisterAppInterfaceResponse object:self rpcResponse:testRegisterAppInterfaceResponse];
-            [[NSNotificationCenter defaultCenter] postNotification:registerAppInterfaceNotification];
-
-            SDLGetSystemCapabilityResponse *testAppServicesGetSystemCapabilityResponse = [[SDLGetSystemCapabilityResponse alloc] init];
-            testAppServicesGetSystemCapabilityResponse.systemCapability = [[SDLSystemCapability alloc] initWithAppServicesCapabilities:[[SDLAppServicesCapabilities alloc] init]];
-            testAppServicesGetSystemCapabilityResponse.success = @YES;
-            SDLRPCResponseNotification *appServicesGetSystemCapabilityNotification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveGetSystemCapabilitiesResponse object:self rpcResponse:testAppServicesGetSystemCapabilityResponse];
-            [[NSNotificationCenter defaultCenter] postNotification:appServicesGetSystemCapabilityNotification];
-
-            SDLGetSystemCapabilityResponse *testNavGetSystemCapabilityResponse = [[SDLGetSystemCapabilityResponse alloc] init];
-            testNavGetSystemCapabilityResponse.systemCapability = [[SDLSystemCapability alloc] initWithNavigationCapability:[[SDLNavigationCapability alloc] init]];
-            testNavGetSystemCapabilityResponse.success = @YES;
-            SDLRPCResponseNotification *navGetSystemCapabilityNotification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveGetSystemCapabilitiesResponse object:self rpcResponse:testNavGetSystemCapabilityResponse];
-            [[NSNotificationCenter defaultCenter] postNotification:navGetSystemCapabilityNotification];
-
-            SDLGetSystemCapabilityResponse *testPhoneGetSystemCapabilityResponse = [[SDLGetSystemCapabilityResponse alloc] init];
-            testPhoneGetSystemCapabilityResponse.systemCapability = [[SDLSystemCapability alloc] initWithPhoneCapability:[[SDLPhoneCapability alloc] initWithDialNumber:YES]];
-            testPhoneGetSystemCapabilityResponse.success = @YES;
-            SDLRPCResponseNotification *phoneGetSystemCapabilityNotification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveGetSystemCapabilitiesResponse object:self rpcResponse:testPhoneGetSystemCapabilityResponse];
-            [[NSNotificationCenter defaultCenter] postNotification:phoneGetSystemCapabilityNotification];
-
-            SDLGetSystemCapabilityResponse *testVideoGetSystemCapabilityResponse = [[SDLGetSystemCapabilityResponse alloc] init];
-            testVideoGetSystemCapabilityResponse.systemCapability = [[SDLSystemCapability alloc] initWithVideoStreamingCapability:[[SDLVideoStreamingCapability alloc] init]];
-            testVideoGetSystemCapabilityResponse.success = @YES;
-            SDLRPCResponseNotification *videoGetSystemCapabilityNotification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveGetSystemCapabilitiesResponse object:self rpcResponse:testVideoGetSystemCapabilityResponse];
-            [[NSNotificationCenter defaultCenter] postNotification:videoGetSystemCapabilityNotification];
-
-            SDLGetSystemCapabilityResponse *testRemoteControlGetSystemCapabilityResponse = [[SDLGetSystemCapabilityResponse alloc] init];
-            testRemoteControlGetSystemCapabilityResponse.systemCapability = [[SDLSystemCapability alloc] initWithRemoteControlCapability:[[SDLRemoteControlCapabilities alloc] init]];
-            testRemoteControlGetSystemCapabilityResponse.success = @YES;
-            SDLRPCResponseNotification *remoteControlGetSystemCapabilityNotification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveGetSystemCapabilitiesResponse object:self rpcResponse:testRemoteControlGetSystemCapabilityResponse];
-            [[NSNotificationCenter defaultCenter] postNotification:remoteControlGetSystemCapabilityNotification];
-
-            expect(testSystemCapabilityManager.displayCapabilities).toNot(beNil());
-            expect(testSystemCapabilityManager.hmiCapabilities).toNot(beNil());
-            expect(testSystemCapabilityManager.softButtonCapabilities).toNot(beNil());
-            expect(testSystemCapabilityManager.buttonCapabilities).toNot(beNil());
-            expect(testSystemCapabilityManager.presetBankCapabilities).toNot(beNil());
-            expect(testSystemCapabilityManager.hmiZoneCapabilities).toNot(beNil());
-            expect(testSystemCapabilityManager.speechCapabilities).toNot(beNil());
-            expect(testSystemCapabilityManager.prerecordedSpeechCapabilities).toNot(beNil());
-            expect(testSystemCapabilityManager.vrCapability).toNot(beFalse());
-            expect(testSystemCapabilityManager.audioPassThruCapabilities).toNot(beNil());
-            expect(testSystemCapabilityManager.pcmStreamCapability).toNot(beNil());
-            expect(testSystemCapabilityManager.phoneCapability).toNot(beNil());
-            expect(testSystemCapabilityManager.navigationCapability).toNot(beNil());
-            expect(testSystemCapabilityManager.videoStreamingCapability).toNot(beNil());
-            expect(testSystemCapabilityManager.remoteControlCapability).toNot(beNil());
-            expect(testSystemCapabilityManager.appServicesCapabilities).toNot(beNil());
+            [testSystemCapabilityManager stop];
         });
 
-        describe(@"When stopped", ^{
-            beforeEach(^{
-                [testSystemCapabilityManager stop];
-            });
-
-            it(@"It should reset the system capability manager properties correctly", ^{
-                expect(testSystemCapabilityManager.displayCapabilities).to(beNil());
-                expect(testSystemCapabilityManager.hmiCapabilities).to(beNil());
-                expect(testSystemCapabilityManager.softButtonCapabilities).to(beNil());
-                expect(testSystemCapabilityManager.buttonCapabilities).to(beNil());
-                expect(testSystemCapabilityManager.presetBankCapabilities).to(beNil());
-                expect(testSystemCapabilityManager.hmiZoneCapabilities).to(beNil());
-                expect(testSystemCapabilityManager.speechCapabilities).to(beNil());
-                expect(testSystemCapabilityManager.prerecordedSpeechCapabilities).to(beNil());
-                expect(testSystemCapabilityManager.vrCapability).to(beFalse());
-                expect(testSystemCapabilityManager.audioPassThruCapabilities).to(beNil());
-                expect(testSystemCapabilityManager.pcmStreamCapability).to(beNil());
-                expect(testSystemCapabilityManager.phoneCapability).to(beNil());
-                expect(testSystemCapabilityManager.navigationCapability).to(beNil());
-                expect(testSystemCapabilityManager.videoStreamingCapability).to(beNil());
-                expect(testSystemCapabilityManager.remoteControlCapability).to(beNil());
-                expect(testSystemCapabilityManager.appServicesCapabilities).to(beNil());
-            });
+        it(@"It should reset the system capability manager properties correctly", ^{
+            expect(testSystemCapabilityManager.displayCapabilities).to(beNil());
+            expect(testSystemCapabilityManager.hmiCapabilities).to(beNil());
+            expect(testSystemCapabilityManager.softButtonCapabilities).to(beNil());
+            expect(testSystemCapabilityManager.buttonCapabilities).to(beNil());
+            expect(testSystemCapabilityManager.presetBankCapabilities).to(beNil());
+            expect(testSystemCapabilityManager.hmiZoneCapabilities).to(beNil());
+            expect(testSystemCapabilityManager.speechCapabilities).to(beNil());
+            expect(testSystemCapabilityManager.prerecordedSpeechCapabilities).to(beNil());
+            expect(testSystemCapabilityManager.vrCapability).to(beFalse());
+            expect(testSystemCapabilityManager.audioPassThruCapabilities).to(beNil());
+            expect(testSystemCapabilityManager.pcmStreamCapability).to(beNil());
+            expect(testSystemCapabilityManager.phoneCapability).to(beNil());
+            expect(testSystemCapabilityManager.navigationCapability).to(beNil());
+            expect(testSystemCapabilityManager.videoStreamingCapability).to(beNil());
+            expect(testSystemCapabilityManager.remoteControlCapability).to(beNil());
+            expect(testSystemCapabilityManager.appServicesCapabilities).to(beNil());
         });
     });
 });

--- a/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
+++ b/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
@@ -1,6 +1,7 @@
 #import <Quick/Quick.h>
 #import <Nimble/Nimble.h>
 
+#import "SDLAppServicesCapabilities.h"
 #import "SDLAudioPassThruCapabilities.h"
 #import "SDLButtonCapabilities.h"
 #import "SDLDisplayCapabilities.h"
@@ -356,19 +357,70 @@ describe(@"System capability manager", ^{
         });
     });
 
-    context(@"When the system capability manager is stopped after being started", ^{
+    fcontext(@"When the system capability manager is stopped after being started", ^{
         beforeEach(^{
-            SDLDisplayCapabilities *testDisplayCapabilities = [[SDLDisplayCapabilities alloc] init];
-            testDisplayCapabilities.graphicSupported = @NO;
-
             SDLRegisterAppInterfaceResponse *testRegisterAppInterfaceResponse = [[SDLRegisterAppInterfaceResponse alloc] init];
-            testRegisterAppInterfaceResponse.displayCapabilities = testDisplayCapabilities;
+            testRegisterAppInterfaceResponse.displayCapabilities = [[SDLDisplayCapabilities alloc] init];
+            testRegisterAppInterfaceResponse.hmiCapabilities = [[SDLHMICapabilities alloc] init];
+            testRegisterAppInterfaceResponse.softButtonCapabilities = @[[[SDLSoftButtonCapabilities alloc] init]];
+            testRegisterAppInterfaceResponse.buttonCapabilities = @[[[SDLButtonCapabilities alloc] init]];
+            testRegisterAppInterfaceResponse.presetBankCapabilities = [[SDLPresetBankCapabilities alloc] init];
+            testRegisterAppInterfaceResponse.hmiZoneCapabilities = @[SDLHMIZoneCapabilitiesFront];
+            testRegisterAppInterfaceResponse.speechCapabilities = @[SDLSpeechCapabilitiesPrerecorded];
+            testRegisterAppInterfaceResponse.prerecordedSpeech = @[SDLPrerecordedSpeechHelp];
+            testRegisterAppInterfaceResponse.vrCapabilities = @[SDLVRCapabilitiesText];
+            testRegisterAppInterfaceResponse.audioPassThruCapabilities = @[[[SDLAudioPassThruCapabilities alloc] init]];
+            testRegisterAppInterfaceResponse.pcmStreamCapabilities = [[SDLAudioPassThruCapabilities alloc] init];
             testRegisterAppInterfaceResponse.success = @YES;
+            SDLRPCResponseNotification *registerAppInterfaceNotification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveRegisterAppInterfaceResponse object:self rpcResponse:testRegisterAppInterfaceResponse];
+            [[NSNotificationCenter defaultCenter] postNotification:registerAppInterfaceNotification];
 
-            SDLRPCResponseNotification *notification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveRegisterAppInterfaceResponse object:self rpcResponse:testRegisterAppInterfaceResponse];
-            [[NSNotificationCenter defaultCenter] postNotification:notification];
+            SDLGetSystemCapabilityResponse *testAppServicesGetSystemCapabilityResponse = [[SDLGetSystemCapabilityResponse alloc] init];
+            testAppServicesGetSystemCapabilityResponse.systemCapability = [[SDLSystemCapability alloc] initWithAppServicesCapabilities:[[SDLAppServicesCapabilities alloc] init]];
+            testAppServicesGetSystemCapabilityResponse.success = @YES;
+            SDLRPCResponseNotification *appServicesGetSystemCapabilityNotification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveGetSystemCapabilitiesResponse object:self rpcResponse:testAppServicesGetSystemCapabilityResponse];
+            [[NSNotificationCenter defaultCenter] postNotification:appServicesGetSystemCapabilityNotification];
 
-            expect(testSystemCapabilityManager.displayCapabilities).to(equal(testDisplayCapabilities));
+            SDLGetSystemCapabilityResponse *testNavGetSystemCapabilityResponse = [[SDLGetSystemCapabilityResponse alloc] init];
+            testNavGetSystemCapabilityResponse.systemCapability = [[SDLSystemCapability alloc] initWithNavigationCapability:[[SDLNavigationCapability alloc] init]];
+            testNavGetSystemCapabilityResponse.success = @YES;
+            SDLRPCResponseNotification *navGetSystemCapabilityNotification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveGetSystemCapabilitiesResponse object:self rpcResponse:testNavGetSystemCapabilityResponse];
+            [[NSNotificationCenter defaultCenter] postNotification:navGetSystemCapabilityNotification];
+
+            SDLGetSystemCapabilityResponse *testPhoneGetSystemCapabilityResponse = [[SDLGetSystemCapabilityResponse alloc] init];
+            testPhoneGetSystemCapabilityResponse.systemCapability = [[SDLSystemCapability alloc] initWithPhoneCapability:[[SDLPhoneCapability alloc] initWithDialNumber:YES]];
+            testPhoneGetSystemCapabilityResponse.success = @YES;
+            SDLRPCResponseNotification *phoneGetSystemCapabilityNotification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveGetSystemCapabilitiesResponse object:self rpcResponse:testPhoneGetSystemCapabilityResponse];
+            [[NSNotificationCenter defaultCenter] postNotification:phoneGetSystemCapabilityNotification];
+
+            SDLGetSystemCapabilityResponse *testVideoGetSystemCapabilityResponse = [[SDLGetSystemCapabilityResponse alloc] init];
+            testVideoGetSystemCapabilityResponse.systemCapability = [[SDLSystemCapability alloc] initWithVideoStreamingCapability:[[SDLVideoStreamingCapability alloc] init]];
+            testVideoGetSystemCapabilityResponse.success = @YES;
+            SDLRPCResponseNotification *videoGetSystemCapabilityNotification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveGetSystemCapabilitiesResponse object:self rpcResponse:testVideoGetSystemCapabilityResponse];
+            [[NSNotificationCenter defaultCenter] postNotification:videoGetSystemCapabilityNotification];
+
+            SDLGetSystemCapabilityResponse *testRemoteControlGetSystemCapabilityResponse = [[SDLGetSystemCapabilityResponse alloc] init];
+            testRemoteControlGetSystemCapabilityResponse.systemCapability = [[SDLSystemCapability alloc] initWithRemoteControlCapability:[[SDLRemoteControlCapabilities alloc] init]];
+            testRemoteControlGetSystemCapabilityResponse.success = @YES;
+            SDLRPCResponseNotification *remoteControlGetSystemCapabilityNotification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveGetSystemCapabilitiesResponse object:self rpcResponse:testRemoteControlGetSystemCapabilityResponse];
+            [[NSNotificationCenter defaultCenter] postNotification:remoteControlGetSystemCapabilityNotification];
+
+            expect(testSystemCapabilityManager.displayCapabilities).toNot(beNil());
+            expect(testSystemCapabilityManager.hmiCapabilities).toNot(beNil());
+            expect(testSystemCapabilityManager.softButtonCapabilities).toNot(beNil());
+            expect(testSystemCapabilityManager.buttonCapabilities).toNot(beNil());
+            expect(testSystemCapabilityManager.presetBankCapabilities).toNot(beNil());
+            expect(testSystemCapabilityManager.hmiZoneCapabilities).toNot(beNil());
+            expect(testSystemCapabilityManager.speechCapabilities).toNot(beNil());
+            expect(testSystemCapabilityManager.prerecordedSpeechCapabilities).toNot(beNil());
+            expect(testSystemCapabilityManager.vrCapability).toNot(beFalse());
+            expect(testSystemCapabilityManager.audioPassThruCapabilities).toNot(beNil());
+            expect(testSystemCapabilityManager.pcmStreamCapability).toNot(beNil());
+            expect(testSystemCapabilityManager.phoneCapability).toNot(beNil());
+            expect(testSystemCapabilityManager.navigationCapability).toNot(beNil());
+            expect(testSystemCapabilityManager.videoStreamingCapability).toNot(beNil());
+            expect(testSystemCapabilityManager.remoteControlCapability).toNot(beNil());
+            expect(testSystemCapabilityManager.appServicesCapabilities).toNot(beNil());
         });
 
         describe(@"When stopped", ^{


### PR DESCRIPTION
Fixes #1212 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Test cases added to the system capability manager

### Summary
* Support `OnSystemCapability` and `GetSystemCapability` with the `subscribe` parameter while also backward compatibility supporting head units that don't support those updates.
* Support updating `AppServicesCapabilities` parameter with the change set update.

### Changelog
##### Enhancements
* Updated the `SDLSystemCapabilityManager` to auto-update the cache based on all `GetSystemCapabilityResponse` and `OnSystemCapability` notifications (v5.1+ only) with full backward-compatibility support.

### Tasks Remaining:
- [x] Fix broken unit tests for the system capability manger

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
