### PR TITLE
Add missing `SDLAppInterfaceUnregisteredReason`

### DIFF
--- a/SmartDeviceLink/SDLAppInterfaceUnregisteredReason.h
+++ b/SmartDeviceLink/SDLAppInterfaceUnregisteredReason.h
@@ -63,3 +63,7 @@ extern SDLAppInterfaceUnregisteredReason const SDLAppInterfaceUnregisteredReason
  * @since SDL 2.0
  */
 extern SDLAppInterfaceUnregisteredReason const SDLAppInterfaceUnregisteredReasonAppUnauthorized;
+
+extern SDLAppInterfaceUnregisteredReason const SDLAppInterfaceUnregisteredReasonProtocolViolation;
+
+extern SDLAppInterfaceUnregisteredReason const SDLAppInterfaceUnregisteredReasonUnsupportedHMIResource;

--- a/SmartDeviceLink/SDLAppInterfaceUnregisteredReason.m
+++ b/SmartDeviceLink/SDLAppInterfaceUnregisteredReason.m
@@ -14,3 +14,5 @@ SDLAppInterfaceUnregisteredReason const SDLAppInterfaceUnregisteredReasonLanguag
 SDLAppInterfaceUnregisteredReason const SDLAppInterfaceUnregisteredReasonMasterReset = @"MASTER_RESET";
 SDLAppInterfaceUnregisteredReason const SDLAppInterfaceUnregisteredReasonFactoryDefaults = @"FACTORY_DEFAULTS";
 SDLAppInterfaceUnregisteredReason const SDLAppInterfaceUnregisteredReasonAppUnauthorized = @"APP_UNAUTHORIZED";
+SDLAppInterfaceUnregisteredReason const SDLAppInterfaceUnregisteredReasonProtocolViolation = @"PROTOCOL_VIOLATION";
+SDLAppInterfaceUnregisteredReason const SDLAppInterfaceUnregisteredReasonUnsupportedHMIResource = @"UNSUPPORTED_HMI_RESOURCE";

--- a/SmartDeviceLinkTests/RPCSpecs/EnumSpecs/SDLAppInterfaceUnregisteredReasonSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/EnumSpecs/SDLAppInterfaceUnregisteredReasonSpec.m
@@ -27,7 +27,8 @@ describe(@"Individual Enum Value Tests", ^ {
         expect(SDLAppInterfaceUnregisteredReasonMasterReset).to(equal(@"MASTER_RESET"));
         expect(SDLAppInterfaceUnregisteredReasonFactoryDefaults).to(equal(@"FACTORY_DEFAULTS"));
         expect(SDLAppInterfaceUnregisteredReasonAppUnauthorized).to(equal(@"APP_UNAUTHORIZED"));
-        //expect(SDLAppInterfaceUnregisteredReason PROTOCOL_VIOLATION).to(equal(@"PROTOCOL_VIOLATION"));
+        expect(SDLAppInterfaceUnregisteredReasonProtocolViolation).to(equal(@"PROTOCOL_VIOLATION"));
+        expect(SDLAppInterfaceUnregisteredReasonUnsupportedHMIResource).to(equal(@"UNSUPPORTED_HMI_RESOURCE"));
     });
 });
 


### PR DESCRIPTION
Fixes #1216 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Added missing `SDLAppInterfaceUnregisteredReason` that was in the RPC spec but missing from the library.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)