### PR TITLE
Update `lastCorrelationId` to be Int32 instead of UInt16

### DIFF
--- a/SmartDeviceLink/SDLLifecycleManager.h
+++ b/SmartDeviceLink/SDLLifecycleManager.h
@@ -82,7 +82,6 @@ typedef void (^SDLManagerReadyBlock)(BOOL success, NSError *_Nullable error);
 @property (strong, nonatomic, nullable) SDLProxy *proxy;
 #pragma clang diagnostic pop
 
-@property (assign, nonatomic) UInt16 lastCorrelationId;
 @property (copy, nonatomic, readonly) SDLLifecycleState *lifecycleState;
 @property (copy, nonatomic, nullable) SDLHMILevel hmiLevel;
 @property (copy, nonatomic, nullable) SDLAudioStreamingState audioStreamingState;

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -87,6 +87,7 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
 @property (strong, nonatomic, nullable) SDLSecondaryTransportManager *secondaryTransportManager;
 @property (copy, nonatomic) SDLManagerReadyBlock readyHandler;
 @property (copy, nonatomic) dispatch_queue_t lifecycleQueue;
+@property (assign, nonatomic) int32_t lastCorrelationId;
 
 @end
 
@@ -651,7 +652,7 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
 
 #pragma mark Helper Methods
 - (NSNumber<SDLInt> *)sdl_getNextCorrelationId {
-    if (self.lastCorrelationId == UINT16_MAX) {
+    if (self.lastCorrelationId == INT32_MAX) {
         self.lastCorrelationId = 0;
     }
 

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleManagerSpec.m
@@ -46,6 +46,7 @@
 @interface SDLLifecycleManager ()
 // this private property is used for testing
 @property (copy, nonatomic) dispatch_queue_t lifecycleQueue;
+@property (assign, nonatomic) int32_t lastCorrelationId;
 @end
 
 QuickConfigurationBegin(SendingRPCsConfiguration)

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLAlertSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLAlertSpec.m
@@ -66,7 +66,7 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testRequest.softButtons).to(equal([@[button] mutableCopy]));
     });
 
-    it(@"Should handle NSNull", ^{
+    fit(@"Should handle NSNull", ^{
         NSMutableDictionary* dict = [@{SDLRPCParameterNameRequest:
                                            @{SDLRPCParameterNameParameters:
                                                  @{SDLRPCParameterNameAlertText1:@"alert#1",
@@ -80,7 +80,7 @@ describe(@"Getter/Setter Tests", ^ {
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameAlert}} mutableCopy];
         SDLAlert* testRequest = [[SDLAlert alloc] initWithDictionary:dict];
         expectAction(^{
-            expect(testRequest.softButtons).to(beNil());
+            NSArray<SDLSoftButton *> *softButtons = testRequest.softButtons;
         }).to(raiseException());
     });
     

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLAlertSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLAlertSpec.m
@@ -66,7 +66,7 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testRequest.softButtons).to(equal([@[button] mutableCopy]));
     });
 
-    fit(@"Should handle NSNull", ^{
+    it(@"Should handle NSNull", ^{
         NSMutableDictionary* dict = [@{SDLRPCParameterNameRequest:
                                            @{SDLRPCParameterNameParameters:
                                                  @{SDLRPCParameterNameAlertText1:@"alert#1",


### PR DESCRIPTION
Fixes #1214

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Testing is completed against older Core versions

### Summary
We should match the updated [protocol_spec 5.2.0](https://github.com/smartdevicelink/protocol_spec/pull/24/files) behavior for correlation ids (which merely describes existing behavior and doesn't change it).

### Changelog
##### Bug Fixes
* Update `SDLLifecycleManager lastCorrelationId` to be Int32 instead of UInt16
* Updated correlation id to go to INT32_MAX
* Updated `lastCorrelationId` to be hidden on `SDLLifecycleManager`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
