### PR TITLE
Add a toggle for disabling bad data assertions

### DIFF
--- a/SmartDeviceLink/NSMutableDictionary+Store.m
+++ b/SmartDeviceLink/NSMutableDictionary+Store.m
@@ -55,8 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
         // The object in the store is not correct, we'll assert in debug and return an error and nil
         NSError *wrongObjectError = [NSError sdl_rpcStore_invalidObjectErrorWithObject:obj expectedType:classType];
 
-        SDLLogE(@"Retrieving object from store error: %@", wrongObjectError.localizedFailureReason);
-        NSAssert(NO, wrongObjectError.localizedFailureReason);
+        SDLLogAssert(@"Retrieving object from store error: %@", wrongObjectError.localizedFailureReason);
 
         if (error) {
             *error = wrongObjectError;
@@ -93,8 +92,7 @@ NS_ASSUME_NONNULL_BEGIN
             wrongObjectError = [NSError sdl_rpcStore_invalidObjectErrorWithObject:array expectedType:NSArray.class];
         }
 
-        SDLLogE(@"Retrieving array from store error: %@", wrongObjectError.localizedFailureReason);
-        NSAssert(NO, wrongObjectError.localizedFailureReason);
+        SDLLogAssert(@"Retrieving array from store error: %@", wrongObjectError.localizedFailureReason);
         if (error) {
             *error = wrongObjectError;
         }

--- a/SmartDeviceLink/SDLLogConfiguration.h
+++ b/SmartDeviceLink/SDLLogConfiguration.h
@@ -50,6 +50,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic, getter=areErrorsAsynchronous) BOOL errorsAsynchronous;
 
 /**
+ Whether or not assert logs will fire assertions in DEBUG mode. Assertions are always disabled in RELEASE builds. If assertions are disabled, only an error log will fire instead. Defaults to NO.
+ */
+@property (assign, nonatomic, getter=areAssertionsDisabled) BOOL disableAssertions;
+
+/**
  Any modules that do not have an explicitly specified level will by default use the global log level. Defaults to Error.
  Do not specify Default for this parameter.
  */

--- a/SmartDeviceLink/SDLLogConfiguration.m
+++ b/SmartDeviceLink/SDLLogConfiguration.m
@@ -28,6 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
     _formatType = SDLLogFormatTypeDefault;
     _asynchronous = YES;
     _errorsAsynchronous = NO;
+    _disableAssertions = NO;
     _globalLogLevel = SDLLogLevelError;
 
     return self;
@@ -80,6 +81,7 @@ NS_ASSUME_NONNULL_BEGIN
     newConfig.formatType = self.formatType;
     newConfig.asynchronous = self.asynchronous;
     newConfig.errorsAsynchronous = self.errorsAsynchronous;
+    newConfig.disableAssertions = self.areAssertionsDisabled;
     newConfig.globalLogLevel = self.globalLogLevel;
 
     return newConfig;

--- a/SmartDeviceLink/SDLLogMacros.h
+++ b/SmartDeviceLink/SDLLogMacros.h
@@ -99,3 +99,11 @@
  @param ... The format arguments to log
  */
 #define SDLLogE(msg, ...) [SDLLogManager logWithLevel:SDLLogLevelError timestamp:[NSDate date] file:SDLLOG_FILE functionName:SDLLOG_FUNC line:__LINE__ queue:SDLLOG_QUEUE formatMessage:msg, ##__VA_ARGS__]
+
+/**
+ Log an assertion log. This will log an error, and assert by default in DEBUG (but this can be disabled in the SDLLogConfiguration).
+
+ @param msg The format string to log
+ @param ... The format arguments to log
+ */
+#define SDLLogAssert(msg, ...) [SDLLogManager logAssertWithTimestamp:[NSDate date] file:SDLLOG_FILE functionName:SDLLOG_FUNC line:__LINE__ queue:SDLLOG_QUEUE formatMessage:msg, ##__VA_ARGS__]

--- a/SmartDeviceLink/SDLLogManager.h
+++ b/SmartDeviceLink/SDLLogManager.h
@@ -63,6 +63,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic, readonly, getter=areErrorsAsynchronous) BOOL errorsAsynchronous;
 
 /**
+ Whether or not assert logs will fire assertions in DEBUG mode. Assertions are always disabled in RELEASE builds. If assertions are disabled, only an error log will fire instead. Defaults to NO.
+ */
+@property (assign, nonatomic, readonly, getter=areAssertionsDisabled) BOOL disableAssertions;
+
+/**
  Active date formatter
  */
 @property (class, strong, nonatomic, readonly) NSDateFormatter *dateFormatter;
@@ -209,6 +214,40 @@ NS_ASSUME_NONNULL_BEGIN
     functionName:(NSString *)functionName
             line:(NSInteger)line
            queue:(NSString *)queueLabel;
+
+/**
+ Log an error to the sharedManager's active log targets and assert. This is used internally to log.
+
+ @param timestamp The time the log was sent
+ @param file The file the log originated from
+ @param functionName The function the log originated from
+ @param line The line the log originated from
+ @param queueLabel The queue the log was sent from
+ @param message The message of the log
+ */
++ (void)logAssertWithTimestamp:(NSDate *)timestamp
+                          file:(NSString *)file
+                  functionName:(NSString *)functionName
+                          line:(NSInteger)line
+                         queue:(NSString *)queueLabel
+                 formatMessage:(NSString *)message, ... NS_FORMAT_FUNCTION(6, 7);
+
+/**
+ Log an error to this manager's active log targets and assert. This is used internally to log.
+
+ @param timestamp The time the log was sent
+ @param file The file the log originated from
+ @param functionName The function the log originated from
+ @param line The line the log originated from
+ @param queueLabel The queue the log was sent from
+ @param message The message of the log
+ */
+- (void)logAssertWithTimestamp:(NSDate *)timestamp
+                          file:(NSString *)file
+                  functionName:(NSString *)functionName
+                          line:(NSInteger)line
+                         queue:(NSString *)queueLabel
+                 formatMessage:(NSString *)message, ... NS_FORMAT_FUNCTION(6, 7);
 
 @end
 

--- a/SmartDeviceLink/SDLLogManager.m
+++ b/SmartDeviceLink/SDLLogManager.m
@@ -27,6 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (assign, nonatomic, readwrite, getter=isAsynchronous) BOOL asynchronous;
 @property (assign, nonatomic, readwrite, getter=areErrorsAsynchronous) BOOL errorsAsynchronous;
+@property (assign, nonatomic, readwrite, getter=areAssertionsDisabled) BOOL disableAssertions;
 
 @end
 
@@ -57,6 +58,7 @@ static dispatch_queue_t _logQueue = NULL;
 
     _asynchronous = YES;
     _errorsAsynchronous = NO;
+    _disableAssertions = NO;
     _globalLogLevel = SDLLogLevelError;
     _formatType = SDLLogFormatTypeDefault;
 
@@ -76,6 +78,7 @@ static dispatch_queue_t _logQueue = NULL;
     self.formatType = configuration.formatType;
     self.asynchronous = configuration.isAsynchronous;
     self.errorsAsynchronous = configuration.areErrorsAsynchronous;
+    self.disableAssertions = configuration.areAssertionsDisabled;
     self.globalLogLevel = configuration.globalLogLevel;
 
     // Start the loggers
@@ -99,6 +102,15 @@ static dispatch_queue_t _logQueue = NULL;
     [[self sharedManager] logBytes:data direction:direction timestamp:timestamp file:file functionName:functionName line:line queue:queueLabel];
 }
 
++ (void)logAssertWithTimestamp:(NSDate *)timestamp file:(NSString *)file functionName:(NSString *)functionName line:(NSInteger)line queue:(NSString *)queueLabel formatMessage:(NSString *)message, ... {
+    va_list args;
+    va_start(args, message);
+    NSString *format = [[NSString alloc] initWithFormat:message arguments:args];
+    va_end(args);
+
+    [[self sharedManager] logAssertWithTimestamp:timestamp file:file functionName:functionName line:line queue:queueLabel formatMessage:@"%@", format];
+}
+
 + (void)logWithLevel:(SDLLogLevel)level timestamp:(NSDate *)timestamp file:(NSString *)file functionName:(NSString *)functionName line:(NSInteger)line queue:(NSString *)queueLabel message:(NSString *)message {
     [[self sharedManager] logWithLevel:level timestamp:timestamp file:file functionName:functionName line:line queue:queueLabel message:message];
 }
@@ -118,6 +130,20 @@ static dispatch_queue_t _logQueue = NULL;
 
     NSString *message = [NSString stringWithFormat:@"%@(%lu bytes): %@", [self sdl_logStringForDirection:direction], (unsigned long)data.length, [SDLHexUtility getHexString:data]];
     [self logWithLevel:SDLLogLevelVerbose timestamp:timestamp file:file functionName:functionName line:line queue:queueLabel message:message];
+}
+
+- (void)logAssertWithTimestamp:(NSDate *)timestamp file:(NSString *)file functionName:(NSString *)functionName line:(NSInteger)line queue:(NSString *)queueLabel formatMessage:(NSString *)message, ... {
+    va_list args;
+    va_start(args, message);
+    NSString *format = [[NSString alloc] initWithFormat:message arguments:args];
+    va_end(args);
+
+    [self logWithLevel:SDLLogLevelError timestamp:timestamp file:file functionName:functionName line:line queue:queueLabel message:format];
+
+    if (!self.areAssertionsDisabled) {
+        NSString *assertString = [NSString stringWithFormat:@"SDL ASSERTION: %@. To disable these assertions, alter your `SDLLogConfiguration` and set `disableAssertions` to `YES`", format];
+        NSAssert(NO, assertString);
+    }
 }
 
 - (void)logWithLevel:(SDLLogLevel)level timestamp:(NSDate *)timestamp file:(NSString *)file functionName:(NSString *)functionName line:(NSInteger)line queue:(NSString *)queueLabel formatMessage:(NSString *)message, ... {

--- a/SmartDeviceLink/SDLLogManager.m
+++ b/SmartDeviceLink/SDLLogManager.m
@@ -140,10 +140,7 @@ static dispatch_queue_t _logQueue = NULL;
 
     [self logWithLevel:SDLLogLevelError timestamp:timestamp file:file functionName:functionName line:line queue:queueLabel message:format];
 
-    if (!self.areAssertionsDisabled) {
-        NSString *assertString = [NSString stringWithFormat:@"SDL ASSERTION: %@. To disable these assertions, alter your `SDLLogConfiguration` and set `disableAssertions` to `YES`", format];
-        NSAssert(NO, assertString);
-    }
+    NSAssert(self.areAssertionsDisabled, @"SDL ASSERTION: %@. To disable these assertions, alter your `SDLLogConfiguration` and set `disableAssertions` to `YES`", format);
 }
 
 - (void)logWithLevel:(SDLLogLevel)level timestamp:(NSDate *)timestamp file:(NSString *)file functionName:(NSString *)functionName line:(NSInteger)line queue:(NSString *)queueLabel formatMessage:(NSString *)message, ... {

--- a/SmartDeviceLinkTests/LoggingSpecs/SDLLogConfigurationSpec.m
+++ b/SmartDeviceLinkTests/LoggingSpecs/SDLLogConfigurationSpec.m
@@ -20,6 +20,7 @@ describe(@"a log configuration", ^{
             expect(@(testConfiguration.formatType)).to(equal(@(SDLLogFormatTypeDefault)));
             expect(@(testConfiguration.asynchronous)).to(equal(@YES));
             expect(@(testConfiguration.errorsAsynchronous)).to(equal(@NO));
+            expect(@(testConfiguration.areAssertionsDisabled)).to(equal(@NO));
             expect(@(testConfiguration.globalLogLevel)).to(equal(@(SDLLogLevelError)));
 
             if ([NSProcessInfo processInfo].operatingSystemVersion.majorVersion >= 10) {
@@ -40,6 +41,7 @@ describe(@"a log configuration", ^{
             expect(@(testConfiguration.formatType)).to(equal(@(SDLLogFormatTypeDetailed)));
             expect(@(testConfiguration.asynchronous)).to(equal(@YES));
             expect(@(testConfiguration.errorsAsynchronous)).to(equal(@NO));
+            expect(@(testConfiguration.areAssertionsDisabled)).to(equal(@NO));
             expect(@(testConfiguration.globalLogLevel)).to(equal(@(SDLLogLevelDebug)));
 
             if ([NSProcessInfo processInfo].operatingSystemVersion.majorVersion >= 10) {


### PR DESCRIPTION
Fixes #1230 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Tests were run

### Changelog
##### Enhancements
* Added a log configuration flag to disable log assertions.
* Added a new log type for assert logging (logs an error, then asserts unless assertions are disabled)

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)