### PR TITLE
Fixing issue that caused SDLTransportDidDisconnect to get called befo…

### DIFF
--- a/SmartDeviceLink/SDLProxy.m
+++ b/SmartDeviceLink/SDLProxy.m
@@ -445,6 +445,7 @@ static float DefaultConnectionTimeout = 45.0;
 
     [self sdl_invokeDelegateMethodsWithFunction:functionName message:newMessage];
     
+    //Intercepting SDLRPCFunctionNameOnAppInterfaceUnregistered must happen after it is broadcasted as a notification above. This will prevent reccoction attempts in the lifecycle manager when the AppInterfaceUnregisteredReason should prevent reconnections.
     if ([functionName isEqualToString:SDLRPCFunctionNameOnAppInterfaceUnregistered] || [functionName isEqualToString:SDLRPCFunctionNameUnregisterAppInterface]) {
         [self handleRPCUnregistered:dict];
     }

--- a/SmartDeviceLink/SDLProxy.m
+++ b/SmartDeviceLink/SDLProxy.m
@@ -403,9 +403,6 @@ static float DefaultConnectionTimeout = 45.0;
     SDLLogV(@"Message received: %@", newMessage);
 
     // Intercept and handle several messages ourselves
-    if ([functionName isEqualToString:SDLRPCFunctionNameOnAppInterfaceUnregistered] || [functionName isEqualToString:SDLRPCFunctionNameUnregisterAppInterface]) {
-        [self handleRPCUnregistered:dict];
-    }
 
     if ([functionName isEqualToString:@"RegisterAppInterfaceResponse"]) {
         [self handleRegisterAppInterfaceResponse:(SDLRPCResponse *)newMessage];
@@ -447,6 +444,10 @@ static float DefaultConnectionTimeout = 45.0;
     }
 
     [self sdl_invokeDelegateMethodsWithFunction:functionName message:newMessage];
+    
+    if ([functionName isEqualToString:SDLRPCFunctionNameOnAppInterfaceUnregistered] || [functionName isEqualToString:SDLRPCFunctionNameUnregisterAppInterface]) {
+        [self handleRPCUnregistered:dict];
+    }
 
     // When an OnHMIStatus notification comes in, after passing it on (above), generate an "OnLockScreenNotification"
     if ([functionName isEqualToString:@"OnHMIStatus"]) {

--- a/SmartDeviceLink/SDLProxy.m
+++ b/SmartDeviceLink/SDLProxy.m
@@ -445,7 +445,7 @@ static float DefaultConnectionTimeout = 45.0;
 
     [self sdl_invokeDelegateMethodsWithFunction:functionName message:newMessage];
     
-    //Intercepting SDLRPCFunctionNameOnAppInterfaceUnregistered must happen after it is broadcasted as a notification above. This will prevent reccoction attempts in the lifecycle manager when the AppInterfaceUnregisteredReason should prevent reconnections.
+    //Intercepting SDLRPCFunctionNameOnAppInterfaceUnregistered must happen after it is broadcasted as a notification above. This will prevent reconnection attempts in the lifecycle manager when the AppInterfaceUnregisteredReason should prevent reconnections.
     if ([functionName isEqualToString:SDLRPCFunctionNameOnAppInterfaceUnregistered] || [functionName isEqualToString:SDLRPCFunctionNameUnregisterAppInterface]) {
         [self handleRPCUnregistered:dict];
     }


### PR DESCRIPTION
Fixes #1097 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Use Core and open the menu, click `UNAUTHORIZED_TRANSPORT_REGISTRATION`, this will fire a `OnAppInterfaceUnregistered` `APP_UNAUTHORIZED`. You can see that the app now stops then manager instead of reconnecting.

### Summary
Fixing issue that caused the proxy to reconnect before stop was called.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)