### PR TITLE
Audio stream manager no longer suspends audio when device app is inactive

### DIFF
--- a/SmartDeviceLink/SDLStreamingAudioLifecycleManager.h
+++ b/SmartDeviceLink/SDLStreamingAudioLifecycleManager.h
@@ -31,7 +31,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic, readonly) SDLAudioStreamManagerState *currentAudioStreamState;
 
 @property (strong, nonatomic, readonly) SDLStateMachine *appStateMachine;
-@property (strong, nonatomic, readonly) SDLAppState *currentAppState;
 
 @property (copy, nonatomic, nullable) SDLHMILevel hmiLevel;
 

--- a/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
@@ -32,7 +32,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SDLStreamingAudioLifecycleManager()
 
-@property (strong, nonatomic, readwrite) SDLStateMachine *appStateMachine;
 @property (strong, nonatomic, readwrite) SDLStateMachine *audioStreamStateMachine;
 @property (assign, nonatomic, readonly, getter=isHmiStateAudioStreamCapable) BOOL hmiStateAudioStreamCapable;
 
@@ -66,26 +65,10 @@ NS_ASSUME_NONNULL_BEGIN
     }
     _secureMakes = [tempMakeArray copy];
 
-    SDLAppState *initialState = SDLAppStateInactive;
-    switch ([[UIApplication sharedApplication] applicationState]) {
-        case UIApplicationStateActive: {
-            initialState = SDLAppStateActive;
-        } break;
-        case UIApplicationStateInactive: // fallthrough
-        case UIApplicationStateBackground: {
-            initialState = SDLAppStateInactive;
-        } break;
-        default: break;
-    }
-
-    _appStateMachine = [[SDLStateMachine alloc] initWithTarget:self initialState:initialState states:[self.class sdl_appStateTransitionDictionary]];
     _audioStreamStateMachine = [[SDLStateMachine alloc] initWithTarget:self initialState:SDLAudioStreamManagerStateStopped states:[self.class sdl_audioStreamingStateTransitionDictionary]];
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_didReceiveRegisterAppInterfaceResponse:) name:SDLDidReceiveRegisterAppInterfaceResponse object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_hmiLevelDidChange:) name:SDLDidChangeHMIStatusNotification object:nil];
-
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_appStateDidUpdate:) name:UIApplicationDidBecomeActiveNotification object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_appStateDidUpdate:) name:UIApplicationWillResignActiveNotification object:nil];
 
     return self;
 }
@@ -132,46 +115,11 @@ NS_ASSUME_NONNULL_BEGIN
     return [self.audioStreamStateMachine isCurrentState:SDLAudioStreamManagerStateReady];
 }
 
-- (SDLAppState *)currentAppState {
-    return self.appStateMachine.currentState;
-}
-
 - (SDLAudioStreamManagerState *)currentAudioStreamState {
     return self.audioStreamStateMachine.currentState;
 }
 
-#pragma mark - State Machines
-#pragma mark App State
-+ (NSDictionary<SDLState *, SDLAllowableStateTransitions *> *)sdl_appStateTransitionDictionary {
-    return @{
-             // Will go from Inactive to Active if coming from a Phone Call.
-             // Will go from Inactive to IsRegainingActive if coming from Background.
-             SDLAppStateInactive : @[SDLAppStateActive],
-             SDLAppStateActive : @[SDLAppStateInactive]
-             };
-}
-
-- (void)sdl_appStateDidUpdate:(NSNotification*)notification {
-    if (notification.name == UIApplicationWillResignActiveNotification) {
-        [self.appStateMachine transitionToState:SDLAppStateInactive];
-    } else if (notification.name == UIApplicationDidBecomeActiveNotification) {
-        [self.appStateMachine transitionToState:SDLAppStateActive];
-    }
-}
-
-- (void)didEnterStateAppInactive {
-    SDLLogD(@"App became inactive");
-    [self sdl_stopAudioSession];
-}
-
-// Per Apple's guidelines: https://developer.apple.com/library/content/documentation/iPhone/Conceptual/iPhoneOSProgrammingGuide/StrategiesforHandlingAppStateTransitions/StrategiesforHandlingAppStateTransitions.html
-// We should be waiting to start any OpenGL drawing until UIApplicationDidBecomeActive is called.
-- (void)didEnterStateAppActive {
-    SDLLogD(@"App became active");
-    [self sdl_startAudioSession];
-}
-
-#pragma mark Audio
+#pragma mark - State Machine
 + (NSDictionary<SDLState *, SDLAllowableStateTransitions *> *)sdl_audioStreamingStateTransitionDictionary {
     return @{
              SDLAudioStreamManagerStateStopped : @[SDLAudioStreamManagerStateStarting],

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingAudioLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingAudioLifecycleManagerSpec.m
@@ -46,7 +46,6 @@ describe(@"the streaming audio manager", ^{
         expect(@(streamingLifecycleManager.isAudioConnected)).to(equal(@NO));
         expect(@(streamingLifecycleManager.isAudioEncrypted)).to(equal(@NO));
         expect(@(streamingLifecycleManager.requestedEncryptionType)).to(equal(@(SDLStreamingEncryptionFlagNone)));
-        expect(streamingLifecycleManager.currentAppState).to(equal(SDLAppStateActive));
         expect(streamingLifecycleManager.currentAudioStreamState).to(equal(SDLAudioStreamManagerStateStopped));
     });
 
@@ -67,7 +66,6 @@ describe(@"the streaming audio manager", ^{
             expect(@(streamingLifecycleManager.isStreamingSupported)).to(equal(@NO));
             expect(@(streamingLifecycleManager.isAudioConnected)).to(equal(@NO));
             expect(@(streamingLifecycleManager.isAudioEncrypted)).to(equal(@NO));
-            expect(streamingLifecycleManager.currentAppState).to(equal(SDLAppStateActive));
             expect(streamingLifecycleManager.currentAudioStreamState).to(match(SDLAudioStreamManagerStateStopped));
         });
 
@@ -196,8 +194,8 @@ describe(@"the streaming audio manager", ^{
                                 [streamingLifecycleManager.appStateMachine setToState:SDLAppStateInactive fromOldState:nil callEnterTransition:YES];
                             });
 
-                            it(@"should suspend the video stream", ^{
-                                expect(streamingLifecycleManager.currentAudioStreamState).to(equal(SDLAudioStreamManagerStateShuttingDown));
+                            it(@"should not close the stream", ^{
+                                expect(streamingLifecycleManager.currentAudioStreamState).to(equal(SDLAudioStreamManagerStateReady));
                             });
                         });
                     });


### PR DESCRIPTION
Fixes #1224 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
* Test cases fixed for the `SDLStreamingAudioLifecycleManager`

### Summary
* Removed logic that suspended audio streaming when device app was backgrounded.
* Removed the public `currentAppState` property from the private `SDLStreamingAudioLifecycleManager` class as the app state has bearing on whether audio can stream.

### Changelog
##### Bug Fixes
* Navigation and projection apps can now stream audio even when the app on the device is backgrounded.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)