### PR TITLE
Fix resetting the example apps

### DIFF
--- a/Example Apps/Example ObjC/ProxyManager.m
+++ b/Example Apps/Example ObjC/ProxyManager.m
@@ -76,12 +76,8 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)reset {
-    if (self.sdlManager == nil) {
-        [self sdlex_updateProxyState:ProxyStateStopped];
-        return;
-    }
-
     [self.sdlManager stop];
+    [self sdlex_updateProxyState:ProxyStateStopped];
 }
 
 - (void)sdlex_updateProxyState:(ProxyState)newState {
@@ -96,9 +92,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)startWithProxyTransportType:(ProxyTransportType)proxyTransportType {
     [self sdlex_updateProxyState:ProxyStateSearchingForConnection];
-
-    // Check for previous instance of sdlManager
-    if (self.sdlManager) { return; }
 
     SDLLifecycleConfiguration *lifecycleConfig = proxyTransportType == ProxyTransportTypeIAP ? [self.class sdlex_iapLifecycleConfiguration] : [self.class sdlex_tcpLifecycleConfiguration];
     [self sdlex_setupConfigurationWithLifecycleConfiguration:lifecycleConfig];

--- a/Example Apps/Example Swift/ProxyManager.swift
+++ b/Example Apps/Example Swift/ProxyManager.swift
@@ -50,12 +50,8 @@ extension ProxyManager {
 
     /// Attempts to close the connection between the this app and the car's head unit. The `SDLManagerDelegate`'s `managerDidDisconnect()` is called when connection is actually closed.
     func resetConnection() {
-        guard sdlManager != nil else {
-            delegate?.didChangeProxyState(ProxyState.stopped)
-            return
-        }
-
         sdlManager.stop()
+        delegate?.didChangeProxyState(ProxyState.stopped)
     }
 }
 


### PR DESCRIPTION
Fixes #1237 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

All changes are example apps only

### Testing Plan
Smoke tests

### Summary
This PR fixes resetting the example apps (mainly TCP changes)

### Changelog
##### Bug Fixes
* Fixes resetting the example apps so that it doesn't need to be killed

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
