### PR TITLE
Fixed alert documentation

### DIFF
--- a/SmartDeviceLink/SDLAlert.h
+++ b/SmartDeviceLink/SDLAlert.h
@@ -23,7 +23,6 @@
  * <ul>
  * <li>alertText1</li>
  * <li>alertText2</li>
- * <li>alertText3</li>
  * <li>ttsChunks</li>
  * </ul>
  * </li>


### PR DESCRIPTION
Fixes #[1233]

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
See Documentation Page 
https://smartdevicelink.com/en/docs/iOS/master/Classes/SDLAlert/

### Summary
Removed alerttext3 from the documentation information . Even though each param is optional, one must be set but not including alerttext3. 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)