### PR TITLE
Fix all crashes due to lockscreen being setup before app window

### DIFF
--- a/SmartDeviceLink/SDLScreenshotViewController.m
+++ b/SmartDeviceLink/SDLScreenshotViewController.m
@@ -32,12 +32,12 @@
     return self;
 }
 
-    // HAX: https://github.com/smartdevicelink/sdl_ios/issues/1250
+// HAX: https://github.com/smartdevicelink/sdl_ios/issues/1250
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations {
     UIViewController *viewController = [self sdl_topMostControllerForWindow:[UIApplication sharedApplication].windows[0]];
 
     if (viewController == self) {
-        @throw [NSException sdl_invalidLockscreenSetupException];
+        return UIInterfaceOrientationMaskAll;
     } else if (viewController != nil) {
         return viewController.supportedInterfaceOrientations;
     }
@@ -45,21 +45,23 @@
     return UIInterfaceOrientationMaskAll;
 }
 
-    // HAX: https://github.com/smartdevicelink/sdl_ios/issues/1250
+// HAX: https://github.com/smartdevicelink/sdl_ios/issues/1250
 - (BOOL)shouldAutorotate {
     UIViewController *viewController = [self sdl_topMostControllerForWindow:[UIApplication sharedApplication].windows[0]];
 
-    if (viewController != nil) {
+    if (viewController == self) {
+        return YES;
+    } else if (viewController != nil) {
         return viewController.shouldAutorotate;
     }
 
-    return super.shouldAutorotate;
+    return YES;
 }
 
 - (UIViewController *)sdl_topMostControllerForWindow:(UIWindow *)window {
     UIViewController *topController = window.rootViewController;
 
-    while (topController.presentedViewController) {
+    while (topController.presentedViewController != nil) {
         topController = topController.presentedViewController;
     }
 


### PR DESCRIPTION
Fixes #1258 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Smoke tests

##### Original Bug Testing
1. Ensure that if a VC is locked to an orientation, the status bar remains fixed when the device is rotated.

##### Crash testing
1. App window and root vc are setup, then SDL is setup (standard case if you’re using storyboards, etc.)
2. App window exists but root vc is not setup, then SDL is setup
3. SDL is setup, then app window / root VC is setup
4. (3) but done in the background due to SDL connection, then app is brought to the foreground 

### Summary
This PR fixes all issues related to the lockscreen being setup before the app window. The previous fix for this issue masked one issue, but there was a second issue as well. This fix should prevent developers from needing to make any change in their code, no matter how their app window is setup.

### Changelog
##### Bug Fixes
* Fix crashes if the app window is setup after SDL.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
