### PR TITLE
Deprecate RPC superclass initializers

### DIFF
--- a/SmartDeviceLink/SDLAddCommand.m
+++ b/SmartDeviceLink/SDLAddCommand.m
@@ -14,11 +14,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLAddCommand
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameAddCommand]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithHandler:(nullable SDLRPCCommandNotificationHandler)handler {
     self = [self init];
@@ -103,36 +106,36 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Getters / Setters
 
 - (void)setCmdID:(NSNumber<SDLInt> *)cmdID {
-    [parameters sdl_setObject:cmdID forName:SDLRPCParameterNameCommandId];
+    [self.parameters sdl_setObject:cmdID forName:SDLRPCParameterNameCommandId];
 }
 
 - (NSNumber<SDLInt> *)cmdID {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameCommandId ofClass:NSNumber.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameCommandId ofClass:NSNumber.class error:&error];
 }
 
 - (void)setMenuParams:(nullable SDLMenuParams *)menuParams {
-    [parameters sdl_setObject:menuParams forName:SDLRPCParameterNameMenuParams];
+    [self.parameters sdl_setObject:menuParams forName:SDLRPCParameterNameMenuParams];
 }
 
 - (nullable SDLMenuParams *)menuParams {
-    return [parameters sdl_objectForName:SDLRPCParameterNameMenuParams ofClass:SDLMenuParams.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameMenuParams ofClass:SDLMenuParams.class error:nil];
 }
 
 - (void)setVrCommands:(nullable NSArray<NSString *> *)vrCommands {
-    [parameters sdl_setObject:vrCommands forName:SDLRPCParameterNameVRCommands];
+    [self.parameters sdl_setObject:vrCommands forName:SDLRPCParameterNameVRCommands];
 }
 
 - (nullable NSArray<NSString *> *)vrCommands {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameVRCommands ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameVRCommands ofClass:NSString.class error:nil];
 }
 
 - (void)setCmdIcon:(nullable SDLImage *)cmdIcon {
-    [parameters sdl_setObject:cmdIcon forName:SDLRPCParameterNameCommandIcon];
+    [self.parameters sdl_setObject:cmdIcon forName:SDLRPCParameterNameCommandIcon];
 }
 
 - (nullable SDLImage *)cmdIcon {
-    return [parameters sdl_objectForName:SDLRPCParameterNameCommandIcon ofClass:SDLImage.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameCommandIcon ofClass:SDLImage.class error:nil];
 }
 
 -(id)copyWithZone:(nullable NSZone *)zone {

--- a/SmartDeviceLink/SDLAddCommandResponse.m
+++ b/SmartDeviceLink/SDLAddCommandResponse.m
@@ -10,11 +10,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLAddCommandResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameAddCommand]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLAddSubMenu.m
+++ b/SmartDeviceLink/SDLAddSubMenu.m
@@ -11,11 +11,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLAddSubMenu
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameAddSubMenu]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithId:(UInt32)menuId menuName:(NSString *)menuName menuIcon:(nullable SDLImage *)icon position:(UInt8)position {
     self = [self initWithId:menuId menuName:menuName];
@@ -44,37 +47,37 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setMenuID:(NSNumber<SDLInt> *)menuID {
-    [parameters sdl_setObject:menuID forName:SDLRPCParameterNameMenuId];
+    [self.parameters sdl_setObject:menuID forName:SDLRPCParameterNameMenuId];
 }
 
 - (NSNumber<SDLInt> *)menuID {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameMenuId ofClass:NSNumber.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameMenuId ofClass:NSNumber.class error:&error];
 }
 
 - (void)setPosition:(nullable NSNumber<SDLInt> *)position {
-    [parameters sdl_setObject:position forName:SDLRPCParameterNamePosition];
+    [self.parameters sdl_setObject:position forName:SDLRPCParameterNamePosition];
 }
 
 - (nullable NSNumber<SDLInt> *)position {
-    return [parameters sdl_objectForName:SDLRPCParameterNamePosition ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNamePosition ofClass:NSNumber.class error:nil];
 }
 
 - (void)setMenuName:(NSString *)menuName {
-    [parameters sdl_setObject:menuName forName:SDLRPCParameterNameMenuName];
+    [self.parameters sdl_setObject:menuName forName:SDLRPCParameterNameMenuName];
 }
 
 - (NSString *)menuName {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameMenuName ofClass:NSString.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameMenuName ofClass:NSString.class error:&error];
 }
 
 - (void)setMenuIcon:(nullable SDLImage *)menuIcon {
-    [parameters sdl_setObject:menuIcon forName:SDLRPCParameterNameMenuIcon];
+    [self.parameters sdl_setObject:menuIcon forName:SDLRPCParameterNameMenuIcon];
 }
 
 - (nullable SDLImage *)menuIcon {
-    return [parameters sdl_objectForName:SDLRPCParameterNameMenuIcon ofClass:[SDLImage class] error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameMenuIcon ofClass:[SDLImage class] error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLAddSubMenuResponse.m
+++ b/SmartDeviceLink/SDLAddSubMenuResponse.m
@@ -10,11 +10,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLAddSubMenuResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameAddSubMenu]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLAirbagStatus.m
+++ b/SmartDeviceLink/SDLAirbagStatus.m
@@ -10,74 +10,74 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation SDLAirbagStatus
 
 - (void)setDriverAirbagDeployed:(SDLVehicleDataEventStatus)driverAirbagDeployed {
-    [store sdl_setObject:driverAirbagDeployed forName:SDLRPCParameterNameDriverAirbagDeployed];
+    [self.store sdl_setObject:driverAirbagDeployed forName:SDLRPCParameterNameDriverAirbagDeployed];
 }
 
 - (SDLVehicleDataEventStatus)driverAirbagDeployed {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameDriverAirbagDeployed error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameDriverAirbagDeployed error:&error];
 }
 
 - (void)setDriverSideAirbagDeployed:(SDLVehicleDataEventStatus)driverSideAirbagDeployed {
-    [store sdl_setObject:driverSideAirbagDeployed forName:SDLRPCParameterNameDriverSideAirbagDeployed];
+    [self.store sdl_setObject:driverSideAirbagDeployed forName:SDLRPCParameterNameDriverSideAirbagDeployed];
 }
 
 - (SDLVehicleDataEventStatus)driverSideAirbagDeployed {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameDriverSideAirbagDeployed error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameDriverSideAirbagDeployed error:&error];
 }
 
 - (void)setDriverCurtainAirbagDeployed:(SDLVehicleDataEventStatus)driverCurtainAirbagDeployed {
-    [store sdl_setObject:driverCurtainAirbagDeployed forName:SDLRPCParameterNameDriverCurtainAirbagDeployed];
+    [self.store sdl_setObject:driverCurtainAirbagDeployed forName:SDLRPCParameterNameDriverCurtainAirbagDeployed];
 }
 
 - (SDLVehicleDataEventStatus)driverCurtainAirbagDeployed {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameDriverCurtainAirbagDeployed error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameDriverCurtainAirbagDeployed error:&error];
 }
 
 - (void)setPassengerAirbagDeployed:(SDLVehicleDataEventStatus)passengerAirbagDeployed {
-    [store sdl_setObject:passengerAirbagDeployed forName:SDLRPCParameterNamePassengerAirbagDeployed];}
+    [self.store sdl_setObject:passengerAirbagDeployed forName:SDLRPCParameterNamePassengerAirbagDeployed];}
 
 - (SDLVehicleDataEventStatus)passengerAirbagDeployed {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNamePassengerAirbagDeployed error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNamePassengerAirbagDeployed error:&error];
 }
 
 - (void)setPassengerCurtainAirbagDeployed:(SDLVehicleDataEventStatus)passengerCurtainAirbagDeployed {
-    [store sdl_setObject:passengerCurtainAirbagDeployed forName:SDLRPCParameterNamePassengerCurtainAirbagDeployed];
+    [self.store sdl_setObject:passengerCurtainAirbagDeployed forName:SDLRPCParameterNamePassengerCurtainAirbagDeployed];
 }
 
 - (SDLVehicleDataEventStatus)passengerCurtainAirbagDeployed {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNamePassengerCurtainAirbagDeployed error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNamePassengerCurtainAirbagDeployed error:&error];
 }
 
 - (void)setDriverKneeAirbagDeployed:(SDLVehicleDataEventStatus)driverKneeAirbagDeployed {
-    [store sdl_setObject:driverKneeAirbagDeployed forName:SDLRPCParameterNameDriverKneeAirbagDeployed];
+    [self.store sdl_setObject:driverKneeAirbagDeployed forName:SDLRPCParameterNameDriverKneeAirbagDeployed];
 }
 
 - (SDLVehicleDataEventStatus)driverKneeAirbagDeployed {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameDriverKneeAirbagDeployed error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameDriverKneeAirbagDeployed error:&error];
 }
 
 - (void)setPassengerSideAirbagDeployed:(SDLVehicleDataEventStatus)passengerSideAirbagDeployed {
-    [store sdl_setObject:passengerSideAirbagDeployed forName:SDLRPCParameterNamePassengerSideAirbagDeployed];
+    [self.store sdl_setObject:passengerSideAirbagDeployed forName:SDLRPCParameterNamePassengerSideAirbagDeployed];
 }
 
 - (SDLVehicleDataEventStatus)passengerSideAirbagDeployed {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNamePassengerSideAirbagDeployed error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNamePassengerSideAirbagDeployed error:&error];
 }
 
 - (void)setPassengerKneeAirbagDeployed:(SDLVehicleDataEventStatus)passengerKneeAirbagDeployed {
-    [store sdl_setObject:passengerKneeAirbagDeployed forName:SDLRPCParameterNamePassengerKneeAirbagDeployed];
+    [self.store sdl_setObject:passengerKneeAirbagDeployed forName:SDLRPCParameterNamePassengerKneeAirbagDeployed];
 }
 
 - (SDLVehicleDataEventStatus)passengerKneeAirbagDeployed {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNamePassengerKneeAirbagDeployed error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNamePassengerKneeAirbagDeployed error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLAlert.m
+++ b/SmartDeviceLink/SDLAlert.m
@@ -14,11 +14,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLAlert
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameAlert]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithAlertText1:(nullable NSString *)alertText1 alertText2:(nullable NSString *)alertText2 alertText3:(nullable NSString *)alertText3 {
     return [self initWithAlertText1:alertText1 alertText2:alertText2 alertText3:alertText3 duration:SDLDefaultDuration];
@@ -75,67 +78,67 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setAlertText1:(nullable NSString *)alertText1 {
-    [parameters sdl_setObject:alertText1 forName:SDLRPCParameterNameAlertText1];
+    [self.parameters sdl_setObject:alertText1 forName:SDLRPCParameterNameAlertText1];
 }
 
 - (nullable NSString *)alertText1 {
-    return [parameters sdl_objectForName:SDLRPCParameterNameAlertText1 ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameAlertText1 ofClass:NSString.class error:nil];
 }
 
 - (void)setAlertText2:(nullable NSString *)alertText2 {
-    [parameters sdl_setObject:alertText2 forName:SDLRPCParameterNameAlertText2];
+    [self.parameters sdl_setObject:alertText2 forName:SDLRPCParameterNameAlertText2];
 }
 
 - (nullable NSString *)alertText2 {
-    return [parameters sdl_objectForName:SDLRPCParameterNameAlertText2 ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameAlertText2 ofClass:NSString.class error:nil];
 }
 
 - (void)setAlertText3:(nullable NSString *)alertText3 {
-    [parameters sdl_setObject:alertText3 forName:SDLRPCParameterNameAlertText3];
+    [self.parameters sdl_setObject:alertText3 forName:SDLRPCParameterNameAlertText3];
 }
 
 - (nullable NSString *)alertText3 {
-    return [parameters sdl_objectForName:SDLRPCParameterNameAlertText3 ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameAlertText3 ofClass:NSString.class error:nil];
 }
 
 - (void)setTtsChunks:(nullable NSArray<SDLTTSChunk *> *)ttsChunks {
-    [parameters sdl_setObject:ttsChunks forName:SDLRPCParameterNameTTSChunks];
+    [self.parameters sdl_setObject:ttsChunks forName:SDLRPCParameterNameTTSChunks];
 }
 
 - (nullable NSArray<SDLTTSChunk *> *)ttsChunks {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameTTSChunks ofClass:SDLTTSChunk.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameTTSChunks ofClass:SDLTTSChunk.class error:nil];
 }
 
 - (void)setDuration:(nullable NSNumber<SDLInt> *)duration {
-    [parameters sdl_setObject:duration forName:SDLRPCParameterNameDuration];
+    [self.parameters sdl_setObject:duration forName:SDLRPCParameterNameDuration];
 }
 
 - (nullable NSNumber<SDLInt> *)duration {
-    return [parameters sdl_objectForName:SDLRPCParameterNameDuration ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameDuration ofClass:NSNumber.class error:nil];
 }
 
 - (void)setPlayTone:(nullable NSNumber<SDLBool> *)playTone {
-    [parameters sdl_setObject:playTone forName:SDLRPCParameterNamePlayTone];
+    [self.parameters sdl_setObject:playTone forName:SDLRPCParameterNamePlayTone];
 }
 
 - (nullable NSNumber<SDLBool> *)playTone {
-    return [parameters sdl_objectForName:SDLRPCParameterNamePlayTone ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNamePlayTone ofClass:NSNumber.class error:nil];
 }
 
 - (void)setProgressIndicator:(nullable NSNumber<SDLBool> *)progressIndicator {
-    [parameters sdl_setObject:progressIndicator forName:SDLRPCParameterNameProgressIndicator];
+    [self.parameters sdl_setObject:progressIndicator forName:SDLRPCParameterNameProgressIndicator];
 }
 
 - (nullable NSNumber<SDLBool> *)progressIndicator {
-    return [parameters sdl_objectForName:SDLRPCParameterNameProgressIndicator ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameProgressIndicator ofClass:NSNumber.class error:nil];
 }
 
 - (void)setSoftButtons:(nullable NSArray<SDLSoftButton *> *)softButtons {
-    [parameters sdl_setObject:softButtons forName:SDLRPCParameterNameSoftButtons];
+    [self.parameters sdl_setObject:softButtons forName:SDLRPCParameterNameSoftButtons];
 }
 
 - (nullable NSArray<SDLSoftButton *> *)softButtons {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameSoftButtons ofClass:SDLSoftButton.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameSoftButtons ofClass:SDLSoftButton.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLAlertManeuver.m
+++ b/SmartDeviceLink/SDLAlertManeuver.m
@@ -14,11 +14,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLAlertManeuver
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameAlertManeuver]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 
 - (instancetype)initWithTTS:(nullable NSString *)ttsText softButtons:(nullable NSArray<SDLSoftButton *> *)softButtons {
@@ -39,19 +42,19 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setTtsChunks:(nullable NSArray<SDLTTSChunk *> *)ttsChunks {
-    [parameters sdl_setObject:ttsChunks forName:SDLRPCParameterNameTTSChunks];
+    [self.parameters sdl_setObject:ttsChunks forName:SDLRPCParameterNameTTSChunks];
 }
 
 - (nullable NSArray<SDLTTSChunk *> *)ttsChunks {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameTTSChunks ofClass:SDLTTSChunk.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameTTSChunks ofClass:SDLTTSChunk.class error:nil];
 }
 
 - (void)setSoftButtons:(nullable NSArray<SDLSoftButton *> *)softButtons {
-    [parameters sdl_setObject:softButtons forName:SDLRPCParameterNameSoftButtons];
+    [self.parameters sdl_setObject:softButtons forName:SDLRPCParameterNameSoftButtons];
 }
 
 - (nullable NSArray<SDLSoftButton *> *)softButtons {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameSoftButtons ofClass:SDLSoftButton.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameSoftButtons ofClass:SDLSoftButton.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLAlertManeuverResponse.m
+++ b/SmartDeviceLink/SDLAlertManeuverResponse.m
@@ -11,11 +11,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLAlertManeuverResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameAlertManeuver]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLAlertResponse.m
+++ b/SmartDeviceLink/SDLAlertResponse.m
@@ -11,17 +11,20 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLAlertResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameAlert]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setTryAgainTime:(nullable NSNumber<SDLInt> *)tryAgainTime {
-    [parameters sdl_setObject:tryAgainTime forName:SDLRPCParameterNameTryAgainTime];}
+    [self.parameters sdl_setObject:tryAgainTime forName:SDLRPCParameterNameTryAgainTime];}
 
 - (nullable NSNumber<SDLInt> *)tryAgainTime {
-    return [parameters sdl_objectForName:SDLRPCParameterNameTryAgainTime ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameTryAgainTime ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLAppInfo.m
+++ b/SmartDeviceLink/SDLAppInfo.m
@@ -27,30 +27,30 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setAppDisplayName:(NSString *)appDisplayName {
-    [store sdl_setObject:appDisplayName forName:SDLRPCParameterNameAppDisplayName];
+    [self.store sdl_setObject:appDisplayName forName:SDLRPCParameterNameAppDisplayName];
 }
 
 - (NSString *)appDisplayName {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameAppDisplayName ofClass:NSString.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameAppDisplayName ofClass:NSString.class error:&error];
 }
 
 - (void)setAppBundleID:(NSString *)appBundleID {
-    [store sdl_setObject:appBundleID forName:SDLRPCParameterNameAppBundleId];
+    [self.store sdl_setObject:appBundleID forName:SDLRPCParameterNameAppBundleId];
 }
 
 - (NSString *)appBundleID {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameAppBundleId ofClass:NSString.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameAppBundleId ofClass:NSString.class error:&error];
 }
 
 - (void)setAppVersion:(NSString *)appVersion {
-    [store sdl_setObject:appVersion forName:SDLRPCParameterNameAppVersion];
+    [self.store sdl_setObject:appVersion forName:SDLRPCParameterNameAppVersion];
 }
 
 - (NSString *)appVersion {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameAppVersion ofClass:NSString.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameAppVersion ofClass:NSString.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLAppServiceCapability.m
+++ b/SmartDeviceLink/SDLAppServiceCapability.m
@@ -40,20 +40,20 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setUpdateReason:(nullable SDLServiceUpdateReason)updateReason {
-    [store sdl_setObject:updateReason forName:SDLRPCParameterNameUpdateReason];
+    [self.store sdl_setObject:updateReason forName:SDLRPCParameterNameUpdateReason];
 }
 
 - (nullable SDLServiceUpdateReason)updateReason {
-    return [store sdl_enumForName:SDLRPCParameterNameUpdateReason error:nil];
+    return [self.store sdl_enumForName:SDLRPCParameterNameUpdateReason error:nil];
 }
 
 - (void)setUpdatedAppServiceRecord:(SDLAppServiceRecord *)updatedAppServiceRecord {
-    [store sdl_setObject:updatedAppServiceRecord forName:SDLRPCParameterNameUpdatedAppServiceRecord];
+    [self.store sdl_setObject:updatedAppServiceRecord forName:SDLRPCParameterNameUpdatedAppServiceRecord];
 }
 
 - (SDLAppServiceRecord *)updatedAppServiceRecord {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameUpdatedAppServiceRecord ofClass:SDLAppServiceRecord.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameUpdatedAppServiceRecord ofClass:SDLAppServiceRecord.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLAppServiceData.m
+++ b/SmartDeviceLink/SDLAppServiceData.m
@@ -78,45 +78,45 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setServiceType:(NSString *)serviceType {
-    [store sdl_setObject:serviceType forName:SDLRPCParameterNameServiceType];
+    [self.store sdl_setObject:serviceType forName:SDLRPCParameterNameServiceType];
 }
 
 - (NSString *)serviceType {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameServiceType ofClass:NSString.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameServiceType ofClass:NSString.class error:&error];
 }
 
 - (void)setServiceId:(NSString *)serviceId {
-    [store sdl_setObject:serviceId forName:SDLRPCParameterNameServiceID];
+    [self.store sdl_setObject:serviceId forName:SDLRPCParameterNameServiceID];
 }
 
 - (NSString *)serviceId {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameServiceID ofClass:NSString.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameServiceID ofClass:NSString.class error:&error];
 }
 
 - (void)setWeatherServiceData:(nullable SDLWeatherServiceData *)weatherServiceData {
-    [store sdl_setObject:weatherServiceData forName:SDLRPCParameterNameWeatherServiceData];
+    [self.store sdl_setObject:weatherServiceData forName:SDLRPCParameterNameWeatherServiceData];
 }
 
 - (nullable SDLWeatherServiceData *)weatherServiceData {
-    return [store sdl_objectForName:SDLRPCParameterNameWeatherServiceData ofClass:SDLWeatherServiceData.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameWeatherServiceData ofClass:SDLWeatherServiceData.class error:nil];
 }
 
 - (void)setMediaServiceData:(nullable SDLMediaServiceData *)mediaServiceData {
-    [store sdl_setObject:mediaServiceData forName:SDLRPCParameterNameMediaServiceData];
+    [self.store sdl_setObject:mediaServiceData forName:SDLRPCParameterNameMediaServiceData];
 }
 
 - (nullable SDLMediaServiceData *)mediaServiceData {
-    return [store sdl_objectForName:SDLRPCParameterNameMediaServiceData ofClass:SDLMediaServiceData.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameMediaServiceData ofClass:SDLMediaServiceData.class error:nil];
 }
 
 - (void)setNavigationServiceData:(nullable SDLNavigationServiceData *)navigationServiceData {
-    [store sdl_setObject:navigationServiceData forName:SDLRPCParameterNameNavigationServiceData];
+    [self.store sdl_setObject:navigationServiceData forName:SDLRPCParameterNameNavigationServiceData];
 }
 
 - (nullable SDLNavigationServiceData *)navigationServiceData {
-    return [store sdl_objectForName:SDLRPCParameterNameNavigationServiceData ofClass:SDLNavigationServiceData.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameNavigationServiceData ofClass:SDLNavigationServiceData.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLAppServiceManifest.m
+++ b/SmartDeviceLink/SDLAppServiceManifest.m
@@ -63,76 +63,76 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setServiceName:(nullable NSString *)serviceName {
-    [store sdl_setObject:serviceName forName:SDLRPCParameterNameServiceName];
+    [self.store sdl_setObject:serviceName forName:SDLRPCParameterNameServiceName];
 }
 
 - (nullable NSString *)serviceName {
-    return [store sdl_objectForName:SDLRPCParameterNameServiceName ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameServiceName ofClass:NSString.class error:nil];
 }
 
 - (void)setServiceType:(NSString *)serviceType {
-    [store sdl_setObject:serviceType forName:SDLRPCParameterNameServiceType];
+    [self.store sdl_setObject:serviceType forName:SDLRPCParameterNameServiceType];
 }
 
 - (NSString *)serviceType {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameServiceType ofClass:NSString.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameServiceType ofClass:NSString.class error:&error];
 }
 
 - (void)setServiceIcon:(nullable SDLImage *)serviceIcon {
-    [store sdl_setObject:serviceIcon forName:SDLRPCParameterNameServiceIcon];
+    [self.store sdl_setObject:serviceIcon forName:SDLRPCParameterNameServiceIcon];
 }
 
 - (nullable SDLImage *)serviceIcon {
-    return [store sdl_objectForName:SDLRPCParameterNameServiceIcon ofClass:SDLImage.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameServiceIcon ofClass:SDLImage.class error:nil];
 }
 
 - (void)setAllowAppConsumers:(nullable  NSNumber<SDLBool> *)allowAppConsumers {
-    [store sdl_setObject:allowAppConsumers forName:SDLRPCParameterNameAllowAppConsumers];
+    [self.store sdl_setObject:allowAppConsumers forName:SDLRPCParameterNameAllowAppConsumers];
 }
 
 - (nullable NSNumber<SDLBool> *)allowAppConsumers {
-    return [store sdl_objectForName:SDLRPCParameterNameAllowAppConsumers ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameAllowAppConsumers ofClass:NSNumber.class error:nil];
 }
 
 - (void)setRpcSpecVersion:(nullable SDLSyncMsgVersion *)rpcSpecVersion {
-    [store sdl_setObject:rpcSpecVersion forName:SDLRPCParameterNameRPCSpecVersion];
+    [self.store sdl_setObject:rpcSpecVersion forName:SDLRPCParameterNameRPCSpecVersion];
 }
 
 - (nullable SDLSyncMsgVersion *)rpcSpecVersion {
-    return [store sdl_objectForName:SDLRPCParameterNameRPCSpecVersion ofClass:SDLSyncMsgVersion.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameRPCSpecVersion ofClass:SDLSyncMsgVersion.class error:nil];
 }
 
 - (void)setHandledRPCs:(nullable NSArray<NSNumber<SDLInt> *> *)handledRPCs {
-    [store sdl_setObject:handledRPCs forName:SDLRPCParameterNameHandledRPCs];
+    [self.store sdl_setObject:handledRPCs forName:SDLRPCParameterNameHandledRPCs];
 }
 
 - (nullable NSArray<NSNumber<SDLInt> *> *)handledRPCs {
-    return [store sdl_objectsForName:SDLRPCParameterNameHandledRPCs ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectsForName:SDLRPCParameterNameHandledRPCs ofClass:NSNumber.class error:nil];
 }
 
 - (void)setWeatherServiceManifest:(nullable SDLWeatherServiceManifest *)weatherServiceManifest {
-    [store sdl_setObject:weatherServiceManifest forName:SDLRPCParameterNameWeatherServiceManifest];
+    [self.store sdl_setObject:weatherServiceManifest forName:SDLRPCParameterNameWeatherServiceManifest];
 }
 
 - (nullable SDLWeatherServiceManifest *)weatherServiceManifest {
-    return [store sdl_objectForName:SDLRPCParameterNameWeatherServiceManifest ofClass:SDLWeatherServiceManifest.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameWeatherServiceManifest ofClass:SDLWeatherServiceManifest.class error:nil];
 }
 
 - (void)setMediaServiceManifest:(nullable SDLMediaServiceManifest *)mediaServiceManifest {
-    [store sdl_setObject:mediaServiceManifest forName:SDLRPCParameterNameMediaServiceManifest];
+    [self.store sdl_setObject:mediaServiceManifest forName:SDLRPCParameterNameMediaServiceManifest];
 }
 
 - (nullable SDLMediaServiceManifest *)mediaServiceManifest {
-    return [store sdl_objectForName:SDLRPCParameterNameMediaServiceManifest ofClass:SDLMediaServiceManifest.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameMediaServiceManifest ofClass:SDLMediaServiceManifest.class error:nil];
 }
 
 - (void)setNavigationServiceManifest:(nullable SDLNavigationServiceManifest *)navigationServiceManifest {
-    [store sdl_setObject:navigationServiceManifest forName:SDLRPCParameterNameNavigationServiceManifest];
+    [self.store sdl_setObject:navigationServiceManifest forName:SDLRPCParameterNameNavigationServiceManifest];
 }
 
 - (nullable SDLNavigationServiceManifest *)navigationServiceManifest {
-    return [store sdl_objectForName:SDLRPCParameterNameNavigationServiceManifest ofClass:SDLNavigationServiceManifest.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameNavigationServiceManifest ofClass:SDLNavigationServiceManifest.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLAppServiceRecord.m
+++ b/SmartDeviceLink/SDLAppServiceRecord.m
@@ -31,39 +31,39 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setServiceID:(NSString *)serviceID {
-    [store sdl_setObject:serviceID forName:SDLRPCParameterNameServiceID];
+    [self.store sdl_setObject:serviceID forName:SDLRPCParameterNameServiceID];
 }
 
 - (NSString *)serviceID {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameServiceID ofClass:NSString.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameServiceID ofClass:NSString.class error:&error];
 }
 
 - (void)setServiceManifest:(SDLAppServiceManifest *)serviceManifest {
-    [store sdl_setObject:serviceManifest forName:SDLRPCParameterNameServiceManifest];
+    [self.store sdl_setObject:serviceManifest forName:SDLRPCParameterNameServiceManifest];
 }
 
 - (SDLAppServiceManifest *)serviceManifest {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameServiceManifest ofClass:SDLAppServiceManifest.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameServiceManifest ofClass:SDLAppServiceManifest.class error:&error];
 }
 
 - (void)setServicePublished:(NSNumber<SDLBool> *)servicePublished {
-    [store sdl_setObject:servicePublished forName:SDLRPCParameterNameServicePublished];
+    [self.store sdl_setObject:servicePublished forName:SDLRPCParameterNameServicePublished];
 }
 
 - (NSNumber<SDLBool> *)servicePublished {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameServicePublished ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameServicePublished ofClass:NSNumber.class error:&error];
 }
 
 - (void)setServiceActive:(NSNumber<SDLBool> *)serviceActive {
-    [store sdl_setObject:serviceActive forName:SDLRPCParameterNameServiceActive];
+    [self.store sdl_setObject:serviceActive forName:SDLRPCParameterNameServiceActive];
 }
 
 - (NSNumber<SDLBool> *)serviceActive {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameServiceActive ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameServiceActive ofClass:NSNumber.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLAppServicesCapabilities.m
+++ b/SmartDeviceLink/SDLAppServicesCapabilities.m
@@ -28,11 +28,11 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setAppServices:(nullable NSArray<SDLAppServiceCapability *> *)appServices {
-    [store sdl_setObject:appServices forName:SDLRPCParameterNameAppServices];
+    [self.store sdl_setObject:appServices forName:SDLRPCParameterNameAppServices];
 }
 
 - (nullable NSArray<SDLAppServiceCapability *> *)appServices {
-    return [store sdl_objectsForName:SDLRPCParameterNameAppServices ofClass:SDLAppServiceCapability.class error:nil];
+    return [self.store sdl_objectsForName:SDLRPCParameterNameAppServices ofClass:SDLAppServiceCapability.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLAudioControlCapabilities.m
+++ b/SmartDeviceLink/SDLAudioControlCapabilities.m
@@ -35,52 +35,52 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setModuleName:(NSString *)moduleName {
-    [store sdl_setObject:moduleName forName:SDLRPCParameterNameModuleName];
+    [self.store sdl_setObject:moduleName forName:SDLRPCParameterNameModuleName];
 }
 
 - (NSString *)moduleName {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameModuleName ofClass:NSString.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameModuleName ofClass:NSString.class error:&error];
 }
 
 - (void)setSourceAvailable:(nullable NSNumber<SDLBool> *)sourceAvailable {
-    [store sdl_setObject:sourceAvailable forName:SDLRPCParameterNameSourceAvailable];
+    [self.store sdl_setObject:sourceAvailable forName:SDLRPCParameterNameSourceAvailable];
 }
 
 - (nullable NSNumber<SDLBool> *)sourceAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameSourceAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameSourceAvailable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setKeepContextAvailable:(nullable NSNumber<SDLBool> *)keepContextAvailable {
-    [store sdl_setObject:keepContextAvailable forName:SDLRPCParameterNameKeepContextAvailable];
+    [self.store sdl_setObject:keepContextAvailable forName:SDLRPCParameterNameKeepContextAvailable];
 }
 
 - (nullable NSNumber<SDLBool> *)keepContextAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameKeepContextAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameKeepContextAvailable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setVolumeAvailable:(nullable NSNumber<SDLBool> *)volumeAvailable {
-    [store sdl_setObject:volumeAvailable forName:SDLRPCParameterNameVolumeAvailable];
+    [self.store sdl_setObject:volumeAvailable forName:SDLRPCParameterNameVolumeAvailable];
 }
 
 - (nullable NSNumber<SDLBool> *)volumeAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameVolumeAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameVolumeAvailable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setEqualizerAvailable:(nullable NSNumber<SDLBool> *)equalizerAvailable {
-    [store sdl_setObject:equalizerAvailable forName:SDLRPCParameterNameEqualizerAvailable];
+    [self.store sdl_setObject:equalizerAvailable forName:SDLRPCParameterNameEqualizerAvailable];
 }
 
 - (nullable NSNumber<SDLBool> *)equalizerAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameEqualizerAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameEqualizerAvailable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setEqualizerMaxChannelId:(nullable NSNumber<SDLInt> *)equalizerMaxChannelId {
-    [store sdl_setObject:equalizerMaxChannelId forName:SDLRPCParameterNameEqualizerMaxChannelId];
+    [self.store sdl_setObject:equalizerMaxChannelId forName:SDLRPCParameterNameEqualizerMaxChannelId];
 }
 
 - (nullable NSNumber<SDLInt> *)equalizerMaxChannelId {
-    return [store sdl_objectForName:SDLRPCParameterNameEqualizerMaxChannelId ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameEqualizerMaxChannelId ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLAudioControlData.m
+++ b/SmartDeviceLink/SDLAudioControlData.m
@@ -25,36 +25,36 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setSource:(nullable SDLPrimaryAudioSource)source {
-    [store sdl_setObject:source forName:SDLRPCParameterNameSource];
+    [self.store sdl_setObject:source forName:SDLRPCParameterNameSource];
 
 }
 
 - (nullable SDLPrimaryAudioSource)source {
-    return [store sdl_enumForName:SDLRPCParameterNameSource error:nil];
+    return [self.store sdl_enumForName:SDLRPCParameterNameSource error:nil];
 }
 
 - (void)setKeepContext:(nullable NSNumber<SDLBool> *)keepContext {
-    [store sdl_setObject:keepContext forName:SDLRPCParameterNameKeepContext];
+    [self.store sdl_setObject:keepContext forName:SDLRPCParameterNameKeepContext];
 }
 
 - (nullable NSNumber<SDLBool> *)keepContext {
-    return [store sdl_objectForName:SDLRPCParameterNameKeepContext ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameKeepContext ofClass:NSNumber.class error:nil];
 }
 
 - (void)setVolume:(nullable NSNumber<SDLInt> *)volume {
-    [store sdl_setObject:volume forName:SDLRPCParameterNameVolume];
+    [self.store sdl_setObject:volume forName:SDLRPCParameterNameVolume];
 }
 
 - (nullable NSNumber<SDLInt> *)volume {
-    return [store sdl_objectForName:SDLRPCParameterNameVolume ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameVolume ofClass:NSNumber.class error:nil];
 }
 
 - (void)setEqualizerSettings:(nullable NSArray<SDLEqualizerSettings *> *)equalizerSettings {
-    [store sdl_setObject:equalizerSettings forName:SDLRPCParameterNameEqualizerSettings];
+    [self.store sdl_setObject:equalizerSettings forName:SDLRPCParameterNameEqualizerSettings];
 }
 
 - (nullable NSArray<SDLEqualizerSettings *> *)equalizerSettings {
-    return [store sdl_objectsForName:SDLRPCParameterNameEqualizerSettings ofClass:SDLEqualizerSettings.class error:nil];
+    return [self.store sdl_objectsForName:SDLRPCParameterNameEqualizerSettings ofClass:SDLEqualizerSettings.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLAudioPassThruCapabilities.m
+++ b/SmartDeviceLink/SDLAudioPassThruCapabilities.m
@@ -12,30 +12,30 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation SDLAudioPassThruCapabilities
 
 - (void)setSamplingRate:(SDLSamplingRate)samplingRate {
-    [store sdl_setObject:samplingRate forName:SDLRPCParameterNameSamplingRate];
+    [self.store sdl_setObject:samplingRate forName:SDLRPCParameterNameSamplingRate];
 }
 
 - (SDLSamplingRate)samplingRate {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameSamplingRate error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameSamplingRate error:&error];
 }
 
 - (void)setBitsPerSample:(SDLBitsPerSample)bitsPerSample {
-    [store sdl_setObject:bitsPerSample forName:SDLRPCParameterNameBitsPerSample];
+    [self.store sdl_setObject:bitsPerSample forName:SDLRPCParameterNameBitsPerSample];
 }
 
 - (SDLBitsPerSample)bitsPerSample {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameBitsPerSample error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameBitsPerSample error:&error];
 }
 
 - (void)setAudioType:(SDLAudioType)audioType {
-    [store sdl_setObject:audioType forName:SDLRPCParameterNameAudioType];
+    [self.store sdl_setObject:audioType forName:SDLRPCParameterNameAudioType];
 }
 
 - (SDLAudioType)audioType {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameAudioType error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameAudioType error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLBeltStatus.m
+++ b/SmartDeviceLink/SDLBeltStatus.m
@@ -12,138 +12,138 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation SDLBeltStatus
 
 - (void)setDriverBeltDeployed:(SDLVehicleDataEventStatus)driverBeltDeployed {
-    [store sdl_setObject:driverBeltDeployed forName:SDLRPCParameterNameDriverBeltDeployed];
+    [self.store sdl_setObject:driverBeltDeployed forName:SDLRPCParameterNameDriverBeltDeployed];
 }
 
 - (SDLVehicleDataEventStatus)driverBeltDeployed {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameDriverBeltDeployed error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameDriverBeltDeployed error:&error];
 }
 
 - (void)setPassengerBeltDeployed:(SDLVehicleDataEventStatus)passengerBeltDeployed {
-    [store sdl_setObject:passengerBeltDeployed forName:SDLRPCParameterNamePassengerBeltDeployed];
+    [self.store sdl_setObject:passengerBeltDeployed forName:SDLRPCParameterNamePassengerBeltDeployed];
 }
 
 - (SDLVehicleDataEventStatus)passengerBeltDeployed {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNamePassengerBeltDeployed error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNamePassengerBeltDeployed error:&error];
 }
 
 - (void)setPassengerBuckleBelted:(SDLVehicleDataEventStatus)passengerBuckleBelted {
-    [store sdl_setObject:passengerBuckleBelted forName:SDLRPCParameterNamePassengerBuckleBelted];
+    [self.store sdl_setObject:passengerBuckleBelted forName:SDLRPCParameterNamePassengerBuckleBelted];
 }
 
 - (SDLVehicleDataEventStatus)passengerBuckleBelted {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNamePassengerBuckleBelted error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNamePassengerBuckleBelted error:&error];
 }
 
 - (void)setDriverBuckleBelted:(SDLVehicleDataEventStatus)driverBuckleBelted {
-    [store sdl_setObject:driverBuckleBelted forName:SDLRPCParameterNameDriverBuckleBelted];
+    [self.store sdl_setObject:driverBuckleBelted forName:SDLRPCParameterNameDriverBuckleBelted];
 }
 
 - (SDLVehicleDataEventStatus)driverBuckleBelted {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameDriverBuckleBelted error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameDriverBuckleBelted error:&error];
 }
 
 - (void)setLeftRow2BuckleBelted:(SDLVehicleDataEventStatus)leftRow2BuckleBelted {
-    [store sdl_setObject:leftRow2BuckleBelted forName:SDLRPCParameterNameLeftRow2BuckleBelted];
+    [self.store sdl_setObject:leftRow2BuckleBelted forName:SDLRPCParameterNameLeftRow2BuckleBelted];
 }
 
 - (SDLVehicleDataEventStatus)leftRow2BuckleBelted {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameLeftRow2BuckleBelted error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameLeftRow2BuckleBelted error:&error];
 }
 
 - (void)setPassengerChildDetected:(SDLVehicleDataEventStatus)passengerChildDetected {
-    [store sdl_setObject:passengerChildDetected forName:SDLRPCParameterNamePassengerChildDetected];
+    [self.store sdl_setObject:passengerChildDetected forName:SDLRPCParameterNamePassengerChildDetected];
 }
 
 - (SDLVehicleDataEventStatus)passengerChildDetected {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNamePassengerChildDetected error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNamePassengerChildDetected error:&error];
 }
 
 - (void)setRightRow2BuckleBelted:(SDLVehicleDataEventStatus)rightRow2BuckleBelted {
-    [store sdl_setObject:rightRow2BuckleBelted forName:SDLRPCParameterNameRightRow2BuckleBelted];
+    [self.store sdl_setObject:rightRow2BuckleBelted forName:SDLRPCParameterNameRightRow2BuckleBelted];
 }
 
 - (SDLVehicleDataEventStatus)rightRow2BuckleBelted {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameRightRow2BuckleBelted error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameRightRow2BuckleBelted error:&error];
 }
 
 - (void)setMiddleRow2BuckleBelted:(SDLVehicleDataEventStatus)middleRow2BuckleBelted {
-    [store sdl_setObject:middleRow2BuckleBelted forName:SDLRPCParameterNameMiddleRow2BuckleBelted];
+    [self.store sdl_setObject:middleRow2BuckleBelted forName:SDLRPCParameterNameMiddleRow2BuckleBelted];
 }
 
 - (SDLVehicleDataEventStatus)middleRow2BuckleBelted {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameMiddleRow2BuckleBelted error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameMiddleRow2BuckleBelted error:&error];
 }
 
 - (void)setMiddleRow3BuckleBelted:(SDLVehicleDataEventStatus)middleRow3BuckleBelted {
-    [store sdl_setObject:middleRow3BuckleBelted forName:SDLRPCParameterNameMiddleRow3BuckleBelted];
+    [self.store sdl_setObject:middleRow3BuckleBelted forName:SDLRPCParameterNameMiddleRow3BuckleBelted];
 }
 
 - (SDLVehicleDataEventStatus)middleRow3BuckleBelted {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameMiddleRow3BuckleBelted error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameMiddleRow3BuckleBelted error:&error];
 }
 
 - (void)setLeftRow3BuckleBelted:(SDLVehicleDataEventStatus)leftRow3BuckleBelted {
-    [store sdl_setObject:leftRow3BuckleBelted forName:SDLRPCParameterNameLeftRow3BuckleBelted];
+    [self.store sdl_setObject:leftRow3BuckleBelted forName:SDLRPCParameterNameLeftRow3BuckleBelted];
 }
 
 - (SDLVehicleDataEventStatus)leftRow3BuckleBelted {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameLeftRow3BuckleBelted error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameLeftRow3BuckleBelted error:&error];
 }
 
 - (void)setRightRow3BuckleBelted:(SDLVehicleDataEventStatus)rightRow3BuckleBelted {
-    [store sdl_setObject:rightRow3BuckleBelted forName:SDLRPCParameterNameRightRow3BuckleBelted];
+    [self.store sdl_setObject:rightRow3BuckleBelted forName:SDLRPCParameterNameRightRow3BuckleBelted];
 }
 
 - (SDLVehicleDataEventStatus)rightRow3BuckleBelted {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameRightRow3BuckleBelted error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameRightRow3BuckleBelted error:&error];
 }
 
 - (void)setLeftRearInflatableBelted:(SDLVehicleDataEventStatus)leftRearInflatableBelted {
-    [store sdl_setObject:leftRearInflatableBelted forName:SDLRPCParameterNameLeftRearInflatableBelted];
+    [self.store sdl_setObject:leftRearInflatableBelted forName:SDLRPCParameterNameLeftRearInflatableBelted];
 }
 
 - (SDLVehicleDataEventStatus)leftRearInflatableBelted {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameLeftRearInflatableBelted error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameLeftRearInflatableBelted error:&error];
 }
 
 - (void)setRightRearInflatableBelted:(SDLVehicleDataEventStatus)rightRearInflatableBelted {
-    [store sdl_setObject:rightRearInflatableBelted forName:SDLRPCParameterNameRightRearInflatableBelted];
+    [self.store sdl_setObject:rightRearInflatableBelted forName:SDLRPCParameterNameRightRearInflatableBelted];
 }
 
 - (SDLVehicleDataEventStatus)rightRearInflatableBelted {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameRightRearInflatableBelted error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameRightRearInflatableBelted error:&error];
 }
 
 - (void)setMiddleRow1BeltDeployed:(SDLVehicleDataEventStatus)middleRow1BeltDeployed {
-    [store sdl_setObject:middleRow1BeltDeployed forName:SDLRPCParameterNameMiddleRow1BeltDeployed];
+    [self.store sdl_setObject:middleRow1BeltDeployed forName:SDLRPCParameterNameMiddleRow1BeltDeployed];
 }
 
 - (SDLVehicleDataEventStatus)middleRow1BeltDeployed {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameMiddleRow1BeltDeployed error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameMiddleRow1BeltDeployed error:&error];
 }
 
 - (void)setMiddleRow1BuckleBelted:(SDLVehicleDataEventStatus)middleRow1BuckleBelted {
-    [store sdl_setObject:middleRow1BuckleBelted forName:SDLRPCParameterNameMiddleRow1BuckleBelted];
+    [self.store sdl_setObject:middleRow1BuckleBelted forName:SDLRPCParameterNameMiddleRow1BuckleBelted];
 }
 
 - (SDLVehicleDataEventStatus)middleRow1BuckleBelted {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameMiddleRow1BuckleBelted error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameMiddleRow1BuckleBelted error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLBodyInformation.m
+++ b/SmartDeviceLink/SDLBodyInformation.m
@@ -14,62 +14,62 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation SDLBodyInformation
 
 - (void)setParkBrakeActive:(NSNumber<SDLBool> *)parkBrakeActive {
-    [store sdl_setObject:parkBrakeActive forName:SDLRPCParameterNameParkBrakeActive];
+    [self.store sdl_setObject:parkBrakeActive forName:SDLRPCParameterNameParkBrakeActive];
 }
 
 - (NSNumber<SDLBool> *)parkBrakeActive {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameParkBrakeActive ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameParkBrakeActive ofClass:NSNumber.class error:&error];
 }
 
 - (void)setIgnitionStableStatus:(SDLIgnitionStableStatus)ignitionStableStatus {
-    [store sdl_setObject:ignitionStableStatus forName:SDLRPCParameterNameIgnitionStableStatus];
+    [self.store sdl_setObject:ignitionStableStatus forName:SDLRPCParameterNameIgnitionStableStatus];
 }
 
 - (SDLIgnitionStableStatus)ignitionStableStatus {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameIgnitionStableStatus error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameIgnitionStableStatus error:&error];
 }
 
 - (void)setIgnitionStatus:(SDLIgnitionStatus)ignitionStatus {
-    [store sdl_setObject:ignitionStatus forName:SDLRPCParameterNameIgnitionStatus];
+    [self.store sdl_setObject:ignitionStatus forName:SDLRPCParameterNameIgnitionStatus];
 }
 
 - (SDLIgnitionStatus)ignitionStatus {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameIgnitionStatus error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameIgnitionStatus error:&error];
 }
 
 - (void)setDriverDoorAjar:(nullable NSNumber<SDLBool> *)driverDoorAjar {
-    [store sdl_setObject:driverDoorAjar forName:SDLRPCParameterNameDriverDoorAjar];
+    [self.store sdl_setObject:driverDoorAjar forName:SDLRPCParameterNameDriverDoorAjar];
 }
 
 - (nullable NSNumber<SDLBool> *)driverDoorAjar {
-    return [store sdl_objectForName:SDLRPCParameterNameDriverDoorAjar ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameDriverDoorAjar ofClass:NSNumber.class error:nil];
 }
 
 - (void)setPassengerDoorAjar:(nullable NSNumber<SDLBool> *)passengerDoorAjar {
-    [store sdl_setObject:passengerDoorAjar forName:SDLRPCParameterNamePassengerDoorAjar];
+    [self.store sdl_setObject:passengerDoorAjar forName:SDLRPCParameterNamePassengerDoorAjar];
 }
 
 - (nullable NSNumber<SDLBool> *)passengerDoorAjar {
-    return [store sdl_objectForName:SDLRPCParameterNamePassengerDoorAjar ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNamePassengerDoorAjar ofClass:NSNumber.class error:nil];
 }
 
 - (void)setRearLeftDoorAjar:(nullable NSNumber<SDLBool> *)rearLeftDoorAjar {
-    [store sdl_setObject:rearLeftDoorAjar forName:SDLRPCParameterNameRearLeftDoorAjar];
+    [self.store sdl_setObject:rearLeftDoorAjar forName:SDLRPCParameterNameRearLeftDoorAjar];
 }
 
 - (nullable NSNumber<SDLBool> *)rearLeftDoorAjar {
-    return [store sdl_objectForName:SDLRPCParameterNameRearLeftDoorAjar ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameRearLeftDoorAjar ofClass:NSNumber.class error:nil];
 }
 
 - (void)setRearRightDoorAjar:(nullable NSNumber<SDLBool> *)rearRightDoorAjar {
-    [store sdl_setObject:rearRightDoorAjar forName:SDLRPCParameterNameRearRightDoorAjar];
+    [self.store sdl_setObject:rearRightDoorAjar forName:SDLRPCParameterNameRearRightDoorAjar];
 }
 
 - (nullable NSNumber<SDLBool> *)rearRightDoorAjar {
-    return [store sdl_objectForName:SDLRPCParameterNameRearRightDoorAjar ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameRearRightDoorAjar ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLButtonCapabilities.m
+++ b/SmartDeviceLink/SDLButtonCapabilities.m
@@ -11,39 +11,39 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation SDLButtonCapabilities
 
 - (void)setName:(SDLButtonName)name {
-    [store sdl_setObject:name forName:SDLRPCParameterNameName];
+    [self.store sdl_setObject:name forName:SDLRPCParameterNameName];
 }
 
 - (SDLButtonName)name {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameName error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameName error:&error];
 }
 
 - (void)setShortPressAvailable:(NSNumber<SDLBool> *)shortPressAvailable {
-    [store sdl_setObject:shortPressAvailable forName:SDLRPCParameterNameShortPressAvailable];
+    [self.store sdl_setObject:shortPressAvailable forName:SDLRPCParameterNameShortPressAvailable];
 }
 
 - (NSNumber<SDLBool> *)shortPressAvailable {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameShortPressAvailable ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameShortPressAvailable ofClass:NSNumber.class error:&error];
 }
 
 - (void)setLongPressAvailable:(NSNumber<SDLBool> *)longPressAvailable {
-    [store sdl_setObject:longPressAvailable forName:SDLRPCParameterNameLongPressAvailable];
+    [self.store sdl_setObject:longPressAvailable forName:SDLRPCParameterNameLongPressAvailable];
 }
 
 - (NSNumber<SDLBool> *)longPressAvailable {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameLongPressAvailable ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameLongPressAvailable ofClass:NSNumber.class error:&error];
 }
 
 - (void)setUpDownAvailable:(NSNumber<SDLBool> *)upDownAvailable {
-    [store sdl_setObject:upDownAvailable forName:SDLRPCParameterNameUpDownAvailable];
+    [self.store sdl_setObject:upDownAvailable forName:SDLRPCParameterNameUpDownAvailable];
 }
 
 - (NSNumber<SDLBool> *)upDownAvailable {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameUpDownAvailable ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameUpDownAvailable ofClass:NSNumber.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLButtonPress.m
+++ b/SmartDeviceLink/SDLButtonPress.m
@@ -11,11 +11,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLButtonPress
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameButtonPress]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithButtonName:(SDLButtonName) buttonName moduleType:(SDLModuleType) moduleType {
     self = [self init];
@@ -30,30 +33,30 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setModuleType:(SDLModuleType)moduleType {
-    [parameters sdl_setObject:moduleType forName:SDLRPCParameterNameModuleType];
+    [self.parameters sdl_setObject:moduleType forName:SDLRPCParameterNameModuleType];
 }
 
 - (SDLModuleType)moduleType {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameModuleType error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameModuleType error:&error];
 }
 
 - (void)setButtonName:(SDLButtonName)buttonName {
-    [parameters sdl_setObject:buttonName forName:SDLRPCParameterNameButtonName];
+    [self.parameters sdl_setObject:buttonName forName:SDLRPCParameterNameButtonName];
 }
 
 - (SDLButtonName)buttonName {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameButtonName error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameButtonName error:&error];
 }
 
 - (void)setButtonPressMode:(SDLButtonPressMode)buttonPressMode {
-    [parameters sdl_setObject:buttonPressMode forName:SDLRPCParameterNameButtonPressMode];
+    [self.parameters sdl_setObject:buttonPressMode forName:SDLRPCParameterNameButtonPressMode];
 }
 
 - (SDLButtonPressMode)buttonPressMode {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameButtonPressMode error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameButtonPressMode error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLButtonPressResponse.m
+++ b/SmartDeviceLink/SDLButtonPressResponse.m
@@ -10,11 +10,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLButtonPressResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameButtonPress]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLChangeRegistration.m
+++ b/SmartDeviceLink/SDLChangeRegistration.m
@@ -13,11 +13,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLChangeRegistration
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameChangeRegistration]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithLanguage:(SDLLanguage)language hmiDisplayLanguage:(SDLLanguage)hmiDisplayLanguage {
     self = [self initWithLanguage:language hmiDisplayLanguage:hmiDisplayLanguage appName:nil ttsName:nil ngnMediaScreenAppName:nil vrSynonyms:nil];
@@ -45,53 +48,53 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setLanguage:(SDLLanguage)language {
-    [parameters sdl_setObject:language forName:SDLRPCParameterNameLanguage];
+    [self.parameters sdl_setObject:language forName:SDLRPCParameterNameLanguage];
 }
 
 - (SDLLanguage)language {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameLanguage error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameLanguage error:&error];
 }
 
 - (void)setHmiDisplayLanguage:(SDLLanguage )hmiDisplayLanguage {
-    [parameters sdl_setObject:hmiDisplayLanguage forName:SDLRPCParameterNameHMIDisplayLanguage];
+    [self.parameters sdl_setObject:hmiDisplayLanguage forName:SDLRPCParameterNameHMIDisplayLanguage];
 }
 
 - (SDLLanguage)hmiDisplayLanguage {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameHMIDisplayLanguage error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameHMIDisplayLanguage error:&error];
 }
 
 - (void)setAppName:(nullable NSString *)appName {
-    [parameters sdl_setObject:appName forName:SDLRPCParameterNameAppName];
+    [self.parameters sdl_setObject:appName forName:SDLRPCParameterNameAppName];
 }
 
 - (nullable NSString *)appName {
-    return [[parameters sdl_objectForName:SDLRPCParameterNameAppName ofClass:NSString.class error:nil] copy];
+    return [[self.parameters sdl_objectForName:SDLRPCParameterNameAppName ofClass:NSString.class error:nil] copy];
 }
 
 - (void)setTtsName:(nullable NSArray<SDLTTSChunk *> *)ttsName {
-    [parameters sdl_setObject:ttsName forName:SDLRPCParameterNameTTSName];
+    [self.parameters sdl_setObject:ttsName forName:SDLRPCParameterNameTTSName];
 }
 
 - (nullable NSArray<SDLTTSChunk *> *)ttsName {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameTTSName ofClass:SDLTTSChunk.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameTTSName ofClass:SDLTTSChunk.class error:nil];
 }
 
 - (void)setNgnMediaScreenAppName:(nullable NSString *)ngnMediaScreenAppName {
-    [parameters sdl_setObject:ngnMediaScreenAppName forName:SDLRPCParameterNameNGNMediaScreenAppName];
+    [self.parameters sdl_setObject:ngnMediaScreenAppName forName:SDLRPCParameterNameNGNMediaScreenAppName];
 }
 
 - (nullable NSString *)ngnMediaScreenAppName {
-    return [parameters sdl_objectForName:SDLRPCParameterNameNGNMediaScreenAppName ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameNGNMediaScreenAppName ofClass:NSString.class error:nil];
 }
 
 - (void)setVrSynonyms:(nullable NSArray<NSString *> *)vrSynonyms {
-    [parameters sdl_setObject:vrSynonyms forName:SDLRPCParameterNameVRSynonyms];
+    [self.parameters sdl_setObject:vrSynonyms forName:SDLRPCParameterNameVRSynonyms];
 }
 
 - (nullable NSArray<NSString *> *)vrSynonyms {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameVRSynonyms ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameVRSynonyms ofClass:NSString.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLChangeRegistrationResponse.m
+++ b/SmartDeviceLink/SDLChangeRegistrationResponse.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLChangeRegistrationResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameChangeRegistration]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLChoice.m
+++ b/SmartDeviceLink/SDLChoice.m
@@ -39,61 +39,61 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setChoiceID:(NSNumber<SDLInt> *)choiceID {
-    [store sdl_setObject:choiceID forName:SDLRPCParameterNameChoiceId];
+    [self.store sdl_setObject:choiceID forName:SDLRPCParameterNameChoiceId];
 }
 
 - (NSNumber<SDLInt> *)choiceID {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameChoiceId ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameChoiceId ofClass:NSNumber.class error:&error];
 }
 
 - (void)setMenuName:(NSString *)menuName {
-    [store sdl_setObject:menuName forName:SDLRPCParameterNameMenuName];
+    [self.store sdl_setObject:menuName forName:SDLRPCParameterNameMenuName];
 }
 
 - (NSString *)menuName {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameMenuName ofClass:NSString.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameMenuName ofClass:NSString.class error:&error];
 }
 
 - (void)setVrCommands:(nullable NSArray<NSString *> *)vrCommands {
-    [store sdl_setObject:vrCommands forName:SDLRPCParameterNameVRCommands];
+    [self.store sdl_setObject:vrCommands forName:SDLRPCParameterNameVRCommands];
 }
 
 - (nullable NSArray<NSString *> *)vrCommands {
-    return [store sdl_objectsForName:SDLRPCParameterNameVRCommands ofClass:NSString.class error:nil];
+    return [self.store sdl_objectsForName:SDLRPCParameterNameVRCommands ofClass:NSString.class error:nil];
 }
 
 - (void)setImage:(nullable SDLImage *)image {
-    [store sdl_setObject:image forName:SDLRPCParameterNameImage];
+    [self.store sdl_setObject:image forName:SDLRPCParameterNameImage];
 }
 
 - (nullable SDLImage *)image {
-    return [store sdl_objectForName:SDLRPCParameterNameImage ofClass:SDLImage.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameImage ofClass:SDLImage.class error:nil];
 }
 
 - (void)setSecondaryText:(nullable NSString *)secondaryText {
-    [store sdl_setObject:secondaryText forName:SDLRPCParameterNameSecondaryText];
+    [self.store sdl_setObject:secondaryText forName:SDLRPCParameterNameSecondaryText];
 }
 
 - (nullable NSString *)secondaryText {
-    return [store sdl_objectForName:SDLRPCParameterNameSecondaryText ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameSecondaryText ofClass:NSString.class error:nil];
 }
 
 - (void)setTertiaryText:(nullable NSString *)tertiaryText {
-    [store sdl_setObject:tertiaryText forName:SDLRPCParameterNameTertiaryText];
+    [self.store sdl_setObject:tertiaryText forName:SDLRPCParameterNameTertiaryText];
 }
 
 - (nullable NSString *)tertiaryText {
-    return [store sdl_objectForName:SDLRPCParameterNameTertiaryText ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameTertiaryText ofClass:NSString.class error:nil];
 }
 
 - (void)setSecondaryImage:(nullable SDLImage *)secondaryImage {
-    [store sdl_setObject:secondaryImage forName:SDLRPCParameterNameSecondaryImage];
+    [self.store sdl_setObject:secondaryImage forName:SDLRPCParameterNameSecondaryImage];
 }
 
 - (nullable SDLImage *)secondaryImage {
-    return [store sdl_objectForName:SDLRPCParameterNameSecondaryImage ofClass:SDLImage.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameSecondaryImage ofClass:SDLImage.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLClimateControlCapabilities.m
+++ b/SmartDeviceLink/SDLClimateControlCapabilities.m
@@ -39,132 +39,132 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setModuleName:(NSString *)moduleName {
-    [store sdl_setObject:moduleName forName:SDLRPCParameterNameModuleName];
+    [self.store sdl_setObject:moduleName forName:SDLRPCParameterNameModuleName];
 }
 
 - (NSString *)moduleName {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameModuleName ofClass:NSString.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameModuleName ofClass:NSString.class error:&error];
 }
 
 - (void)setFanSpeedAvailable:(nullable NSNumber<SDLBool> *)fanSpeedAvailable {
-    [store sdl_setObject:fanSpeedAvailable forName:SDLRPCParameterNameFanSpeedAvailable];
+    [self.store sdl_setObject:fanSpeedAvailable forName:SDLRPCParameterNameFanSpeedAvailable];
 }
 
 - (nullable NSNumber<SDLBool> *)fanSpeedAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameFanSpeedAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameFanSpeedAvailable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setDesiredTemperatureAvailable:(nullable NSNumber<SDLBool> *)desiredTemperatureAvailable {
-    [store sdl_setObject:desiredTemperatureAvailable forName:SDLRPCParameterNameDesiredTemperatureAvailable];
+    [self.store sdl_setObject:desiredTemperatureAvailable forName:SDLRPCParameterNameDesiredTemperatureAvailable];
 }
 
 - (nullable NSNumber<SDLBool> *)desiredTemperatureAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameDesiredTemperatureAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameDesiredTemperatureAvailable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setAcEnableAvailable:(nullable NSNumber<SDLBool> *)acEnableAvailable {
-    [store sdl_setObject:acEnableAvailable forName:SDLRPCParameterNameACEnableAvailable];
+    [self.store sdl_setObject:acEnableAvailable forName:SDLRPCParameterNameACEnableAvailable];
 }
 
 - (nullable NSNumber<SDLBool> *)acEnableAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameACEnableAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameACEnableAvailable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setAcMaxEnableAvailable:(nullable NSNumber<SDLBool> *)acMaxEnableAvailable {
-    [store sdl_setObject:acMaxEnableAvailable forName:SDLRPCParameterNameACMaxEnableAvailable];
+    [self.store sdl_setObject:acMaxEnableAvailable forName:SDLRPCParameterNameACMaxEnableAvailable];
 }
 
 - (nullable NSNumber<SDLBool> *)acMaxEnableAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameACMaxEnableAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameACMaxEnableAvailable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setCirculateAirEnableAvailable:(nullable NSNumber<SDLBool> *)circulateAirEnableAvailable {
-    [store sdl_setObject:circulateAirEnableAvailable forName:SDLRPCParameterNameCirculateAirEnableAvailable];
+    [self.store sdl_setObject:circulateAirEnableAvailable forName:SDLRPCParameterNameCirculateAirEnableAvailable];
 }
 
 - (nullable NSNumber<SDLBool> *)circulateAirEnableAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameCirculateAirEnableAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameCirculateAirEnableAvailable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setAutoModeEnableAvailable:(nullable NSNumber<SDLBool> *)autoModeEnableAvailable {
-    [store sdl_setObject:autoModeEnableAvailable forName:SDLRPCParameterNameAutoModeEnableAvailable];
+    [self.store sdl_setObject:autoModeEnableAvailable forName:SDLRPCParameterNameAutoModeEnableAvailable];
 }
 
 - (nullable NSNumber<SDLBool> *)autoModeEnableAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameAutoModeEnableAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameAutoModeEnableAvailable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setDualModeEnableAvailable:(nullable NSNumber<SDLBool> *)dualModeEnableAvailable {
-    [store sdl_setObject:dualModeEnableAvailable forName:SDLRPCParameterNameDualModeEnableAvailable];
+    [self.store sdl_setObject:dualModeEnableAvailable forName:SDLRPCParameterNameDualModeEnableAvailable];
 }
 
 - (nullable NSNumber<SDLBool> *)dualModeEnableAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameDualModeEnableAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameDualModeEnableAvailable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setDefrostZoneAvailable:(nullable NSNumber<SDLBool> *)defrostZoneAvailable {
-    [store sdl_setObject:defrostZoneAvailable forName:SDLRPCParameterNameDefrostZoneAvailable];
+    [self.store sdl_setObject:defrostZoneAvailable forName:SDLRPCParameterNameDefrostZoneAvailable];
 }
 
 - (nullable NSNumber<SDLBool> *)defrostZoneAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameDefrostZoneAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameDefrostZoneAvailable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setDefrostZone:(nullable NSArray <SDLDefrostZone>*)defrostZone {
-    [store sdl_setObject:defrostZone forName:SDLRPCParameterNameDefrostZone];
+    [self.store sdl_setObject:defrostZone forName:SDLRPCParameterNameDefrostZone];
 }
 
 - (nullable NSArray<SDLDefrostZone> *)defrostZone {
-    return [store sdl_enumsForName:SDLRPCParameterNameDefrostZone error:nil];
+    return [self.store sdl_enumsForName:SDLRPCParameterNameDefrostZone error:nil];
 }
 
 - (void)setVentilationModeAvailable:(nullable NSNumber<SDLBool> *)ventilationModeAvailable {
-    [store sdl_setObject:ventilationModeAvailable forName:SDLRPCParameterNameVentilationModeAvailable];
+    [self.store sdl_setObject:ventilationModeAvailable forName:SDLRPCParameterNameVentilationModeAvailable];
 }
 
 - (nullable NSNumber<SDLBool> *)ventilationModeAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameVentilationModeAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameVentilationModeAvailable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setVentilationMode:(nullable NSArray<SDLVentilationMode> *)ventilationMode {
-    [store sdl_setObject:ventilationMode forName:SDLRPCParameterNameVentilationMode];
+    [self.store sdl_setObject:ventilationMode forName:SDLRPCParameterNameVentilationMode];
 }
 
 - (nullable NSArray<SDLVentilationMode> *)ventilationMode {
-    return [store sdl_enumsForName:SDLRPCParameterNameVentilationMode error:nil];
+    return [self.store sdl_enumsForName:SDLRPCParameterNameVentilationMode error:nil];
 }
 
 - (void)setHeatedSteeringWheelAvailable:(nullable NSNumber<SDLBool> *)heatedSteeringWheelAvailable {
-    [store sdl_setObject:heatedSteeringWheelAvailable forName:SDLRPCParameterNameHeatedSteeringWheelAvailable];
+    [self.store sdl_setObject:heatedSteeringWheelAvailable forName:SDLRPCParameterNameHeatedSteeringWheelAvailable];
 }
 
 - (nullable NSNumber<SDLBool> *)heatedSteeringWheelAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameHeatedSteeringWheelAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameHeatedSteeringWheelAvailable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setHeatedWindshieldAvailable:(nullable NSNumber<SDLBool> *)heatedWindshieldAvailable {
-    [store sdl_setObject:heatedWindshieldAvailable forName:SDLRPCParameterNameHeatedWindshieldAvailable];
+    [self.store sdl_setObject:heatedWindshieldAvailable forName:SDLRPCParameterNameHeatedWindshieldAvailable];
 }
 
 - (nullable NSNumber<SDLBool> *)heatedWindshieldAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameHeatedWindshieldAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameHeatedWindshieldAvailable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setHeatedRearWindowAvailable:(nullable NSNumber<SDLBool> *)heatedRearWindowAvailable {
-    [store sdl_setObject:heatedRearWindowAvailable forName:SDLRPCParameterNameHeatedRearWindowAvailable];
+    [self.store sdl_setObject:heatedRearWindowAvailable forName:SDLRPCParameterNameHeatedRearWindowAvailable];
 }
 
 - (nullable NSNumber<SDLBool> *)heatedRearWindowAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameHeatedRearWindowAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameHeatedRearWindowAvailable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setHeatedMirrorsAvailable:(nullable NSNumber<SDLBool> *)heatedMirrorsAvailable {
-    [store sdl_setObject:heatedMirrorsAvailable forName:SDLRPCParameterNameHeatedMirrorsAvailable];
+    [self.store sdl_setObject:heatedMirrorsAvailable forName:SDLRPCParameterNameHeatedMirrorsAvailable];
 }
 
 - (nullable NSNumber<SDLBool> *)heatedMirrorsAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameHeatedMirrorsAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameHeatedMirrorsAvailable ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLClimateControlData.m
+++ b/SmartDeviceLink/SDLClimateControlData.m
@@ -39,115 +39,115 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setFanSpeed:(nullable NSNumber<SDLInt> *)fanSpeed {
-    [store sdl_setObject:fanSpeed forName:SDLRPCParameterNameFanSpeed];
+    [self.store sdl_setObject:fanSpeed forName:SDLRPCParameterNameFanSpeed];
 }
 
 - (nullable NSNumber<SDLInt> *)fanSpeed {
-    return [store sdl_objectForName:SDLRPCParameterNameFanSpeed ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameFanSpeed ofClass:NSNumber.class error:nil];
 }
 
 - (void)setCurrentTemperature:(nullable SDLTemperature *)currentTemperature {
-    [store sdl_setObject:currentTemperature forName:SDLRPCParameterNameCurrentTemperature];
+    [self.store sdl_setObject:currentTemperature forName:SDLRPCParameterNameCurrentTemperature];
 }
 
 - (nullable SDLTemperature *)currentTemperature {
-    return [store sdl_objectForName:SDLRPCParameterNameCurrentTemperature ofClass:SDLTemperature.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameCurrentTemperature ofClass:SDLTemperature.class error:nil];
 }
 
 - (void)setDesiredTemperature:(nullable SDLTemperature *)desiredTemperature {
-    [store sdl_setObject:desiredTemperature forName:SDLRPCParameterNameDesiredTemperature];
+    [self.store sdl_setObject:desiredTemperature forName:SDLRPCParameterNameDesiredTemperature];
 }
 
 - (nullable SDLTemperature *)desiredTemperature {
-    return [store sdl_objectForName:SDLRPCParameterNameDesiredTemperature ofClass:SDLTemperature.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameDesiredTemperature ofClass:SDLTemperature.class error:nil];
 }
 
 - (void)setAcEnable:(nullable NSNumber<SDLBool> *)acEnable {
-    [store sdl_setObject:acEnable forName:SDLRPCParameterNameACEnable];
+    [self.store sdl_setObject:acEnable forName:SDLRPCParameterNameACEnable];
 }
 
 - (nullable NSNumber<SDLBool> *)acEnable {
-    return [store sdl_objectForName:SDLRPCParameterNameACEnable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameACEnable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setCirculateAirEnable:(nullable NSNumber<SDLBool> *)circulateAirEnable {
-    [store sdl_setObject:circulateAirEnable forName:SDLRPCParameterNameCirculateAirEnable];
+    [self.store sdl_setObject:circulateAirEnable forName:SDLRPCParameterNameCirculateAirEnable];
 }
 
 - (nullable NSNumber<SDLBool> *)circulateAirEnable {
-    return [store sdl_objectForName:SDLRPCParameterNameCirculateAirEnable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameCirculateAirEnable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setAutoModeEnable:(nullable NSNumber<SDLBool> *)autoModeEnable {
-    [store sdl_setObject:autoModeEnable forName:SDLRPCParameterNameAutoModeEnable];
+    [self.store sdl_setObject:autoModeEnable forName:SDLRPCParameterNameAutoModeEnable];
 }
 
 - (nullable NSNumber<SDLBool> *)autoModeEnable {
-    return [store sdl_objectForName:SDLRPCParameterNameAutoModeEnable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameAutoModeEnable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setDefrostZone:(nullable SDLDefrostZone)defrostZone {
-    [store sdl_setObject:defrostZone forName:SDLRPCParameterNameDefrostZone];
+    [self.store sdl_setObject:defrostZone forName:SDLRPCParameterNameDefrostZone];
 }
 
 - (nullable SDLDefrostZone)defrostZone {
-    return [store sdl_enumForName:SDLRPCParameterNameDefrostZone error:nil];
+    return [self.store sdl_enumForName:SDLRPCParameterNameDefrostZone error:nil];
 }
 
 - (void)setDualModeEnable:(nullable NSNumber<SDLBool> *)dualModeEnable {
-    [store sdl_setObject:dualModeEnable forName:SDLRPCParameterNameDualModeEnable];
+    [self.store sdl_setObject:dualModeEnable forName:SDLRPCParameterNameDualModeEnable];
 }
 
 - (nullable NSNumber<SDLBool> *)dualModeEnable {
-    return [store sdl_objectForName:SDLRPCParameterNameDualModeEnable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameDualModeEnable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setAcMaxEnable:(nullable NSNumber<SDLBool> *)acMaxEnable {
-    [store sdl_setObject:acMaxEnable forName:SDLRPCParameterNameACMaxEnable];
+    [self.store sdl_setObject:acMaxEnable forName:SDLRPCParameterNameACMaxEnable];
 }
 
 - (nullable NSNumber<SDLBool> *)acMaxEnable {
-    return [store sdl_objectForName:SDLRPCParameterNameACMaxEnable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameACMaxEnable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setVentilationMode:(nullable SDLVentilationMode)ventilationMode {
-    [store sdl_setObject:ventilationMode forName:SDLRPCParameterNameVentilationMode];
+    [self.store sdl_setObject:ventilationMode forName:SDLRPCParameterNameVentilationMode];
 }
 
 - (nullable SDLVentilationMode)ventilationMode {
-    return [store sdl_enumForName:SDLRPCParameterNameVentilationMode error:nil];
+    return [self.store sdl_enumForName:SDLRPCParameterNameVentilationMode error:nil];
 }
 
 - (void)setHeatedSteeringWheelEnable:(nullable NSNumber<SDLBool> *)heatedSteeringWheelEnable {
-    [store sdl_setObject:heatedSteeringWheelEnable forName:SDLRPCParameterNameHeatedSteeringWheelEnable];
+    [self.store sdl_setObject:heatedSteeringWheelEnable forName:SDLRPCParameterNameHeatedSteeringWheelEnable];
 }
 
 - (nullable NSNumber<SDLBool> *)heatedSteeringWheelEnable {
-    return [store sdl_objectForName:SDLRPCParameterNameHeatedSteeringWheelEnable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameHeatedSteeringWheelEnable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setHeatedWindshieldEnable:(nullable NSNumber<SDLBool> *)heatedWindshieldEnable {
-    [store sdl_setObject:heatedWindshieldEnable forName:SDLRPCParameterNameHeatedWindshieldEnable];
+    [self.store sdl_setObject:heatedWindshieldEnable forName:SDLRPCParameterNameHeatedWindshieldEnable];
 }
 
 - (nullable NSNumber<SDLBool> *)heatedWindshieldEnable {
-    return [store sdl_objectForName:SDLRPCParameterNameHeatedWindshieldEnable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameHeatedWindshieldEnable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setHeatedRearWindowEnable:(nullable NSNumber<SDLBool> *)heatedRearWindowEnable {
-    [store sdl_setObject:heatedRearWindowEnable forName:SDLRPCParameterNameHeatedRearWindowEnable];
+    [self.store sdl_setObject:heatedRearWindowEnable forName:SDLRPCParameterNameHeatedRearWindowEnable];
 }
 
 - (nullable NSNumber<SDLBool> *)heatedRearWindowEnable {
-    return [store sdl_objectForName:SDLRPCParameterNameHeatedRearWindowEnable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameHeatedRearWindowEnable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setHeatedMirrorsEnable:(nullable NSNumber<SDLBool> *)heatedMirrorsEnable {
-    [store sdl_setObject:heatedMirrorsEnable forName:SDLRPCParameterNameHeatedMirrorsEnable];
+    [self.store sdl_setObject:heatedMirrorsEnable forName:SDLRPCParameterNameHeatedMirrorsEnable];
 }
 
 - (nullable NSNumber<SDLBool> *)heatedMirrorsEnable {
-    return [store sdl_objectForName:SDLRPCParameterNameHeatedMirrorsEnable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameHeatedMirrorsEnable ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLCloudAppProperties.m
+++ b/SmartDeviceLink/SDLCloudAppProperties.m
@@ -44,60 +44,60 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setNicknames:(nullable NSArray<NSString *> *)nicknames {
-    [store sdl_setObject:nicknames forName:SDLRPCParameterNameNicknames];
+    [self.store sdl_setObject:nicknames forName:SDLRPCParameterNameNicknames];
 }
 
 - (nullable NSArray<NSString *> *)nicknames {
-    return [store sdl_objectsForName:SDLRPCParameterNameNicknames ofClass:NSString.class error:nil];
+    return [self.store sdl_objectsForName:SDLRPCParameterNameNicknames ofClass:NSString.class error:nil];
 }
 
 - (void)setAppID:(NSString *)appID {
-    [store sdl_setObject:appID forName:SDLRPCParameterNameAppId];
+    [self.store sdl_setObject:appID forName:SDLRPCParameterNameAppId];
 }
 
 - (NSString *)appID {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameAppId ofClass:NSString.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameAppId ofClass:NSString.class error:&error];
 }
 
 - (void)setEnabled:(nullable NSNumber<SDLBool> *)enabled {
-    [store sdl_setObject:enabled forName:SDLRPCParameterNameEnabled];
+    [self.store sdl_setObject:enabled forName:SDLRPCParameterNameEnabled];
 }
 
 - (nullable NSNumber<SDLBool> *)enabled {
-    return [store sdl_objectForName:SDLRPCParameterNameEnabled ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameEnabled ofClass:NSNumber.class error:nil];
 }
 
 - (void)setAuthToken:(nullable NSString *)authToken {
-    [store sdl_setObject:authToken forName:SDLRPCParameterNameAuthToken];
+    [self.store sdl_setObject:authToken forName:SDLRPCParameterNameAuthToken];
 }
 
 - (nullable NSString *)authToken {
-    return [store sdl_objectForName:SDLRPCParameterNameAuthToken ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameAuthToken ofClass:NSString.class error:nil];
 }
 
 - (void)setCloudTransportType:(nullable NSString *)cloudTransportType {
-    [store sdl_setObject:cloudTransportType forName:SDLRPCParameterNameCloudTransportType];
+    [self.store sdl_setObject:cloudTransportType forName:SDLRPCParameterNameCloudTransportType];
 }
 
 - (nullable NSString *)cloudTransportType {
-    return [store sdl_objectForName:SDLRPCParameterNameCloudTransportType ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameCloudTransportType ofClass:NSString.class error:nil];
 }
 
 - (void)setHybridAppPreference:(nullable SDLHybridAppPreference)hybridAppPreference {
-    [store sdl_setObject:hybridAppPreference forName:SDLRPCParameterNameHybridAppPreference];
+    [self.store sdl_setObject:hybridAppPreference forName:SDLRPCParameterNameHybridAppPreference];
 }
 
 - (nullable SDLHybridAppPreference)hybridAppPreference {
-    return [store sdl_enumForName:SDLRPCParameterNameHybridAppPreference error:nil];
+    return [self.store sdl_enumForName:SDLRPCParameterNameHybridAppPreference error:nil];
 }
 
 - (void)setEndpoint:(nullable NSString *)endpoint {
-    [store sdl_setObject:endpoint forName:SDLRPCParameterNameEndpoint];
+    [self.store sdl_setObject:endpoint forName:SDLRPCParameterNameEndpoint];
 }
 
 - (nullable NSString *)endpoint {
-    return [store sdl_objectForName:SDLRPCParameterNameEndpoint ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameEndpoint ofClass:NSString.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLClusterModeStatus.m
+++ b/SmartDeviceLink/SDLClusterModeStatus.m
@@ -11,39 +11,39 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation SDLClusterModeStatus
 
 - (void)setPowerModeActive:(NSNumber<SDLBool> *)powerModeActive {
-    [store sdl_setObject:powerModeActive forName:SDLRPCParameterNamePowerModeActive];
+    [self.store sdl_setObject:powerModeActive forName:SDLRPCParameterNamePowerModeActive];
 }
 
 - (NSNumber<SDLBool> *)powerModeActive {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNamePowerModeActive ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNamePowerModeActive ofClass:NSNumber.class error:&error];
 }
 
 - (void)setPowerModeQualificationStatus:(SDLPowerModeQualificationStatus)powerModeQualificationStatus {
-    [store sdl_setObject:powerModeQualificationStatus forName:SDLRPCParameterNamePowerModeQualificationStatus];
+    [self.store sdl_setObject:powerModeQualificationStatus forName:SDLRPCParameterNamePowerModeQualificationStatus];
 }
 
 - (SDLPowerModeQualificationStatus)powerModeQualificationStatus {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNamePowerModeQualificationStatus error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNamePowerModeQualificationStatus error:&error];
 }
 
 - (void)setCarModeStatus:(SDLCarModeStatus)carModeStatus {
-    [store sdl_setObject:carModeStatus forName:SDLRPCParameterNameCarModeStatus];
+    [self.store sdl_setObject:carModeStatus forName:SDLRPCParameterNameCarModeStatus];
 }
 
 - (SDLCarModeStatus)carModeStatus {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameCarModeStatus error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameCarModeStatus error:&error];
 }
 
 - (void)setPowerModeStatus:(SDLPowerModeStatus)powerModeStatus {
-    [store sdl_setObject:powerModeStatus forName:SDLRPCParameterNamePowerModeStatus];
+    [self.store sdl_setObject:powerModeStatus forName:SDLRPCParameterNamePowerModeStatus];
 }
 
 - (SDLPowerModeStatus)powerModeStatus {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNamePowerModeStatus error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNamePowerModeStatus error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLCreateInteractionChoiceSet.m
+++ b/SmartDeviceLink/SDLCreateInteractionChoiceSet.m
@@ -13,11 +13,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLCreateInteractionChoiceSet
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameCreateInteractionChoiceSet]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithId:(UInt32)choiceId choiceSet:(NSArray<SDLChoice *> *)choiceSet {
     self = [self init];
@@ -31,21 +34,21 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setInteractionChoiceSetID:(NSNumber<SDLInt> *)interactionChoiceSetID {
-    [parameters sdl_setObject:interactionChoiceSetID forName:SDLRPCParameterNameInteractionChoiceSetId];
+    [self.parameters sdl_setObject:interactionChoiceSetID forName:SDLRPCParameterNameInteractionChoiceSetId];
 }
 
 - (NSNumber<SDLInt> *)interactionChoiceSetID {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameInteractionChoiceSetId ofClass:NSNumber.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameInteractionChoiceSetId ofClass:NSNumber.class error:&error];
 }
 
 - (void)setChoiceSet:(NSArray<SDLChoice *> *)choiceSet {
-    [parameters sdl_setObject:choiceSet forName:SDLRPCParameterNameChoiceSet];
+    [self.parameters sdl_setObject:choiceSet forName:SDLRPCParameterNameChoiceSet];
 }
 
 - (NSArray<SDLChoice *> *)choiceSet {
     NSError *error = nil;
-    return [parameters sdl_objectsForName:SDLRPCParameterNameChoiceSet ofClass:SDLChoice.class error:&error];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameChoiceSet ofClass:SDLChoice.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLCreateInteractionChoiceSetResponse.m
+++ b/SmartDeviceLink/SDLCreateInteractionChoiceSetResponse.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLCreateInteractionChoiceSetResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameCreateInteractionChoiceSet]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLDIDResult.m
+++ b/SmartDeviceLink/SDLDIDResult.m
@@ -11,29 +11,29 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation SDLDIDResult
 
 - (void)setResultCode:(SDLVehicleDataResultCode)resultCode {
-    [store sdl_setObject:resultCode forName:SDLRPCParameterNameResultCode];
+    [self.store sdl_setObject:resultCode forName:SDLRPCParameterNameResultCode];
 }
 
 - (SDLVehicleDataResultCode)resultCode {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameResultCode error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameResultCode error:&error];
 }
 
 - (void)setDidLocation:(NSNumber<SDLInt> *)didLocation {
-    [store sdl_setObject:didLocation forName:SDLRPCParameterNameDIDLocation];
+    [self.store sdl_setObject:didLocation forName:SDLRPCParameterNameDIDLocation];
 }
 
 - (NSNumber<SDLInt> *)didLocation {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameDIDLocation ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameDIDLocation ofClass:NSNumber.class error:&error];
 }
 
 - (void)setData:(nullable NSString *)data {
-    [store sdl_setObject:data forName:SDLRPCParameterNameData];
+    [self.store sdl_setObject:data forName:SDLRPCParameterNameData];
 }
 
 - (nullable NSString *)data {
-    return [store sdl_objectForName:SDLRPCParameterNameData ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameData ofClass:NSString.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLDateTime.m
+++ b/SmartDeviceLink/SDLDateTime.m
@@ -59,84 +59,84 @@
 }
 
 - (void)setMillisecond:(NSNumber<SDLInt> *)millisecond {
-    [store sdl_setObject:millisecond forName:SDLRPCParameterNameMillisecond];
+    [self.store sdl_setObject:millisecond forName:SDLRPCParameterNameMillisecond];
 }
 
 - (NSNumber<SDLInt> *)millisecond {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameMillisecond ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameMillisecond ofClass:NSNumber.class error:&error];
 }
 
 - (void)setSecond:(NSNumber<SDLInt> *)second {
-    [store sdl_setObject:second forName:SDLRPCParameterNameSecond];
+    [self.store sdl_setObject:second forName:SDLRPCParameterNameSecond];
 }
 
 - (NSNumber<SDLInt> *)second {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameSecond ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameSecond ofClass:NSNumber.class error:&error];
 }
 
 - (void)setMinute:(NSNumber<SDLInt> *)minute {
-    [store sdl_setObject:minute forName:SDLRPCParameterNameMinute];
+    [self.store sdl_setObject:minute forName:SDLRPCParameterNameMinute];
 }
 
 - (NSNumber<SDLInt> *)minute {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameMinute ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameMinute ofClass:NSNumber.class error:&error];
 }
 
 - (void)setHour:(NSNumber<SDLInt> *)hour {
-    [store sdl_setObject:hour forName:SDLRPCParameterNameHour];
+    [self.store sdl_setObject:hour forName:SDLRPCParameterNameHour];
 }
 
 - (NSNumber<SDLInt> *)hour {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameHour ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameHour ofClass:NSNumber.class error:&error];
 }
 
 - (void)setDay:(NSNumber<SDLInt> *)day {
-    [store sdl_setObject:day forName:SDLRPCParameterNameDay];
+    [self.store sdl_setObject:day forName:SDLRPCParameterNameDay];
 }
 
 - (NSNumber<SDLInt> *)day {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameDay ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameDay ofClass:NSNumber.class error:&error];
 }
 
 - (void)setMonth:(NSNumber<SDLInt> *)month {
-    [store sdl_setObject:month forName:SDLRPCParameterNameMonth];
+    [self.store sdl_setObject:month forName:SDLRPCParameterNameMonth];
 }
 
 - (NSNumber<SDLInt> *)month {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameMonth ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameMonth ofClass:NSNumber.class error:&error];
 }
 
 - (void)setYear:(NSNumber<SDLInt> *)year {
-    [store sdl_setObject:year forName:SDLRPCParameterNameYear];
+    [self.store sdl_setObject:year forName:SDLRPCParameterNameYear];
 }
 
 - (NSNumber<SDLInt> *)year {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameYear ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameYear ofClass:NSNumber.class error:&error];
 }
 
 - (void)setTimezoneMinuteOffset:(NSNumber<SDLInt> *)timezoneMinuteOffset {
-    [store sdl_setObject:timezoneMinuteOffset forName:SDLRPCParameterNameTimezoneMinuteOffset];
+    [self.store sdl_setObject:timezoneMinuteOffset forName:SDLRPCParameterNameTimezoneMinuteOffset];
 }
 
 - (NSNumber<SDLInt> *)timezoneMinuteOffset {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameTimezoneMinuteOffset ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameTimezoneMinuteOffset ofClass:NSNumber.class error:&error];
 }
 
 - (void)setTimezoneHourOffset:(NSNumber<SDLInt> *)timezoneHourOffset {
-    [store sdl_setObject:timezoneHourOffset forName:SDLRPCParameterNameTimezoneHourOffset];
+    [self.store sdl_setObject:timezoneHourOffset forName:SDLRPCParameterNameTimezoneHourOffset];
 }
 
 - (NSNumber<SDLInt> *)timezoneHourOffset {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameTimezoneHourOffset ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameTimezoneHourOffset ofClass:NSNumber.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLDeleteCommand.m
+++ b/SmartDeviceLink/SDLDeleteCommand.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLDeleteCommand
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameDeleteCommand]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithId:(UInt32)commandId {
     self = [self init];
@@ -30,12 +33,12 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setCmdID:(NSNumber<SDLInt> *)cmdID {
-    [parameters sdl_setObject:cmdID forName:SDLRPCParameterNameCommandId];
+    [self.parameters sdl_setObject:cmdID forName:SDLRPCParameterNameCommandId];
 }
 
 - (NSNumber<SDLInt> *)cmdID {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameCommandId ofClass:NSNumber.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameCommandId ofClass:NSNumber.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLDeleteCommandResponse.m
+++ b/SmartDeviceLink/SDLDeleteCommandResponse.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLDeleteCommandResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameDeleteCommand]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLDeleteFile.m
+++ b/SmartDeviceLink/SDLDeleteFile.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLDeleteFile
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameDeleteFile]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithFileName:(NSString *)fileName {
     self = [self init];
@@ -30,12 +33,12 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setSyncFileName:(NSString *)syncFileName {
-    [parameters sdl_setObject:syncFileName forName:SDLRPCParameterNameSyncFileName];
+    [self.parameters sdl_setObject:syncFileName forName:SDLRPCParameterNameSyncFileName];
 }
 
 - (NSString *)syncFileName {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameSyncFileName ofClass:NSString.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameSyncFileName ofClass:NSString.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLDeleteFileResponse.m
+++ b/SmartDeviceLink/SDLDeleteFileResponse.m
@@ -12,18 +12,21 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLDeleteFileResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameDeleteFile]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setSpaceAvailable:(nullable NSNumber<SDLInt> *)spaceAvailable {
-    [parameters sdl_setObject:spaceAvailable forName:SDLRPCParameterNameSpaceAvailable];
+    [self.parameters sdl_setObject:spaceAvailable forName:SDLRPCParameterNameSpaceAvailable];
 }
 
 - (nullable NSNumber<SDLInt> *)spaceAvailable {
-    return [parameters sdl_objectForName:SDLRPCParameterNameSpaceAvailable ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameSpaceAvailable ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLDeleteInteractionChoiceSet.m
+++ b/SmartDeviceLink/SDLDeleteInteractionChoiceSet.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLDeleteInteractionChoiceSet
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameDeleteInteractionChoiceSet]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithId:(UInt32)choiceId {
     self = [self init];
@@ -30,12 +33,12 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setInteractionChoiceSetID:(NSNumber<SDLInt> *)interactionChoiceSetID {
-    [parameters sdl_setObject:interactionChoiceSetID forName:SDLRPCParameterNameInteractionChoiceSetId];
+    [self.parameters sdl_setObject:interactionChoiceSetID forName:SDLRPCParameterNameInteractionChoiceSetId];
 }
 
 - (NSNumber<SDLInt> *)interactionChoiceSetID {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameInteractionChoiceSetId ofClass:NSNumber.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameInteractionChoiceSetId ofClass:NSNumber.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLDeleteInteractionChoiceSetResponse.m
+++ b/SmartDeviceLink/SDLDeleteInteractionChoiceSetResponse.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLDeleteInteractionChoiceSetResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameDeleteInteractionChoiceSet]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLDeleteSubMenu.m
+++ b/SmartDeviceLink/SDLDeleteSubMenu.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLDeleteSubMenu
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameDeleteSubMenu]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithId:(UInt32)menuId {
     self = [self init];
@@ -30,12 +33,12 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setMenuID:(NSNumber<SDLInt> *)menuID {
-    [parameters sdl_setObject:menuID forName:SDLRPCParameterNameMenuId];
+    [self.parameters sdl_setObject:menuID forName:SDLRPCParameterNameMenuId];
 }
 
 - (NSNumber<SDLInt> *)menuID {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameMenuId ofClass:NSNumber.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameMenuId ofClass:NSNumber.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLDeleteSubMenuResponse.m
+++ b/SmartDeviceLink/SDLDeleteSubMenuResponse.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLDeleteSubMenuResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameDeleteSubMenu]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLDeviceInfo.m
+++ b/SmartDeviceLink/SDLDeviceInfo.m
@@ -30,51 +30,51 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setHardware:(nullable NSString *)hardware {
-    [store sdl_setObject:hardware forName:SDLRPCParameterNameHardware];
+    [self.store sdl_setObject:hardware forName:SDLRPCParameterNameHardware];
 }
 
 - (nullable NSString *)hardware {
-    return [store sdl_objectForName:SDLRPCParameterNameHardware ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameHardware ofClass:NSString.class error:nil];
 }
 
 - (void)setFirmwareRev:(nullable NSString *)firmwareRev {
-    [store sdl_setObject:firmwareRev forName:SDLRPCParameterNameFirmwareRevision];
+    [self.store sdl_setObject:firmwareRev forName:SDLRPCParameterNameFirmwareRevision];
 }
 
 - (nullable NSString *)firmwareRev {
-    return [store sdl_objectForName:SDLRPCParameterNameFirmwareRevision ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameFirmwareRevision ofClass:NSString.class error:nil];
 }
 
 - (void)setOs:(nullable NSString *)os {
-    [store sdl_setObject:os forName:SDLRPCParameterNameOS];
+    [self.store sdl_setObject:os forName:SDLRPCParameterNameOS];
 }
 
 - (nullable NSString *)os {
-    return [store sdl_objectForName:SDLRPCParameterNameOS ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameOS ofClass:NSString.class error:nil];
 }
 
 - (void)setOsVersion:(nullable NSString *)osVersion {
-    [store sdl_setObject:osVersion forName:SDLRPCParameterNameOSVersion];
+    [self.store sdl_setObject:osVersion forName:SDLRPCParameterNameOSVersion];
 }
 
 - (nullable NSString *)osVersion {
-    return [store sdl_objectForName:SDLRPCParameterNameOSVersion ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameOSVersion ofClass:NSString.class error:nil];
 }
 
 - (void)setCarrier:(nullable NSString *)carrier {
-    [store sdl_setObject:carrier forName:SDLRPCParameterNameCarrier];
+    [self.store sdl_setObject:carrier forName:SDLRPCParameterNameCarrier];
 }
 
 - (nullable NSString *)carrier {
-    return [store sdl_objectForName:SDLRPCParameterNameCarrier ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameCarrier ofClass:NSString.class error:nil];
 }
 
 - (void)setMaxNumberRFCOMMPorts:(nullable NSNumber<SDLInt> *)maxNumberRFCOMMPorts {
-    [store sdl_setObject:maxNumberRFCOMMPorts forName:SDLRPCParameterNameMaxNumberRFCOMMPorts];
+    [self.store sdl_setObject:maxNumberRFCOMMPorts forName:SDLRPCParameterNameMaxNumberRFCOMMPorts];
 }
 
 - (nullable NSNumber<SDLInt> *)maxNumberRFCOMMPorts {
-    return [store sdl_objectForName:SDLRPCParameterNameMaxNumberRFCOMMPorts ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameMaxNumberRFCOMMPorts ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLDeviceStatus.m
+++ b/SmartDeviceLink/SDLDeviceStatus.m
@@ -13,102 +13,102 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation SDLDeviceStatus
 
 - (void)setVoiceRecOn:(NSNumber<SDLBool> *)voiceRecOn {
-    [store sdl_setObject:voiceRecOn forName:SDLRPCParameterNameVoiceRecognitionOn];
+    [self.store sdl_setObject:voiceRecOn forName:SDLRPCParameterNameVoiceRecognitionOn];
 }
 
 - (NSNumber<SDLBool> *)voiceRecOn {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameVoiceRecognitionOn ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameVoiceRecognitionOn ofClass:NSNumber.class error:&error];
 }
 
 - (void)setBtIconOn:(NSNumber<SDLBool> *)btIconOn {
-    [store sdl_setObject:btIconOn forName:SDLRPCParameterNameBluetoothIconOn];
+    [self.store sdl_setObject:btIconOn forName:SDLRPCParameterNameBluetoothIconOn];
 }
 
 - (NSNumber<SDLBool> *)btIconOn {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameBluetoothIconOn ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameBluetoothIconOn ofClass:NSNumber.class error:&error];
 }
 
 - (void)setCallActive:(NSNumber<SDLBool> *)callActive {
-    [store sdl_setObject:callActive forName:SDLRPCParameterNameCallActive];
+    [self.store sdl_setObject:callActive forName:SDLRPCParameterNameCallActive];
 }
 
 - (NSNumber<SDLBool> *)callActive {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameCallActive ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameCallActive ofClass:NSNumber.class error:&error];
 }
 
 - (void)setPhoneRoaming:(NSNumber<SDLBool> *)phoneRoaming {
-    [store sdl_setObject:phoneRoaming forName:SDLRPCParameterNamePhoneRoaming];
+    [self.store sdl_setObject:phoneRoaming forName:SDLRPCParameterNamePhoneRoaming];
 }
 
 - (NSNumber<SDLBool> *)phoneRoaming {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNamePhoneRoaming ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNamePhoneRoaming ofClass:NSNumber.class error:&error];
 }
 
 - (void)setTextMsgAvailable:(NSNumber<SDLBool> *)textMsgAvailable {
-    [store sdl_setObject:textMsgAvailable forName:SDLRPCParameterNameTextMessageAvailable];
+    [self.store sdl_setObject:textMsgAvailable forName:SDLRPCParameterNameTextMessageAvailable];
 }
 
 - (NSNumber<SDLBool> *)textMsgAvailable {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameTextMessageAvailable ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameTextMessageAvailable ofClass:NSNumber.class error:&error];
 }
 
 - (void)setBattLevelStatus:(SDLDeviceLevelStatus )battLevelStatus {
-    [store sdl_setObject:battLevelStatus forName:SDLRPCParameterNameBatteryLevelStatus];
+    [self.store sdl_setObject:battLevelStatus forName:SDLRPCParameterNameBatteryLevelStatus];
 }
 
 - (SDLDeviceLevelStatus)battLevelStatus {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameBatteryLevelStatus error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameBatteryLevelStatus error:&error];
 }
 
 - (void)setStereoAudioOutputMuted:(NSNumber<SDLBool> *)stereoAudioOutputMuted {
-    [store sdl_setObject:stereoAudioOutputMuted forName:SDLRPCParameterNameStereoAudioOutputMuted];
+    [self.store sdl_setObject:stereoAudioOutputMuted forName:SDLRPCParameterNameStereoAudioOutputMuted];
 }
 
 - (NSNumber<SDLBool> *)stereoAudioOutputMuted {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameStereoAudioOutputMuted ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameStereoAudioOutputMuted ofClass:NSNumber.class error:&error];
 }
 
 - (void)setMonoAudioOutputMuted:(NSNumber<SDLBool> *)monoAudioOutputMuted {
-    [store sdl_setObject:monoAudioOutputMuted forName:SDLRPCParameterNameMonoAudioOutputMuted];
+    [self.store sdl_setObject:monoAudioOutputMuted forName:SDLRPCParameterNameMonoAudioOutputMuted];
 }
 
 - (NSNumber<SDLBool> *)monoAudioOutputMuted {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameMonoAudioOutputMuted ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameMonoAudioOutputMuted ofClass:NSNumber.class error:&error];
 }
 
 - (void)setSignalLevelStatus:(SDLDeviceLevelStatus)signalLevelStatus {
-    [store sdl_setObject:signalLevelStatus forName:SDLRPCParameterNameSignalLevelStatus];
+    [self.store sdl_setObject:signalLevelStatus forName:SDLRPCParameterNameSignalLevelStatus];
 }
 
 - (SDLDeviceLevelStatus)signalLevelStatus {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameSignalLevelStatus error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameSignalLevelStatus error:&error];
 }
 
 - (void)setPrimaryAudioSource:(SDLPrimaryAudioSource)primaryAudioSource {
-    [store sdl_setObject:primaryAudioSource forName:SDLRPCParameterNamePrimaryAudioSource];
+    [self.store sdl_setObject:primaryAudioSource forName:SDLRPCParameterNamePrimaryAudioSource];
 }
 
 - (SDLPrimaryAudioSource)primaryAudioSource {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNamePrimaryAudioSource error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNamePrimaryAudioSource error:&error];
 }
 
 - (void)setECallEventActive:(NSNumber<SDLBool> *)eCallEventActive {
-    [store sdl_setObject:eCallEventActive forName:SDLRPCParameterNameECallEventActive];
+    [self.store sdl_setObject:eCallEventActive forName:SDLRPCParameterNameECallEventActive];
 }
 
 - (NSNumber<SDLBool> *)eCallEventActive {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameECallEventActive ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameECallEventActive ofClass:NSNumber.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLDiagnosticMessage.m
+++ b/SmartDeviceLink/SDLDiagnosticMessage.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLDiagnosticMessage
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameDiagnosticMessage]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithTargetId:(UInt16)targetId length:(UInt16)length data:(NSArray<NSData *> *)data {
     self = [self init];
@@ -32,30 +35,30 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setTargetID:(NSNumber<SDLInt> *)targetID {
-    [parameters sdl_setObject:targetID forName:SDLRPCParameterNameTargetId];
+    [self.parameters sdl_setObject:targetID forName:SDLRPCParameterNameTargetId];
 }
 
 - (NSNumber<SDLInt> *)targetID {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameTargetId ofClass:NSNumber.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameTargetId ofClass:NSNumber.class error:&error];
 }
 
 - (void)setMessageLength:(NSNumber<SDLInt> *)messageLength {
-    [parameters sdl_setObject:messageLength forName:SDLRPCParameterNameMessageLength];
+    [self.parameters sdl_setObject:messageLength forName:SDLRPCParameterNameMessageLength];
 }
 
 - (NSNumber<SDLInt> *)messageLength {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameMessageLength ofClass:NSNumber.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameMessageLength ofClass:NSNumber.class error:&error];
 }
 
 - (void)setMessageData:(NSArray<NSNumber<SDLInt> *> *)messageData {
-    [parameters sdl_setObject:messageData forName:SDLRPCParameterNameMessageData];
+    [self.parameters sdl_setObject:messageData forName:SDLRPCParameterNameMessageData];
 }
 
 - (NSArray<NSNumber<SDLInt> *> *)messageData {
     NSError *error = nil;
-    return [parameters sdl_objectsForName:SDLRPCParameterNameMessageData ofClass:NSNumber.class error:&error];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameMessageData ofClass:NSNumber.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLDiagnosticMessageResponse.m
+++ b/SmartDeviceLink/SDLDiagnosticMessageResponse.m
@@ -11,19 +11,22 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLDiagnosticMessageResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameDiagnosticMessage]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setMessageDataResult:(NSArray<NSNumber<SDLInt> *> *)messageDataResult {
-    [parameters sdl_setObject:messageDataResult forName:SDLRPCParameterNameMessageDataResult];
+    [self.parameters sdl_setObject:messageDataResult forName:SDLRPCParameterNameMessageDataResult];
 }
 
 - (NSArray<NSNumber<SDLInt> *> *)messageDataResult {
     NSError *error = nil;
-    return [parameters sdl_objectsForName:SDLRPCParameterNameMessageDataResult ofClass:NSNumber.class error:&error];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameMessageDataResult ofClass:NSNumber.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLDialNumber.m
+++ b/SmartDeviceLink/SDLDialNumber.m
@@ -10,11 +10,14 @@
 
 @implementation SDLDialNumber
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameDialNumber]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithNumber:(NSString *)number {
     self = [self init];
@@ -28,12 +31,12 @@
 }
 
 - (void)setNumber:(NSString *)number {
-    [parameters sdl_setObject:number forName:SDLRPCParameterNameNumber];
+    [self.parameters sdl_setObject:number forName:SDLRPCParameterNameNumber];
 }
 
 - (NSString *)number {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameNumber ofClass:NSString.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameNumber ofClass:NSString.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLDialNumberResponse.m
+++ b/SmartDeviceLink/SDLDialNumberResponse.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLDialNumberResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameDialNumber]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLDisplayCapabilities.m
+++ b/SmartDeviceLink/SDLDisplayCapabilities.m
@@ -14,79 +14,79 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation SDLDisplayCapabilities
 
 - (void)setDisplayType:(SDLDisplayType)displayType {
-    [store sdl_setObject:displayType forName:SDLRPCParameterNameDisplayType];
+    [self.store sdl_setObject:displayType forName:SDLRPCParameterNameDisplayType];
 }
 
 - (SDLDisplayType)displayType {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameDisplayType error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameDisplayType error:&error];
 }
 
 - (void)setDisplayName:(nullable NSString *)displayName {
-    [store sdl_setObject:displayName forName:SDLRPCParameterNameDisplayName];
+    [self.store sdl_setObject:displayName forName:SDLRPCParameterNameDisplayName];
 }
 
 - (nullable NSString *)displayName {
-    return [store sdl_objectForName:SDLRPCParameterNameDisplayName ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameDisplayName ofClass:NSString.class error:nil];
 }
 
 - (void)setTextFields:(NSArray<SDLTextField *> *)textFields {
-    [store sdl_setObject:textFields forName:SDLRPCParameterNameTextFields];
+    [self.store sdl_setObject:textFields forName:SDLRPCParameterNameTextFields];
 }
 
 - (NSArray<SDLTextField *> *)textFields {
     NSError *error = nil;
-    return [store sdl_objectsForName:SDLRPCParameterNameTextFields ofClass:SDLTextField.class error:&error];
+    return [self.store sdl_objectsForName:SDLRPCParameterNameTextFields ofClass:SDLTextField.class error:&error];
 }
 
 - (void)setImageFields:(nullable NSArray<SDLImageField *> *)imageFields {
-    [store sdl_setObject:imageFields forName:SDLRPCParameterNameImageFields];
+    [self.store sdl_setObject:imageFields forName:SDLRPCParameterNameImageFields];
 }
 
 - (nullable NSArray<SDLImageField *> *)imageFields {
-    return [store sdl_objectsForName:SDLRPCParameterNameImageFields ofClass:SDLImageField.class error:nil];
+    return [self.store sdl_objectsForName:SDLRPCParameterNameImageFields ofClass:SDLImageField.class error:nil];
 }
 
 - (void)setMediaClockFormats:(NSArray<SDLMediaClockFormat> *)mediaClockFormats {
-    [store sdl_setObject:mediaClockFormats forName:SDLRPCParameterNameMediaClockFormats];
+    [self.store sdl_setObject:mediaClockFormats forName:SDLRPCParameterNameMediaClockFormats];
 }
 
 - (NSArray<SDLMediaClockFormat> *)mediaClockFormats {
     NSError *error = nil;
-    return [store sdl_enumsForName:SDLRPCParameterNameMediaClockFormats error:&error];
+    return [self.store sdl_enumsForName:SDLRPCParameterNameMediaClockFormats error:&error];
 }
 
 - (void)setGraphicSupported:(NSNumber<SDLBool> *)graphicSupported {
-    [store sdl_setObject:graphicSupported forName:SDLRPCParameterNameGraphicSupported];
+    [self.store sdl_setObject:graphicSupported forName:SDLRPCParameterNameGraphicSupported];
 }
 
 - (NSNumber<SDLBool> *)graphicSupported {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameGraphicSupported ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameGraphicSupported ofClass:NSNumber.class error:&error];
 }
 
 - (void)setTemplatesAvailable:(nullable NSArray<NSString *> *)templatesAvailable {
-    [store sdl_setObject:templatesAvailable forName:SDLRPCParameterNameTemplatesAvailable];
+    [self.store sdl_setObject:templatesAvailable forName:SDLRPCParameterNameTemplatesAvailable];
 }
 
 - (nullable NSArray<NSString *> *)templatesAvailable {
-    return [store sdl_objectsForName:SDLRPCParameterNameTemplatesAvailable ofClass:NSString.class error:nil];
+    return [self.store sdl_objectsForName:SDLRPCParameterNameTemplatesAvailable ofClass:NSString.class error:nil];
 }
 
 - (void)setScreenParams:(nullable SDLScreenParams *)screenParams {
-    [store sdl_setObject:screenParams forName:SDLRPCParameterNameScreenParams];
+    [self.store sdl_setObject:screenParams forName:SDLRPCParameterNameScreenParams];
 }
 
 - (nullable SDLScreenParams *)screenParams {
-    return [store sdl_objectForName:SDLRPCParameterNameScreenParams ofClass:SDLScreenParams.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameScreenParams ofClass:SDLScreenParams.class error:nil];
 }
 
 - (void)setNumCustomPresetsAvailable:(nullable NSNumber<SDLInt> *)numCustomPresetsAvailable {
-    [store sdl_setObject:numCustomPresetsAvailable forName:SDLRPCParameterNameNumberCustomPresetsAvailable];
+    [self.store sdl_setObject:numCustomPresetsAvailable forName:SDLRPCParameterNameNumberCustomPresetsAvailable];
 }
 
 - (nullable NSNumber<SDLInt> *)numCustomPresetsAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameNumberCustomPresetsAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameNumberCustomPresetsAvailable ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLECallInfo.m
+++ b/SmartDeviceLink/SDLECallInfo.m
@@ -11,30 +11,30 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation SDLECallInfo
 
 - (void)setECallNotificationStatus:(SDLVehicleDataNotificationStatus)eCallNotificationStatus {
-    [store sdl_setObject:eCallNotificationStatus forName:SDLRPCParameterNameECallNotificationStatus];
+    [self.store sdl_setObject:eCallNotificationStatus forName:SDLRPCParameterNameECallNotificationStatus];
 }
 
 - (SDLVehicleDataNotificationStatus)eCallNotificationStatus {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameECallNotificationStatus error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameECallNotificationStatus error:&error];
 }
 
 - (void)setAuxECallNotificationStatus:(SDLVehicleDataNotificationStatus)auxECallNotificationStatus {
-    [store sdl_setObject:auxECallNotificationStatus forName:SDLRPCParameterNameAuxECallNotificationStatus];
+    [self.store sdl_setObject:auxECallNotificationStatus forName:SDLRPCParameterNameAuxECallNotificationStatus];
 }
 
 - (SDLVehicleDataNotificationStatus)auxECallNotificationStatus {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameAuxECallNotificationStatus error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameAuxECallNotificationStatus error:&error];
 }
 
 - (void)setECallConfirmationStatus:(SDLECallConfirmationStatus)eCallConfirmationStatus {
-    [store sdl_setObject:eCallConfirmationStatus forName:SDLRPCParameterNameECallConfirmationStatus];
+    [self.store sdl_setObject:eCallConfirmationStatus forName:SDLRPCParameterNameECallConfirmationStatus];
 }
 
 - (SDLECallConfirmationStatus)eCallConfirmationStatus {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameECallConfirmationStatus error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameECallConfirmationStatus error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLEmergencyEvent.m
+++ b/SmartDeviceLink/SDLEmergencyEvent.m
@@ -11,48 +11,48 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation SDLEmergencyEvent
 
 - (void)setEmergencyEventType:(SDLEmergencyEventType)emergencyEventType {
-    [store sdl_setObject:emergencyEventType forName:SDLRPCParameterNameEmergencyEventType];
+    [self.store sdl_setObject:emergencyEventType forName:SDLRPCParameterNameEmergencyEventType];
 }
 
 - (SDLEmergencyEventType)emergencyEventType {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameEmergencyEventType error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameEmergencyEventType error:&error];
 }
 
 - (void)setFuelCutoffStatus:(SDLFuelCutoffStatus)fuelCutoffStatus {
-    [store sdl_setObject:fuelCutoffStatus forName:SDLRPCParameterNameFuelCutoffStatus];
+    [self.store sdl_setObject:fuelCutoffStatus forName:SDLRPCParameterNameFuelCutoffStatus];
 }
 
 - (SDLFuelCutoffStatus)fuelCutoffStatus {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameFuelCutoffStatus error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameFuelCutoffStatus error:&error];
 }
 
 - (void)setRolloverEvent:(SDLVehicleDataEventStatus)rolloverEvent {
-    [store sdl_setObject:rolloverEvent forName:SDLRPCParameterNameRolloverEvent];
+    [self.store sdl_setObject:rolloverEvent forName:SDLRPCParameterNameRolloverEvent];
 }
 
 - (SDLVehicleDataEventStatus)rolloverEvent {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameRolloverEvent error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameRolloverEvent error:&error];
 }
 
 - (void)setMaximumChangeVelocity:(NSNumber<SDLInt> *)maximumChangeVelocity {
-    [store sdl_setObject:maximumChangeVelocity forName:SDLRPCParameterNameMaximumChangeVelocity];
+    [self.store sdl_setObject:maximumChangeVelocity forName:SDLRPCParameterNameMaximumChangeVelocity];
 }
 
 - (NSNumber<SDLInt> *)maximumChangeVelocity {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameMaximumChangeVelocity ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameMaximumChangeVelocity ofClass:NSNumber.class error:&error];
 }
 
 - (void)setMultipleEvents:(SDLVehicleDataEventStatus)multipleEvents {
-    [store sdl_setObject:multipleEvents forName:SDLRPCParameterNameMultipleEvents];
+    [self.store sdl_setObject:multipleEvents forName:SDLRPCParameterNameMultipleEvents];
 }
 
 - (SDLVehicleDataEventStatus)multipleEvents {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameMultipleEvents error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameMultipleEvents error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLEncodedSyncPData.m
+++ b/SmartDeviceLink/SDLEncodedSyncPData.m
@@ -12,19 +12,22 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLEncodedSyncPData
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameEncodedSyncPData]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setData:(NSArray<NSString *> *)data {
-    [parameters sdl_setObject:data forName:SDLRPCParameterNameData];
+    [self.parameters sdl_setObject:data forName:SDLRPCParameterNameData];
 }
 
 - (NSArray<NSString *> *)data {
     NSError *error = nil;
-    return [parameters sdl_objectsForName:SDLRPCParameterNameData ofClass:NSString.class error:&error];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameData ofClass:NSString.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLEncodedSyncPDataResponse.m
+++ b/SmartDeviceLink/SDLEncodedSyncPDataResponse.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLEncodedSyncPDataResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameEncodedSyncPData]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLEndAudioPassThru.m
+++ b/SmartDeviceLink/SDLEndAudioPassThru.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLEndAudioPassThru
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameEndAudioPassThru]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLEndAudioPassThruResponse.m
+++ b/SmartDeviceLink/SDLEndAudioPassThruResponse.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLEndAudioPassThruResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameEndAudioPassThru]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLEqualizerSettings.m
+++ b/SmartDeviceLink/SDLEqualizerSettings.m
@@ -22,29 +22,29 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setChannelId:(NSNumber<SDLInt> *)channelId {
-    [store sdl_setObject:channelId forName:SDLRPCParameterNameChannelId];
+    [self.store sdl_setObject:channelId forName:SDLRPCParameterNameChannelId];
 }
 
 - (NSNumber<SDLInt> *)channelId {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameChannelId ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameChannelId ofClass:NSNumber.class error:&error];
 }
 
 - (void)setChannelName:(nullable NSString *)channelName {
-    [store sdl_setObject:channelName forName:SDLRPCParameterNameChannelName];
+    [self.store sdl_setObject:channelName forName:SDLRPCParameterNameChannelName];
 }
 
 - (nullable NSString *)channelName {
-    return [store sdl_objectForName:SDLRPCParameterNameChannelName ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameChannelName ofClass:NSString.class error:nil];
 }
 
 - (void)setChannelSetting:(NSNumber<SDLInt> *)channelSetting {
-    [store sdl_setObject:channelSetting forName:SDLRPCParameterNameChannelSetting];
+    [self.store sdl_setObject:channelSetting forName:SDLRPCParameterNameChannelSetting];
 }
 
 - (NSNumber<SDLInt> *)channelSetting {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameChannelSetting ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameChannelSetting ofClass:NSNumber.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLFuelRange.m
+++ b/SmartDeviceLink/SDLFuelRange.m
@@ -16,19 +16,19 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation SDLFuelRange
 
 - (void)setType:(nullable SDLFuelType)type {
-    [store sdl_setObject:type forName:SDLRPCParameterNameType];
+    [self.store sdl_setObject:type forName:SDLRPCParameterNameType];
 }
 
 - (nullable SDLFuelType)type {
-    return [store sdl_enumForName:SDLRPCParameterNameType error:nil];
+    return [self.store sdl_enumForName:SDLRPCParameterNameType error:nil];
 }
 
 - (void)setRange:(nullable NSNumber<SDLFloat> *)range {
-    [store sdl_setObject:range forName:SDLRPCParameterNameRange];
+    [self.store sdl_setObject:range forName:SDLRPCParameterNameRange];
 }
 
 - (nullable NSNumber<SDLFloat> *)range {
-    return [store sdl_objectForName:SDLRPCParameterNameRange ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameRange ofClass:NSNumber.class error:nil];
 }
 
 

--- a/SmartDeviceLink/SDLGPSData.m
+++ b/SmartDeviceLink/SDLGPSData.m
@@ -11,149 +11,149 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation SDLGPSData
 
 - (void)setLongitudeDegrees:(NSNumber<SDLFloat> *)longitudeDegrees {
-    [store sdl_setObject:longitudeDegrees forName:SDLRPCParameterNameLongitudeDegrees];
+    [self.store sdl_setObject:longitudeDegrees forName:SDLRPCParameterNameLongitudeDegrees];
 }
 
 - (NSNumber<SDLFloat> *)longitudeDegrees {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameLongitudeDegrees ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameLongitudeDegrees ofClass:NSNumber.class error:&error];
 }
 
 - (void)setLatitudeDegrees:(NSNumber<SDLFloat> *)latitudeDegrees {
-    [store sdl_setObject:latitudeDegrees forName:SDLRPCParameterNameLatitudeDegrees];
+    [self.store sdl_setObject:latitudeDegrees forName:SDLRPCParameterNameLatitudeDegrees];
 }
 
 - (NSNumber<SDLFloat> *)latitudeDegrees {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameLatitudeDegrees ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameLatitudeDegrees ofClass:NSNumber.class error:&error];
 }
 
 - (void)setUtcYear:(nullable NSNumber<SDLInt> *)utcYear {
-    [store sdl_setObject:utcYear forName:SDLRPCParameterNameUTCYear];
+    [self.store sdl_setObject:utcYear forName:SDLRPCParameterNameUTCYear];
 }
 
 - (nullable NSNumber<SDLInt> *)utcYear {
-    return [store sdl_objectForName:SDLRPCParameterNameUTCYear ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameUTCYear ofClass:NSNumber.class error:nil];
 }
 
 - (void)setUtcMonth:(nullable NSNumber<SDLInt> *)utcMonth {
-    [store sdl_setObject:utcMonth forName:SDLRPCParameterNameUTCMonth];
+    [self.store sdl_setObject:utcMonth forName:SDLRPCParameterNameUTCMonth];
 }
 
 - (nullable NSNumber<SDLInt> *)utcMonth {
-    return [store sdl_objectForName:SDLRPCParameterNameUTCMonth ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameUTCMonth ofClass:NSNumber.class error:nil];
 }
 
 - (void)setUtcDay:(nullable NSNumber<SDLInt> *)utcDay {
-    [store sdl_setObject:utcDay forName:SDLRPCParameterNameUTCDay];
+    [self.store sdl_setObject:utcDay forName:SDLRPCParameterNameUTCDay];
 }
 
 - (nullable NSNumber<SDLInt> *)utcDay {
-    return [store sdl_objectForName:SDLRPCParameterNameUTCDay ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameUTCDay ofClass:NSNumber.class error:nil];
 }
 
 - (void)setUtcHours:(nullable NSNumber<SDLInt> *)utcHours {
-    [store sdl_setObject:utcHours forName:SDLRPCParameterNameUTCHours];
+    [self.store sdl_setObject:utcHours forName:SDLRPCParameterNameUTCHours];
 }
 
 - (nullable NSNumber<SDLInt> *)utcHours {
-    return [store sdl_objectForName:SDLRPCParameterNameUTCHours ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameUTCHours ofClass:NSNumber.class error:nil];
 }
 
 - (void)setUtcMinutes:(nullable NSNumber<SDLInt> *)utcMinutes {
-    [store sdl_setObject:utcMinutes forName:SDLRPCParameterNameUTCMinutes];
+    [self.store sdl_setObject:utcMinutes forName:SDLRPCParameterNameUTCMinutes];
 }
 
 - (nullable NSNumber<SDLInt> *)utcMinutes {
-    return [store sdl_objectForName:SDLRPCParameterNameUTCMinutes ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameUTCMinutes ofClass:NSNumber.class error:nil];
 }
 
 - (void)setUtcSeconds:(nullable NSNumber<SDLInt> *)utcSeconds {
-    [store sdl_setObject:utcSeconds forName:SDLRPCParameterNameUTCSeconds];
+    [self.store sdl_setObject:utcSeconds forName:SDLRPCParameterNameUTCSeconds];
 }
 
 - (nullable NSNumber<SDLInt> *)utcSeconds {
-    return [store sdl_objectForName:SDLRPCParameterNameUTCSeconds ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameUTCSeconds ofClass:NSNumber.class error:nil];
 }
 
 - (void)setCompassDirection:(nullable SDLCompassDirection)compassDirection {
-    [store sdl_setObject:compassDirection forName:SDLRPCParameterNameCompassDirection];
+    [self.store sdl_setObject:compassDirection forName:SDLRPCParameterNameCompassDirection];
 }
 
 - (nullable SDLCompassDirection)compassDirection {
-    return [store sdl_enumForName:SDLRPCParameterNameCompassDirection error:nil];
+    return [self.store sdl_enumForName:SDLRPCParameterNameCompassDirection error:nil];
 }
 
 - (void)setPdop:(nullable NSNumber<SDLFloat> *)pdop {
-    [store sdl_setObject:pdop forName:SDLRPCParameterNamePDOP];
+    [self.store sdl_setObject:pdop forName:SDLRPCParameterNamePDOP];
 }
 
 - (nullable NSNumber<SDLFloat> *)pdop {
-    return [store sdl_objectForName:SDLRPCParameterNamePDOP ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNamePDOP ofClass:NSNumber.class error:nil];
 }
 
 - (void)setHdop:(nullable NSNumber<SDLFloat> *)hdop {
-    [store sdl_setObject:hdop forName:SDLRPCParameterNameHDOP];
+    [self.store sdl_setObject:hdop forName:SDLRPCParameterNameHDOP];
 }
 
 - (nullable NSNumber<SDLFloat> *)hdop {
-    return [store sdl_objectForName:SDLRPCParameterNameHDOP ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameHDOP ofClass:NSNumber.class error:nil];
 }
 
 - (void)setVdop:(nullable NSNumber<SDLFloat> *)vdop {
-    [store sdl_setObject:vdop forName:SDLRPCParameterNameVDOP];
+    [self.store sdl_setObject:vdop forName:SDLRPCParameterNameVDOP];
 }
 
 - (nullable NSNumber<SDLFloat> *)vdop {
-    return [store sdl_objectForName:SDLRPCParameterNameVDOP ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameVDOP ofClass:NSNumber.class error:nil];
 }
 
 - (void)setActual:(nullable NSNumber<SDLBool> *)actual {
-    [store sdl_setObject:actual forName:SDLRPCParameterNameActual];
+    [self.store sdl_setObject:actual forName:SDLRPCParameterNameActual];
 }
 
 - (nullable NSNumber<SDLBool> *)actual {
-    return [store sdl_objectForName:SDLRPCParameterNameActual ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameActual ofClass:NSNumber.class error:nil];
 }
 
 - (void)setSatellites:(nullable NSNumber<SDLInt> *)satellites {
-    [store sdl_setObject:satellites forName:SDLRPCParameterNameSatellites];
+    [self.store sdl_setObject:satellites forName:SDLRPCParameterNameSatellites];
 }
 
 - (nullable NSNumber<SDLInt> *)satellites {
-    return [store sdl_objectForName:SDLRPCParameterNameSatellites ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameSatellites ofClass:NSNumber.class error:nil];
 }
 
 - (void)setDimension:(nullable SDLDimension)dimension {
-    [store sdl_setObject:dimension forName:SDLRPCParameterNameDimension];
+    [self.store sdl_setObject:dimension forName:SDLRPCParameterNameDimension];
 }
 
 - (nullable SDLDimension)dimension {
-    return [store sdl_enumForName:SDLRPCParameterNameDimension error:nil];
+    return [self.store sdl_enumForName:SDLRPCParameterNameDimension error:nil];
 }
 
 - (void)setAltitude:(nullable NSNumber<SDLFloat> *)altitude {
-    [store sdl_setObject:altitude forName:SDLRPCParameterNameAltitude];
+    [self.store sdl_setObject:altitude forName:SDLRPCParameterNameAltitude];
 }
 
 - (nullable NSNumber<SDLFloat> *)altitude {
-    return [store sdl_objectForName:SDLRPCParameterNameAltitude ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameAltitude ofClass:NSNumber.class error:nil];
 }
 
 - (void)setHeading:(nullable NSNumber<SDLFloat> *)heading {
-    [store sdl_setObject:heading forName:SDLRPCParameterNameHeading];
+    [self.store sdl_setObject:heading forName:SDLRPCParameterNameHeading];
 }
 
 - (nullable NSNumber<SDLFloat> *)heading {
-    return [store sdl_objectForName:SDLRPCParameterNameHeading ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameHeading ofClass:NSNumber.class error:nil];
 }
 
 - (void)setSpeed:(nullable NSNumber<SDLFloat> *)speed {
-    [store sdl_setObject:speed forName:SDLRPCParameterNameSpeed];
+    [self.store sdl_setObject:speed forName:SDLRPCParameterNameSpeed];
 }
 
 - (nullable NSNumber<SDLFloat> *)speed {
-    return [store sdl_objectForName:SDLRPCParameterNameSpeed ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameSpeed ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLGenericResponse.m
+++ b/SmartDeviceLink/SDLGenericResponse.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLGenericResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameGenericResponse]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLGetAppServiceData.m
+++ b/SmartDeviceLink/SDLGetAppServiceData.m
@@ -16,11 +16,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLGetAppServiceData
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameGetAppServiceData]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithAppServiceType:(SDLAppServiceType)serviceType {
     self = [self init];
@@ -53,20 +56,20 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setServiceType:(NSString *)serviceType {
-    [parameters sdl_setObject:serviceType forName:SDLRPCParameterNameServiceType];
+    [self.parameters sdl_setObject:serviceType forName:SDLRPCParameterNameServiceType];
 }
 
 - (NSString *)serviceType {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameServiceType ofClass:NSString.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameServiceType ofClass:NSString.class error:&error];
 }
 
 - (void)setSubscribe:(nullable NSNumber<SDLBool> *)subscribe {
-    [parameters sdl_setObject:subscribe forName:SDLRPCParameterNameSubscribe];
+    [self.parameters sdl_setObject:subscribe forName:SDLRPCParameterNameSubscribe];
 }
 
 - (nullable NSNumber<SDLBool> *)subscribe {
-    return [parameters sdl_objectForName:SDLRPCParameterNameSubscribe ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameSubscribe ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLGetAppServiceDataResponse.m
+++ b/SmartDeviceLink/SDLGetAppServiceDataResponse.m
@@ -17,11 +17,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLGetAppServiceDataResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameGetAppServiceData]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithAppServiceData:(SDLAppServiceData *)serviceData {
     self = [self init];
@@ -35,11 +38,11 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setServiceData:(nullable SDLAppServiceData *)serviceData {
-    [parameters sdl_setObject:serviceData forName:SDLRPCParameterNameServiceData];
+    [self.parameters sdl_setObject:serviceData forName:SDLRPCParameterNameServiceData];
 }
 
 - (nullable SDLAppServiceData *)serviceData {
-    return [parameters sdl_objectForName:SDLRPCParameterNameServiceData ofClass:SDLAppServiceData.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameServiceData ofClass:SDLAppServiceData.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLGetCloudAppProperties.m
+++ b/SmartDeviceLink/SDLGetCloudAppProperties.m
@@ -16,11 +16,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLGetCloudAppProperties
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameGetCloudAppProperties]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithAppID:(NSString *)appID {
     self = [self init];
@@ -34,12 +37,12 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setAppID:(NSString *)appID {
-    [parameters sdl_setObject:appID forName:SDLRPCParameterNameAppId];
+    [self.parameters sdl_setObject:appID forName:SDLRPCParameterNameAppId];
 }
 
 - (NSString *)appID {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameAppId ofClass:NSString.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameAppId ofClass:NSString.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLGetCloudAppPropertiesResponse.m
+++ b/SmartDeviceLink/SDLGetCloudAppPropertiesResponse.m
@@ -18,11 +18,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLGetCloudAppPropertiesResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameGetCloudAppProperties]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithProperties:(SDLCloudAppProperties *)properties {
     self = [self init];
@@ -36,11 +39,11 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setProperties:(nullable SDLCloudAppProperties *)properties {
-    [parameters sdl_setObject:properties forName:SDLRPCParameterNameProperties];
+    [self.parameters sdl_setObject:properties forName:SDLRPCParameterNameProperties];
 }
 
 - (nullable SDLCloudAppProperties *)properties {
-    return [parameters sdl_objectForName:SDLRPCParameterNameProperties ofClass:SDLCloudAppProperties.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameProperties ofClass:SDLCloudAppProperties.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLGetDTCs.m
+++ b/SmartDeviceLink/SDLGetDTCs.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLGetDTCs
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameGetDTCs]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithECUName:(UInt16)name mask:(UInt8)mask {
     self = [self initWithECUName:name];
@@ -41,20 +44,20 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setEcuName:(NSNumber<SDLInt> *)ecuName {
-    [parameters sdl_setObject:ecuName forName:SDLRPCParameterNameECUName];
+    [self.parameters sdl_setObject:ecuName forName:SDLRPCParameterNameECUName];
 }
 
 - (NSNumber<SDLInt> *)ecuName {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameECUName ofClass:NSNumber.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameECUName ofClass:NSNumber.class error:&error];
 }
 
 - (void)setDtcMask:(nullable NSNumber<SDLInt> *)dtcMask {
-    [parameters sdl_setObject:dtcMask forName:SDLRPCParameterNameDTCMask];
+    [self.parameters sdl_setObject:dtcMask forName:SDLRPCParameterNameDTCMask];
 }
 
 - (nullable NSNumber<SDLInt> *)dtcMask {
-    return [parameters sdl_objectForName:SDLRPCParameterNameDTCMask ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameDTCMask ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLGetDTCsResponse.m
+++ b/SmartDeviceLink/SDLGetDTCsResponse.m
@@ -12,28 +12,31 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLGetDTCsResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameGetDTCs]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setEcuHeader:(NSNumber<SDLInt> *)ecuHeader {
-    [parameters sdl_setObject:ecuHeader forName:SDLRPCParameterNameECUHeader];
+    [self.parameters sdl_setObject:ecuHeader forName:SDLRPCParameterNameECUHeader];
 }
 
 - (NSNumber<SDLInt> *)ecuHeader {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameECUHeader ofClass:NSNumber.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameECUHeader ofClass:NSNumber.class error:&error];
 }
 
 - (void)setDtc:(NSArray<NSString *> *)dtc {
-    [parameters sdl_setObject:dtc forName:SDLRPCParameterNameDTC];
+    [self.parameters sdl_setObject:dtc forName:SDLRPCParameterNameDTC];
 }
 
 - (NSArray<NSString *> *)dtc {
     NSError *error = nil;
-    return [parameters sdl_objectsForName:SDLRPCParameterNameDTC ofClass:NSString.class error:&error];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameDTC ofClass:NSString.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLGetFile.m
+++ b/SmartDeviceLink/SDLGetFile.m
@@ -17,11 +17,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLGetFile
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameGetFile]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithFileName:(NSString *)fileName {
     self = [self init];
@@ -59,44 +62,44 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setFileName:(NSString *)fileName {
-    [parameters sdl_setObject:fileName forName:SDLRPCParameterNameFilename];
+    [self.parameters sdl_setObject:fileName forName:SDLRPCParameterNameFilename];
 }
 
 - (NSString *)fileName {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameFilename ofClass:NSString.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameFilename ofClass:NSString.class error:&error];
 }
 
 - (void)setAppServiceId:(nullable NSString *)appServiceId {
-    [parameters sdl_setObject:appServiceId forName:SDLRPCParameterNameAppServiceId];
+    [self.parameters sdl_setObject:appServiceId forName:SDLRPCParameterNameAppServiceId];
 }
 
 - (nullable NSString *)appServiceId {
-    return [parameters sdl_objectForName:SDLRPCParameterNameAppServiceId ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameAppServiceId ofClass:NSString.class error:nil];
 }
 
 - (void)setFileType:(nullable SDLFileType)fileType {
-    [parameters sdl_setObject:fileType forName:SDLRPCParameterNameFileType];
+    [self.parameters sdl_setObject:fileType forName:SDLRPCParameterNameFileType];
 }
 
 - (nullable SDLFileType)fileType {
-    return [parameters sdl_enumForName:SDLRPCParameterNameFileType error:nil];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameFileType error:nil];
 }
 
 - (void)setOffset:(nullable NSNumber<SDLUInt> *)offset {
-    [parameters sdl_setObject:offset forName:SDLRPCParameterNameOffset];
+    [self.parameters sdl_setObject:offset forName:SDLRPCParameterNameOffset];
 }
 
 - (nullable NSNumber<SDLUInt> *)offset {
-    return [parameters sdl_objectForName:SDLRPCParameterNameOffset ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameOffset ofClass:NSNumber.class error:nil];
 }
 
 - (void)setLength:(nullable NSNumber<SDLUInt> *)length {
-    [parameters sdl_setObject:length forName:SDLRPCParameterNameLength];
+    [self.parameters sdl_setObject:length forName:SDLRPCParameterNameLength];
 }
 
 - (nullable NSNumber<SDLUInt> *)length {
-    return [parameters sdl_objectForName:SDLRPCParameterNameLength ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameLength ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLGetFileResponse.m
+++ b/SmartDeviceLink/SDLGetFileResponse.m
@@ -16,11 +16,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLGetFileResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameGetFile]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithOffset:(UInt32)offset length:(UInt32)length fileType:(nullable SDLFileType)fileType crc:(UInt32)crc {
     self = [self init];
@@ -37,35 +40,35 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setOffset:(nullable NSNumber<SDLUInt> *)offset {
-    [parameters sdl_setObject:offset forName:SDLRPCParameterNameOffset];
+    [self.parameters sdl_setObject:offset forName:SDLRPCParameterNameOffset];
 }
 
 - (nullable NSNumber<SDLUInt> *)offset {
-    return [parameters sdl_objectForName:SDLRPCParameterNameOffset ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameOffset ofClass:NSNumber.class error:nil];
 }
 
 - (void)setLength:(nullable NSNumber<SDLUInt> *)length {
-    [parameters sdl_setObject:length forName:SDLRPCParameterNameLength];
+    [self.parameters sdl_setObject:length forName:SDLRPCParameterNameLength];
 }
 
 - (nullable NSNumber<SDLUInt> *)length {
-    return [parameters sdl_objectForName:SDLRPCParameterNameLength ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameLength ofClass:NSNumber.class error:nil];
 }
 
 - (void)setFileType:(nullable SDLFileType)fileType {
-    [parameters sdl_setObject:fileType forName:SDLRPCParameterNameFileType];
+    [self.parameters sdl_setObject:fileType forName:SDLRPCParameterNameFileType];
 }
 
 - (nullable SDLFileType)fileType {
-    return [parameters sdl_enumForName:SDLRPCParameterNameFileType error:nil];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameFileType error:nil];
 }
 
 - (void)setCrc:(nullable NSNumber<SDLUInt> *)crc {
-    [parameters sdl_setObject:crc forName:SDLRPCParameterNameCRC];
+    [self.parameters sdl_setObject:crc forName:SDLRPCParameterNameCRC];
 }
 
 - (nullable NSNumber<SDLUInt> *)crc {
-    return [parameters sdl_objectForName:SDLRPCParameterNameCRC ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameCRC ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLGetInteriorVehicleData.m
+++ b/SmartDeviceLink/SDLGetInteriorVehicleData.m
@@ -11,11 +11,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLGetInteriorVehicleData
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameGetInteriorVehicleData]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithModuleType:(SDLModuleType)moduleType; {
     self = [self init];
@@ -53,20 +56,20 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setModuleType:(SDLModuleType)moduleType {
-    [parameters sdl_setObject:moduleType forName:SDLRPCParameterNameModuleType];
+    [self.parameters sdl_setObject:moduleType forName:SDLRPCParameterNameModuleType];
 }
 
 - (SDLModuleType)moduleType {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameModuleType error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameModuleType error:&error];
 }
 
 - (void)setSubscribe:(nullable NSNumber<SDLBool> *)subscribe {
-    [parameters sdl_setObject:subscribe forName:SDLRPCParameterNameSubscribe];
+    [self.parameters sdl_setObject:subscribe forName:SDLRPCParameterNameSubscribe];
 }
 
 - (nullable NSNumber<SDLBool> *)subscribe {
-    return [parameters sdl_objectForName:SDLRPCParameterNameSubscribe ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameSubscribe ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLGetInteriorVehicleDataResponse.m
+++ b/SmartDeviceLink/SDLGetInteriorVehicleDataResponse.m
@@ -13,27 +13,30 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLGetInteriorVehicleDataResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameGetInteriorVehicleData]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setModuleData:(SDLModuleData *)moduleData {
-    [parameters sdl_setObject:moduleData forName:SDLRPCParameterNameModuleData];
+    [self.parameters sdl_setObject:moduleData forName:SDLRPCParameterNameModuleData];
 }
 
 - (SDLModuleData *)moduleData {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameModuleData ofClass:SDLModuleData.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameModuleData ofClass:SDLModuleData.class error:&error];
 }
 
 - (void)setIsSubscribed:(nullable NSNumber<SDLBool> *)isSubscribed {
-    [parameters sdl_setObject:isSubscribed forName:SDLRPCParameterNameIsSubscribed];
+    [self.parameters sdl_setObject:isSubscribed forName:SDLRPCParameterNameIsSubscribed];
 }
 
 - (nullable NSNumber<SDLBool> *)isSubscribed {
-    return [parameters sdl_objectForName:SDLRPCParameterNameIsSubscribed ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameIsSubscribed ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLGetSystemCapability.m
+++ b/SmartDeviceLink/SDLGetSystemCapability.m
@@ -17,11 +17,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLGetSystemCapability
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameGetSystemCapability]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithType:(SDLSystemCapabilityType)type {
     self = [self init];
@@ -46,20 +49,20 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setSystemCapabilityType:(SDLSystemCapabilityType)type {
-    [parameters sdl_setObject:type forName:SDLRPCParameterNameSystemCapabilityType];
+    [self.parameters sdl_setObject:type forName:SDLRPCParameterNameSystemCapabilityType];
 }
 
 - (SDLSystemCapabilityType)systemCapabilityType {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameSystemCapabilityType error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameSystemCapabilityType error:&error];
 }
 
 - (void)setSubscribe:(nullable NSNumber<SDLBool> *)subscribe {
-    [parameters sdl_setObject:subscribe forName:SDLRPCParameterNameSubscribe];
+    [self.parameters sdl_setObject:subscribe forName:SDLRPCParameterNameSubscribe];
 }
 
 - (nullable NSNumber<SDLBool> *)subscribe {
-    return [parameters sdl_objectForName:SDLRPCParameterNameSubscribe ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameSubscribe ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLGetSystemCapabilityResponse.m
+++ b/SmartDeviceLink/SDLGetSystemCapabilityResponse.m
@@ -18,6 +18,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLGetSystemCapabilityResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     self = [super initWithName:SDLRPCFunctionNameGetSystemCapability];
     if (!self) {
@@ -26,14 +28,15 @@ NS_ASSUME_NONNULL_BEGIN
 
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setSystemCapability:(SDLSystemCapability *)systemCapability {
-    [parameters sdl_setObject:systemCapability forName:SDLRPCParameterNameSystemCapability];
+    [self.parameters sdl_setObject:systemCapability forName:SDLRPCParameterNameSystemCapability];
 }
 
 - (SDLSystemCapability *)systemCapability {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameSystemCapability ofClass:SDLSystemCapability.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameSystemCapability ofClass:SDLSystemCapability.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLGetVehicleData.m
+++ b/SmartDeviceLink/SDLGetVehicleData.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLGetVehicleData
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameGetVehicleData]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithAccelerationPedalPosition:(BOOL)accelerationPedalPosition airbagStatus:(BOOL)airbagStatus beltStatus:(BOOL)beltStatus bodyInformation:(BOOL)bodyInformation clusterModeStatus:(BOOL)clusterModeStatus deviceStatus:(BOOL)deviceStatus driverBraking:(BOOL)driverBraking eCallInfo:(BOOL)eCallInfo emergencyEvent:(BOOL)emergencyEvent engineTorque:(BOOL)engineTorque externalTemperature:(BOOL)externalTemperature fuelLevel:(BOOL)fuelLevel fuelLevelState:(BOOL)fuelLevelState gps:(BOOL)gps headLampStatus:(BOOL)headLampStatus instantFuelConsumption:(BOOL)instantFuelConsumption myKey:(BOOL)myKey odometer:(BOOL)odometer prndl:(BOOL)prndl rpm:(BOOL)rpm speed:(BOOL)speed steeringWheelAngle:(BOOL)steeringWheelAngle tirePressure:(BOOL)tirePressure vin:(BOOL)vin wiperStatus:(BOOL)wiperStatus {
     return [self initWithAccelerationPedalPosition:accelerationPedalPosition airbagStatus:airbagStatus beltStatus:beltStatus bodyInformation:bodyInformation clusterModeStatus:clusterModeStatus deviceStatus:deviceStatus driverBraking:driverBraking eCallInfo:eCallInfo electronicParkBrakeStatus:NO emergencyEvent:emergencyEvent engineOilLife:NO engineTorque:engineTorque externalTemperature:externalTemperature fuelLevel:fuelLevel fuelLevelState:fuelLevelState fuelRange:NO gps:gps headLampStatus:headLampStatus instantFuelConsumption:instantFuelConsumption myKey:myKey odometer:odometer prndl:prndl rpm:rpm speed:speed steeringWheelAngle:steeringWheelAngle tirePressure:tirePressure turnSignal:NO vin:vin wiperStatus:wiperStatus];
@@ -67,243 +70,243 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setGps:(nullable NSNumber<SDLBool> *)gps {
-    [parameters sdl_setObject:gps forName:SDLRPCParameterNameGPS];
+    [self.parameters sdl_setObject:gps forName:SDLRPCParameterNameGPS];
 }
 
 - (nullable NSNumber<SDLBool> *)gps {
-    return [parameters sdl_objectForName:SDLRPCParameterNameGPS ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameGPS ofClass:NSNumber.class error:nil];
 }
 
 - (void)setSpeed:(nullable NSNumber<SDLBool> *)speed {
-    [parameters sdl_setObject:speed forName:SDLRPCParameterNameSpeed];
+    [self.parameters sdl_setObject:speed forName:SDLRPCParameterNameSpeed];
 }
 
 - (nullable NSNumber<SDLBool> *)speed {
-    return [parameters sdl_objectForName:SDLRPCParameterNameSpeed ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameSpeed ofClass:NSNumber.class error:nil];
 }
 
 - (void)setRpm:(nullable NSNumber<SDLBool> *)rpm {
-    [parameters sdl_setObject:rpm forName:SDLRPCParameterNameRPM];
+    [self.parameters sdl_setObject:rpm forName:SDLRPCParameterNameRPM];
 }
 
 - (nullable NSNumber<SDLBool> *)rpm {
-    return [parameters sdl_objectForName:SDLRPCParameterNameRPM ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameRPM ofClass:NSNumber.class error:nil];
 }
 
 - (void)setFuelLevel:(nullable NSNumber<SDLBool> *)fuelLevel {
-    [parameters sdl_setObject:fuelLevel forName:SDLRPCParameterNameFuelLevel];
+    [self.parameters sdl_setObject:fuelLevel forName:SDLRPCParameterNameFuelLevel];
 }
 
 - (nullable NSNumber<SDLBool> *)fuelLevel {
-    return [parameters sdl_objectForName:SDLRPCParameterNameFuelLevel ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameFuelLevel ofClass:NSNumber.class error:nil];
 }
 
 - (void)setFuelLevel_State:(nullable NSNumber<SDLBool> *)fuelLevel_State {
-    [parameters sdl_setObject:fuelLevel_State forName:SDLRPCParameterNameFuelLevelState];
+    [self.parameters sdl_setObject:fuelLevel_State forName:SDLRPCParameterNameFuelLevelState];
 }
 
 - (nullable NSNumber<SDLBool> *)fuelLevel_State {
-    return [parameters sdl_objectForName:SDLRPCParameterNameFuelLevelState ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameFuelLevelState ofClass:NSNumber.class error:nil];
 }
 
 - (void)setFuelRange:(nullable NSNumber<SDLBool> *)fuelRange {
-    [parameters sdl_setObject:fuelRange forName:SDLRPCParameterNameFuelRange];
+    [self.parameters sdl_setObject:fuelRange forName:SDLRPCParameterNameFuelRange];
 }
 
 - (nullable NSNumber<SDLBool> *)fuelRange {
-    return [parameters sdl_objectForName:SDLRPCParameterNameFuelRange ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameFuelRange ofClass:NSNumber.class error:nil];
 }
 
 - (void)setInstantFuelConsumption:(nullable NSNumber<SDLBool> *)instantFuelConsumption {
-    [parameters sdl_setObject:instantFuelConsumption forName:SDLRPCParameterNameInstantFuelConsumption];
+    [self.parameters sdl_setObject:instantFuelConsumption forName:SDLRPCParameterNameInstantFuelConsumption];
 }
 
 - (nullable NSNumber<SDLBool> *)instantFuelConsumption {
-    return [parameters sdl_objectForName:SDLRPCParameterNameInstantFuelConsumption ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameInstantFuelConsumption ofClass:NSNumber.class error:nil];
 }
 
 - (void)setExternalTemperature:(nullable NSNumber<SDLBool> *)externalTemperature {
-    [parameters sdl_setObject:externalTemperature forName:SDLRPCParameterNameExternalTemperature];
+    [self.parameters sdl_setObject:externalTemperature forName:SDLRPCParameterNameExternalTemperature];
 }
 
 - (nullable NSNumber<SDLBool> *)externalTemperature {
-    return [parameters sdl_objectForName:SDLRPCParameterNameExternalTemperature ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameExternalTemperature ofClass:NSNumber.class error:nil];
 }
 
 - (void)setVin:(nullable NSNumber<SDLBool> *)vin {
-    [parameters sdl_setObject:vin forName:SDLRPCParameterNameVIN];
+    [self.parameters sdl_setObject:vin forName:SDLRPCParameterNameVIN];
 }
 
 - (nullable NSNumber<SDLBool> *)vin {
-    return [parameters sdl_objectForName:SDLRPCParameterNameVIN ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameVIN ofClass:NSNumber.class error:nil];
 }
 
 - (void)setPrndl:(nullable NSNumber<SDLBool> *)prndl {
-    [parameters sdl_setObject:prndl forName:SDLRPCParameterNamePRNDL];
+    [self.parameters sdl_setObject:prndl forName:SDLRPCParameterNamePRNDL];
 }
 
 - (nullable NSNumber<SDLBool> *)prndl {
-    return [parameters sdl_objectForName:SDLRPCParameterNamePRNDL ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNamePRNDL ofClass:NSNumber.class error:nil];
 }
 
 - (void)setTirePressure:(nullable NSNumber<SDLBool> *)tirePressure {
-    [parameters sdl_setObject:tirePressure forName:SDLRPCParameterNameTirePressure];
+    [self.parameters sdl_setObject:tirePressure forName:SDLRPCParameterNameTirePressure];
 }
 
 - (nullable NSNumber<SDLBool> *)tirePressure {
-    return [parameters sdl_objectForName:SDLRPCParameterNameTirePressure ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameTirePressure ofClass:NSNumber.class error:nil];
 }
 
 - (void)setOdometer:(nullable NSNumber<SDLBool> *)odometer {
-    [parameters sdl_setObject:odometer forName:SDLRPCParameterNameOdometer];
+    [self.parameters sdl_setObject:odometer forName:SDLRPCParameterNameOdometer];
 }
 
 - (nullable NSNumber<SDLBool> *)odometer {
-    return [parameters sdl_objectForName:SDLRPCParameterNameOdometer ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameOdometer ofClass:NSNumber.class error:nil];
 }
 
 - (void)setBeltStatus:(nullable NSNumber<SDLBool> *)beltStatus {
-    [parameters sdl_setObject:beltStatus forName:SDLRPCParameterNameBeltStatus];
+    [self.parameters sdl_setObject:beltStatus forName:SDLRPCParameterNameBeltStatus];
 }
 
 - (nullable NSNumber<SDLBool> *)beltStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameBeltStatus ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameBeltStatus ofClass:NSNumber.class error:nil];
 }
 
 - (void)setBodyInformation:(nullable NSNumber<SDLBool> *)bodyInformation {
-    [parameters sdl_setObject:bodyInformation forName:SDLRPCParameterNameBodyInformation];
+    [self.parameters sdl_setObject:bodyInformation forName:SDLRPCParameterNameBodyInformation];
 }
 
 - (nullable NSNumber<SDLBool> *)bodyInformation {
-    return [parameters sdl_objectForName:SDLRPCParameterNameBodyInformation ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameBodyInformation ofClass:NSNumber.class error:nil];
 }
 
 - (void)setDeviceStatus:(nullable NSNumber<SDLBool> *)deviceStatus {
-    [parameters sdl_setObject:deviceStatus forName:SDLRPCParameterNameDeviceStatus];
+    [self.parameters sdl_setObject:deviceStatus forName:SDLRPCParameterNameDeviceStatus];
 }
 
 - (nullable NSNumber<SDLBool> *)deviceStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameDeviceStatus ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameDeviceStatus ofClass:NSNumber.class error:nil];
 }
 
 - (void)setDriverBraking:(nullable NSNumber<SDLBool> *)driverBraking {
-    [parameters sdl_setObject:driverBraking forName:SDLRPCParameterNameDriverBraking];
+    [self.parameters sdl_setObject:driverBraking forName:SDLRPCParameterNameDriverBraking];
 }
 
 - (nullable NSNumber<SDLBool> *)driverBraking {
-    return [parameters sdl_objectForName:SDLRPCParameterNameDriverBraking ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameDriverBraking ofClass:NSNumber.class error:nil];
 }
 
 - (void)setWiperStatus:(nullable NSNumber<SDLBool> *)wiperStatus {
-    [parameters sdl_setObject:wiperStatus forName:SDLRPCParameterNameWiperStatus];
+    [self.parameters sdl_setObject:wiperStatus forName:SDLRPCParameterNameWiperStatus];
 }
 
 - (nullable NSNumber<SDLBool> *)wiperStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameWiperStatus ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameWiperStatus ofClass:NSNumber.class error:nil];
 }
 
 - (void)setHeadLampStatus:(nullable NSNumber<SDLBool> *)headLampStatus {
-    [parameters sdl_setObject:headLampStatus forName:SDLRPCParameterNameHeadLampStatus];
+    [self.parameters sdl_setObject:headLampStatus forName:SDLRPCParameterNameHeadLampStatus];
 }
 
 - (nullable NSNumber<SDLBool> *)headLampStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameHeadLampStatus ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameHeadLampStatus ofClass:NSNumber.class error:nil];
 }
 
 - (void)setEngineOilLife:(nullable NSNumber<SDLBool> *)engineOilLife {
-    [parameters sdl_setObject:engineOilLife forName:SDLRPCParameterNameEngineOilLife];
+    [self.parameters sdl_setObject:engineOilLife forName:SDLRPCParameterNameEngineOilLife];
 }
 
 - (nullable NSNumber<SDLBool> *)engineOilLife {
-    return [parameters sdl_objectForName:SDLRPCParameterNameEngineOilLife ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameEngineOilLife ofClass:NSNumber.class error:nil];
 }
 
 - (void)setEngineTorque:(nullable NSNumber<SDLBool> *)engineTorque {
-    [parameters sdl_setObject:engineTorque forName:SDLRPCParameterNameEngineTorque];
+    [self.parameters sdl_setObject:engineTorque forName:SDLRPCParameterNameEngineTorque];
 }
 
 - (nullable NSNumber<SDLBool> *)engineTorque {
-    return [parameters sdl_objectForName:SDLRPCParameterNameEngineTorque ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameEngineTorque ofClass:NSNumber.class error:nil];
 }
 
 - (void)setAccPedalPosition:(nullable NSNumber<SDLBool> *)accPedalPosition {
-    [parameters sdl_setObject:accPedalPosition forName:SDLRPCParameterNameAccelerationPedalPosition];
+    [self.parameters sdl_setObject:accPedalPosition forName:SDLRPCParameterNameAccelerationPedalPosition];
 }
 
 - (nullable NSNumber<SDLBool> *)accPedalPosition {
-    return [parameters sdl_objectForName:SDLRPCParameterNameAccelerationPedalPosition ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameAccelerationPedalPosition ofClass:NSNumber.class error:nil];
 }
 
 - (void)setSteeringWheelAngle:(nullable NSNumber<SDLBool> *)steeringWheelAngle {
-    [parameters sdl_setObject:steeringWheelAngle forName:SDLRPCParameterNameSteeringWheelAngle];
+    [self.parameters sdl_setObject:steeringWheelAngle forName:SDLRPCParameterNameSteeringWheelAngle];
 }
 
 - (nullable NSNumber<SDLBool> *)steeringWheelAngle {
-    return [parameters sdl_objectForName:SDLRPCParameterNameSteeringWheelAngle ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameSteeringWheelAngle ofClass:NSNumber.class error:nil];
 }
 
 - (void)setECallInfo:(nullable NSNumber<SDLBool> *)eCallInfo {
-    [parameters sdl_setObject:eCallInfo forName:SDLRPCParameterNameECallInfo];
+    [self.parameters sdl_setObject:eCallInfo forName:SDLRPCParameterNameECallInfo];
 }
 
 - (nullable NSNumber<SDLBool> *)eCallInfo {
-    return [parameters sdl_objectForName:SDLRPCParameterNameECallInfo ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameECallInfo ofClass:NSNumber.class error:nil];
 }
 
 - (void)setAirbagStatus:(nullable NSNumber<SDLBool> *)airbagStatus {
-    [parameters sdl_setObject:airbagStatus forName:SDLRPCParameterNameAirbagStatus];
+    [self.parameters sdl_setObject:airbagStatus forName:SDLRPCParameterNameAirbagStatus];
 }
 
 - (nullable NSNumber<SDLBool> *)airbagStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameAirbagStatus ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameAirbagStatus ofClass:NSNumber.class error:nil];
 }
 
 - (void)setEmergencyEvent:(nullable NSNumber<SDLBool> *)emergencyEvent {
-    [parameters sdl_setObject:emergencyEvent forName:SDLRPCParameterNameEmergencyEvent];
+    [self.parameters sdl_setObject:emergencyEvent forName:SDLRPCParameterNameEmergencyEvent];
 }
 
 - (nullable NSNumber<SDLBool> *)emergencyEvent {
-    return [parameters sdl_objectForName:SDLRPCParameterNameEmergencyEvent ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameEmergencyEvent ofClass:NSNumber.class error:nil];
 }
 
 - (void)setClusterModeStatus:(nullable NSNumber<SDLBool> *)clusterModeStatus {
-    [parameters sdl_setObject:clusterModeStatus forName:SDLRPCParameterNameClusterModeStatus];
+    [self.parameters sdl_setObject:clusterModeStatus forName:SDLRPCParameterNameClusterModeStatus];
 }
 
 - (nullable NSNumber<SDLBool> *)clusterModeStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameClusterModeStatus ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameClusterModeStatus ofClass:NSNumber.class error:nil];
 }
 
 - (void)setMyKey:(nullable NSNumber<SDLBool> *)myKey {
-    [parameters sdl_setObject:myKey forName:SDLRPCParameterNameMyKey];
+    [self.parameters sdl_setObject:myKey forName:SDLRPCParameterNameMyKey];
 }
 
 - (nullable NSNumber<SDLBool> *)myKey {
-    return [parameters sdl_objectForName:SDLRPCParameterNameMyKey ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameMyKey ofClass:NSNumber.class error:nil];
 }
 
 - (void)setElectronicParkBrakeStatus:(nullable NSNumber<SDLBool> *)electronicParkBrakeStatus {
-    [parameters sdl_setObject:electronicParkBrakeStatus forName:SDLRPCParameterNameElectronicParkBrakeStatus];
+    [self.parameters sdl_setObject:electronicParkBrakeStatus forName:SDLRPCParameterNameElectronicParkBrakeStatus];
 }
 
 - (nullable NSNumber<SDLBool> *)electronicParkBrakeStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameElectronicParkBrakeStatus ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameElectronicParkBrakeStatus ofClass:NSNumber.class error:nil];
 }
 
 - (void)setTurnSignal:(nullable NSNumber<SDLBool> *)turnSignal {
-    [parameters sdl_setObject:turnSignal forName:SDLRPCParameterNameTurnSignal];
+    [self.parameters sdl_setObject:turnSignal forName:SDLRPCParameterNameTurnSignal];
 }
 
 - (nullable NSNumber<SDLBool> *)turnSignal {
-    return [parameters sdl_objectForName:SDLRPCParameterNameTurnSignal ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameTurnSignal ofClass:NSNumber.class error:nil];
 }
 
 - (void)setCloudAppVehicleID:(nullable NSNumber<SDLBool> *)cloudAppVehicleID {
-    [parameters sdl_setObject:cloudAppVehicleID forName:SDLRPCParameterNameCloudAppVehicleID];
+    [self.parameters sdl_setObject:cloudAppVehicleID forName:SDLRPCParameterNameCloudAppVehicleID];
 }
 
 - (nullable NSNumber<SDLBool> *)cloudAppVehicleID {
-    return [parameters sdl_objectForName:SDLRPCParameterNameCloudAppVehicleID ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameCloudAppVehicleID ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLGetVehicleDataResponse.m
+++ b/SmartDeviceLink/SDLGetVehicleDataResponse.m
@@ -24,250 +24,253 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLGetVehicleDataResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameGetVehicleData]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setGps:(nullable SDLGPSData *)gps {
-    [parameters sdl_setObject:gps forName:SDLRPCParameterNameGPS];
+    [self.parameters sdl_setObject:gps forName:SDLRPCParameterNameGPS];
 }
 
 - (nullable SDLGPSData *)gps {
-    return [parameters sdl_objectForName:SDLRPCParameterNameGPS ofClass:SDLGPSData.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameGPS ofClass:SDLGPSData.class error:nil];
 }
 
 - (void)setSpeed:(nullable NSNumber<SDLFloat> *)speed {
-    [parameters sdl_setObject:speed forName:SDLRPCParameterNameSpeed];
+    [self.parameters sdl_setObject:speed forName:SDLRPCParameterNameSpeed];
 }
 
 - (nullable NSNumber<SDLFloat> *)speed {
-    return [parameters sdl_objectForName:SDLRPCParameterNameSpeed ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameSpeed ofClass:NSNumber.class error:nil];
 }
 
 - (void)setRpm:(nullable NSNumber<SDLInt> *)rpm {
-    [parameters sdl_setObject:rpm forName:SDLRPCParameterNameRPM];
+    [self.parameters sdl_setObject:rpm forName:SDLRPCParameterNameRPM];
 }
 
 - (nullable NSNumber<SDLInt> *)rpm {
-    return [parameters sdl_objectForName:SDLRPCParameterNameRPM ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameRPM ofClass:NSNumber.class error:nil];
 }
 
 - (void)setFuelLevel:(nullable NSNumber<SDLFloat> *)fuelLevel {
-    [parameters sdl_setObject:fuelLevel forName:SDLRPCParameterNameFuelLevel];
+    [self.parameters sdl_setObject:fuelLevel forName:SDLRPCParameterNameFuelLevel];
 }
 
 - (nullable NSNumber<SDLFloat> *)fuelLevel {
-    return [parameters sdl_objectForName:SDLRPCParameterNameFuelLevel ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameFuelLevel ofClass:NSNumber.class error:nil];
 }
 
 - (void)setFuelLevel_State:(nullable SDLComponentVolumeStatus)fuelLevel_State {
-    [parameters sdl_setObject:fuelLevel_State forName:SDLRPCParameterNameFuelLevelState];
+    [self.parameters sdl_setObject:fuelLevel_State forName:SDLRPCParameterNameFuelLevelState];
 }
 
 - (nullable SDLComponentVolumeStatus)fuelLevel_State {
-    return [parameters sdl_enumForName:SDLRPCParameterNameFuelLevelState error:nil];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameFuelLevelState error:nil];
 }
 
 - (void)setInstantFuelConsumption:(nullable NSNumber<SDLFloat> *)instantFuelConsumption {
-    [parameters sdl_setObject:instantFuelConsumption forName:SDLRPCParameterNameInstantFuelConsumption];
+    [self.parameters sdl_setObject:instantFuelConsumption forName:SDLRPCParameterNameInstantFuelConsumption];
 }
 
 - (void)setFuelRange:(nullable NSArray<SDLFuelRange *> *)fuelRange {
-    [parameters sdl_setObject:fuelRange forName:SDLRPCParameterNameFuelRange];
+    [self.parameters sdl_setObject:fuelRange forName:SDLRPCParameterNameFuelRange];
 }
 
 - (nullable NSArray<SDLFuelRange *> *)fuelRange {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameFuelRange ofClass:SDLFuelRange.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameFuelRange ofClass:SDLFuelRange.class error:nil];
 }
 
 - (nullable NSNumber<SDLFloat> *)instantFuelConsumption {
-    return [parameters sdl_objectForName:SDLRPCParameterNameInstantFuelConsumption ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameInstantFuelConsumption ofClass:NSNumber.class error:nil];
 }
 
 - (void)setExternalTemperature:(nullable NSNumber<SDLFloat> *)externalTemperature {
-    [parameters sdl_setObject:externalTemperature forName:SDLRPCParameterNameExternalTemperature];
+    [self.parameters sdl_setObject:externalTemperature forName:SDLRPCParameterNameExternalTemperature];
 }
 
 - (nullable NSNumber<SDLFloat> *)externalTemperature {
-    return [parameters sdl_objectForName:SDLRPCParameterNameExternalTemperature ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameExternalTemperature ofClass:NSNumber.class error:nil];
 }
 
 - (void)setVin:(nullable NSString *)vin {
-    [parameters sdl_setObject:vin forName:SDLRPCParameterNameVIN];
+    [self.parameters sdl_setObject:vin forName:SDLRPCParameterNameVIN];
 }
 
 - (nullable NSString *)vin {
-    return [parameters sdl_objectForName:SDLRPCParameterNameVIN ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameVIN ofClass:NSString.class error:nil];
 }
 
 - (void)setPrndl:(nullable SDLPRNDL)prndl {
-    [parameters sdl_setObject:prndl forName:SDLRPCParameterNamePRNDL];
+    [self.parameters sdl_setObject:prndl forName:SDLRPCParameterNamePRNDL];
 }
 
 - (nullable SDLPRNDL)prndl {
-    return [parameters sdl_enumForName:SDLRPCParameterNamePRNDL error:nil];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNamePRNDL error:nil];
 }
 
 - (void)setTirePressure:(nullable SDLTireStatus *)tirePressure {
-    [parameters sdl_setObject:tirePressure forName:SDLRPCParameterNameTirePressure];
+    [self.parameters sdl_setObject:tirePressure forName:SDLRPCParameterNameTirePressure];
 }
 
 - (nullable SDLTireStatus *)tirePressure {
-    return [parameters sdl_objectForName:SDLRPCParameterNameTirePressure ofClass:SDLTireStatus.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameTirePressure ofClass:SDLTireStatus.class error:nil];
 }
 
 - (void)setOdometer:(nullable NSNumber<SDLInt> *)odometer {
-    [parameters sdl_setObject:odometer forName:SDLRPCParameterNameOdometer];
+    [self.parameters sdl_setObject:odometer forName:SDLRPCParameterNameOdometer];
 }
 
 - (nullable NSNumber<SDLInt> *)odometer {
-    return [parameters sdl_objectForName:SDLRPCParameterNameOdometer ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameOdometer ofClass:NSNumber.class error:nil];
 }
 
 - (void)setBeltStatus:(nullable SDLBeltStatus *)beltStatus {
-    [parameters sdl_setObject:beltStatus forName:SDLRPCParameterNameBeltStatus];
+    [self.parameters sdl_setObject:beltStatus forName:SDLRPCParameterNameBeltStatus];
 }
 
 - (nullable SDLBeltStatus *)beltStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameBeltStatus ofClass:SDLBeltStatus.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameBeltStatus ofClass:SDLBeltStatus.class error:nil];
 }
 
 - (void)setBodyInformation:(nullable SDLBodyInformation *)bodyInformation {
-    [parameters sdl_setObject:bodyInformation forName:SDLRPCParameterNameBodyInformation];
+    [self.parameters sdl_setObject:bodyInformation forName:SDLRPCParameterNameBodyInformation];
 }
 
 - (nullable SDLBodyInformation *)bodyInformation {
-    return [parameters sdl_objectForName:SDLRPCParameterNameBodyInformation ofClass:SDLBodyInformation.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameBodyInformation ofClass:SDLBodyInformation.class error:nil];
 }
 
 - (void)setDeviceStatus:(nullable SDLDeviceStatus *)deviceStatus {
-    [parameters sdl_setObject:deviceStatus forName:SDLRPCParameterNameDeviceStatus];
+    [self.parameters sdl_setObject:deviceStatus forName:SDLRPCParameterNameDeviceStatus];
 }
 
 - (nullable SDLDeviceStatus *)deviceStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameDeviceStatus ofClass:SDLDeviceStatus.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameDeviceStatus ofClass:SDLDeviceStatus.class error:nil];
 }
 
 - (void)setDriverBraking:(nullable SDLVehicleDataEventStatus)driverBraking {
-    [parameters sdl_setObject:driverBraking forName:SDLRPCParameterNameDriverBraking];
+    [self.parameters sdl_setObject:driverBraking forName:SDLRPCParameterNameDriverBraking];
 }
 
 - (nullable SDLVehicleDataEventStatus)driverBraking {
-    return [parameters sdl_enumForName:SDLRPCParameterNameDriverBraking error:nil];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameDriverBraking error:nil];
 }
 
 - (void)setWiperStatus:(nullable SDLWiperStatus)wiperStatus {
-    [parameters sdl_setObject:wiperStatus forName:SDLRPCParameterNameWiperStatus];
+    [self.parameters sdl_setObject:wiperStatus forName:SDLRPCParameterNameWiperStatus];
 }
 
 - (nullable SDLWiperStatus)wiperStatus {
-    return [parameters sdl_enumForName:SDLRPCParameterNameWiperStatus error:nil];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameWiperStatus error:nil];
 }
 
 - (void)setHeadLampStatus:(nullable SDLHeadLampStatus *)headLampStatus {
-    [parameters sdl_setObject:headLampStatus forName:SDLRPCParameterNameHeadLampStatus];
+    [self.parameters sdl_setObject:headLampStatus forName:SDLRPCParameterNameHeadLampStatus];
 }
 
 - (nullable SDLHeadLampStatus *)headLampStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameHeadLampStatus ofClass:SDLHeadLampStatus.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameHeadLampStatus ofClass:SDLHeadLampStatus.class error:nil];
 }
 
 - (void)setEngineOilLife:(nullable NSNumber<SDLFloat> *)engineOilLife {
-    [parameters sdl_setObject:engineOilLife forName:SDLRPCParameterNameEngineOilLife];
+    [self.parameters sdl_setObject:engineOilLife forName:SDLRPCParameterNameEngineOilLife];
 }
 
 - (nullable NSNumber<SDLFloat> *)engineOilLife {
-    return [parameters sdl_objectForName:SDLRPCParameterNameEngineOilLife ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameEngineOilLife ofClass:NSNumber.class error:nil];
 }
 
 - (void)setEngineTorque:(nullable NSNumber<SDLFloat> *)engineTorque {
-    [parameters sdl_setObject:engineTorque forName:SDLRPCParameterNameEngineTorque];
+    [self.parameters sdl_setObject:engineTorque forName:SDLRPCParameterNameEngineTorque];
 }
 
 - (nullable NSNumber<SDLFloat> *)engineTorque {
-    return [parameters sdl_objectForName:SDLRPCParameterNameEngineTorque ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameEngineTorque ofClass:NSNumber.class error:nil];
 }
 
 - (void)setAccPedalPosition:(nullable NSNumber<SDLFloat> *)accPedalPosition {
-    [parameters sdl_setObject:accPedalPosition forName:SDLRPCParameterNameAccelerationPedalPosition];
+    [self.parameters sdl_setObject:accPedalPosition forName:SDLRPCParameterNameAccelerationPedalPosition];
 }
 
 - (nullable NSNumber<SDLFloat> *)accPedalPosition {
-    return [parameters sdl_objectForName:SDLRPCParameterNameAccelerationPedalPosition ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameAccelerationPedalPosition ofClass:NSNumber.class error:nil];
 }
 
 - (void)setSteeringWheelAngle:(nullable NSNumber<SDLFloat> *)steeringWheelAngle {
-    [parameters sdl_setObject:steeringWheelAngle forName:SDLRPCParameterNameSteeringWheelAngle];
+    [self.parameters sdl_setObject:steeringWheelAngle forName:SDLRPCParameterNameSteeringWheelAngle];
 }
 
 - (nullable NSNumber<SDLFloat> *)steeringWheelAngle {
-    return [parameters sdl_objectForName:SDLRPCParameterNameSteeringWheelAngle ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameSteeringWheelAngle ofClass:NSNumber.class error:nil];
 }
 
 - (void)setECallInfo:(nullable SDLECallInfo *)eCallInfo {
-    [parameters sdl_setObject:eCallInfo forName:SDLRPCParameterNameECallInfo];
+    [self.parameters sdl_setObject:eCallInfo forName:SDLRPCParameterNameECallInfo];
 }
 
 - (nullable SDLECallInfo *)eCallInfo {
-    return [parameters sdl_objectForName:SDLRPCParameterNameECallInfo ofClass:SDLECallInfo.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameECallInfo ofClass:SDLECallInfo.class error:nil];
 }
 
 - (void)setAirbagStatus:(nullable SDLAirbagStatus *)airbagStatus {
-    [parameters sdl_setObject:airbagStatus forName:SDLRPCParameterNameAirbagStatus];
+    [self.parameters sdl_setObject:airbagStatus forName:SDLRPCParameterNameAirbagStatus];
 }
 
 - (nullable SDLAirbagStatus *)airbagStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameAirbagStatus ofClass:SDLAirbagStatus.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameAirbagStatus ofClass:SDLAirbagStatus.class error:nil];
 }
 
 - (void)setEmergencyEvent:(nullable SDLEmergencyEvent *)emergencyEvent {
-    [parameters sdl_setObject:emergencyEvent forName:SDLRPCParameterNameEmergencyEvent];
+    [self.parameters sdl_setObject:emergencyEvent forName:SDLRPCParameterNameEmergencyEvent];
 }
 
 - (nullable SDLEmergencyEvent *)emergencyEvent {
-    return [parameters sdl_objectForName:SDLRPCParameterNameEmergencyEvent ofClass:SDLEmergencyEvent.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameEmergencyEvent ofClass:SDLEmergencyEvent.class error:nil];
 }
 
 - (void)setClusterModeStatus:(nullable SDLClusterModeStatus *)clusterModeStatus {
-    [parameters sdl_setObject:clusterModeStatus forName:SDLRPCParameterNameClusterModeStatus];
+    [self.parameters sdl_setObject:clusterModeStatus forName:SDLRPCParameterNameClusterModeStatus];
 }
 
 - (nullable SDLClusterModeStatus *)clusterModeStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameClusterModeStatus ofClass:SDLClusterModeStatus.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameClusterModeStatus ofClass:SDLClusterModeStatus.class error:nil];
 }
 
 - (void)setMyKey:(nullable SDLMyKey *)myKey {
-    [parameters sdl_setObject:myKey forName:SDLRPCParameterNameMyKey];
+    [self.parameters sdl_setObject:myKey forName:SDLRPCParameterNameMyKey];
 }
 
 - (nullable SDLMyKey *)myKey {
-    return [parameters sdl_objectForName:SDLRPCParameterNameMyKey ofClass:SDLMyKey.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameMyKey ofClass:SDLMyKey.class error:nil];
 }
 
 - (void)setElectronicParkBrakeStatus:(nullable SDLElectronicParkBrakeStatus)electronicParkBrakeStatus {
-    [parameters sdl_setObject:electronicParkBrakeStatus forName:SDLRPCParameterNameElectronicParkBrakeStatus];
+    [self.parameters sdl_setObject:electronicParkBrakeStatus forName:SDLRPCParameterNameElectronicParkBrakeStatus];
 }
 
 - (nullable SDLElectronicParkBrakeStatus)electronicParkBrakeStatus {
-    return [parameters sdl_enumForName:SDLRPCParameterNameElectronicParkBrakeStatus error:nil];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameElectronicParkBrakeStatus error:nil];
 }
 
 - (void)setTurnSignal:(nullable SDLTurnSignal)turnSignal {
-    [parameters sdl_setObject:turnSignal forName:SDLRPCParameterNameTurnSignal];
+    [self.parameters sdl_setObject:turnSignal forName:SDLRPCParameterNameTurnSignal];
 }
 
 - (nullable SDLTurnSignal)turnSignal {
-    return [parameters sdl_enumForName:SDLRPCParameterNameTurnSignal error:nil];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameTurnSignal error:nil];
 }
 
 - (void)setCloudAppVehicleID:(nullable NSString *)cloudAppVehicleID {
-    [parameters sdl_setObject:cloudAppVehicleID forName:SDLRPCParameterNameCloudAppVehicleID];
+    [self.parameters sdl_setObject:cloudAppVehicleID forName:SDLRPCParameterNameCloudAppVehicleID];
 }
 
 - (nullable NSString *)cloudAppVehicleID {
-    return [parameters sdl_objectForName:SDLRPCParameterNameCloudAppVehicleID ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameCloudAppVehicleID ofClass:NSString.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLGetWayPoints.m
+++ b/SmartDeviceLink/SDLGetWayPoints.m
@@ -11,11 +11,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLGetWayPoints
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameGetWayPoints]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 
 - (instancetype)initWithType:(SDLWayPointType)type {
@@ -30,11 +33,11 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setWaypointType:(nullable SDLWayPointType)waypointType {
-    [parameters sdl_setObject:waypointType forName:SDLRPCParameterNameWayPointType];
+    [self.parameters sdl_setObject:waypointType forName:SDLRPCParameterNameWayPointType];
 }
 
 - (nullable SDLWayPointType)waypointType {
-    return [parameters sdl_enumForName:SDLRPCParameterNameWayPointType error:nil];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameWayPointType error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLGetWayPointsResponse.m
+++ b/SmartDeviceLink/SDLGetWayPointsResponse.m
@@ -12,18 +12,21 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLGetWayPointsResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameGetWayPoints]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setWaypoints:(nullable NSArray<SDLLocationDetails *> *)waypoints {
-    [parameters sdl_setObject:waypoints forName:SDLRPCParameterNameWayPoints];
+    [self.parameters sdl_setObject:waypoints forName:SDLRPCParameterNameWayPoints];
 }
 
 - (nullable NSArray<SDLLocationDetails *> *)waypoints {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameWayPoints ofClass:SDLLocationDetails.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameWayPoints ofClass:SDLLocationDetails.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLHMICapabilities.m
+++ b/SmartDeviceLink/SDLHMICapabilities.m
@@ -12,27 +12,27 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation SDLHMICapabilities
 
 - (void)setNavigation:(nullable NSNumber<SDLBool> *)navigation {
-    [store sdl_setObject:navigation forName:SDLRPCParameterNameNavigation];
+    [self.store sdl_setObject:navigation forName:SDLRPCParameterNameNavigation];
 }
 
 - (nullable NSNumber<SDLBool> *)navigation {
-    return [store sdl_objectForName:SDLRPCParameterNameNavigation ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameNavigation ofClass:NSNumber.class error:nil];
 }
 
 - (void)setPhoneCall:(nullable NSNumber<SDLBool> *)phoneCall {
-    [store sdl_setObject:phoneCall forName:SDLRPCParameterNamePhoneCall];
+    [self.store sdl_setObject:phoneCall forName:SDLRPCParameterNamePhoneCall];
 }
 
 - (nullable NSNumber<SDLBool> *)phoneCall {
-    return [store sdl_objectForName:SDLRPCParameterNamePhoneCall ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNamePhoneCall ofClass:NSNumber.class error:nil];
 }
 
 - (void)setVideoStreaming:(nullable NSNumber<SDLBool> *)videoStreaming {
-    [store sdl_setObject:videoStreaming forName:SDLRPCParameterNameVideoStreaming];
+    [self.store sdl_setObject:videoStreaming forName:SDLRPCParameterNameVideoStreaming];
 }
 
 - (nullable NSNumber<SDLBool> *)videoStreaming {
-    return [store sdl_objectForName:SDLRPCParameterNameVideoStreaming ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameVideoStreaming ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLHMIPermissions.m
+++ b/SmartDeviceLink/SDLHMIPermissions.m
@@ -12,21 +12,21 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation SDLHMIPermissions
 
 - (void)setAllowed:(NSArray<SDLHMILevel> *)allowed {
-    [store sdl_setObject:allowed forName:SDLRPCParameterNameAllowed];
+    [self.store sdl_setObject:allowed forName:SDLRPCParameterNameAllowed];
 }
 
 - (NSArray<SDLHMILevel> *)allowed {
     NSError *error = nil;
-    return [store sdl_enumsForName:SDLRPCParameterNameAllowed error:&error];
+    return [self.store sdl_enumsForName:SDLRPCParameterNameAllowed error:&error];
 }
 
 - (void)setUserDisallowed:(NSArray<SDLHMILevel> *)userDisallowed {
-    [store sdl_setObject:userDisallowed forName:SDLRPCParameterNameUserDisallowed];
+    [self.store sdl_setObject:userDisallowed forName:SDLRPCParameterNameUserDisallowed];
 }
 
 - (NSArray<SDLHMILevel> *)userDisallowed {
     NSError *error = nil;
-    return [store sdl_enumsForName:SDLRPCParameterNameUserDisallowed error:&error];
+    return [self.store sdl_enumsForName:SDLRPCParameterNameUserDisallowed error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLHMISettingsControlCapabilities.m
+++ b/SmartDeviceLink/SDLHMISettingsControlCapabilities.m
@@ -33,37 +33,37 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setModuleName:(NSString *)moduleName {
-    [store sdl_setObject:moduleName forName:SDLRPCParameterNameModuleName];
+    [self.store sdl_setObject:moduleName forName:SDLRPCParameterNameModuleName];
 }
 
 - (NSString *)moduleName {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameModuleName ofClass:NSString.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameModuleName ofClass:NSString.class error:&error];
 }
 
 
 - (void)setDistanceUnitAvailable:(nullable NSNumber<SDLBool> *)distanceUnitAvailable {
-    [store sdl_setObject:distanceUnitAvailable forName:SDLRPCParameterNameDistanceUnitAvailable];
+    [self.store sdl_setObject:distanceUnitAvailable forName:SDLRPCParameterNameDistanceUnitAvailable];
 }
 
 - (nullable NSNumber<SDLBool> *)distanceUnitAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameDistanceUnitAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameDistanceUnitAvailable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setTemperatureUnitAvailable:(nullable NSNumber<SDLBool> *)temperatureUnitAvailable {
-    [store sdl_setObject:temperatureUnitAvailable forName:SDLRPCParameterNameTemperatureUnitAvailable];
+    [self.store sdl_setObject:temperatureUnitAvailable forName:SDLRPCParameterNameTemperatureUnitAvailable];
 }
 
 - (nullable NSNumber<SDLBool> *)temperatureUnitAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameTemperatureUnitAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameTemperatureUnitAvailable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setDisplayModeUnitAvailable:(nullable NSNumber<SDLBool> *)displayModeUnitAvailable {
-    [store sdl_setObject:displayModeUnitAvailable forName:SDLRPCParameterNameDisplayModeUnitAvailable];
+    [self.store sdl_setObject:displayModeUnitAvailable forName:SDLRPCParameterNameDisplayModeUnitAvailable];
 }
 
 - (nullable NSNumber<SDLBool> *)displayModeUnitAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameDisplayModeUnitAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameDisplayModeUnitAvailable ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLHMISettingsControlData.m
+++ b/SmartDeviceLink/SDLHMISettingsControlData.m
@@ -22,27 +22,27 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setDisplayMode:(nullable SDLDisplayMode)displayMode {
-    [store sdl_setObject:displayMode forName:SDLRPCParameterNameDisplayMode];
+    [self.store sdl_setObject:displayMode forName:SDLRPCParameterNameDisplayMode];
 }
 
 - (nullable SDLDisplayMode)displayMode {
-    return [store sdl_enumForName:SDLRPCParameterNameDisplayMode error:nil];
+    return [self.store sdl_enumForName:SDLRPCParameterNameDisplayMode error:nil];
 }
 
 - (void)setDistanceUnit:(nullable SDLDistanceUnit)distanceUnit {
-    [store sdl_setObject:distanceUnit forName:SDLRPCParameterNameDistanceUnit];
+    [self.store sdl_setObject:distanceUnit forName:SDLRPCParameterNameDistanceUnit];
 }
 
 - (nullable SDLDistanceUnit)distanceUnit {
-    return [store sdl_enumForName:SDLRPCParameterNameDistanceUnit error:nil];
+    return [self.store sdl_enumForName:SDLRPCParameterNameDistanceUnit error:nil];
 }
 
 - (void)setTemperatureUnit:(nullable SDLTemperatureUnit)temperatureUnit {
-    [store sdl_setObject:temperatureUnit forName:SDLRPCParameterNameTemperatureUnit];
+    [self.store sdl_setObject:temperatureUnit forName:SDLRPCParameterNameTemperatureUnit];
 }
 
 - (nullable SDLTemperatureUnit)temperatureUnit {
-    return [store sdl_enumForName:SDLRPCParameterNameTemperatureUnit error:nil];
+    return [self.store sdl_enumForName:SDLRPCParameterNameTemperatureUnit error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLHapticRect.m
+++ b/SmartDeviceLink/SDLHapticRect.m
@@ -28,20 +28,20 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setId:(NSNumber<SDLInt> *)id {
-    [store sdl_setObject:id forName:SDLRPCParameterNameId];
+    [self.store sdl_setObject:id forName:SDLRPCParameterNameId];
 }
 
 - (NSNumber<SDLInt> *)id {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameId ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameId ofClass:NSNumber.class error:&error];
 }
 
 - (void)setRect:(SDLRectangle *)rect {
-    [store sdl_setObject:rect forName:SDLRPCParameterNameRect];
+    [self.store sdl_setObject:rect forName:SDLRPCParameterNameRect];
 }
 
 - (SDLRectangle *)rect {
-    return [store sdl_objectForName:SDLRPCParameterNameRect ofClass:SDLRectangle.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameRect ofClass:SDLRectangle.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLHeadLampStatus.m
+++ b/SmartDeviceLink/SDLHeadLampStatus.m
@@ -12,29 +12,29 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation SDLHeadLampStatus
 
 - (void)setLowBeamsOn:(NSNumber<SDLBool> *)lowBeamsOn {
-    [store sdl_setObject:lowBeamsOn forName:SDLRPCParameterNameLowBeamsOn];
+    [self.store sdl_setObject:lowBeamsOn forName:SDLRPCParameterNameLowBeamsOn];
 }
 
 - (NSNumber<SDLBool> *)lowBeamsOn {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameLowBeamsOn ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameLowBeamsOn ofClass:NSNumber.class error:&error];
 }
 
 - (void)setHighBeamsOn:(NSNumber<SDLBool> *)highBeamsOn {
-    [store sdl_setObject:highBeamsOn forName:SDLRPCParameterNameHighBeamsOn];
+    [self.store sdl_setObject:highBeamsOn forName:SDLRPCParameterNameHighBeamsOn];
 }
 
 - (NSNumber<SDLBool> *)highBeamsOn {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameHighBeamsOn ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameHighBeamsOn ofClass:NSNumber.class error:&error];
 }
 
 - (void)setAmbientLightSensorStatus:(nullable SDLAmbientLightStatus)ambientLightSensorStatus {
-    [store sdl_setObject:ambientLightSensorStatus forName:SDLRPCParameterNameAmbientLightSensorStatus];
+    [self.store sdl_setObject:ambientLightSensorStatus forName:SDLRPCParameterNameAmbientLightSensorStatus];
 }
 
 - (nullable SDLAmbientLightStatus)ambientLightSensorStatus {
-    return [store sdl_enumForName:SDLRPCParameterNameAmbientLightSensorStatus error:nil];
+    return [self.store sdl_enumForName:SDLRPCParameterNameAmbientLightSensorStatus error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLImage.m
+++ b/SmartDeviceLink/SDLImage.m
@@ -57,29 +57,29 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Getters / Setters
 
 - (void)setValue:(NSString *)value {
-    [store sdl_setObject:value forName:SDLRPCParameterNameValue];
+    [self.store sdl_setObject:value forName:SDLRPCParameterNameValue];
 }
 
 - (NSString *)value {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameValue ofClass:NSString.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameValue ofClass:NSString.class error:&error];
 }
 
 - (void)setImageType:(SDLImageType)imageType {
-    [store sdl_setObject:imageType forName:SDLRPCParameterNameImageType];
+    [self.store sdl_setObject:imageType forName:SDLRPCParameterNameImageType];
 }
 
 - (SDLImageType)imageType {
-    return [store sdl_enumForName:SDLRPCParameterNameImageType error:nil];
+    return [self.store sdl_enumForName:SDLRPCParameterNameImageType error:nil];
 }
 
 - (void)setIsTemplate:(NSNumber<SDLBool> *)isTemplate {
-    [store sdl_setObject:isTemplate forName:SDLRPCParameterNameImageTemplate];
+    [self.store sdl_setObject:isTemplate forName:SDLRPCParameterNameImageTemplate];
 }
 
 - (NSNumber<SDLBool> *)isTemplate {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameImageTemplate ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameImageTemplate ofClass:NSNumber.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLImageField.m
+++ b/SmartDeviceLink/SDLImageField.m
@@ -13,29 +13,29 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation SDLImageField
 
 - (void)setName:(SDLImageFieldName)name {
-    [store sdl_setObject:name forName:SDLRPCParameterNameName];
+    [self.store sdl_setObject:name forName:SDLRPCParameterNameName];
 }
 
 - (SDLImageFieldName)name {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameName error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameName error:&error];
 }
 
 - (void)setImageTypeSupported:(NSArray<SDLFileType> *)imageTypeSupported {
-    [store sdl_setObject:imageTypeSupported forName:SDLRPCParameterNameImageTypeSupported];
+    [self.store sdl_setObject:imageTypeSupported forName:SDLRPCParameterNameImageTypeSupported];
 }
 
 - (NSArray<SDLFileType> *)imageTypeSupported {
     NSError *error = nil;
-    return [store sdl_enumsForName:SDLRPCParameterNameImageTypeSupported error:&error];
+    return [self.store sdl_enumsForName:SDLRPCParameterNameImageTypeSupported error:&error];
 }
 
 - (void)setImageResolution:(nullable SDLImageResolution *)imageResolution {
-    [store sdl_setObject:imageResolution forName:SDLRPCParameterNameImageResolution];
+    [self.store sdl_setObject:imageResolution forName:SDLRPCParameterNameImageResolution];
 }
 
 - (nullable SDLImageResolution *)imageResolution {
-    return [store sdl_objectForName:SDLRPCParameterNameImageResolution ofClass:SDLImageResolution.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameImageResolution ofClass:SDLImageResolution.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLImageResolution.m
+++ b/SmartDeviceLink/SDLImageResolution.m
@@ -22,21 +22,21 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setResolutionWidth:(NSNumber<SDLInt> *)resolutionWidth {
-    [store sdl_setObject:resolutionWidth forName:SDLRPCParameterNameResolutionWidth];
+    [self.store sdl_setObject:resolutionWidth forName:SDLRPCParameterNameResolutionWidth];
 }
 
 - (NSNumber<SDLInt> *)resolutionWidth {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameResolutionWidth ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameResolutionWidth ofClass:NSNumber.class error:&error];
 }
 
 - (void)setResolutionHeight:(NSNumber<SDLInt> *)resolutionHeight {
-    [store sdl_setObject:resolutionHeight forName:SDLRPCParameterNameResolutionHeight];
+    [self.store sdl_setObject:resolutionHeight forName:SDLRPCParameterNameResolutionHeight];
 }
 
 - (NSNumber<SDLInt> *)resolutionHeight {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameResolutionHeight ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameResolutionHeight ofClass:NSNumber.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLKeyboardProperties.m
+++ b/SmartDeviceLink/SDLKeyboardProperties.m
@@ -26,43 +26,43 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setLanguage:(nullable SDLLanguage)language {
-    [store sdl_setObject:language forName:SDLRPCParameterNameLanguage];
+    [self.store sdl_setObject:language forName:SDLRPCParameterNameLanguage];
 }
 
 - (nullable SDLLanguage)language {
-    return [store sdl_enumForName:SDLRPCParameterNameLanguage error:nil];
+    return [self.store sdl_enumForName:SDLRPCParameterNameLanguage error:nil];
 }
 
 - (void)setKeyboardLayout:(nullable SDLKeyboardLayout)keyboardLayout {
-    [store sdl_setObject:keyboardLayout forName:SDLRPCParameterNameKeyboardLayout];
+    [self.store sdl_setObject:keyboardLayout forName:SDLRPCParameterNameKeyboardLayout];
 }
 
 - (nullable SDLKeyboardLayout)keyboardLayout {
-    return [store sdl_enumForName:SDLRPCParameterNameKeyboardLayout error:nil];
+    return [self.store sdl_enumForName:SDLRPCParameterNameKeyboardLayout error:nil];
 }
 
 - (void)setKeypressMode:(nullable SDLKeypressMode)keypressMode {
-    [store sdl_setObject:keypressMode forName:SDLRPCParameterNameKeypressMode];
+    [self.store sdl_setObject:keypressMode forName:SDLRPCParameterNameKeypressMode];
 }
 
 - (nullable SDLKeypressMode)keypressMode {
-    return [store sdl_enumForName:SDLRPCParameterNameKeypressMode error:nil];
+    return [self.store sdl_enumForName:SDLRPCParameterNameKeypressMode error:nil];
 }
 
 - (void)setLimitedCharacterList:(nullable NSArray<NSString *> *)limitedCharacterList {
-    [store sdl_setObject:limitedCharacterList forName:SDLRPCParameterNameLimitedCharacterList];
+    [self.store sdl_setObject:limitedCharacterList forName:SDLRPCParameterNameLimitedCharacterList];
 }
 
 - (nullable NSArray<NSString *> *)limitedCharacterList {
-    return [store sdl_objectsForName:SDLRPCParameterNameLimitedCharacterList ofClass:NSString.class error:nil];
+    return [self.store sdl_objectsForName:SDLRPCParameterNameLimitedCharacterList ofClass:NSString.class error:nil];
 }
 
 - (void)setAutoCompleteText:(nullable NSString *)autoCompleteText {
-    [store sdl_setObject:autoCompleteText forName:SDLRPCParameterNameAutoCompleteText];
+    [self.store sdl_setObject:autoCompleteText forName:SDLRPCParameterNameAutoCompleteText];
 }
 
 - (nullable NSString *)autoCompleteText {
-    return [store sdl_objectForName:SDLRPCParameterNameAutoCompleteText ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameAutoCompleteText ofClass:NSString.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLLightCapabilities.m
+++ b/SmartDeviceLink/SDLLightCapabilities.m
@@ -33,36 +33,36 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setName:(SDLLightName)name {
-    [store sdl_setObject:name forName:SDLRPCParameterNameName];
+    [self.store sdl_setObject:name forName:SDLRPCParameterNameName];
 }
 
 - (SDLLightName)name {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameName error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameName error:&error];
 }
 
 - (void)setDensityAvailable:(nullable NSNumber<SDLBool> *)densityAvailable {
-    [store sdl_setObject:densityAvailable forName:SDLRPCParameterNameDensityAvailable];
+    [self.store sdl_setObject:densityAvailable forName:SDLRPCParameterNameDensityAvailable];
 }
 
 - (nullable NSNumber<SDLBool> *)densityAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameDensityAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameDensityAvailable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setColorAvailable:(nullable NSNumber<SDLBool> *)colorAvailable {
-    [store sdl_setObject:colorAvailable forName:SDLRPCParameterNameRGBColorSpaceAvailable];
+    [self.store sdl_setObject:colorAvailable forName:SDLRPCParameterNameRGBColorSpaceAvailable];
 }
 
 - (nullable NSNumber<SDLBool> *)colorAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameRGBColorSpaceAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameRGBColorSpaceAvailable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setStatusAvailable:(nullable NSNumber<SDLBool> *)statusAvailable {
-    [store sdl_setObject:statusAvailable forName:SDLRPCParameterNameStatusAvailable];
+    [self.store sdl_setObject:statusAvailable forName:SDLRPCParameterNameStatusAvailable];
 }
 
 - (nullable NSNumber<SDLBool> *)statusAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameStatusAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameStatusAvailable ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLLightControlCapabilities.m
+++ b/SmartDeviceLink/SDLLightControlCapabilities.m
@@ -23,22 +23,22 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setModuleName:(NSString *)moduleName {
-    [store sdl_setObject:moduleName forName:SDLRPCParameterNameModuleName];
+    [self.store sdl_setObject:moduleName forName:SDLRPCParameterNameModuleName];
 }
 
 - (NSString *)moduleName {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameModuleName ofClass:NSString.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameModuleName ofClass:NSString.class error:&error];
 }
 
 - (void)setSupportedLights:(NSArray<SDLLightCapabilities *> *)supportedLights {
-    [store sdl_setObject:supportedLights forName:SDLRPCParameterNameSupportedLights];
+    [self.store sdl_setObject:supportedLights forName:SDLRPCParameterNameSupportedLights];
 
 }
 
 - (NSArray<SDLLightCapabilities *> *)supportedLights {
     NSError *error = nil;
-    return [store sdl_objectsForName:SDLRPCParameterNameSupportedLights ofClass:SDLLightCapabilities.class error:&error];
+    return [self.store sdl_objectsForName:SDLRPCParameterNameSupportedLights ofClass:SDLLightCapabilities.class error:&error];
 }
 
 

--- a/SmartDeviceLink/SDLLightControlData.m
+++ b/SmartDeviceLink/SDLLightControlData.m
@@ -21,12 +21,12 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setLightState:(NSArray<SDLLightState *> *)lightState {
-    [store sdl_setObject:lightState forName:SDLRPCParameterNameLightState];
+    [self.store sdl_setObject:lightState forName:SDLRPCParameterNameLightState];
 }
 
 - (NSArray<SDLLightState *> *)lightState {
     NSError *error = nil;
-    return [store sdl_objectsForName:SDLRPCParameterNameLightState ofClass:SDLLightState.class error:&error];
+    return [self.store sdl_objectsForName:SDLRPCParameterNameLightState ofClass:SDLLightState.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLLightState.m
+++ b/SmartDeviceLink/SDLLightState.m
@@ -48,37 +48,37 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setId:(SDLLightName)id {
-    [store sdl_setObject:id forName:SDLRPCParameterNameId];
+    [self.store sdl_setObject:id forName:SDLRPCParameterNameId];
 }
 
 - (SDLLightName)id {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameId error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameId error:&error];
 }
 
 - (void)setStatus:(SDLLightStatus)status {
-    [store sdl_setObject:status forName:SDLRPCParameterNameStatus];
+    [self.store sdl_setObject:status forName:SDLRPCParameterNameStatus];
 }
 
 - (SDLLightStatus)status {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameStatus error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameStatus error:&error];
 }
 
 - (void)setDensity:(nullable NSNumber<SDLFloat> *)density {
-    [store sdl_setObject:density forName:SDLRPCParameterNameDensity];
+    [self.store sdl_setObject:density forName:SDLRPCParameterNameDensity];
 }
 
 - (nullable NSNumber<SDLFloat> *)density {
-    return [store sdl_objectForName:SDLRPCParameterNameDensity ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameDensity ofClass:NSNumber.class error:nil];
 }
 
 - (void)setColor:(nullable SDLRGBColor *)color {
-    [store sdl_setObject:color forName:SDLRPCParameterNameColor];
+    [self.store sdl_setObject:color forName:SDLRPCParameterNameColor];
 }
 
 - (nullable SDLRGBColor *)color {
-    return [store sdl_objectForName:SDLRPCParameterNameColor ofClass:SDLRGBColor.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameColor ofClass:SDLRGBColor.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLListFiles.m
+++ b/SmartDeviceLink/SDLListFiles.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLListFiles
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameListFiles]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLListFilesResponse.m
+++ b/SmartDeviceLink/SDLListFilesResponse.m
@@ -12,26 +12,29 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLListFilesResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameListFiles]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setFilenames:(nullable NSArray<NSString *> *)filenames {
-    [parameters sdl_setObject:filenames forName:SDLRPCParameterNameFilenames];
+    [self.parameters sdl_setObject:filenames forName:SDLRPCParameterNameFilenames];
 }
 
 - (nullable NSArray<NSString *> *)filenames {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameFilenames ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameFilenames ofClass:NSString.class error:nil];
 }
 
 - (void)setSpaceAvailable:(nullable NSNumber<SDLInt> *)spaceAvailable {
-    [parameters sdl_setObject:spaceAvailable forName:SDLRPCParameterNameSpaceAvailable];
+    [self.parameters sdl_setObject:spaceAvailable forName:SDLRPCParameterNameSpaceAvailable];
 }
 
 - (nullable NSNumber<SDLInt> *)spaceAvailable {
-    return [parameters sdl_objectForName:SDLRPCParameterNameSpaceAvailable ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameSpaceAvailable ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLLocationCoordinate.m
+++ b/SmartDeviceLink/SDLLocationCoordinate.m
@@ -23,21 +23,21 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setLongitudeDegrees:(NSNumber<SDLFloat> *)longitudeDegrees {
-    [store sdl_setObject:longitudeDegrees forName:SDLRPCParameterNameLongitudeDegrees];
+    [self.store sdl_setObject:longitudeDegrees forName:SDLRPCParameterNameLongitudeDegrees];
 }
 
 - (NSNumber<SDLFloat> *)longitudeDegrees {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameLongitudeDegrees ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameLongitudeDegrees ofClass:NSNumber.class error:&error];
 }
 
 - (void)setLatitudeDegrees:(NSNumber<SDLFloat> *)latitudeDegrees {
-    [store sdl_setObject:latitudeDegrees forName:SDLRPCParameterNameLatitudeDegrees];
+    [self.store sdl_setObject:latitudeDegrees forName:SDLRPCParameterNameLatitudeDegrees];
 }
 
 - (NSNumber<SDLFloat> *)latitudeDegrees {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameLatitudeDegrees ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameLatitudeDegrees ofClass:NSNumber.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLLocationDetails.m
+++ b/SmartDeviceLink/SDLLocationDetails.m
@@ -41,59 +41,59 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setCoordinate:(nullable SDLLocationCoordinate *)coordinate {
-    [store sdl_setObject:coordinate forName:SDLRPCParameterNameLocationCoordinate];
+    [self.store sdl_setObject:coordinate forName:SDLRPCParameterNameLocationCoordinate];
 }
 
 - (nullable SDLLocationCoordinate *)coordinate {
-    return [store sdl_objectForName:SDLRPCParameterNameLocationCoordinate ofClass:SDLLocationCoordinate.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameLocationCoordinate ofClass:SDLLocationCoordinate.class error:nil];
 }
 
 - (void)setLocationName:(nullable NSString *)locationName {
-    [store sdl_setObject:locationName forName:SDLRPCParameterNameLocationName];
+    [self.store sdl_setObject:locationName forName:SDLRPCParameterNameLocationName];
 }
 
 - (nullable NSString *)locationName {
-    return [store sdl_objectForName:SDLRPCParameterNameLocationName ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameLocationName ofClass:NSString.class error:nil];
 }
 
 - (void)setAddressLines:(nullable NSArray<NSString *> *)addressLines {
-    [store sdl_setObject:addressLines forName:SDLRPCParameterNameAddressLines];
+    [self.store sdl_setObject:addressLines forName:SDLRPCParameterNameAddressLines];
 }
 
 - (nullable NSArray<NSString *> *)addressLines {
-    return [store sdl_objectsForName:SDLRPCParameterNameAddressLines ofClass:NSString.class error:nil];
+    return [self.store sdl_objectsForName:SDLRPCParameterNameAddressLines ofClass:NSString.class error:nil];
 }
 
 - (void)setLocationDescription:(nullable NSString *)locationDescription {
-    [store sdl_setObject:locationDescription forName:SDLRPCParameterNameLocationDescription];
+    [self.store sdl_setObject:locationDescription forName:SDLRPCParameterNameLocationDescription];
 }
 
 - (nullable NSString *)locationDescription {
-    return [store sdl_objectForName:SDLRPCParameterNameLocationDescription ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameLocationDescription ofClass:NSString.class error:nil];
 }
 
 - (void)setPhoneNumber:(nullable NSString *)phoneNumber {
-    [store sdl_setObject:phoneNumber forName:SDLRPCParameterNamePhoneNumber];
+    [self.store sdl_setObject:phoneNumber forName:SDLRPCParameterNamePhoneNumber];
 }
 
 - (nullable NSString *)phoneNumber {
-    return [store sdl_objectForName:SDLRPCParameterNamePhoneNumber ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNamePhoneNumber ofClass:NSString.class error:nil];
 }
 
 - (void)setLocationImage:(nullable SDLImage *)locationImage {
-    [store sdl_setObject:locationImage forName:SDLRPCParameterNameLocationImage];
+    [self.store sdl_setObject:locationImage forName:SDLRPCParameterNameLocationImage];
 }
 
 - (nullable SDLImage *)locationImage {
-    return [store sdl_objectForName:SDLRPCParameterNameLocationImage ofClass:SDLImage.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameLocationImage ofClass:SDLImage.class error:nil];
 }
 
 - (void)setSearchAddress:(nullable SDLOasisAddress *)searchAddress {
-    [store sdl_setObject:searchAddress forName:SDLRPCParameterNameSearchAddress];
+    [self.store sdl_setObject:searchAddress forName:SDLRPCParameterNameSearchAddress];
 }
 
 - (nullable SDLOasisAddress *)searchAddress {
-    return [store sdl_objectForName:SDLRPCParameterNameSearchAddress ofClass:SDLOasisAddress.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameSearchAddress ofClass:SDLOasisAddress.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLMassageCushionFirmness.m
+++ b/SmartDeviceLink/SDLMassageCushionFirmness.m
@@ -22,21 +22,21 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setCushion:(SDLMassageCushion)cushion {
-    [store sdl_setObject:cushion forName:SDLRPCParameterNameCushion];
+    [self.store sdl_setObject:cushion forName:SDLRPCParameterNameCushion];
 }
 
 - (SDLMassageCushion)cushion {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameCushion error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameCushion error:&error];
 }
 
 - (void)setFirmness:(NSNumber<SDLInt> *)firmness {
-    [store sdl_setObject:firmness forName:SDLRPCParameterNameFirmness];
+    [self.store sdl_setObject:firmness forName:SDLRPCParameterNameFirmness];
 }
 
 - (NSNumber<SDLInt> *)firmness {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameFirmness ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameFirmness ofClass:NSNumber.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLMassageModeData.m
+++ b/SmartDeviceLink/SDLMassageModeData.m
@@ -22,21 +22,21 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setMassageMode:(SDLMassageMode)massageMode {
-    [store sdl_setObject:massageMode forName:SDLRPCParameterNameMassageMode];
+    [self.store sdl_setObject:massageMode forName:SDLRPCParameterNameMassageMode];
 }
 
 - (SDLMassageMode)massageMode {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameMassageMode error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameMassageMode error:&error];
 }
 
 - (void)setMassageZone:(SDLMassageZone)massageZone {
-    [store sdl_setObject:massageZone forName:SDLRPCParameterNameMassageZone];
+    [self.store sdl_setObject:massageZone forName:SDLRPCParameterNameMassageZone];
 }
 
 - (SDLMassageZone)massageZone {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameMassageZone error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameMassageZone error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLMediaServiceData.m
+++ b/SmartDeviceLink/SDLMediaServiceData.m
@@ -38,99 +38,99 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setMediaType:(nullable SDLMediaType)mediaType {
-    [store sdl_setObject:mediaType forName:SDLRPCParameterNameMediaType];
+    [self.store sdl_setObject:mediaType forName:SDLRPCParameterNameMediaType];
 }
 
 - (nullable SDLMediaType)mediaType {
-    return [store sdl_enumForName:SDLRPCParameterNameMediaType error:nil];
+    return [self.store sdl_enumForName:SDLRPCParameterNameMediaType error:nil];
 }
 
 - (void)setMediaTitle:(nullable NSString *)mediaTitle {
-    [store sdl_setObject:mediaTitle forName:SDLRPCParameterNameMediaTitle];
+    [self.store sdl_setObject:mediaTitle forName:SDLRPCParameterNameMediaTitle];
 }
 
 - (nullable NSString *)mediaTitle {
-    return [store sdl_objectForName:SDLRPCParameterNameMediaTitle ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameMediaTitle ofClass:NSString.class error:nil];
 }
 
 - (void)setMediaArtist:(nullable NSString *)mediaArtist {
-    [store sdl_setObject:mediaArtist forName:SDLRPCParameterNameMediaArtist];
+    [self.store sdl_setObject:mediaArtist forName:SDLRPCParameterNameMediaArtist];
 }
 
 - (nullable NSString *)mediaArtist {
-    return [store sdl_objectForName:SDLRPCParameterNameMediaArtist ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameMediaArtist ofClass:NSString.class error:nil];
 }
 
 - (void)setMediaAlbum:(nullable NSString *)mediaAlbum {
-    [store sdl_setObject:mediaAlbum forName:SDLRPCParameterNameMediaAlbum];
+    [self.store sdl_setObject:mediaAlbum forName:SDLRPCParameterNameMediaAlbum];
 }
 
 - (nullable NSString *)mediaAlbum {
-    return [store sdl_objectForName:SDLRPCParameterNameMediaAlbum ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameMediaAlbum ofClass:NSString.class error:nil];
 }
 
 - (void)setPlaylistName:(nullable NSString *)playlistName {
-    [store sdl_setObject:playlistName forName:SDLRPCParameterNamePlaylistName];
+    [self.store sdl_setObject:playlistName forName:SDLRPCParameterNamePlaylistName];
 }
 
 - (nullable NSString *)playlistName {
-    return [store sdl_objectForName:SDLRPCParameterNamePlaylistName ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNamePlaylistName ofClass:NSString.class error:nil];
 }
 
 - (void)setIsExplicit:(nullable NSNumber<SDLBool> *)isExplicit {
-    [store sdl_setObject:isExplicit forName:SDLRPCParameterNameIsExplicit];
+    [self.store sdl_setObject:isExplicit forName:SDLRPCParameterNameIsExplicit];
 }
 
 - (nullable NSNumber<SDLBool> *)isExplicit {
-    return [store sdl_objectForName:SDLRPCParameterNameIsExplicit ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameIsExplicit ofClass:NSNumber.class error:nil];
 }
 
 - (void)setTrackPlaybackProgress:(nullable NSNumber<SDLInt> *)trackPlaybackProgress {
-    [store sdl_setObject:trackPlaybackProgress forName:SDLRPCParameterNameTrackPlaybackProgress];
+    [self.store sdl_setObject:trackPlaybackProgress forName:SDLRPCParameterNameTrackPlaybackProgress];
 }
 
 - (nullable NSNumber<SDLInt> *)trackPlaybackProgress {
-    return [store sdl_objectForName:SDLRPCParameterNameTrackPlaybackProgress ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameTrackPlaybackProgress ofClass:NSNumber.class error:nil];
 }
 
 - (void)setTrackPlaybackDuration:(nullable NSNumber<SDLInt> *)trackPlaybackDuration {
-    [store sdl_setObject:trackPlaybackDuration forName:SDLRPCParameterNameTrackPlaybackDuration];
+    [self.store sdl_setObject:trackPlaybackDuration forName:SDLRPCParameterNameTrackPlaybackDuration];
 }
 
 - (nullable NSNumber<SDLInt> *)trackPlaybackDuration {
-    return [store sdl_objectForName:SDLRPCParameterNameTrackPlaybackDuration ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameTrackPlaybackDuration ofClass:NSNumber.class error:nil];
 }
 
 - (void)setQueuePlaybackProgress:(nullable NSNumber<SDLInt> *)queuePlaybackProgress {
-    [store sdl_setObject:queuePlaybackProgress forName:SDLRPCParameterNameQueuePlaybackProgress];
+    [self.store sdl_setObject:queuePlaybackProgress forName:SDLRPCParameterNameQueuePlaybackProgress];
 }
 
 - (nullable NSNumber<SDLInt> *)queuePlaybackProgress {
-    return [store sdl_objectForName:SDLRPCParameterNameQueuePlaybackProgress ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameQueuePlaybackProgress ofClass:NSNumber.class error:nil];
 }
 
 - (void)setQueuePlaybackDuration:(nullable NSNumber<SDLInt> *)queuePlaybackDuration {
-    [store sdl_setObject:queuePlaybackDuration forName:SDLRPCParameterNameQueuePlaybackDuration];
+    [self.store sdl_setObject:queuePlaybackDuration forName:SDLRPCParameterNameQueuePlaybackDuration];
 }
 
 - (nullable NSNumber<SDLInt> *)queuePlaybackDuration {
-    return [store sdl_objectForName:SDLRPCParameterNameQueuePlaybackDuration ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameQueuePlaybackDuration ofClass:NSNumber.class error:nil];
 }
 
 - (void)setQueueCurrentTrackNumber:(nullable NSNumber<SDLInt> *)queueCurrentTrackNumber {
-    [store sdl_setObject:queueCurrentTrackNumber forName:SDLRPCParameterNameQueueCurrentTrackNumber];
+    [self.store sdl_setObject:queueCurrentTrackNumber forName:SDLRPCParameterNameQueueCurrentTrackNumber];
 }
 
 - (nullable NSNumber<SDLInt> *)queueCurrentTrackNumber {
-    return [store sdl_objectForName:SDLRPCParameterNameQueueCurrentTrackNumber ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameQueueCurrentTrackNumber ofClass:NSNumber.class error:nil];
 }
 
 - (void)setQueueTotalTrackCount:(nullable NSNumber<SDLInt> *)queueTotalTrackCount {
-    [store sdl_setObject:queueTotalTrackCount forName:SDLRPCParameterNameQueueTotalTrackCount];
+    [self.store sdl_setObject:queueTotalTrackCount forName:SDLRPCParameterNameQueueTotalTrackCount];
 }
 
 - (nullable NSNumber<SDLInt> *)queueTotalTrackCount {
-    return [store sdl_objectForName:SDLRPCParameterNameQueueTotalTrackCount ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameQueueTotalTrackCount ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLMenuParams.m
+++ b/SmartDeviceLink/SDLMenuParams.m
@@ -35,27 +35,27 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setParentID:(nullable NSNumber<SDLInt> *)parentID {
-    [store sdl_setObject:parentID forName:SDLRPCParameterNameParentId];
+    [self.store sdl_setObject:parentID forName:SDLRPCParameterNameParentId];
 }
 
 - (nullable NSNumber<SDLInt> *)parentID {
-    return [store sdl_objectForName:SDLRPCParameterNameParentId ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameParentId ofClass:NSNumber.class error:nil];
 }
 
 - (void)setPosition:(nullable NSNumber<SDLInt> *)position {
-    [store sdl_setObject:position forName:SDLRPCParameterNamePosition];
+    [self.store sdl_setObject:position forName:SDLRPCParameterNamePosition];
 }
 
 - (nullable NSNumber<SDLInt> *)position {
-    return [store sdl_objectForName:SDLRPCParameterNamePosition ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNamePosition ofClass:NSNumber.class error:nil];
 }
 
 - (void)setMenuName:(NSString *)menuName {
-    [store sdl_setObject:menuName forName:SDLRPCParameterNameMenuName];
+    [self.store sdl_setObject:menuName forName:SDLRPCParameterNameMenuName];
 }
 
 - (NSString *)menuName {
-    return [store sdl_objectForName:SDLRPCParameterNameMenuName ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameMenuName ofClass:NSString.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLMetadataTags.m
+++ b/SmartDeviceLink/SDLMetadataTags.m
@@ -42,35 +42,35 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setMainField1:(nullable NSArray<SDLMetadataType> *)mainField1 {
-    [store sdl_setObject:mainField1 forName:SDLRPCParameterNameMainField1];
+    [self.store sdl_setObject:mainField1 forName:SDLRPCParameterNameMainField1];
 }
 
 - (nullable NSArray<SDLMetadataType> *)mainField1 {
-    return [store sdl_enumsForName:SDLRPCParameterNameMainField1 error:nil];
+    return [self.store sdl_enumsForName:SDLRPCParameterNameMainField1 error:nil];
 }
 
 - (void)setMainField2:(nullable NSArray<SDLMetadataType> *)mainField2 {
-    [store sdl_setObject:mainField2 forName:SDLRPCParameterNameMainField2];
+    [self.store sdl_setObject:mainField2 forName:SDLRPCParameterNameMainField2];
 }
 
 - (nullable NSArray<SDLMetadataType> *)mainField2 {
-    return [store sdl_enumsForName:SDLRPCParameterNameMainField2 error:nil];
+    return [self.store sdl_enumsForName:SDLRPCParameterNameMainField2 error:nil];
 }
 
 - (void)setMainField3:(nullable NSArray<SDLMetadataType> *)mainField3 {
-    [store sdl_setObject:mainField3 forName:SDLRPCParameterNameMainField3];
+    [self.store sdl_setObject:mainField3 forName:SDLRPCParameterNameMainField3];
 }
 
 - (nullable NSArray<SDLMetadataType> *)mainField3 {
-    return [store sdl_enumsForName:SDLRPCParameterNameMainField3 error:nil];
+    return [self.store sdl_enumsForName:SDLRPCParameterNameMainField3 error:nil];
 }
 
 - (void)setMainField4:(nullable NSArray<SDLMetadataType> *)mainField4 {
-    [store sdl_setObject:mainField4 forName:SDLRPCParameterNameMainField4];
+    [self.store sdl_setObject:mainField4 forName:SDLRPCParameterNameMainField4];
 }
 
 - (nullable NSArray<SDLMetadataType> *)mainField4 {
-    return [store sdl_enumsForName:SDLRPCParameterNameMainField4 error:nil];
+    return [self.store sdl_enumsForName:SDLRPCParameterNameMainField4 error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLModuleData.m
+++ b/SmartDeviceLink/SDLModuleData.m
@@ -89,60 +89,60 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setModuleType:(SDLModuleType)moduleType {
-    [store sdl_setObject:moduleType forName:SDLRPCParameterNameModuleType];
+    [self.store sdl_setObject:moduleType forName:SDLRPCParameterNameModuleType];
 }
 
 - (SDLModuleType)moduleType {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameModuleType error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameModuleType error:&error];
 }
 
 - (void)setRadioControlData:(nullable SDLRadioControlData *)radioControlData {
-    [store sdl_setObject:radioControlData forName:SDLRPCParameterNameRadioControlData];
+    [self.store sdl_setObject:radioControlData forName:SDLRPCParameterNameRadioControlData];
 }
 
 - (nullable SDLRadioControlData *)radioControlData {
-    return [store sdl_objectForName:SDLRPCParameterNameRadioControlData ofClass:SDLRadioControlData.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameRadioControlData ofClass:SDLRadioControlData.class error:nil];
 }
 
 - (void)setClimateControlData:(nullable SDLClimateControlData *)climateControlData {
-    [store sdl_setObject:climateControlData forName:SDLRPCParameterNameClimateControlData];
+    [self.store sdl_setObject:climateControlData forName:SDLRPCParameterNameClimateControlData];
 }
 
 - (nullable SDLClimateControlData *)climateControlData {
-    return [store sdl_objectForName:SDLRPCParameterNameClimateControlData ofClass:SDLClimateControlData.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameClimateControlData ofClass:SDLClimateControlData.class error:nil];
 }
 
 - (void)setSeatControlData:(nullable SDLSeatControlData *)seatControlData {
-    [store sdl_setObject:seatControlData forName:SDLRPCParameterNameSeatControlData];
+    [self.store sdl_setObject:seatControlData forName:SDLRPCParameterNameSeatControlData];
 }
 
 - (nullable SDLSeatControlData *)seatControlData {
-    return [store sdl_objectForName:SDLRPCParameterNameSeatControlData ofClass:SDLSeatControlData.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameSeatControlData ofClass:SDLSeatControlData.class error:nil];
 }
 
 - (void)setAudioControlData:(nullable SDLAudioControlData *)audioControlData {
-    [store sdl_setObject:audioControlData forName:SDLRPCParameterNameAudioControlData];
+    [self.store sdl_setObject:audioControlData forName:SDLRPCParameterNameAudioControlData];
 }
 
 - (nullable SDLAudioControlData *)audioControlData {
-    return [store sdl_objectForName:SDLRPCParameterNameAudioControlData ofClass:SDLAudioControlData.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameAudioControlData ofClass:SDLAudioControlData.class error:nil];
 }
 
 - (void)setLightControlData:(nullable SDLLightControlData *)lightControlData {
-    [store sdl_setObject:lightControlData forName:SDLRPCParameterNameLightControlData];
+    [self.store sdl_setObject:lightControlData forName:SDLRPCParameterNameLightControlData];
 }
 
 - (nullable SDLLightControlData *)lightControlData {
-    return [store sdl_objectForName:SDLRPCParameterNameLightControlData ofClass:SDLLightControlData.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameLightControlData ofClass:SDLLightControlData.class error:nil];
 }
 
 - (void)setHmiSettingsControlData:(nullable SDLHMISettingsControlData *)hmiSettingsControlData {
-    [store sdl_setObject:hmiSettingsControlData forName:SDLRPCParameterNameHmiSettingsControlData];
+    [self.store sdl_setObject:hmiSettingsControlData forName:SDLRPCParameterNameHmiSettingsControlData];
 }
 
 - (nullable SDLHMISettingsControlData *)hmiSettingsControlData {
-    return [store sdl_objectForName:SDLRPCParameterNameHmiSettingsControlData ofClass:SDLHMISettingsControlData.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameHmiSettingsControlData ofClass:SDLHMISettingsControlData.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLMyKey.m
+++ b/SmartDeviceLink/SDLMyKey.m
@@ -12,12 +12,12 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation SDLMyKey
 
 - (void)setE911Override:(SDLVehicleDataStatus)e911Override {
-    [store sdl_setObject:e911Override forName:SDLRPCParameterNameE911Override];
+    [self.store sdl_setObject:e911Override forName:SDLRPCParameterNameE911Override];
 }
 
 - (SDLVehicleDataStatus)e911Override {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameE911Override error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameE911Override error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLNavigationCapability.m
+++ b/SmartDeviceLink/SDLNavigationCapability.m
@@ -28,19 +28,19 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setSendLocationEnabled:(nullable NSNumber *)sendLocationEnabled {
-    [store sdl_setObject:sendLocationEnabled forName:SDLRPCParameterNameSendLocationEnabled];
+    [self.store sdl_setObject:sendLocationEnabled forName:SDLRPCParameterNameSendLocationEnabled];
 }
 
 - (nullable NSNumber *)sendLocationEnabled {
-    return [store sdl_objectForName:SDLRPCParameterNameSendLocationEnabled ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameSendLocationEnabled ofClass:NSNumber.class error:nil];
 }
 
 - (void)setGetWayPointsEnabled:(nullable NSNumber *)getWayPointsEnabled {
-    [store sdl_setObject:getWayPointsEnabled forName:SDLRPCParameterNameGetWayPointsEnabled];
+    [self.store sdl_setObject:getWayPointsEnabled forName:SDLRPCParameterNameGetWayPointsEnabled];
 }
 
 - (nullable NSNumber *)getWayPointsEnabled {
-    return [store sdl_objectForName:SDLRPCParameterNameGetWayPointsEnabled ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameGetWayPointsEnabled ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLNavigationInstruction.m
+++ b/SmartDeviceLink/SDLNavigationInstruction.m
@@ -48,67 +48,67 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setLocationDetails:(SDLLocationDetails *)locationDetails {
-    [store sdl_setObject:locationDetails forName:SDLRPCParameterNameLocationDetails];
+    [self.store sdl_setObject:locationDetails forName:SDLRPCParameterNameLocationDetails];
 }
 
 - (SDLLocationDetails *)locationDetails {
-    return [store sdl_objectForName:SDLRPCParameterNameLocationDetails ofClass:SDLLocationDetails.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameLocationDetails ofClass:SDLLocationDetails.class error:nil];
 }
 
 - (void)setAction:(SDLNavigationAction)action {
-    [store sdl_setObject:action forName:SDLRPCParameterNameAction];
+    [self.store sdl_setObject:action forName:SDLRPCParameterNameAction];
 }
 
 - (SDLNavigationAction)action {
-    return [store sdl_enumForName:SDLRPCParameterNameAction error:nil];
+    return [self.store sdl_enumForName:SDLRPCParameterNameAction error:nil];
 }
 
 - (void)setEta:(nullable SDLDateTime *)eta {
-    [store sdl_setObject:eta forName:SDLRPCParameterNameETA];
+    [self.store sdl_setObject:eta forName:SDLRPCParameterNameETA];
 }
 
 - (nullable SDLDateTime *)eta {
-    return [store sdl_objectForName:SDLRPCParameterNameETA ofClass:SDLDateTime.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameETA ofClass:SDLDateTime.class error:nil];
 }
 
 - (void)setBearing:(nullable NSNumber<SDLInt> *)bearing {
-    [store sdl_setObject:bearing forName:SDLRPCParameterNameBearing];
+    [self.store sdl_setObject:bearing forName:SDLRPCParameterNameBearing];
 }
 
 - (nullable NSNumber<SDLInt> *)bearing {
-    return [store sdl_objectForName:SDLRPCParameterNameBearing ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameBearing ofClass:NSNumber.class error:nil];
 }
 
 - (void)setJunctionType:(nullable SDLNavigationJunction)junctionType {
-    [store sdl_setObject:junctionType forName:SDLRPCParameterNameJunctionType];
+    [self.store sdl_setObject:junctionType forName:SDLRPCParameterNameJunctionType];
 }
 
 - (nullable SDLNavigationJunction)junctionType {
-    return [store sdl_enumForName:SDLRPCParameterNameJunctionType error:nil];
+    return [self.store sdl_enumForName:SDLRPCParameterNameJunctionType error:nil];
 }
 
 - (void)setDrivingSide:(nullable SDLDirection)drivingSide {
-    [store sdl_setObject:drivingSide forName:SDLRPCParameterNameDrivingSide];
+    [self.store sdl_setObject:drivingSide forName:SDLRPCParameterNameDrivingSide];
 }
 
 - (nullable SDLDirection)drivingSide {
-    return [store sdl_enumForName:SDLRPCParameterNameDrivingSide error:nil];
+    return [self.store sdl_enumForName:SDLRPCParameterNameDrivingSide error:nil];
 }
 
 - (void)setDetails:(nullable NSString *)details {
-    [store sdl_setObject:details forName:SDLRPCParameterNameDetails];
+    [self.store sdl_setObject:details forName:SDLRPCParameterNameDetails];
 }
 
 - (nullable NSString *)details {
-    return [store sdl_objectForName:SDLRPCParameterNameDetails ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameDetails ofClass:NSString.class error:nil];
 }
 
 - (void)setImage:(nullable SDLImage *)image {
-    [store sdl_setObject:image forName:SDLRPCParameterNameImage];
+    [self.store sdl_setObject:image forName:SDLRPCParameterNameImage];
 }
 
 - (nullable SDLImage *)image {
-    return [store sdl_objectForName:SDLRPCParameterNameImage ofClass:SDLImage.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameImage ofClass:SDLImage.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLNavigationServiceData.m
+++ b/SmartDeviceLink/SDLNavigationServiceData.m
@@ -48,75 +48,75 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setTimestamp:(SDLDateTime *)timestamp {
-    [store sdl_setObject:timestamp forName:SDLRPCParameterNameTimeStamp];
+    [self.store sdl_setObject:timestamp forName:SDLRPCParameterNameTimeStamp];
 }
 
 - (SDLDateTime *)timestamp {
-    return [store sdl_objectForName:SDLRPCParameterNameTimeStamp ofClass:SDLDateTime.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameTimeStamp ofClass:SDLDateTime.class error:nil];
 }
 
 - (void)setOrigin:(nullable SDLLocationDetails *)origin {
-    [store sdl_setObject:origin forName:SDLRPCParameterNameOrigin];
+    [self.store sdl_setObject:origin forName:SDLRPCParameterNameOrigin];
 }
 
 - (nullable SDLLocationDetails *)origin {
-    return [store sdl_objectForName:SDLRPCParameterNameOrigin ofClass:SDLLocationDetails.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameOrigin ofClass:SDLLocationDetails.class error:nil];
 }
 
 - (void)setDestination:(nullable SDLLocationDetails *)destination {
-    [store sdl_setObject:destination forName:SDLRPCParameterNameDestination];
+    [self.store sdl_setObject:destination forName:SDLRPCParameterNameDestination];
 }
 
 - (nullable SDLLocationDetails *)destination {
-    return [store sdl_objectForName:SDLRPCParameterNameDestination ofClass:SDLLocationDetails.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameDestination ofClass:SDLLocationDetails.class error:nil];
 }
 
 - (void)setDestinationETA:(nullable SDLDateTime *)destinationETA {
-    [store sdl_setObject:destinationETA forName:SDLRPCParameterNameDestinationETA];
+    [self.store sdl_setObject:destinationETA forName:SDLRPCParameterNameDestinationETA];
 }
 
 - (nullable SDLDateTime *)destinationETA {
-    return [store sdl_objectForName:SDLRPCParameterNameDestinationETA ofClass:SDLDateTime.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameDestinationETA ofClass:SDLDateTime.class error:nil];
 }
 
 - (void)setInstructions:(nullable NSArray<SDLNavigationInstruction *> *)instructions {
-    [store sdl_setObject:instructions forName:SDLRPCParameterNameInstructions];
+    [self.store sdl_setObject:instructions forName:SDLRPCParameterNameInstructions];
 }
 
 - (nullable NSArray<SDLNavigationInstruction *> *)instructions {
-    return [store sdl_objectsForName:SDLRPCParameterNameInstructions ofClass:SDLNavigationInstruction.class error:nil];
+    return [self.store sdl_objectsForName:SDLRPCParameterNameInstructions ofClass:SDLNavigationInstruction.class error:nil];
 }
 
 - (void)setNextInstructionETA:(nullable SDLDateTime *)nextInstructionETA {
-    [store sdl_setObject:nextInstructionETA forName:SDLRPCParameterNameNextInstructionETA];
+    [self.store sdl_setObject:nextInstructionETA forName:SDLRPCParameterNameNextInstructionETA];
 }
 
 - (nullable SDLDateTime *)nextInstructionETA {
-    return [store sdl_objectForName:SDLRPCParameterNameNextInstructionETA ofClass:SDLDateTime.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameNextInstructionETA ofClass:SDLDateTime.class error:nil];
 }
 
 - (void)setNextInstructionDistance:(nullable NSNumber<SDLFloat> *)nextInstructionDistance {
-    [store sdl_setObject:nextInstructionDistance forName:SDLRPCParameterNameNextInstructionDistance];
+    [self.store sdl_setObject:nextInstructionDistance forName:SDLRPCParameterNameNextInstructionDistance];
 }
 
 - (nullable NSNumber<SDLFloat> *)nextInstructionDistance {
-    return [store sdl_objectForName:SDLRPCParameterNameNextInstructionDistance ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameNextInstructionDistance ofClass:NSNumber.class error:nil];
 }
 
 - (void)setNextInstructionDistanceScale:(nullable NSNumber<SDLFloat> *)nextInstructionDistanceScale {
-    [store sdl_setObject:nextInstructionDistanceScale forName:SDLRPCParameterNameNextInstructionDistanceScale];
+    [self.store sdl_setObject:nextInstructionDistanceScale forName:SDLRPCParameterNameNextInstructionDistanceScale];
 }
 
 - (nullable NSNumber<SDLFloat> *)nextInstructionDistanceScale {
-    return [store sdl_objectForName:SDLRPCParameterNameNextInstructionDistanceScale ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameNextInstructionDistanceScale ofClass:NSNumber.class error:nil];
 }
 
 - (void)setPrompt:(nullable NSString *)prompt {
-    [store sdl_setObject:prompt forName:SDLRPCParameterNamePrompt];
+    [self.store sdl_setObject:prompt forName:SDLRPCParameterNamePrompt];
 }
 
 - (nullable NSString *)prompt {
-    return [store sdl_objectForName:SDLRPCParameterNamePrompt ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNamePrompt ofClass:NSString.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLNavigationServiceManifest.m
+++ b/SmartDeviceLink/SDLNavigationServiceManifest.m
@@ -27,11 +27,11 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setAcceptsWayPoints:(nullable NSNumber<SDLBool> *)acceptsWayPoints {
-    [store sdl_setObject:acceptsWayPoints forName:SDLRPCParameterNameAcceptsWayPoints];
+    [self.store sdl_setObject:acceptsWayPoints forName:SDLRPCParameterNameAcceptsWayPoints];
 }
 
 - (nullable NSNumber<SDLBool> *)acceptsWayPoints {
-    return [store sdl_objectForName:SDLRPCParameterNameAcceptsWayPoints ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameAcceptsWayPoints ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLOasisAddress.m
+++ b/SmartDeviceLink/SDLOasisAddress.m
@@ -34,75 +34,75 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setCountryName:(nullable NSString *)countryName {
-    [store sdl_setObject:countryName forName:SDLRPCParameterNameCountryName];
+    [self.store sdl_setObject:countryName forName:SDLRPCParameterNameCountryName];
 }
 
 - (nullable NSString *)countryName {
-    return [store sdl_objectForName:SDLRPCParameterNameCountryName ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameCountryName ofClass:NSString.class error:nil];
 }
 
 - (void)setCountryCode:(nullable NSString *)countryCode {
-    [store sdl_setObject:countryCode forName:SDLRPCParameterNameCountryCode];
+    [self.store sdl_setObject:countryCode forName:SDLRPCParameterNameCountryCode];
 }
 
 - (nullable NSString *)countryCode {
-    return [store sdl_objectForName:SDLRPCParameterNameCountryCode ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameCountryCode ofClass:NSString.class error:nil];
 }
 
 - (void)setPostalCode:(nullable NSString *)postalCode {
-    [store sdl_setObject:postalCode forName:SDLRPCParameterNamePostalCode];
+    [self.store sdl_setObject:postalCode forName:SDLRPCParameterNamePostalCode];
 }
 
 - (nullable NSString *)postalCode {
-    return [store sdl_objectForName:SDLRPCParameterNamePostalCode ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNamePostalCode ofClass:NSString.class error:nil];
 }
 
 - (void)setAdministrativeArea:(nullable NSString *)administrativeArea {
-    [store sdl_setObject:administrativeArea forName:SDLRPCParameterNameAdministrativeArea];
+    [self.store sdl_setObject:administrativeArea forName:SDLRPCParameterNameAdministrativeArea];
 }
 
 - (nullable NSString *)administrativeArea {
-    return [store sdl_objectForName:SDLRPCParameterNameAdministrativeArea ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameAdministrativeArea ofClass:NSString.class error:nil];
 }
 
 - (void)setSubAdministrativeArea:(nullable NSString *)subAdministrativeArea {
-    [store sdl_setObject:subAdministrativeArea forName:SDLRPCParameterNameSubAdministrativeArea];
+    [self.store sdl_setObject:subAdministrativeArea forName:SDLRPCParameterNameSubAdministrativeArea];
 }
 
 - (nullable NSString *)subAdministrativeArea {
-    return [store sdl_objectForName:SDLRPCParameterNameSubAdministrativeArea ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameSubAdministrativeArea ofClass:NSString.class error:nil];
 }
 
 - (void)setLocality:(nullable NSString *)locality {
-    [store sdl_setObject:locality forName:SDLRPCParameterNameLocality];
+    [self.store sdl_setObject:locality forName:SDLRPCParameterNameLocality];
 }
 
 - (nullable NSString *)locality {
-    return [store sdl_objectForName:SDLRPCParameterNameLocality ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameLocality ofClass:NSString.class error:nil];
 }
 
 - (void)setSubLocality:(nullable NSString *)subLocality {
-    [store sdl_setObject:subLocality forName:SDLRPCParameterNameSubLocality];
+    [self.store sdl_setObject:subLocality forName:SDLRPCParameterNameSubLocality];
 }
 
 - (nullable NSString *)subLocality {
-    return [store sdl_objectForName:SDLRPCParameterNameSubLocality ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameSubLocality ofClass:NSString.class error:nil];
 }
 
 - (void)setThoroughfare:(nullable NSString *)thoroughfare {
-    [store sdl_setObject:thoroughfare forName:SDLRPCParameterNameThoroughfare];
+    [self.store sdl_setObject:thoroughfare forName:SDLRPCParameterNameThoroughfare];
 }
 
 - (nullable NSString *)thoroughfare {
-    return [store sdl_objectForName:SDLRPCParameterNameThoroughfare ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameThoroughfare ofClass:NSString.class error:nil];
 }
 
 - (void)setSubThoroughfare:(nullable NSString *)subThoroughfare {
-    [store sdl_setObject:subThoroughfare forName:SDLRPCParameterNameSubThoroughfare];
+    [self.store sdl_setObject:subThoroughfare forName:SDLRPCParameterNameSubThoroughfare];
 }
 
 - (nullable NSString *)subThoroughfare {
-    return [store sdl_objectForName:SDLRPCParameterNameSubThoroughfare ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameSubThoroughfare ofClass:NSString.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLOnAppInterfaceUnregistered.m
+++ b/SmartDeviceLink/SDLOnAppInterfaceUnregistered.m
@@ -11,19 +11,22 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLOnAppInterfaceUnregistered
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameOnAppInterfaceUnregistered]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setReason:(SDLAppInterfaceUnregisteredReason)reason {
-    [parameters sdl_setObject:reason forName:SDLRPCParameterNameReason];
+    [self.parameters sdl_setObject:reason forName:SDLRPCParameterNameReason];
 }
 
 - (SDLAppInterfaceUnregisteredReason)reason {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameReason error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameReason error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLOnAppServiceData.m
+++ b/SmartDeviceLink/SDLOnAppServiceData.m
@@ -17,11 +17,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLOnAppServiceData
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameOnAppServiceData]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithServiceData:(SDLAppServiceData *)serviceData {
     self = [self init];
@@ -35,12 +38,12 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setServiceData:(SDLAppServiceData *)serviceData {
-    [parameters sdl_setObject:serviceData forName:SDLRPCParameterNameServiceData];
+    [self.parameters sdl_setObject:serviceData forName:SDLRPCParameterNameServiceData];
 }
 
 - (SDLAppServiceData *)serviceData {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameServiceData ofClass:SDLAppServiceData.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameServiceData ofClass:SDLAppServiceData.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLOnAudioPassThru.m
+++ b/SmartDeviceLink/SDLOnAudioPassThru.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLOnAudioPassThru
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameOnAudioPassThru]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLOnButtonEvent.m
+++ b/SmartDeviceLink/SDLOnButtonEvent.m
@@ -11,36 +11,39 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLOnButtonEvent
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameOnButtonEvent]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setButtonName:(SDLButtonName)buttonName {
-    [parameters sdl_setObject:buttonName forName:SDLRPCParameterNameButtonName];
+    [self.parameters sdl_setObject:buttonName forName:SDLRPCParameterNameButtonName];
 }
 
 - (SDLButtonName)buttonName {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameButtonName error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameButtonName error:&error];
 }
 
 - (void)setButtonEventMode:(SDLButtonEventMode)buttonEventMode {
-    [parameters sdl_setObject:buttonEventMode forName:SDLRPCParameterNameButtonEventMode];
+    [self.parameters sdl_setObject:buttonEventMode forName:SDLRPCParameterNameButtonEventMode];
 }
 
 - (SDLButtonEventMode)buttonEventMode {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameButtonEventMode error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameButtonEventMode error:&error];
 }
 
 - (void)setCustomButtonID:(nullable NSNumber<SDLInt> *)customButtonID {
-    [parameters sdl_setObject:customButtonID forName:SDLRPCParameterNameCustomButtonId];
+    [self.parameters sdl_setObject:customButtonID forName:SDLRPCParameterNameCustomButtonId];
 }
 
 - (nullable NSNumber<SDLInt> *)customButtonID {
-    return [parameters sdl_objectForName:SDLRPCParameterNameCustomButtonId ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameCustomButtonId ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLOnButtonPress.m
+++ b/SmartDeviceLink/SDLOnButtonPress.m
@@ -11,36 +11,39 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLOnButtonPress
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameOnButtonPress]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setButtonName:(SDLButtonName)buttonName {
-    [parameters sdl_setObject:buttonName forName:SDLRPCParameterNameButtonName];
+    [self.parameters sdl_setObject:buttonName forName:SDLRPCParameterNameButtonName];
 }
 
 - (SDLButtonName)buttonName {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameButtonName error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameButtonName error:&error];
 }
 
 - (void)setButtonPressMode:(SDLButtonPressMode)buttonPressMode {
-    [parameters sdl_setObject:buttonPressMode forName:SDLRPCParameterNameButtonPressMode];
+    [self.parameters sdl_setObject:buttonPressMode forName:SDLRPCParameterNameButtonPressMode];
 }
 
 - (SDLButtonPressMode)buttonPressMode {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameButtonPressMode error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameButtonPressMode error:&error];
 }
 
 - (void)setCustomButtonID:(nullable NSNumber<SDLInt> *)customButtonID {
-    [parameters sdl_setObject:customButtonID forName:SDLRPCParameterNameCustomButtonId];
+    [self.parameters sdl_setObject:customButtonID forName:SDLRPCParameterNameCustomButtonId];
 }
 
 - (nullable NSNumber<SDLInt> *)customButtonID {
-    return [parameters sdl_objectForName:SDLRPCParameterNameCustomButtonId ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameCustomButtonId ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLOnCommand.m
+++ b/SmartDeviceLink/SDLOnCommand.m
@@ -11,28 +11,31 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLOnCommand
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameOnCommand]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setCmdID:(NSNumber<SDLInt> *)cmdID {
-    [parameters sdl_setObject:cmdID forName:SDLRPCParameterNameCommandId];
+    [self.parameters sdl_setObject:cmdID forName:SDLRPCParameterNameCommandId];
 }
 
 - (NSNumber<SDLInt> *)cmdID {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameCommandId ofClass:NSNumber.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameCommandId ofClass:NSNumber.class error:&error];
 }
 
 - (void)setTriggerSource:(SDLTriggerSource)triggerSource {
-    [parameters sdl_setObject:triggerSource forName:SDLRPCParameterNameTriggerSource];
+    [self.parameters sdl_setObject:triggerSource forName:SDLRPCParameterNameTriggerSource];
 }
 
 - (SDLTriggerSource)triggerSource {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameTriggerSource error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameTriggerSource error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLOnDriverDistraction.m
+++ b/SmartDeviceLink/SDLOnDriverDistraction.m
@@ -12,19 +12,22 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLOnDriverDistraction
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameOnDriverDistraction]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setState:(SDLDriverDistractionState)state {
-    [parameters sdl_setObject:state forName:SDLRPCParameterNameState];
+    [self.parameters sdl_setObject:state forName:SDLRPCParameterNameState];
 }
 
 - (SDLDriverDistractionState)state {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameState error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameState error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLOnEncodedSyncPData.m
+++ b/SmartDeviceLink/SDLOnEncodedSyncPData.m
@@ -11,35 +11,38 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLOnEncodedSyncPData
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameOnEncodedSyncPData]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setData:(NSArray<NSString *> *)data {
-    [parameters sdl_setObject:data forName:SDLRPCParameterNameData];
+    [self.parameters sdl_setObject:data forName:SDLRPCParameterNameData];
 }
 
 - (NSArray<NSString *> *)data {
     NSError *error = nil;
-    return [parameters sdl_objectsForName:SDLRPCParameterNameData ofClass:NSString.class error:&error];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameData ofClass:NSString.class error:&error];
 }
 
 - (void)setURL:(nullable NSString *)URL {
-    [parameters sdl_setObject:URL forName:SDLRPCParameterNameURLUppercase];
+    [self.parameters sdl_setObject:URL forName:SDLRPCParameterNameURLUppercase];
 }
 
 - (nullable NSString *)URL {
-    return [parameters sdl_objectForName:SDLRPCParameterNameURLUppercase ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameURLUppercase ofClass:NSString.class error:nil];
 }
 
 - (void)setTimeout:(nullable NSNumber<SDLInt> *)Timeout {
-    [parameters sdl_setObject:Timeout forName:SDLRPCParameterNameTimeoutCapitalized];
+    [self.parameters sdl_setObject:Timeout forName:SDLRPCParameterNameTimeoutCapitalized];
 }
 
 - (nullable NSNumber<SDLInt> *)Timeout {
-    return [parameters sdl_objectForName:SDLRPCParameterNameTimeoutCapitalized ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameTimeoutCapitalized ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLOnHMIStatus.m
+++ b/SmartDeviceLink/SDLOnHMIStatus.m
@@ -14,45 +14,48 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLOnHMIStatus
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameOnHMIStatus]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setHmiLevel:(SDLHMILevel)hmiLevel {
-    [parameters sdl_setObject:hmiLevel forName:SDLRPCParameterNameHMILevel];
+    [self.parameters sdl_setObject:hmiLevel forName:SDLRPCParameterNameHMILevel];
 }
 
 - (SDLHMILevel)hmiLevel {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameHMILevel error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameHMILevel error:&error];
 }
 
 - (void)setAudioStreamingState:(SDLAudioStreamingState)audioStreamingState {
-    [parameters sdl_setObject:audioStreamingState forName:SDLRPCParameterNameAudioStreamingState];
+    [self.parameters sdl_setObject:audioStreamingState forName:SDLRPCParameterNameAudioStreamingState];
 }
 
 - (SDLAudioStreamingState)audioStreamingState {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameAudioStreamingState error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameAudioStreamingState error:&error];
 }
 
 - (void)setVideoStreamingState:(nullable SDLVideoStreamingState)videoStreamingState {
-    [parameters sdl_setObject:videoStreamingState forName:SDLRPCParameterNameVideoStreamingState];
+    [self.parameters sdl_setObject:videoStreamingState forName:SDLRPCParameterNameVideoStreamingState];
 }
 
 - (nullable SDLVideoStreamingState)videoStreamingState {
-    return [parameters sdl_enumForName:SDLRPCParameterNameVideoStreamingState error:nil];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameVideoStreamingState error:nil];
 }
 
 - (void)setSystemContext:(SDLSystemContext)systemContext {
-    [parameters sdl_setObject:systemContext forName:SDLRPCParameterNameSystemContext];
+    [self.parameters sdl_setObject:systemContext forName:SDLRPCParameterNameSystemContext];
 }
 
 - (SDLSystemContext)systemContext {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameSystemContext error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameSystemContext error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLOnHashChange.m
+++ b/SmartDeviceLink/SDLOnHashChange.m
@@ -12,19 +12,22 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLOnHashChange
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameOnHashChange]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setHashID:(NSString *)hashID {
-    [parameters sdl_setObject:hashID forName:SDLRPCParameterNameHashId];
+    [self.parameters sdl_setObject:hashID forName:SDLRPCParameterNameHashId];
 }
 
 - (NSString *)hashID {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameHashId ofClass:NSString.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameHashId ofClass:NSString.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLOnInteriorVehicleData.m
+++ b/SmartDeviceLink/SDLOnInteriorVehicleData.m
@@ -12,19 +12,22 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLOnInteriorVehicleData
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameOnInteriorVehicleData]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setModuleData:(SDLModuleData *)moduleData {
-    [parameters sdl_setObject:moduleData forName:SDLRPCParameterNameModuleData];
+    [self.parameters sdl_setObject:moduleData forName:SDLRPCParameterNameModuleData];
 }
 
 - (SDLModuleData *)moduleData {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameModuleData ofClass:SDLModuleData.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameModuleData ofClass:SDLModuleData.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLOnKeyboardInput.m
+++ b/SmartDeviceLink/SDLOnKeyboardInput.m
@@ -11,27 +11,30 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLOnKeyboardInput
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameOnKeyboardInput]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setEvent:(SDLKeyboardEvent)event {
-    [parameters sdl_setObject:event forName:SDLRPCParameterNameEvent];
+    [self.parameters sdl_setObject:event forName:SDLRPCParameterNameEvent];
 }
 
 - (SDLKeyboardEvent)event {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameEvent error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameEvent error:&error];
 }
 
 - (void)setData:(nullable NSString *)data {
-    [parameters sdl_setObject:data forName:SDLRPCParameterNameData];
+    [self.parameters sdl_setObject:data forName:SDLRPCParameterNameData];
 }
 
 - (nullable NSString *)data {
-    return [parameters sdl_objectForName:SDLRPCParameterNameData ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameData ofClass:NSString.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLOnLanguageChange.m
+++ b/SmartDeviceLink/SDLOnLanguageChange.m
@@ -12,28 +12,31 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLOnLanguageChange
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameOnLanguageChange]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setLanguage:(SDLLanguage)language {
-    [parameters sdl_setObject:language forName:SDLRPCParameterNameLanguage];
+    [self.parameters sdl_setObject:language forName:SDLRPCParameterNameLanguage];
 }
 
 - (SDLLanguage)language {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameLanguage error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameLanguage error:&error];
 }
 
 - (void)setHmiDisplayLanguage:(SDLLanguage)hmiDisplayLanguage {
-    [parameters sdl_setObject:hmiDisplayLanguage forName:SDLRPCParameterNameHMIDisplayLanguage];
+    [self.parameters sdl_setObject:hmiDisplayLanguage forName:SDLRPCParameterNameHMIDisplayLanguage];
 }
 
 - (SDLLanguage)hmiDisplayLanguage {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameHMIDisplayLanguage error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameHMIDisplayLanguage error:&error];
 }
 
 

--- a/SmartDeviceLink/SDLOnLockScreenStatus.m
+++ b/SmartDeviceLink/SDLOnLockScreenStatus.m
@@ -15,46 +15,49 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLOnLockScreenStatus
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameOnLockScreenStatus]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setLockScreenStatus:(SDLLockScreenStatus)lockScreenStatus {
-    [parameters sdl_setObject:lockScreenStatus forName:SDLRPCParameterNameOnLockScreenStatus];
+    [self.parameters sdl_setObject:lockScreenStatus forName:SDLRPCParameterNameOnLockScreenStatus];
 }
 
 - (SDLLockScreenStatus)lockScreenStatus {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameOnLockScreenStatus error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameOnLockScreenStatus error:&error];
 }
 
 - (void)setHmiLevel:(SDLHMILevel)hmiLevel {
-    [parameters sdl_setObject:hmiLevel forName:SDLRPCParameterNameHMILevel];
+    [self.parameters sdl_setObject:hmiLevel forName:SDLRPCParameterNameHMILevel];
 }
 
 - (SDLHMILevel)hmiLevel {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameHMILevel error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameHMILevel error:&error];
 }
 
 - (void)setUserSelected:(NSNumber<SDLBool> *)userSelected {
-    [parameters sdl_setObject:userSelected forName:SDLRPCParameterNameUserSelected];
+    [self.parameters sdl_setObject:userSelected forName:SDLRPCParameterNameUserSelected];
 }
 
 - (NSNumber<SDLBool> *)userSelected {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameUserSelected ofClass:NSNumber.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameUserSelected ofClass:NSNumber.class error:&error];
 }
 
 - (void)setDriverDistractionStatus:(NSNumber<SDLBool> *)driverDistractionStatus {
-    [parameters sdl_setObject:driverDistractionStatus forName:SDLRPCParameterNameDriverDistractionStatus];
+    [self.parameters sdl_setObject:driverDistractionStatus forName:SDLRPCParameterNameDriverDistractionStatus];
 }
 
 - (NSNumber<SDLBool> *)driverDistractionStatus {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameDriverDistractionStatus ofClass:NSNumber.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameDriverDistractionStatus ofClass:NSNumber.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLOnPermissionsChange.m
+++ b/SmartDeviceLink/SDLOnPermissionsChange.m
@@ -12,19 +12,22 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLOnPermissionsChange
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameOnPermissionsChange]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setPermissionItem:(NSArray<SDLPermissionItem *> *)permissionItem {
-    [parameters sdl_setObject:permissionItem forName:SDLRPCParameterNamePermissionItem];
+    [self.parameters sdl_setObject:permissionItem forName:SDLRPCParameterNamePermissionItem];
 }
 
 - (NSArray<SDLPermissionItem *> *)permissionItem {
     NSError *error = nil;
-    return [parameters sdl_objectsForName:SDLRPCParameterNamePermissionItem ofClass:SDLPermissionItem.class error:&error];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNamePermissionItem ofClass:SDLPermissionItem.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLOnRCStatus.m
+++ b/SmartDeviceLink/SDLOnRCStatus.m
@@ -12,37 +12,40 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLOnRCStatus
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameOnRCStatus]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (nullable NSNumber<SDLBool> *)allowed {
-    return [parameters sdl_objectForName:SDLRPCParameterNameAllowed ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameAllowed ofClass:NSNumber.class error:nil];
 }
 
 - (void)setAllowed:(nullable NSNumber<SDLBool> *)allowed {
-    [parameters sdl_setObject:allowed forName:SDLRPCParameterNameAllowed];
+    [self.parameters sdl_setObject:allowed forName:SDLRPCParameterNameAllowed];
 }
 
 - (void)setAllocatedModules:(NSArray<SDLModuleData *> *)allocatedModules {
-    [parameters sdl_setObject:allocatedModules forName:SDLRPCParameterNameAllocatedModules];
+    [self.parameters sdl_setObject:allocatedModules forName:SDLRPCParameterNameAllocatedModules];
 
 }
 
 - (NSArray<SDLModuleData *> *)allocatedModules {
     NSError *error = nil;
-    return [parameters sdl_objectsForName:SDLRPCParameterNameAllocatedModules ofClass:SDLModuleData.class error:&error];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameAllocatedModules ofClass:SDLModuleData.class error:&error];
 }
 
 - (void)setFreeModules:(NSArray<SDLModuleData *> *)freeModules {
-    [parameters sdl_setObject:freeModules forName:SDLRPCParameterNameFreeModules];
+    [self.parameters sdl_setObject:freeModules forName:SDLRPCParameterNameFreeModules];
 }
 
 - (NSArray<SDLModuleData *> *)freeModules {
     NSError *error = nil;
-    return [parameters sdl_objectsForName:SDLRPCParameterNameFreeModules ofClass:SDLModuleData.class error:&error];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameFreeModules ofClass:SDLModuleData.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLOnSyncPData.m
+++ b/SmartDeviceLink/SDLOnSyncPData.m
@@ -13,26 +13,29 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLOnSyncPData
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameOnSyncPData]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setURL:(nullable NSString *)URL {
-    [parameters sdl_setObject:URL forName:SDLRPCParameterNameURLUppercase];
+    [self.parameters sdl_setObject:URL forName:SDLRPCParameterNameURLUppercase];
 }
 
 - (nullable NSString *)URL {
-    return [parameters sdl_objectForName:SDLRPCParameterNameURLUppercase ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameURLUppercase ofClass:NSString.class error:nil];
 }
 
 - (void)setTimeout:(nullable NSNumber<SDLInt> *)Timeout {
-    [parameters sdl_setObject:Timeout forName:SDLRPCParameterNameTimeoutCapitalized];
+    [self.parameters sdl_setObject:Timeout forName:SDLRPCParameterNameTimeoutCapitalized];
 }
 
 - (nullable NSNumber<SDLInt> *)Timeout {
-    return [parameters sdl_objectForName:SDLRPCParameterNameTimeoutCapitalized ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameTimeoutCapitalized ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLOnSystemCapabilityUpdated.m
+++ b/SmartDeviceLink/SDLOnSystemCapabilityUpdated.m
@@ -17,11 +17,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLOnSystemCapabilityUpdated
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameOnSystemCapabilityUpdated]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithSystemCapability:(SDLSystemCapability *)systemCapability {
     self = [self init];
@@ -35,12 +38,12 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setSystemCapability:(SDLSystemCapability *)systemCapability {
-    [parameters sdl_setObject:systemCapability forName:SDLRPCParameterNameSystemCapability];
+    [self.parameters sdl_setObject:systemCapability forName:SDLRPCParameterNameSystemCapability];
 }
 
 - (SDLSystemCapability *)systemCapability {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameSystemCapability ofClass:SDLSystemCapability.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameSystemCapability ofClass:SDLSystemCapability.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLOnSystemRequest.m
+++ b/SmartDeviceLink/SDLOnSystemRequest.m
@@ -11,67 +11,70 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLOnSystemRequest
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameOnSystemRequest]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setRequestType:(SDLRequestType)requestType {
-    [parameters sdl_setObject:requestType forName:SDLRPCParameterNameRequestType];
+    [self.parameters sdl_setObject:requestType forName:SDLRPCParameterNameRequestType];
 }
 
 - (SDLRequestType)requestType {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameRequestType error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameRequestType error:&error];
 }
 
 - (void)setRequestSubType:(nullable NSString *)requestSubType {
-    [parameters sdl_setObject:requestSubType forName:SDLRPCParameterNameRequestSubType];
+    [self.parameters sdl_setObject:requestSubType forName:SDLRPCParameterNameRequestSubType];
 }
 
 - (nullable NSString *)requestSubType {
-    return [parameters sdl_objectForName:SDLRPCParameterNameRequestSubType ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameRequestSubType ofClass:NSString.class error:nil];
 }
 
 - (void)setUrl:(nullable NSString *)url {
-    [parameters sdl_setObject:url forName:SDLRPCParameterNameURL];
+    [self.parameters sdl_setObject:url forName:SDLRPCParameterNameURL];
 }
 
 - (nullable NSString *)url {
-    return [parameters sdl_objectForName:SDLRPCParameterNameURL ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameURL ofClass:NSString.class error:nil];
 }
 
 - (void)setTimeout:(nullable NSNumber<SDLInt> *)timeout {
-    [parameters sdl_setObject:timeout forName:SDLRPCParameterNameTimeout];
+    [self.parameters sdl_setObject:timeout forName:SDLRPCParameterNameTimeout];
 }
 
 - (nullable NSNumber<SDLInt> *)timeout {
-    return [parameters sdl_objectForName:SDLRPCParameterNameTimeout ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameTimeout ofClass:NSNumber.class error:nil];
 }
 
 - (void)setFileType:(nullable SDLFileType)fileType {
-    [parameters sdl_setObject:fileType forName:SDLRPCParameterNameFileType];
+    [self.parameters sdl_setObject:fileType forName:SDLRPCParameterNameFileType];
 }
 
 - (nullable SDLFileType)fileType {
-    return [parameters sdl_enumForName:SDLRPCParameterNameFileType error:nil];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameFileType error:nil];
 }
 
 - (void)setOffset:(nullable NSNumber<SDLInt> *)offset {
-    [parameters sdl_setObject:offset forName:SDLRPCParameterNameOffset];
+    [self.parameters sdl_setObject:offset forName:SDLRPCParameterNameOffset];
 }
 
 - (nullable NSNumber<SDLInt> *)offset {
-    return [parameters sdl_objectForName:SDLRPCParameterNameOffset ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameOffset ofClass:NSNumber.class error:nil];
 }
 
 - (void)setLength:(nullable NSNumber<SDLInt> *)length {
-    [parameters sdl_setObject:length forName:SDLRPCParameterNameLength];
+    [self.parameters sdl_setObject:length forName:SDLRPCParameterNameLength];
 }
 
 - (nullable NSNumber<SDLInt> *)length {
-    return [parameters sdl_objectForName:SDLRPCParameterNameLength ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameLength ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLOnTBTClientState.m
+++ b/SmartDeviceLink/SDLOnTBTClientState.m
@@ -11,19 +11,22 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLOnTBTClientState
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameOnTBTClientState]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setState:(SDLTBTState)state {
-    [parameters sdl_setObject:state forName:SDLRPCParameterNameState];
+    [self.parameters sdl_setObject:state forName:SDLRPCParameterNameState];
 }
 
 - (SDLTBTState)state {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameState error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameState error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLOnTouchEvent.m
+++ b/SmartDeviceLink/SDLOnTouchEvent.m
@@ -12,28 +12,31 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLOnTouchEvent
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameOnTouchEvent]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setType:(SDLTouchType)type {
-    [parameters sdl_setObject:type forName:SDLRPCParameterNameType];
+    [self.parameters sdl_setObject:type forName:SDLRPCParameterNameType];
 }
 
 - (SDLTouchType)type {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameType error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameType error:&error];
 }
 
 - (void)setEvent:(NSArray<SDLTouchEvent *> *)event {
-    [parameters sdl_setObject:event forName:SDLRPCParameterNameEvent];
+    [self.parameters sdl_setObject:event forName:SDLRPCParameterNameEvent];
 }
 
 - (NSArray<SDLTouchEvent *> *)event {
     NSError *error = nil;
-    return [parameters sdl_objectsForName:SDLRPCParameterNameEvent ofClass:SDLTouchEvent.class error:&error];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameEvent ofClass:SDLTouchEvent.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLOnVehicleData.m
+++ b/SmartDeviceLink/SDLOnVehicleData.m
@@ -23,250 +23,253 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLOnVehicleData
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameOnVehicleData]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setGps:(nullable SDLGPSData *)gps {
-    [parameters sdl_setObject:gps forName:SDLRPCParameterNameGPS];
+    [self.parameters sdl_setObject:gps forName:SDLRPCParameterNameGPS];
 }
 
 - (nullable SDLGPSData *)gps {
-    return [parameters sdl_objectForName:SDLRPCParameterNameGPS ofClass:SDLGPSData.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameGPS ofClass:SDLGPSData.class error:nil];
 }
 
 - (void)setSpeed:(nullable NSNumber<SDLFloat> *)speed {
-    [parameters sdl_setObject:speed forName:SDLRPCParameterNameSpeed];
+    [self.parameters sdl_setObject:speed forName:SDLRPCParameterNameSpeed];
 }
 
 - (nullable NSNumber<SDLFloat> *)speed {
-    return [parameters sdl_objectForName:SDLRPCParameterNameSpeed ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameSpeed ofClass:NSNumber.class error:nil];
 }
 
 - (void)setRpm:(nullable NSNumber<SDLInt> *)rpm {
-    [parameters sdl_setObject:rpm forName:SDLRPCParameterNameRPM];
+    [self.parameters sdl_setObject:rpm forName:SDLRPCParameterNameRPM];
 }
 
 - (nullable NSNumber<SDLInt> *)rpm {
-    return [parameters sdl_objectForName:SDLRPCParameterNameRPM ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameRPM ofClass:NSNumber.class error:nil];
 }
 
 - (void)setFuelLevel:(nullable NSNumber<SDLFloat> *)fuelLevel {
-    [parameters sdl_setObject:fuelLevel forName:SDLRPCParameterNameFuelLevel];
+    [self.parameters sdl_setObject:fuelLevel forName:SDLRPCParameterNameFuelLevel];
 }
 
 - (nullable NSNumber<SDLFloat> *)fuelLevel {
-    return [parameters sdl_objectForName:SDLRPCParameterNameFuelLevel ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameFuelLevel ofClass:NSNumber.class error:nil];
 }
 
 - (void)setFuelLevel_State:(nullable SDLComponentVolumeStatus)fuelLevel_State {
-    [parameters sdl_setObject:fuelLevel_State forName:SDLRPCParameterNameFuelLevelState];
+    [self.parameters sdl_setObject:fuelLevel_State forName:SDLRPCParameterNameFuelLevelState];
 }
 
 - (nullable SDLComponentVolumeStatus)fuelLevel_State {
-    return [parameters sdl_enumForName:SDLRPCParameterNameFuelLevelState error:nil];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameFuelLevelState error:nil];
 }
 
 - (void)setFuelRange:(nullable NSArray<SDLFuelRange *> *)fuelRange {
-    [parameters sdl_setObject:fuelRange forName:SDLRPCParameterNameFuelRange];
+    [self.parameters sdl_setObject:fuelRange forName:SDLRPCParameterNameFuelRange];
 }
 
 - (nullable NSArray<SDLFuelRange *> *)fuelRange {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameFuelRange ofClass:SDLFuelRange.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameFuelRange ofClass:SDLFuelRange.class error:nil];
 }
 
 - (void)setInstantFuelConsumption:(nullable NSNumber<SDLFloat> *)instantFuelConsumption {
-    [parameters sdl_setObject:instantFuelConsumption forName:SDLRPCParameterNameInstantFuelConsumption];
+    [self.parameters sdl_setObject:instantFuelConsumption forName:SDLRPCParameterNameInstantFuelConsumption];
 }
 
 - (nullable NSNumber<SDLFloat> *)instantFuelConsumption {
-    return [parameters sdl_objectForName:SDLRPCParameterNameInstantFuelConsumption ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameInstantFuelConsumption ofClass:NSNumber.class error:nil];
 }
 
 - (void)setExternalTemperature:(nullable NSNumber<SDLFloat> *)externalTemperature {
-    [parameters sdl_setObject:externalTemperature forName:SDLRPCParameterNameExternalTemperature];
+    [self.parameters sdl_setObject:externalTemperature forName:SDLRPCParameterNameExternalTemperature];
 }
 
 - (nullable NSNumber<SDLFloat> *)externalTemperature {
-    return [parameters sdl_objectForName:SDLRPCParameterNameExternalTemperature ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameExternalTemperature ofClass:NSNumber.class error:nil];
 }
 
 - (void)setVin:(nullable NSString *)vin {
-    [parameters sdl_setObject:vin forName:SDLRPCParameterNameVIN];
+    [self.parameters sdl_setObject:vin forName:SDLRPCParameterNameVIN];
 }
 
 - (nullable NSString *)vin {
-    return [parameters sdl_objectForName:SDLRPCParameterNameVIN ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameVIN ofClass:NSString.class error:nil];
 }
 
 - (void)setPrndl:(nullable SDLPRNDL)prndl {
-    [parameters sdl_setObject:prndl forName:SDLRPCParameterNamePRNDL];
+    [self.parameters sdl_setObject:prndl forName:SDLRPCParameterNamePRNDL];
 }
 
 - (nullable SDLPRNDL)prndl {
-    return [parameters sdl_enumForName:SDLRPCParameterNamePRNDL error:nil];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNamePRNDL error:nil];
 }
 
 - (void)setTirePressure:(nullable SDLTireStatus *)tirePressure {
-    [parameters sdl_setObject:tirePressure forName:SDLRPCParameterNameTirePressure];
+    [self.parameters sdl_setObject:tirePressure forName:SDLRPCParameterNameTirePressure];
 }
 
 - (nullable SDLTireStatus *)tirePressure {
-    return [parameters sdl_objectForName:SDLRPCParameterNameTirePressure ofClass:SDLTireStatus.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameTirePressure ofClass:SDLTireStatus.class error:nil];
 }
 
 - (void)setOdometer:(nullable NSNumber<SDLInt> *)odometer {
-    [parameters sdl_setObject:odometer forName:SDLRPCParameterNameOdometer];
+    [self.parameters sdl_setObject:odometer forName:SDLRPCParameterNameOdometer];
 }
 
 - (nullable NSNumber<SDLInt> *)odometer {
-    return [parameters sdl_objectForName:SDLRPCParameterNameOdometer ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameOdometer ofClass:NSNumber.class error:nil];
 }
 
 - (void)setBeltStatus:(nullable SDLBeltStatus *)beltStatus {
-    [parameters sdl_setObject:beltStatus forName:SDLRPCParameterNameBeltStatus];
+    [self.parameters sdl_setObject:beltStatus forName:SDLRPCParameterNameBeltStatus];
 }
 
 - (nullable SDLBeltStatus *)beltStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameBeltStatus ofClass:SDLBeltStatus.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameBeltStatus ofClass:SDLBeltStatus.class error:nil];
 }
 
 - (void)setBodyInformation:(nullable SDLBodyInformation *)bodyInformation {
-    [parameters sdl_setObject:bodyInformation forName:SDLRPCParameterNameBodyInformation];
+    [self.parameters sdl_setObject:bodyInformation forName:SDLRPCParameterNameBodyInformation];
 }
 
 - (nullable SDLBodyInformation *)bodyInformation {
-    return [parameters sdl_objectForName:SDLRPCParameterNameBodyInformation ofClass:SDLBodyInformation.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameBodyInformation ofClass:SDLBodyInformation.class error:nil];
 }
 
 - (void)setDeviceStatus:(nullable SDLDeviceStatus *)deviceStatus {
-    [parameters sdl_setObject:deviceStatus forName:SDLRPCParameterNameDeviceStatus];
+    [self.parameters sdl_setObject:deviceStatus forName:SDLRPCParameterNameDeviceStatus];
 }
 
 - (nullable SDLDeviceStatus *)deviceStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameDeviceStatus ofClass:SDLDeviceStatus.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameDeviceStatus ofClass:SDLDeviceStatus.class error:nil];
 }
 
 - (void)setDriverBraking:(nullable SDLVehicleDataEventStatus)driverBraking {
-    [parameters sdl_setObject:driverBraking forName:SDLRPCParameterNameDriverBraking];
+    [self.parameters sdl_setObject:driverBraking forName:SDLRPCParameterNameDriverBraking];
 }
 
 - (nullable SDLVehicleDataEventStatus)driverBraking {
-    return [parameters sdl_enumForName:SDLRPCParameterNameDriverBraking error:nil];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameDriverBraking error:nil];
 }
 
 - (void)setWiperStatus:(nullable SDLWiperStatus)wiperStatus {
-    [parameters sdl_setObject:wiperStatus forName:SDLRPCParameterNameWiperStatus];
+    [self.parameters sdl_setObject:wiperStatus forName:SDLRPCParameterNameWiperStatus];
 }
 
 - (nullable SDLWiperStatus)wiperStatus {
-    return [parameters sdl_enumForName:SDLRPCParameterNameWiperStatus error:nil];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameWiperStatus error:nil];
 }
 
 - (void)setHeadLampStatus:(nullable SDLHeadLampStatus *)headLampStatus {
-    [parameters sdl_setObject:headLampStatus forName:SDLRPCParameterNameHeadLampStatus];
+    [self.parameters sdl_setObject:headLampStatus forName:SDLRPCParameterNameHeadLampStatus];
 }
 
 - (nullable SDLHeadLampStatus *)headLampStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameHeadLampStatus ofClass:SDLHeadLampStatus.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameHeadLampStatus ofClass:SDLHeadLampStatus.class error:nil];
 }
 
 - (void)setEngineOilLife:(nullable NSNumber<SDLFloat> *)engineOilLife {
-    [parameters sdl_setObject:engineOilLife forName:SDLRPCParameterNameEngineOilLife];
+    [self.parameters sdl_setObject:engineOilLife forName:SDLRPCParameterNameEngineOilLife];
 }
 
 - (nullable NSNumber<SDLFloat> *)engineOilLife {
-    return [parameters sdl_objectForName:SDLRPCParameterNameEngineOilLife ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameEngineOilLife ofClass:NSNumber.class error:nil];
 }
 
 - (void)setEngineTorque:(nullable NSNumber<SDLFloat> *)engineTorque {
-    [parameters sdl_setObject:engineTorque forName:SDLRPCParameterNameEngineTorque];
+    [self.parameters sdl_setObject:engineTorque forName:SDLRPCParameterNameEngineTorque];
 }
 
 - (nullable NSNumber<SDLFloat> *)engineTorque {
-    return [parameters sdl_objectForName:SDLRPCParameterNameEngineTorque ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameEngineTorque ofClass:NSNumber.class error:nil];
 }
 
 - (void)setAccPedalPosition:(nullable NSNumber<SDLFloat> *)accPedalPosition {
-    [parameters sdl_setObject:accPedalPosition forName:SDLRPCParameterNameAccelerationPedalPosition];
+    [self.parameters sdl_setObject:accPedalPosition forName:SDLRPCParameterNameAccelerationPedalPosition];
 }
 
 - (nullable NSNumber<SDLFloat> *)accPedalPosition {
-    return [parameters sdl_objectForName:SDLRPCParameterNameAccelerationPedalPosition ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameAccelerationPedalPosition ofClass:NSNumber.class error:nil];
 }
 
 - (void)setSteeringWheelAngle:(nullable NSNumber<SDLFloat> *)steeringWheelAngle {
-    [parameters sdl_setObject:steeringWheelAngle forName:SDLRPCParameterNameSteeringWheelAngle];
+    [self.parameters sdl_setObject:steeringWheelAngle forName:SDLRPCParameterNameSteeringWheelAngle];
 }
 
 - (nullable NSNumber<SDLFloat> *)steeringWheelAngle {
-    return [parameters sdl_objectForName:SDLRPCParameterNameSteeringWheelAngle ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameSteeringWheelAngle ofClass:NSNumber.class error:nil];
 }
 
 - (void)setECallInfo:(nullable SDLECallInfo *)eCallInfo {
-    [parameters sdl_setObject:eCallInfo forName:SDLRPCParameterNameECallInfo];
+    [self.parameters sdl_setObject:eCallInfo forName:SDLRPCParameterNameECallInfo];
 }
 
 - (nullable SDLECallInfo *)eCallInfo {
-    return [parameters sdl_objectForName:SDLRPCParameterNameECallInfo ofClass:SDLECallInfo.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameECallInfo ofClass:SDLECallInfo.class error:nil];
 }
 
 - (void)setAirbagStatus:(nullable SDLAirbagStatus *)airbagStatus {
-    [parameters sdl_setObject:airbagStatus forName:SDLRPCParameterNameAirbagStatus];
+    [self.parameters sdl_setObject:airbagStatus forName:SDLRPCParameterNameAirbagStatus];
 }
 
 - (nullable SDLAirbagStatus *)airbagStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameAirbagStatus ofClass:SDLAirbagStatus.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameAirbagStatus ofClass:SDLAirbagStatus.class error:nil];
 }
 
 - (void)setEmergencyEvent:(nullable SDLEmergencyEvent *)emergencyEvent {
-    [parameters sdl_setObject:emergencyEvent forName:SDLRPCParameterNameEmergencyEvent];
+    [self.parameters sdl_setObject:emergencyEvent forName:SDLRPCParameterNameEmergencyEvent];
 }
 
 - (nullable SDLEmergencyEvent *)emergencyEvent {
-    return [parameters sdl_objectForName:SDLRPCParameterNameEmergencyEvent ofClass:SDLEmergencyEvent.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameEmergencyEvent ofClass:SDLEmergencyEvent.class error:nil];
 }
 
 - (void)setClusterModeStatus:(nullable SDLClusterModeStatus *)clusterModeStatus {
-    [parameters sdl_setObject:clusterModeStatus forName:SDLRPCParameterNameClusterModeStatus];
+    [self.parameters sdl_setObject:clusterModeStatus forName:SDLRPCParameterNameClusterModeStatus];
 }
 
 - (nullable SDLClusterModeStatus *)clusterModeStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameClusterModeStatus ofClass:SDLClusterModeStatus.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameClusterModeStatus ofClass:SDLClusterModeStatus.class error:nil];
 }
 
 - (void)setMyKey:(nullable SDLMyKey *)myKey {
-    [parameters sdl_setObject:myKey forName:SDLRPCParameterNameMyKey];
+    [self.parameters sdl_setObject:myKey forName:SDLRPCParameterNameMyKey];
 }
 
 - (nullable SDLMyKey *)myKey {
-    return [parameters sdl_objectForName:SDLRPCParameterNameMyKey ofClass:SDLMyKey.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameMyKey ofClass:SDLMyKey.class error:nil];
 }
 
 - (void)setElectronicParkBrakeStatus:(nullable SDLElectronicParkBrakeStatus)electronicParkBrakeStatus {
-    [parameters sdl_setObject:electronicParkBrakeStatus forName:SDLRPCParameterNameElectronicParkBrakeStatus];
+    [self.parameters sdl_setObject:electronicParkBrakeStatus forName:SDLRPCParameterNameElectronicParkBrakeStatus];
 }
 
 - (nullable SDLElectronicParkBrakeStatus)electronicParkBrakeStatus {
-    return [parameters sdl_enumForName:SDLRPCParameterNameElectronicParkBrakeStatus error:nil];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameElectronicParkBrakeStatus error:nil];
 }
 
 - (void)setTurnSignal:(nullable SDLTurnSignal)turnSignal {
-    [parameters sdl_setObject:turnSignal forName:SDLRPCParameterNameTurnSignal];
+    [self.parameters sdl_setObject:turnSignal forName:SDLRPCParameterNameTurnSignal];
 }
 
 - (nullable SDLTurnSignal)turnSignal {
-    return [parameters sdl_enumForName:SDLRPCParameterNameTurnSignal error:nil];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameTurnSignal error:nil];
 }
 
 - (void)setCloudAppVehicleID:(nullable NSString *)cloudAppVehicleID {
-    [parameters sdl_setObject:cloudAppVehicleID forName:SDLRPCParameterNameCloudAppVehicleID];
+    [self.parameters sdl_setObject:cloudAppVehicleID forName:SDLRPCParameterNameCloudAppVehicleID];
 }
 
 - (nullable NSString *)cloudAppVehicleID {
-    return [parameters sdl_objectForName:SDLRPCParameterNameCloudAppVehicleID ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameCloudAppVehicleID ofClass:NSString.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLOnWayPointChange.m
+++ b/SmartDeviceLink/SDLOnWayPointChange.m
@@ -12,19 +12,22 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLOnWayPointChange
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameOnWayPointChange]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setWaypoints:(NSArray<SDLLocationDetails *> *)waypoints {
-    [parameters sdl_setObject:waypoints forName:SDLRPCParameterNameWayPoints];
+    [self.parameters sdl_setObject:waypoints forName:SDLRPCParameterNameWayPoints];
 }
 
 - (NSArray<SDLLocationDetails *> *)waypoints {
     NSError *error = nil;
-    return [parameters sdl_objectsForName:SDLRPCParameterNameWayPoints ofClass:SDLLocationDetails.class error:&error];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameWayPoints ofClass:SDLLocationDetails.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLParameterPermissions.m
+++ b/SmartDeviceLink/SDLParameterPermissions.m
@@ -12,21 +12,21 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation SDLParameterPermissions
 
 - (void)setAllowed:(NSArray<NSString *> *)allowed {
-    [store sdl_setObject:allowed forName:SDLRPCParameterNameAllowed];
+    [self.store sdl_setObject:allowed forName:SDLRPCParameterNameAllowed];
 }
 
 - (NSArray<NSString *> *)allowed {
     NSError *error = nil;
-    return [store sdl_objectsForName:SDLRPCParameterNameAllowed ofClass:NSString.class error:&error];
+    return [self.store sdl_objectsForName:SDLRPCParameterNameAllowed ofClass:NSString.class error:&error];
 }
 
 - (void)setUserDisallowed:(NSArray<NSString *> *)userDisallowed {
-    [store sdl_setObject:userDisallowed forName:SDLRPCParameterNameUserDisallowed];
+    [self.store sdl_setObject:userDisallowed forName:SDLRPCParameterNameUserDisallowed];
 }
 
 - (NSArray<NSString *> *)userDisallowed {
     NSError *error = nil;
-    return [store sdl_objectsForName:SDLRPCParameterNameUserDisallowed ofClass:NSString.class error:&error];
+    return [self.store sdl_objectsForName:SDLRPCParameterNameUserDisallowed ofClass:NSString.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLPerformAppServiceInteraction.m
+++ b/SmartDeviceLink/SDLPerformAppServiceInteraction.m
@@ -17,11 +17,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLPerformAppServiceInteraction
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNamePerformAppServiceInteraction]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithServiceUri:(NSString *)serviceUri serviceID:(NSString *)serviceID originApp:(NSString *)originApp {
     self = [self init];
@@ -48,38 +51,38 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setServiceUri:(NSString *)serviceUri {
-    [parameters sdl_setObject:serviceUri forName:SDLRPCParameterNameServiceUri];
+    [self.parameters sdl_setObject:serviceUri forName:SDLRPCParameterNameServiceUri];
 }
 
 - (NSString *)serviceUri {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameServiceUri ofClass:NSString.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameServiceUri ofClass:NSString.class error:&error];
 }
 
 - (void)setServiceID:(NSString *)serviceID {
-    [parameters sdl_setObject:serviceID forName:SDLRPCParameterNameServiceID];
+    [self.parameters sdl_setObject:serviceID forName:SDLRPCParameterNameServiceID];
 }
 
 - (NSString *)serviceID {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameServiceID ofClass:NSString.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameServiceID ofClass:NSString.class error:&error];
 }
 
 - (void)setOriginApp:(NSString *)originApp {
-    [parameters sdl_setObject:originApp forName:SDLRPCParameterNameOriginApp];
+    [self.parameters sdl_setObject:originApp forName:SDLRPCParameterNameOriginApp];
 }
 
 - (NSString *)originApp {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameOriginApp ofClass:NSString.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameOriginApp ofClass:NSString.class error:&error];
 }
 
 - (void)setRequestServiceActive:(nullable NSNumber<SDLBool> *)requestServiceActive {
-    [parameters sdl_setObject:requestServiceActive forName:SDLRPCParameterNameRequestServiceActive];
+    [self.parameters sdl_setObject:requestServiceActive forName:SDLRPCParameterNameRequestServiceActive];
 }
 
 - (nullable NSNumber<SDLBool> *)requestServiceActive {
-    return [parameters sdl_objectForName:SDLRPCParameterNameRequestServiceActive ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameRequestServiceActive ofClass:NSNumber.class error:nil];
 }
 @end
 

--- a/SmartDeviceLink/SDLPerformAppServiceInteractionResponse.m
+++ b/SmartDeviceLink/SDLPerformAppServiceInteractionResponse.m
@@ -16,11 +16,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLPerformAppServiceInteractionResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNamePerformAppServiceInteraction]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithServiceSpecificResult:(NSString *)serviceSpecificResult {
     self = [self init];
@@ -34,11 +37,11 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setServiceSpecificResult:(nullable NSString *)serviceSpecificResult {
-    [parameters sdl_setObject:serviceSpecificResult forName:SDLRPCParameterNameServiceSpecificResult];
+    [self.parameters sdl_setObject:serviceSpecificResult forName:SDLRPCParameterNameServiceSpecificResult];
 }
 
 - (nullable NSString *)serviceSpecificResult {
-    return [parameters sdl_objectForName:SDLRPCParameterNameServiceSpecificResult ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameServiceSpecificResult ofClass:NSString.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLPerformAudioPassThru.m
+++ b/SmartDeviceLink/SDLPerformAudioPassThru.m
@@ -13,11 +13,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLPerformAudioPassThru
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNamePerformAudioPassThru]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithInitialPrompt:(nullable NSString *)initialPrompt audioPassThruDisplayText1:(nullable NSString *)audioPassThruDisplayText1 audioPassThruDisplayText2:(nullable NSString *)audioPassThruDisplayText2 samplingRate:(SDLSamplingRate)samplingRate bitsPerSample:(SDLBitsPerSample)bitsPerSample audioType:(SDLAudioType)audioType maxDuration:(UInt32)maxDuration muteAudio:(BOOL)muteAudio {
     return [self initWithInitialPrompt:initialPrompt audioPassThruDisplayText1:audioPassThruDisplayText1 audioPassThruDisplayText2:audioPassThruDisplayText2 samplingRate:samplingRate bitsPerSample:bitsPerSample audioType:audioType maxDuration:maxDuration muteAudio:muteAudio audioDataHandler:nil];
@@ -58,71 +61,71 @@ NS_ASSUME_NONNULL_BEGIN
     
 
 - (void)setInitialPrompt:(nullable NSArray<SDLTTSChunk *> *)initialPrompt {
-    [parameters sdl_setObject:initialPrompt forName:SDLRPCParameterNameInitialPrompt];
+    [self.parameters sdl_setObject:initialPrompt forName:SDLRPCParameterNameInitialPrompt];
 }
 
 - (nullable NSArray<SDLTTSChunk *> *)initialPrompt {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameInitialPrompt ofClass:SDLTTSChunk.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameInitialPrompt ofClass:SDLTTSChunk.class error:nil];
 }
 
 - (void)setAudioPassThruDisplayText1:(nullable NSString *)audioPassThruDisplayText1 {
-    [parameters sdl_setObject:audioPassThruDisplayText1 forName:SDLRPCParameterNameAudioPassThruDisplayText1];
+    [self.parameters sdl_setObject:audioPassThruDisplayText1 forName:SDLRPCParameterNameAudioPassThruDisplayText1];
 }
 
 - (nullable NSString *)audioPassThruDisplayText1 {
-    return [parameters sdl_objectForName:SDLRPCParameterNameAudioPassThruDisplayText1 ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameAudioPassThruDisplayText1 ofClass:NSString.class error:nil];
 }
 
 - (void)setAudioPassThruDisplayText2:(nullable NSString *)audioPassThruDisplayText2 {
-    [parameters sdl_setObject:audioPassThruDisplayText2 forName:SDLRPCParameterNameAudioPassThruDisplayText2];
+    [self.parameters sdl_setObject:audioPassThruDisplayText2 forName:SDLRPCParameterNameAudioPassThruDisplayText2];
 }
 
 - (nullable NSString *)audioPassThruDisplayText2 {
-    return [parameters sdl_objectForName:SDLRPCParameterNameAudioPassThruDisplayText2 ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameAudioPassThruDisplayText2 ofClass:NSString.class error:nil];
 }
 
 - (void)setSamplingRate:(SDLSamplingRate)samplingRate {
-    [parameters sdl_setObject:samplingRate forName:SDLRPCParameterNameSamplingRate];
+    [self.parameters sdl_setObject:samplingRate forName:SDLRPCParameterNameSamplingRate];
 }
 
 - (SDLSamplingRate)samplingRate {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameSamplingRate error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameSamplingRate error:&error];
 }
 
 - (void)setMaxDuration:(NSNumber<SDLInt> *)maxDuration {
-    [parameters sdl_setObject:maxDuration forName:SDLRPCParameterNameMaxDuration];
+    [self.parameters sdl_setObject:maxDuration forName:SDLRPCParameterNameMaxDuration];
 }
 
 - (NSNumber<SDLInt> *)maxDuration {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameMaxDuration ofClass:NSNumber.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameMaxDuration ofClass:NSNumber.class error:&error];
 }
 
 - (void)setBitsPerSample:(SDLBitsPerSample)bitsPerSample {
-    [parameters sdl_setObject:bitsPerSample forName:SDLRPCParameterNameBitsPerSample];
+    [self.parameters sdl_setObject:bitsPerSample forName:SDLRPCParameterNameBitsPerSample];
 }
 
 - (SDLBitsPerSample)bitsPerSample {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameBitsPerSample error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameBitsPerSample error:&error];
 }
 
 - (void)setAudioType:(SDLAudioType)audioType {
-    [parameters sdl_setObject:audioType forName:SDLRPCParameterNameAudioType];
+    [self.parameters sdl_setObject:audioType forName:SDLRPCParameterNameAudioType];
 }
 
 - (SDLAudioType)audioType {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameAudioType error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameAudioType error:&error];
 }
 
 - (void)setMuteAudio:(nullable NSNumber<SDLBool> *)muteAudio {
-    [parameters sdl_setObject:muteAudio forName:SDLRPCParameterNameMuteAudio];
+    [self.parameters sdl_setObject:muteAudio forName:SDLRPCParameterNameMuteAudio];
 }
 
 - (nullable NSNumber<SDLBool> *)muteAudio {
-    return [parameters sdl_objectForName:SDLRPCParameterNameMuteAudio ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameMuteAudio ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLPerformAudioPassThruResponse.m
+++ b/SmartDeviceLink/SDLPerformAudioPassThruResponse.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLPerformAudioPassThruResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNamePerformAudioPassThru]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLPerformInteraction.m
+++ b/SmartDeviceLink/SDLPerformInteraction.m
@@ -14,11 +14,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLPerformInteraction
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNamePerformInteraction]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithInteractionChoiceSetId:(UInt16)interactionChoiceSetId {
     return [self initWithInteractionChoiceSetIdList:@[@(interactionChoiceSetId)]];
@@ -92,78 +95,78 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setInitialText:(NSString *)initialText {
-    [parameters sdl_setObject:initialText forName:SDLRPCParameterNameInitialText];
+    [self.parameters sdl_setObject:initialText forName:SDLRPCParameterNameInitialText];
 }
 
 - (NSString *)initialText {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameInitialText ofClass:NSString.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameInitialText ofClass:NSString.class error:&error];
 }
 
 - (void)setInitialPrompt:(nullable NSArray<SDLTTSChunk *> *)initialPrompt {
-    [parameters sdl_setObject:initialPrompt forName:SDLRPCParameterNameInitialPrompt];
+    [self.parameters sdl_setObject:initialPrompt forName:SDLRPCParameterNameInitialPrompt];
 }
 
 - (nullable NSArray<SDLTTSChunk *> *)initialPrompt {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameInitialPrompt ofClass:SDLTTSChunk.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameInitialPrompt ofClass:SDLTTSChunk.class error:nil];
 }
 
 - (void)setInteractionMode:(SDLInteractionMode)interactionMode {
-    [parameters sdl_setObject:interactionMode forName:SDLRPCParameterNameInteractionMode];
+    [self.parameters sdl_setObject:interactionMode forName:SDLRPCParameterNameInteractionMode];
 }
 
 - (SDLInteractionMode)interactionMode {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameInteractionMode error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameInteractionMode error:&error];
 }
 
 - (void)setInteractionChoiceSetIDList:(NSArray<NSNumber<SDLInt> *> *)interactionChoiceSetIDList {
-    [parameters sdl_setObject:interactionChoiceSetIDList forName:SDLRPCParameterNameInteractionChoiceSetIdList];
+    [self.parameters sdl_setObject:interactionChoiceSetIDList forName:SDLRPCParameterNameInteractionChoiceSetIdList];
 }
 
 - (NSArray<NSNumber<SDLInt> *> *)interactionChoiceSetIDList {
     NSError *error = nil;
-    return [parameters sdl_objectsForName:SDLRPCParameterNameInteractionChoiceSetIdList ofClass:NSNumber.class error:&error];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameInteractionChoiceSetIdList ofClass:NSNumber.class error:&error];
 }
 
 - (void)setHelpPrompt:(nullable NSArray<SDLTTSChunk *> *)helpPrompt {
-    [parameters sdl_setObject:helpPrompt forName:SDLRPCParameterNameHelpPrompt];
+    [self.parameters sdl_setObject:helpPrompt forName:SDLRPCParameterNameHelpPrompt];
 }
 
 - (nullable NSArray<SDLTTSChunk *> *)helpPrompt {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameHelpPrompt ofClass:SDLTTSChunk.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameHelpPrompt ofClass:SDLTTSChunk.class error:nil];
 }
 
 - (void)setTimeoutPrompt:(nullable NSArray<SDLTTSChunk *> *)timeoutPrompt {
-    [parameters sdl_setObject:timeoutPrompt forName:SDLRPCParameterNameTimeoutPrompt];
+    [self.parameters sdl_setObject:timeoutPrompt forName:SDLRPCParameterNameTimeoutPrompt];
 }
 
 - (nullable NSArray<SDLTTSChunk *> *)timeoutPrompt {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameTimeoutPrompt ofClass:SDLTTSChunk.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameTimeoutPrompt ofClass:SDLTTSChunk.class error:nil];
 }
 
 - (void)setTimeout:(nullable NSNumber<SDLInt> *)timeout {
-    [parameters sdl_setObject:timeout forName:SDLRPCParameterNameTimeout];
+    [self.parameters sdl_setObject:timeout forName:SDLRPCParameterNameTimeout];
 }
 
 - (nullable NSNumber<SDLInt> *)timeout {
-    return [parameters sdl_objectForName:SDLRPCParameterNameTimeout ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameTimeout ofClass:NSNumber.class error:nil];
 }
 
 - (void)setVrHelp:(nullable NSArray<SDLVRHelpItem *> *)vrHelp {
-    [parameters sdl_setObject:vrHelp forName:SDLRPCParameterNameVRHelp];
+    [self.parameters sdl_setObject:vrHelp forName:SDLRPCParameterNameVRHelp];
 }
 
 - (nullable NSArray<SDLVRHelpItem *> *)vrHelp {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameVRHelp ofClass:SDLVRHelpItem.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameVRHelp ofClass:SDLVRHelpItem.class error:nil];
 }
 
 - (void)setInteractionLayout:(nullable SDLLayoutMode)interactionLayout {
-    [parameters sdl_setObject:interactionLayout forName:SDLRPCParameterNameInteractionLayout];
+    [self.parameters sdl_setObject:interactionLayout forName:SDLRPCParameterNameInteractionLayout];
 }
 
 - (nullable SDLLayoutMode)interactionLayout {
-    return [parameters sdl_enumForName:SDLRPCParameterNameInteractionLayout error:nil];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameInteractionLayout error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLPerformInteractionResponse.m
+++ b/SmartDeviceLink/SDLPerformInteractionResponse.m
@@ -12,34 +12,37 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLPerformInteractionResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNamePerformInteraction]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setChoiceID:(nullable NSNumber<SDLInt> *)choiceID {
-    [parameters sdl_setObject:choiceID forName:SDLRPCParameterNameChoiceId];
+    [self.parameters sdl_setObject:choiceID forName:SDLRPCParameterNameChoiceId];
 }
 
 - (nullable NSNumber<SDLInt> *)choiceID {
-    return [parameters sdl_objectForName:SDLRPCParameterNameChoiceId ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameChoiceId ofClass:NSNumber.class error:nil];
 }
 
 - (void)setManualTextEntry:(nullable NSString *)manualTextEntry {
-    [parameters sdl_setObject:manualTextEntry forName:SDLRPCParameterNameManualTextEntry];
+    [self.parameters sdl_setObject:manualTextEntry forName:SDLRPCParameterNameManualTextEntry];
 }
 
 - (nullable NSString *)manualTextEntry {
-    return [parameters sdl_objectForName:SDLRPCParameterNameManualTextEntry ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameManualTextEntry ofClass:NSString.class error:nil];
 }
 
 - (void)setTriggerSource:(nullable SDLTriggerSource)triggerSource {
-    [parameters sdl_setObject:triggerSource forName:SDLRPCParameterNameTriggerSource];
+    [self.parameters sdl_setObject:triggerSource forName:SDLRPCParameterNameTriggerSource];
 }
 
 - (nullable SDLTriggerSource)triggerSource {
-    return [parameters sdl_enumForName:SDLRPCParameterNameTriggerSource error:nil];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameTriggerSource error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLPermissionItem.m
+++ b/SmartDeviceLink/SDLPermissionItem.m
@@ -13,30 +13,30 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation SDLPermissionItem
 
 - (void)setRpcName:(NSString *)rpcName {
-    [store sdl_setObject:rpcName forName:SDLRPCParameterNameRPCName];
+    [self.store sdl_setObject:rpcName forName:SDLRPCParameterNameRPCName];
 }
 
 - (NSString *)rpcName {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameRPCName ofClass:NSString.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameRPCName ofClass:NSString.class error:&error];
 }
 
 - (void)setHmiPermissions:(SDLHMIPermissions *)hmiPermissions {
-    [store sdl_setObject:hmiPermissions forName:SDLRPCParameterNameHMIPermissions];
+    [self.store sdl_setObject:hmiPermissions forName:SDLRPCParameterNameHMIPermissions];
 }
 
 - (SDLHMIPermissions *)hmiPermissions {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameHMIPermissions ofClass:SDLHMIPermissions.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameHMIPermissions ofClass:SDLHMIPermissions.class error:&error];
 }
 
 - (void)setParameterPermissions:(SDLParameterPermissions *)parameterPermissions {
-    [store sdl_setObject:parameterPermissions forName:SDLRPCParameterNameParameterPermissions];
+    [self.store sdl_setObject:parameterPermissions forName:SDLRPCParameterNameParameterPermissions];
 }
 
 - (SDLParameterPermissions *)parameterPermissions {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameParameterPermissions ofClass:SDLParameterPermissions.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameParameterPermissions ofClass:SDLParameterPermissions.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLPhoneCapability.m
+++ b/SmartDeviceLink/SDLPhoneCapability.m
@@ -27,11 +27,11 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setDialNumberEnabled:(nullable NSNumber *)dialNumberEnabled {
-    [store sdl_setObject:dialNumberEnabled forName:SDLRPCParameterNameDialNumberEnabled];
+    [self.store sdl_setObject:dialNumberEnabled forName:SDLRPCParameterNameDialNumberEnabled];
 }
 
 - (nullable NSNumber *)dialNumberEnabled {
-    return [store sdl_objectForName:SDLRPCParameterNameDialNumberEnabled ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameDialNumberEnabled ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLPresetBankCapabilities.m
+++ b/SmartDeviceLink/SDLPresetBankCapabilities.m
@@ -12,12 +12,12 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation SDLPresetBankCapabilities
 
 - (void)setOnScreenPresetsAvailable:(NSNumber<SDLBool> *)onScreenPresetsAvailable {
-    [store sdl_setObject:onScreenPresetsAvailable forName:SDLRPCParameterNameOnScreenPresetsAvailable];
+    [self.store sdl_setObject:onScreenPresetsAvailable forName:SDLRPCParameterNameOnScreenPresetsAvailable];
 }
 
 - (NSNumber<SDLBool> *)onScreenPresetsAvailable {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameOnScreenPresetsAvailable ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameOnScreenPresetsAvailable ofClass:NSNumber.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLProtocol.m
+++ b/SmartDeviceLink/SDLProtocol.m
@@ -266,8 +266,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)sendRPC:(SDLRPCMessage *)message encrypted:(BOOL)encryption error:(NSError *__autoreleasing *)error {
     NSParameterAssert(message != nil);
-    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:[message serializeAsDictionary:(Byte)[SDLGlobals sharedGlobals].protocolVersion.major] options:kNilOptions error:error];
     
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:[message serializeAsDictionary:(Byte)[SDLGlobals sharedGlobals].protocolVersion.major] options:kNilOptions error:error];
+#pragma clang diagnostic pop
+
     if (error != nil) {
         SDLLogW(@"Error encoding JSON data: %@", *error);
     }
@@ -289,7 +293,7 @@ NS_ASSUME_NONNULL_BEGIN
             // Build a binary header
             // Serialize the RPC data into an NSData
             SDLRPCPayload *rpcPayload = [[SDLRPCPayload alloc] init];
-            rpcPayload.functionID = [[[SDLFunctionID sharedInstance] functionIdForName:[message getFunctionName]] unsignedIntValue];
+            rpcPayload.functionID = [[[SDLFunctionID sharedInstance] functionIdForName:message.name] unsignedIntValue];
             rpcPayload.jsonData = jsonData;
             rpcPayload.binaryData = message.bulkData;
 

--- a/SmartDeviceLink/SDLProxy.m
+++ b/SmartDeviceLink/SDLProxy.m
@@ -282,10 +282,10 @@ static float DefaultConnectionTimeout = 45.0;
 
 #pragma mark - Message sending
 - (void)sendRPC:(SDLRPCMessage *)message {
-    if ([message.getFunctionName isEqualToString:@"SubscribeButton"]) {
+    if ([message.name isEqualToString:SDLRPCFunctionNameSubscribeButton]) {
         BOOL handledRPC = [self sdl_adaptButtonSubscribeMessage:(SDLSubscribeButton *)message];
         if (handledRPC) { return; }
-    } else if ([message.getFunctionName isEqualToString:@"UnsubscribeButton"]) {
+    } else if ([message.name isEqualToString:SDLRPCFunctionNameUnsubscribeButton]) {
         BOOL handledRPC = [self sdl_adaptButtonUnsubscribeMessage:(SDLUnsubscribeButton *)message];
         if (handledRPC) { return; }
     }
@@ -383,13 +383,16 @@ static float DefaultConnectionTimeout = 45.0;
 }
 
 - (void)handleRPCDictionary:(NSDictionary<NSString *, id> *)dict {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     SDLRPCMessage *message = [[SDLRPCMessage alloc] initWithDictionary:[dict mutableCopy]];
-    NSString *functionName = [message getFunctionName];
-    NSString *messageType = [message messageType];
+#pragma clang diagnostic pop
+    NSString *functionName = message.name;
+    NSString *messageType = message.messageType;
 
     // If it's a response, append response
     if ([messageType isEqualToString:SDLRPCParameterNameResponse]) {
-        BOOL notGenericResponseMessage = ![functionName isEqualToString:@"GenericResponse"];
+        BOOL notGenericResponseMessage = ![functionName isEqualToString:SDLRPCFunctionNameGenericResponse];
         if (notGenericResponseMessage) {
             functionName = [NSString stringWithFormat:@"%@Response", functionName];
         }
@@ -496,9 +499,9 @@ static float DefaultConnectionTimeout = 45.0;
     // If URL != nil, perform HTTP Post and don't pass the notification to proxy listeners
     SDLLogV(@"OnEncodedSyncPData: %@", message);
 
-    NSString *urlString = (NSString *)[message getParameters:@"URL"];
-    NSDictionary<NSString *, id> *encodedSyncPData = (NSDictionary<NSString *, id> *)[message getParameters:@"data"];
-    NSNumber *encodedSyncPTimeout = (NSNumber *)[message getParameters:@"Timeout"];
+    NSString *urlString = (NSString *)message.parameters[SDLRPCParameterNameURLUppercase];
+    NSDictionary<NSString *, id> *encodedSyncPData = (NSDictionary<NSString *, id> *)message.parameters[SDLRPCParameterNameData];
+    NSNumber *encodedSyncPTimeout = (NSNumber *)message.parameters[SDLRPCParameterNameTimeoutCapitalized];
 
     if (urlString && encodedSyncPData && encodedSyncPTimeout) {
         [self sendEncodedSyncPData:encodedSyncPData toURL:urlString withTimeout:encodedSyncPTimeout];
@@ -508,8 +511,11 @@ static float DefaultConnectionTimeout = 45.0;
 - (void)handleSystemRequest:(NSDictionary<NSString *, id> *)dict {
     SDLLogV(@"OnSystemRequest");
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     SDLOnSystemRequest *systemRequest = [[SDLOnSystemRequest alloc] initWithDictionary:[dict mutableCopy]];
     SDLRequestType requestType = systemRequest.requestType;
+#pragma clang diagnostic pop
 
     // Handle the various OnSystemRequest types
     if ([requestType isEqualToEnum:SDLRequestTypeProprietary]) {
@@ -615,7 +621,7 @@ static float DefaultConnectionTimeout = 45.0;
 
 #pragma mark Handle Post-Invoke of Delegate Methods
 - (void)handleAfterHMIStatus:(SDLRPCMessage *)message {
-    SDLHMILevel hmiLevel = (SDLHMILevel)[message getParameters:SDLRPCParameterNameHMILevel];
+    SDLHMILevel hmiLevel = (SDLHMILevel)message.parameters[SDLRPCParameterNameHMILevel];
     _lsm.hmiLevel = hmiLevel;
 
     SEL callbackSelector = NSSelectorFromString(@"onOnLockScreenNotification:");
@@ -623,7 +629,7 @@ static float DefaultConnectionTimeout = 45.0;
 }
 
 - (void)handleAfterDriverDistraction:(SDLRPCMessage *)message {
-    NSString *stateString = (NSString *)[message getParameters:SDLRPCParameterNameState];
+    NSString *stateString = (NSString *)message.parameters[SDLRPCParameterNameState];
     BOOL state = [stateString isEqualToString:@"DD_ON"] ? YES : NO;
     _lsm.driverDistracted = state;
 

--- a/SmartDeviceLink/SDLPublishAppService.m
+++ b/SmartDeviceLink/SDLPublishAppService.m
@@ -18,11 +18,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLPublishAppService
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNamePublishAppService]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithAppServiceManifest:(SDLAppServiceManifest *)appServiceManifest {
     self = [self init];
@@ -36,12 +39,12 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setAppServiceManifest:(SDLAppServiceManifest *)appServiceManifest {
-    [parameters sdl_setObject:appServiceManifest forName:SDLRPCParameterNameAppServiceManifest];
+    [self.parameters sdl_setObject:appServiceManifest forName:SDLRPCParameterNameAppServiceManifest];
 }
 
 - (SDLAppServiceManifest *)appServiceManifest {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameAppServiceManifest ofClass:SDLAppServiceManifest.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameAppServiceManifest ofClass:SDLAppServiceManifest.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLPublishAppServiceResponse.m
+++ b/SmartDeviceLink/SDLPublishAppServiceResponse.m
@@ -17,11 +17,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLPublishAppServiceResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNamePublishAppService]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithAppServiceRecord:(SDLAppServiceRecord *)appServiceRecord {
     self = [self init];
@@ -35,11 +38,11 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setAppServiceRecord:(nullable SDLAppServiceRecord *)appServiceRecord {
-    [parameters sdl_setObject:appServiceRecord forName:SDLRPCParameterNameAppServiceRecord];
+    [self.parameters sdl_setObject:appServiceRecord forName:SDLRPCParameterNameAppServiceRecord];
 }
 
 - (nullable SDLAppServiceRecord *)appServiceRecord {
-    return [parameters sdl_objectForName:SDLRPCParameterNameAppServiceRecord ofClass:SDLAppServiceRecord.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameAppServiceRecord ofClass:SDLAppServiceRecord.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLPutFile.m
+++ b/SmartDeviceLink/SDLPutFile.m
@@ -13,11 +13,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLPutFile
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNamePutFile]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithFileName:(NSString *)fileName fileType:(SDLFileType)fileType {
     self = [self init];
@@ -84,61 +87,61 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Getters and Setters
 
 - (void)setSyncFileName:(NSString *)syncFileName {
-    [parameters sdl_setObject:syncFileName forName:SDLRPCParameterNameSyncFileName];
+    [self.parameters sdl_setObject:syncFileName forName:SDLRPCParameterNameSyncFileName];
 }
 
 - (NSString *)syncFileName {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameSyncFileName ofClass:NSString.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameSyncFileName ofClass:NSString.class error:&error];
 }
 
 - (void)setFileType:(SDLFileType)fileType {
-    [parameters sdl_setObject:fileType forName:SDLRPCParameterNameFileType];
+    [self.parameters sdl_setObject:fileType forName:SDLRPCParameterNameFileType];
 }
 
 - (SDLFileType)fileType {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameFileType error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameFileType error:&error];
 }
 
 - (void)setPersistentFile:(nullable NSNumber<SDLBool> *)persistentFile {
-    [parameters sdl_setObject:persistentFile forName:SDLRPCParameterNamePersistentFile];
+    [self.parameters sdl_setObject:persistentFile forName:SDLRPCParameterNamePersistentFile];
 }
 
 - (nullable NSNumber<SDLBool> *)persistentFile {
-    return [parameters sdl_objectForName:SDLRPCParameterNamePersistentFile ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNamePersistentFile ofClass:NSNumber.class error:nil];
 }
 
 - (void)setSystemFile:(nullable NSNumber<SDLBool> *)systemFile {
-    [parameters sdl_setObject:systemFile forName:SDLRPCParameterNameSystemFile];
+    [self.parameters sdl_setObject:systemFile forName:SDLRPCParameterNameSystemFile];
 }
 
 - (nullable NSNumber<SDLBool> *)systemFile {
-    return [parameters sdl_objectForName:SDLRPCParameterNameSystemFile ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameSystemFile ofClass:NSNumber.class error:nil];
 }
 
 - (void)setOffset:(nullable NSNumber<SDLUInt> *)offset {
-    [parameters sdl_setObject:offset forName:SDLRPCParameterNameOffset];
+    [self.parameters sdl_setObject:offset forName:SDLRPCParameterNameOffset];
 }
 
 - (nullable NSNumber<SDLUInt> *)offset {
-    return [parameters sdl_objectForName:SDLRPCParameterNameOffset ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameOffset ofClass:NSNumber.class error:nil];
 }
 
 - (void)setLength:(nullable NSNumber<SDLUInt> *)length {
-    [parameters sdl_setObject:length forName:SDLRPCParameterNameLength];
+    [self.parameters sdl_setObject:length forName:SDLRPCParameterNameLength];
 }
 
 - (nullable NSNumber<SDLUInt> *)length {
-    return [parameters sdl_objectForName:SDLRPCParameterNameLength ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameLength ofClass:NSNumber.class error:nil];
 }
 
 - (void)setCrc:(nullable NSNumber<SDLUInt> *)crc {
-    [parameters sdl_setObject:crc forName:SDLRPCParameterNameCRC];
+    [self.parameters sdl_setObject:crc forName:SDLRPCParameterNameCRC];
 }
 
 - (nullable NSNumber<SDLUInt> *)crc {
-    return [parameters sdl_objectForName:SDLRPCParameterNameCRC ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameCRC ofClass:NSNumber.class error:nil];
 }
 
 #pragma mark - Helpers

--- a/SmartDeviceLink/SDLPutFileResponse.m
+++ b/SmartDeviceLink/SDLPutFileResponse.m
@@ -12,18 +12,21 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLPutFileResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNamePutFile]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setSpaceAvailable:(nullable NSNumber<SDLInt> *)spaceAvailable {
-    [parameters sdl_setObject:spaceAvailable forName:SDLRPCParameterNameSpaceAvailable];
+    [self.parameters sdl_setObject:spaceAvailable forName:SDLRPCParameterNameSpaceAvailable];
 }
 
 - (nullable NSNumber<SDLInt> *)spaceAvailable {
-    return [parameters sdl_objectForName:SDLRPCParameterNameSpaceAvailable ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameSpaceAvailable ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLRDSData.m
+++ b/SmartDeviceLink/SDLRDSData.m
@@ -27,67 +27,67 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setProgramService:(nullable NSString *)programService {
-    [store sdl_setObject:programService forName:SDLRPCParameterNameProgramService];
+    [self.store sdl_setObject:programService forName:SDLRPCParameterNameProgramService];
 }
 
 - (nullable NSString *)programService {
-    return [store sdl_objectForName:SDLRPCParameterNameProgramService ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameProgramService ofClass:NSString.class error:nil];
 }
 
 - (void)setRadioText:(nullable NSString *)radioText {
-    [store sdl_setObject:radioText forName:SDLRPCParameterNameRadioText];
+    [self.store sdl_setObject:radioText forName:SDLRPCParameterNameRadioText];
 }
 
 - (nullable NSString *)radioText {
-    return [store sdl_objectForName:SDLRPCParameterNameRadioText ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameRadioText ofClass:NSString.class error:nil];
 }
 
 - (void)setClockText:(nullable NSString *)clockText {
-    [store sdl_setObject:clockText forName:SDLRPCParameterNameClockText];
+    [self.store sdl_setObject:clockText forName:SDLRPCParameterNameClockText];
 }
 
 - (nullable NSString *)clockText {
-    return [store sdl_objectForName:SDLRPCParameterNameClockText ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameClockText ofClass:NSString.class error:nil];
 }
 
 - (void)setProgramIdentification:(nullable NSString *)programIdentification {
-    [store sdl_setObject:programIdentification forName:SDLRPCParameterNameProgramIdentification];
+    [self.store sdl_setObject:programIdentification forName:SDLRPCParameterNameProgramIdentification];
 }
 
 - (nullable NSString *)programIdentification {
-    return [store sdl_objectForName:SDLRPCParameterNameProgramIdentification ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameProgramIdentification ofClass:NSString.class error:nil];
 }
 
 - (void)setProgramType:(nullable NSNumber<SDLInt> *)programType {
-    [store sdl_setObject:programType forName:SDLRPCParameterNameProgramType];
+    [self.store sdl_setObject:programType forName:SDLRPCParameterNameProgramType];
 }
 
 - (nullable NSNumber<SDLInt> *)programType {
-    return [store sdl_objectForName:SDLRPCParameterNameProgramType ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameProgramType ofClass:NSNumber.class error:nil];
 }
 
 - (void)setTrafficProgramIdentification:(nullable NSNumber<SDLBool> *)trafficProgramIdentification {
-    [store sdl_setObject:trafficProgramIdentification forName:SDLRPCParameterNameTrafficProgramIdentification];
+    [self.store sdl_setObject:trafficProgramIdentification forName:SDLRPCParameterNameTrafficProgramIdentification];
 }
 
 - (nullable NSNumber<SDLBool> *)trafficProgramIdentification {
-    return [store sdl_objectForName:SDLRPCParameterNameTrafficProgramIdentification ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameTrafficProgramIdentification ofClass:NSNumber.class error:nil];
 }
 
 - (void)setTrafficAnnouncementIdentification:(nullable NSNumber<SDLBool> *)trafficAnnouncementIdentification {
-    [store sdl_setObject:trafficAnnouncementIdentification forName:SDLRPCParameterNameTrafficAnnouncementIdentification];
+    [self.store sdl_setObject:trafficAnnouncementIdentification forName:SDLRPCParameterNameTrafficAnnouncementIdentification];
 }
 
 - (nullable NSNumber<SDLBool> *)trafficAnnouncementIdentification {
-    return [store sdl_objectForName:SDLRPCParameterNameTrafficAnnouncementIdentification ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameTrafficAnnouncementIdentification ofClass:NSNumber.class error:nil];
 }
 
 - (void)setRegion:(nullable NSString *)region {
-    [store sdl_setObject:region forName:SDLRPCParameterNameRegion];
+    [self.store sdl_setObject:region forName:SDLRPCParameterNameRegion];
 }
 
 - (nullable NSString *)region {
-    return [store sdl_objectForName:SDLRPCParameterNameRegion ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameRegion ofClass:NSString.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLRGBColor.m
+++ b/SmartDeviceLink/SDLRGBColor.m
@@ -41,30 +41,30 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Setters
 
 - (void)setRed:(NSNumber<SDLInt> *)red {
-    [store sdl_setObject:red forName:SDLRPCParameterNameRed];
+    [self.store sdl_setObject:red forName:SDLRPCParameterNameRed];
 }
 
 - (NSNumber<SDLInt> *)red {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameRed ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameRed ofClass:NSNumber.class error:&error];
 }
 
 - (void)setGreen:(NSNumber<SDLInt> *)green {
-    [store sdl_setObject:green forName:SDLRPCParameterNameGreen];
+    [self.store sdl_setObject:green forName:SDLRPCParameterNameGreen];
 }
 
 - (NSNumber<SDLInt> *)green {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameGreen ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameGreen ofClass:NSNumber.class error:&error];
 }
 
 - (void)setBlue:(NSNumber<SDLInt> *)blue {
-    [store sdl_setObject:blue forName:SDLRPCParameterNameBlue];
+    [self.store sdl_setObject:blue forName:SDLRPCParameterNameBlue];
 }
 
 - (NSNumber<SDLInt> *)blue {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameBlue ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameBlue ofClass:NSNumber.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLRPCMessage.h
+++ b/SmartDeviceLink/SDLRPCMessage.h
@@ -7,11 +7,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SDLRPCMessage : SDLRPCStruct <NSCopying> {
-    NSMutableDictionary<NSString *, id> *function;
-    NSMutableDictionary<NSString *, id> *parameters;
-    NSString *messageType;
-}
+@interface SDLRPCMessage : SDLRPCStruct <NSCopying>
 
 /**
  *  Convenience init
@@ -19,29 +15,21 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param name    The name of the message
  *  @return        A SDLRPCMessage object
  */
-- (instancetype)initWithName:(NSString *)name;
-
-/**
- *  Convenience init
- *
- *  @param dict    A dictionary with the format @{messageType: @{parameters}}
- *  @return        A SDLRPCMessage object
- */
-- (instancetype)initWithDictionary:(NSDictionary<NSString *, id> *)dict;
+- (instancetype)initWithName:(NSString *)name __deprecated_msg("This is not intended to be a public facing API");
 
 /**
  *  Returns the function name.
  *
  *  @return The function name
  */
-- (nullable NSString *)getFunctionName;
+- (nullable NSString *)getFunctionName __deprecated_msg("Call the .name property instead");
 
 /**
  *  Sets the function name.
  *
  *  @param functionName The function name
  */
-- (void)setFunctionName:(nullable NSString *)functionName;
+- (void)setFunctionName:(nullable NSString *)functionName __deprecated_msg("This is not intended to be a public facing API");
 
 /**
  *  Returns the value associated with the provided key. If the key does not exist, null is returned.
@@ -49,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param functionName    The key name
  *  @return                The value associated with the function name
  */
-- (nullable NSObject *)getParameters:(NSString *)functionName;
+- (nullable NSObject *)getParameters:(NSString *)functionName __deprecated_msg("Call the .parameters property instead");
 
 /**
  *  Sets a key-value pair using the function name as the key.
@@ -57,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param functionName    The name for the key
  *  @param value           The value associated with the function name
  */
-- (void)setParameters:(NSString *)functionName value:(nullable NSObject *)value;
+- (void)setParameters:(NSString *)functionName value:(nullable NSObject *)value __deprecated_msg("This is not intended to be a public facing API");
 
 /**
  *  The data in the message
@@ -68,6 +56,11 @@ NS_ASSUME_NONNULL_BEGIN
  *  The name of the message
  */
 @property (strong, nonatomic, readonly) NSString *name;
+
+/**
+ The JSONRPC parameters
+ */
+@property (strong, nonatomic, readonly) NSMutableDictionary<NSString *, id> *parameters;
 
 /**
  *  The type of data in the message

--- a/SmartDeviceLink/SDLRPCMessage.h
+++ b/SmartDeviceLink/SDLRPCMessage.h
@@ -58,7 +58,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic, readonly) NSString *name;
 
 /**
- The JSONRPC parameters
+ The JSON-RPC parameters
  */
 @property (strong, nonatomic, readonly) NSMutableDictionary<NSString *, id> *parameters;
 

--- a/SmartDeviceLink/SDLRPCMessage.m
+++ b/SmartDeviceLink/SDLRPCMessage.m
@@ -9,71 +9,90 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@interface SDLRPCMessage ()
+
+@property (strong, nonatomic, readwrite) NSString *messageType;
+@property (strong, nonatomic) NSMutableDictionary<NSString *, id> *function;
+
+@end
+
+
 @implementation SDLRPCMessage
 
-@synthesize messageType;
-
 - (instancetype)initWithName:(NSString *)name {
-    if (self = [super init]) {
-        function = [[NSMutableDictionary alloc] initWithCapacity:3];
-        parameters = [[NSMutableDictionary alloc] init];
-        messageType = SDLRPCParameterNameRequest;
-        [store setObject:function forKey:messageType];
-        [function setObject:parameters forKey:SDLRPCParameterNameParameters];
-        [function setObject:name forKey:SDLRPCParameterNameOperationName];
+    self = [super init];
+    if (!self) {
+        return nil;
     }
-    return self;
-}
 
-- (instancetype)initWithDictionary:(NSDictionary *)dict {
-    if (self = [super initWithDictionary:dict]) {
-        NSEnumerator *enumerator = [store keyEnumerator];
-        while (messageType = [enumerator nextObject]) {
-            if (![messageType isEqualToString:SDLRPCParameterNameBulkData]) {
-                break;
-            }
-        }
-        if (messageType != nil) {
-            store[messageType] = [store[messageType] mutableCopy];
-            function = store[messageType];
+    _function = [NSMutableDictionary dictionaryWithCapacity:3];
+    _parameters = [NSMutableDictionary dictionary];
+    _messageType = SDLRPCParameterNameRequest;
+    self.store[_messageType] = _function;
 
-            function[SDLRPCParameterNameParameters] = [function[SDLRPCParameterNameParameters] mutableCopy];
-            parameters = function[SDLRPCParameterNameParameters];
-        }
-        self.bulkData = dict[SDLRPCParameterNameBulkData];
-    }
+    _function[SDLRPCParameterNameParameters] = _parameters;
+    _function[SDLRPCParameterNameOperationName] = name;
     
     return self;
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
+- (instancetype)initWithDictionary:(NSDictionary *)dict {
+    self = [super initWithDictionary:dict];
+    if (!self) {
+        return nil;
+    }
+
+    NSEnumerator *enumerator = [self.store keyEnumerator];
+    while (_messageType = [enumerator nextObject]) {
+        if (![_messageType isEqualToString:SDLRPCParameterNameBulkData]) {
+            break;
+        }
+    }
+
+    if (_messageType != nil) {
+        self.store[_messageType] = [self.store[_messageType] mutableCopy];
+        _function = self.store[_messageType];
+
+        _function[SDLRPCParameterNameParameters] = [_function[SDLRPCParameterNameParameters] mutableCopy];
+        _parameters = _function[SDLRPCParameterNameParameters];
+    }
+
+    _bulkData = dict[SDLRPCParameterNameBulkData];
+    
+    return self;
+}
+#pragma clang diagnostic pop
+
 - (nullable NSString *)getFunctionName {
-    return [function sdl_objectForName:SDLRPCParameterNameOperationName ofClass:NSString.class error:nil];
+    return self.name;
 }
 
 - (void)setFunctionName:(nullable NSString *)functionName {
-    [function sdl_setObject:functionName forName:SDLRPCParameterNameOperationName];
+    [_function sdl_setObject:functionName forName:SDLRPCParameterNameOperationName];
 }
 
 - (nullable NSObject *)getParameters:(NSString *)functionName {
-    return [parameters sdl_objectForName:functionName ofClass:NSObject.class error:nil];
+    return [_parameters sdl_objectForName:functionName ofClass:NSObject.class error:nil];
 }
 
 - (void)setParameters:(NSString *)functionName value:(nullable NSObject *)value {
-    [parameters sdl_setObject:value forName:functionName];
+    [_parameters sdl_setObject:value forName:functionName];
 }
 
 - (NSString *)name {
-    return [self getFunctionName];
+    return [_function sdl_objectForName:SDLRPCParameterNameOperationName ofClass:NSString.class error:nil];
 }
 
 - (NSString *)description {
-    NSMutableString *description = [NSMutableString stringWithFormat:@"%@ (%@)\n%@", self.name, self.messageType, self->parameters];
+    NSMutableString *description = [NSMutableString stringWithFormat:@"%@ (%@)\n%@", self.name, self.messageType, self.parameters];
 
     return description;
 }
 
 - (id)copyWithZone:(nullable NSZone *)zone {
-    SDLRPCMessage *newMessage = [[self.class allocWithZone:zone] initWithDictionary:self->store];
+    SDLRPCMessage *newMessage = [[self.class allocWithZone:zone] initWithDictionary:self.store];
 
     return newMessage;
 }

--- a/SmartDeviceLink/SDLRPCNotification.m
+++ b/SmartDeviceLink/SDLRPCNotification.m
@@ -9,16 +9,25 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@interface SDLRPCMessage ()
+
+@property (strong, nonatomic, readwrite) NSString *messageType;
+@property (strong, nonatomic) NSMutableDictionary<NSString *, id> *function;
+
+@end
+
 @implementation SDLRPCNotification
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (instancetype)initWithName:(NSString *)name {
     self = [super initWithName:name];
     if (!self) {
         return nil;
     }
 
-    messageType = SDLRPCParameterNameNotification;
-    [store setObject:function forKey:messageType];
+    self.messageType = SDLRPCParameterNameNotification;
+    [self.store setObject:self.function forKey:self.messageType];
 
     return self;
 }
@@ -29,11 +38,12 @@ NS_ASSUME_NONNULL_BEGIN
         return nil;
     }
 
-    messageType = SDLRPCParameterNameNotification;
-    [store setObject:function forKey:messageType];
+    self.messageType = SDLRPCParameterNameNotification;
+    [self.store setObject:self.function forKey:self.messageType];
 
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLRPCRequest.m
+++ b/SmartDeviceLink/SDLRPCRequest.m
@@ -9,15 +9,21 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@interface SDLRPCMessage ()
+
+@property (strong, nonatomic) NSMutableDictionary<NSString *, id> *function;
+
+@end
+
 @implementation SDLRPCRequest
 
 - (NSNumber<SDLInt> *)correlationID {
     NSError *error = nil;
-    return [function sdl_objectForName:SDLRPCParameterNameCorrelationId ofClass:NSNumber.class error:&error];
+    return [self.function sdl_objectForName:SDLRPCParameterNameCorrelationId ofClass:NSNumber.class error:&error];
 }
 
 - (void)setCorrelationID:(NSNumber<SDLInt> *)corrID {
-    [function sdl_setObject:corrID forName:SDLRPCParameterNameCorrelationId];
+    [self.function sdl_setObject:corrID forName:SDLRPCParameterNameCorrelationId];
 }
 
 @end

--- a/SmartDeviceLink/SDLRPCResponse.m
+++ b/SmartDeviceLink/SDLRPCResponse.m
@@ -10,16 +10,25 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@interface SDLRPCMessage ()
+
+@property (strong, nonatomic, readwrite) NSString *messageType;
+@property (strong, nonatomic) NSMutableDictionary<NSString *, id> *function;
+
+@end
+
 @implementation SDLRPCResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (instancetype)initWithName:(NSString *)name {
     self = [super initWithName:name];
     if (!self) {
         return nil;
     }
 
-    messageType = SDLRPCParameterNameResponse;
-    [store sdl_setObject:function forName:messageType];
+    self.messageType = SDLRPCParameterNameResponse;
+    [self.store sdl_setObject:self.function forName:self.messageType];
 
     return self;
 }
@@ -30,45 +39,46 @@ NS_ASSUME_NONNULL_BEGIN
         return nil;
     }
 
-    messageType = SDLRPCParameterNameResponse;
-    [store sdl_setObject:function forName:messageType];
+    self.messageType = SDLRPCParameterNameResponse;
+    [self.store sdl_setObject:self.function forName:self.messageType];
     
     return self;
 }
+#pragma clang diagnostic pop
 
 - (NSNumber<SDLInt> *)correlationID {
     NSError *error = nil;
-    return [function sdl_objectForName:SDLRPCParameterNameCorrelationId ofClass:NSNumber.class error:&error];
+    return [self.function sdl_objectForName:SDLRPCParameterNameCorrelationId ofClass:NSNumber.class error:&error];
 }
 
 - (void)setCorrelationID:(NSNumber<SDLInt> *)corrID {
-    [function sdl_setObject:corrID forName:SDLRPCParameterNameCorrelationId];
+    [self.function sdl_setObject:corrID forName:SDLRPCParameterNameCorrelationId];
 }
 
 - (void)setSuccess:(NSNumber<SDLBool> *)success {
-    [parameters sdl_setObject:success forName:SDLRPCParameterNameSuccess];
+    [self.parameters sdl_setObject:success forName:SDLRPCParameterNameSuccess];
 }
 
 - (NSNumber<SDLBool> *)success {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameSuccess ofClass:NSNumber.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameSuccess ofClass:NSNumber.class error:&error];
 }
 
 - (void)setResultCode:(SDLResult)resultCode {
-    [parameters sdl_setObject:resultCode forName:SDLRPCParameterNameResultCode];
+    [self.parameters sdl_setObject:resultCode forName:SDLRPCParameterNameResultCode];
 }
 
 - (SDLResult)resultCode {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameResultCode error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameResultCode error:&error];
 }
 
 - (void)setInfo:(nullable NSString *)info {
-    [parameters sdl_setObject:info forName:SDLRPCParameterNameInfo];
+    [self.parameters sdl_setObject:info forName:SDLRPCParameterNameInfo];
 }
 
 - (nullable NSString *)info {
-    return [parameters sdl_objectForName:SDLRPCParameterNameInfo ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameInfo ofClass:NSString.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLRPCStruct.h
+++ b/SmartDeviceLink/SDLRPCStruct.h
@@ -8,9 +8,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SDLRPCStruct : NSObject <NSCopying> {
-    NSMutableDictionary<NSString *, id> *store;
-}
+@interface SDLRPCStruct : NSObject <NSCopying>
+
+@property (strong, nonatomic, readonly) NSMutableDictionary<NSString *, id> *store;
 
 /**
  *  Convenience init
@@ -18,14 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param dict A dictionary
  *  @return     A SDLRPCStruct object
  */
-- (instancetype)initWithDictionary:(NSDictionary<NSString *, id> *)dict;
-
-/**
- *  Init
- *
- *  @return A SDLRPCStruct object
- */
-- (instancetype)init;
+- (instancetype)initWithDictionary:(NSDictionary<NSString *, id> *)dict __deprecated_msg("This is not intended for public use");
 
 /**
  *  Converts struct to JSON formatted data
@@ -33,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param version The protocol version
  *  @return        JSON formatted data
  */
-- (NSDictionary<NSString *, id> *)serializeAsDictionary:(Byte)version;
+- (NSDictionary<NSString *, id> *)serializeAsDictionary:(Byte)version __deprecated_msg("This is not intended for public use");
 
 @end
 

--- a/SmartDeviceLink/SDLRPCStruct.m
+++ b/SmartDeviceLink/SDLRPCStruct.m
@@ -11,43 +11,49 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLRPCStruct
 
-- (id)initWithDictionary:(NSDictionary<NSString *, id> *)dict {
-    if (self = [super init]) {
-        if (dict != nil) {
-            store = [dict mutableCopy];
-        } else {
-            store = [NSMutableDictionary dictionary];
-        }
+- (instancetype)initWithDictionary:(NSDictionary<NSString *, id> *)dict {
+    self = [super init];
+    if (!self) {
+        return nil;
     }
+
+    _store = [dict mutableCopy];
+
     return self;
 }
 
-- (id)init {
-    if (self = [super init]) {
-        store = [NSMutableDictionary dictionary];
+- (instancetype)init {
+    self = [super init];
+    if (!self) {
+        return nil;
     }
+
+    _store = [NSMutableDictionary dictionary];
+
     return self;
 }
 
 - (NSDictionary<NSString *, id> *)serializeAsDictionary:(Byte)version {
     if (version >= 2) {
-        NSString *messageType = store.keyEnumerator.nextObject;
-        NSMutableDictionary<NSString *, id> *function = store[messageType];
+        NSString *messageType = self.store.keyEnumerator.nextObject;
+        NSMutableDictionary<NSString *, id> *function = _store[messageType];
         if ([function isKindOfClass:NSMutableDictionary.class]) {
             NSMutableDictionary<NSString *, id> *parameters = function[SDLRPCParameterNameParameters];
             return [self.class sdl_serializeDictionary:parameters version:version];
         } else {
-            return [self.class sdl_serializeDictionary:store version:version];
+            return [self.class sdl_serializeDictionary:self.store version:version];
         }
     } else {
-        return [self.class sdl_serializeDictionary:store version:version];
+        return [self.class sdl_serializeDictionary:self.store version:version];
     }
 }
 
 - (NSString *)description {
-    return [store description];
+    return [self.store description];
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 + (NSDictionary<NSString *, id> *)sdl_serializeDictionary:(NSDictionary *)dict version:(Byte)version {
     NSMutableDictionary<NSString *, id> *ret = [NSMutableDictionary dictionaryWithCapacity:dict.count];
     for (NSString *key in dict.keyEnumerator) {
@@ -74,16 +80,16 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return ret;
 }
+#pragma clang diagnostic pop
 
 - (id)copyWithZone:(nullable NSZone *)zone {
-    SDLRPCStruct *newStruct = [[[self class] allocWithZone:zone] init];
-    newStruct->store = [self->store mutableCopy];
+    SDLRPCStruct *newStruct = [[[self class] allocWithZone:zone] initWithDictionary:_store];
 
     return newStruct;
 }
 
 - (BOOL)isEqualToRPC:(SDLRPCStruct *)rpc {
-    return [rpc->store isEqualToDictionary:self->store];
+    return [rpc.store isEqualToDictionary:_store];
 }
 
 - (BOOL)isEqual:(id)object {

--- a/SmartDeviceLink/SDLRadioControlCapabilities.m
+++ b/SmartDeviceLink/SDLRadioControlCapabilities.m
@@ -38,108 +38,108 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setModuleName:(NSString *)moduleName {
-    [store sdl_setObject:moduleName forName:SDLRPCParameterNameModuleName];
+    [self.store sdl_setObject:moduleName forName:SDLRPCParameterNameModuleName];
 }
 
 - (NSString *)moduleName {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameModuleName ofClass:NSString.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameModuleName ofClass:NSString.class error:&error];
 }
 
 - (void)setRadioEnableAvailable:(nullable NSNumber<SDLBool> *)radioEnableAvailable {
-    [store sdl_setObject:radioEnableAvailable forName:SDLRPCParameterNameRadioEnableAvailable];
+    [self.store sdl_setObject:radioEnableAvailable forName:SDLRPCParameterNameRadioEnableAvailable];
 }
 
 - (nullable NSNumber<SDLBool> *)radioEnableAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameRadioEnableAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameRadioEnableAvailable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setRadioBandAvailable:(nullable NSNumber<SDLBool> *)radioBandAvailable {
-    [store sdl_setObject:radioBandAvailable forName:SDLRPCParameterNameRadioBandAvailable];
+    [self.store sdl_setObject:radioBandAvailable forName:SDLRPCParameterNameRadioBandAvailable];
 }
 
 - (nullable NSNumber<SDLBool> *)radioBandAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameRadioBandAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameRadioBandAvailable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setRadioFrequencyAvailable:(nullable NSNumber<SDLBool> *)radioFrequencyAvailable {
-    [store sdl_setObject:radioFrequencyAvailable forName:SDLRPCParameterNameRadioFrequencyAvailable];
+    [self.store sdl_setObject:radioFrequencyAvailable forName:SDLRPCParameterNameRadioFrequencyAvailable];
 }
 
 - (nullable NSNumber<SDLBool> *)radioFrequencyAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameRadioFrequencyAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameRadioFrequencyAvailable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setHdChannelAvailable:(nullable NSNumber<SDLBool> *)hdChannelAvailable {
-    [store sdl_setObject:hdChannelAvailable forName:SDLRPCParameterNameHDChannelAvailable];
+    [self.store sdl_setObject:hdChannelAvailable forName:SDLRPCParameterNameHDChannelAvailable];
 }
 
 - (nullable NSNumber<SDLBool> *)hdChannelAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameHDChannelAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameHDChannelAvailable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setRdsDataAvailable:(nullable NSNumber<SDLBool> *)rdsDataAvailable {
-    [store sdl_setObject:rdsDataAvailable forName:SDLRPCParameterNameRDSDataAvailable];
+    [self.store sdl_setObject:rdsDataAvailable forName:SDLRPCParameterNameRDSDataAvailable];
 }
 
 - (nullable NSNumber<SDLBool> *)rdsDataAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameRDSDataAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameRDSDataAvailable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setAvailableHDsAvailable:(nullable NSNumber<SDLBool> *)availableHDsAvailable {
-    [store sdl_setObject:availableHDsAvailable forName:SDLRPCParameterNameAvailableHDsAvailable];
+    [self.store sdl_setObject:availableHDsAvailable forName:SDLRPCParameterNameAvailableHDsAvailable];
 }
 
 - (nullable NSNumber<SDLBool> *)availableHDsAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameAvailableHDsAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameAvailableHDsAvailable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setStateAvailable:(nullable NSNumber<SDLBool> *)stateAvailable {
-    [store sdl_setObject:stateAvailable forName:SDLRPCParameterNameStateAvailable];
+    [self.store sdl_setObject:stateAvailable forName:SDLRPCParameterNameStateAvailable];
 }
 
 - (nullable NSNumber<SDLBool> *)stateAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameStateAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameStateAvailable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setSignalStrengthAvailable:(nullable NSNumber<SDLBool> *)signalStrengthAvailable {
-    [store sdl_setObject:signalStrengthAvailable forName:SDLRPCParameterNameSignalStrengthAvailable];
+    [self.store sdl_setObject:signalStrengthAvailable forName:SDLRPCParameterNameSignalStrengthAvailable];
 }
 
 - (nullable NSNumber<SDLBool> *)signalStrengthAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameSignalStrengthAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameSignalStrengthAvailable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setSignalChangeThresholdAvailable:(nullable NSNumber<SDLBool> *)signalChangeThresholdAvailable {
-    [store sdl_setObject:signalChangeThresholdAvailable forName:SDLRPCParameterNameSignalChangeThresholdAvailable];
+    [self.store sdl_setObject:signalChangeThresholdAvailable forName:SDLRPCParameterNameSignalChangeThresholdAvailable];
 }
 
 - (nullable NSNumber<SDLBool> *)signalChangeThresholdAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameSignalChangeThresholdAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameSignalChangeThresholdAvailable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setHdRadioEnableAvailable:(nullable NSNumber<SDLBool> *)hdRadioEnableAvailable {
-    [store sdl_setObject:hdRadioEnableAvailable forName:SDLRPCParameterNameHDRadioEnableAvailable];
+    [self.store sdl_setObject:hdRadioEnableAvailable forName:SDLRPCParameterNameHDRadioEnableAvailable];
 }
 
 - (nullable NSNumber<SDLBool> *)hdRadioEnableAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameHDRadioEnableAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameHDRadioEnableAvailable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setSiriusXMRadioAvailable:(nullable NSNumber<SDLBool> *)siriusXMRadioAvailable {
-    [store sdl_setObject:siriusXMRadioAvailable forName:SDLRPCParameterNameSiriusXMRadioAvailable];
+    [self.store sdl_setObject:siriusXMRadioAvailable forName:SDLRPCParameterNameSiriusXMRadioAvailable];
 }
 
 - (nullable NSNumber<SDLBool> *)siriusXMRadioAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameSiriusXMRadioAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameSiriusXMRadioAvailable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setSisDataAvailable:(nullable NSNumber<SDLBool> *)sisDataAvailable {
-    [store sdl_setObject:sisDataAvailable forName:SDLRPCParameterNameSISDataAvailable];
+    [self.store sdl_setObject:sisDataAvailable forName:SDLRPCParameterNameSISDataAvailable];
 }
 
 - (nullable NSNumber<SDLBool> *)sisDataAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameSISDataAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameSISDataAvailable ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLRadioControlData.m
+++ b/SmartDeviceLink/SDLRadioControlData.m
@@ -44,99 +44,99 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setFrequencyInteger:(nullable NSNumber<SDLInt> *)frequencyInteger {
-    [store sdl_setObject:frequencyInteger forName:SDLRPCParameterNameFrequencyInteger];
+    [self.store sdl_setObject:frequencyInteger forName:SDLRPCParameterNameFrequencyInteger];
 }
 
 - (nullable NSNumber<SDLInt> *)frequencyInteger {
-    return [store sdl_objectForName:SDLRPCParameterNameFrequencyInteger ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameFrequencyInteger ofClass:NSNumber.class error:nil];
 }
 
 - (void)setFrequencyFraction:(nullable NSNumber<SDLInt> *)frequencyFraction {
-    [store sdl_setObject:frequencyFraction forName:SDLRPCParameterNameFrequencyFraction];
+    [self.store sdl_setObject:frequencyFraction forName:SDLRPCParameterNameFrequencyFraction];
 }
 
 - (nullable NSNumber<SDLInt> *)frequencyFraction {
-    return [store sdl_objectForName:SDLRPCParameterNameFrequencyFraction ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameFrequencyFraction ofClass:NSNumber.class error:nil];
 }
 
 - (void)setBand:(nullable SDLRadioBand)band {
-    [store sdl_setObject:band forName:SDLRPCParameterNameBand];
+    [self.store sdl_setObject:band forName:SDLRPCParameterNameBand];
 }
 
 - (nullable SDLRadioBand)band{
-    return [store sdl_enumForName:SDLRPCParameterNameBand error:nil];
+    return [self.store sdl_enumForName:SDLRPCParameterNameBand error:nil];
 }
 
 - (void)setRdsData:(nullable SDLRDSData *)rdsData {
-    [store sdl_setObject:rdsData forName:SDLRPCParameterNameRDSData];
+    [self.store sdl_setObject:rdsData forName:SDLRPCParameterNameRDSData];
 }
 
 - (nullable SDLRDSData *)rdsData {
-    return [store sdl_objectForName:SDLRPCParameterNameRDSData ofClass:SDLRDSData.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameRDSData ofClass:SDLRDSData.class error:nil];
 }
 
 - (void)setAvailableHDs:(nullable NSNumber<SDLInt> *)availableHDs {
-    [store sdl_setObject:availableHDs forName:SDLRPCParameterNameAvailableHDs];
+    [self.store sdl_setObject:availableHDs forName:SDLRPCParameterNameAvailableHDs];
 }
 
 - (nullable NSNumber<SDLInt> *)availableHDs {
-    return [store sdl_objectForName:SDLRPCParameterNameAvailableHDs ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameAvailableHDs ofClass:NSNumber.class error:nil];
 }
 
 - (void)setHdChannel:(nullable NSNumber<SDLInt> *)hdChannel {
-    [store sdl_setObject:hdChannel forName:SDLRPCParameterNameHDChannel];
+    [self.store sdl_setObject:hdChannel forName:SDLRPCParameterNameHDChannel];
 }
 
 - (nullable NSNumber<SDLInt> *)hdChannel {
-    return [store sdl_objectForName:SDLRPCParameterNameHDChannel ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameHDChannel ofClass:NSNumber.class error:nil];
 }
 
 - (void)setSignalStrength:(nullable NSNumber<SDLInt> *)signalStrength {
-    [store sdl_setObject:signalStrength forName:SDLRPCParameterNameSignalStrength];
+    [self.store sdl_setObject:signalStrength forName:SDLRPCParameterNameSignalStrength];
 }
 
 - (nullable NSNumber<SDLInt> *)signalStrength {
-    return [store sdl_objectForName:SDLRPCParameterNameSignalStrength ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameSignalStrength ofClass:NSNumber.class error:nil];
 }
 
 - (void)setSignalChangeThreshold:(nullable NSNumber<SDLInt> *)signalChangeThreshold {
-    [store sdl_setObject:signalChangeThreshold forName:SDLRPCParameterNameSignalChangeThreshold];
+    [self.store sdl_setObject:signalChangeThreshold forName:SDLRPCParameterNameSignalChangeThreshold];
 }
 
 - (nullable NSNumber<SDLInt> *)signalChangeThreshold {
-    return [store sdl_objectForName:SDLRPCParameterNameSignalChangeThreshold ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameSignalChangeThreshold ofClass:NSNumber.class error:nil];
 }
 
 - (void)setRadioEnable:(nullable NSNumber<SDLBool> *)radioEnable {
-    [store sdl_setObject:radioEnable forName:SDLRPCParameterNameRadioEnable];
+    [self.store sdl_setObject:radioEnable forName:SDLRPCParameterNameRadioEnable];
 }
 
 - (nullable NSNumber<SDLBool> *)radioEnable {
-    return [store sdl_objectForName:SDLRPCParameterNameRadioEnable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameRadioEnable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setState:(nullable SDLRadioState)state {
-    [store sdl_setObject:state forName:SDLRPCParameterNameState];
+    [self.store sdl_setObject:state forName:SDLRPCParameterNameState];
 }
 
 - (nullable SDLRadioState)state {
-    return [store sdl_enumForName:SDLRPCParameterNameState error:nil];
+    return [self.store sdl_enumForName:SDLRPCParameterNameState error:nil];
 }
 
 - (void)setHdRadioEnable:(nullable NSNumber<SDLBool> *)hdRadioEnable {
-    [store sdl_setObject:hdRadioEnable forName:SDLRPCParameterNameHDRadioEnable];
+    [self.store sdl_setObject:hdRadioEnable forName:SDLRPCParameterNameHDRadioEnable];
 }
 
 - (nullable NSNumber<SDLBool> *)hdRadioEnable {
-    return [store sdl_objectForName:SDLRPCParameterNameHDRadioEnable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameHDRadioEnable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setSisData:(nullable SDLSISData *)sisData {
-    [store sdl_setObject:sisData forName:SDLRPCParameterNameSISData];
+    [self.store sdl_setObject:sisData forName:SDLRPCParameterNameSISData];
 }
 
 - (nullable SDLSISData *)sisData {
-    return [store sdl_objectForName:SDLRPCParameterNameSISData ofClass:SDLSISData.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameSISData ofClass:SDLSISData.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLReadDID.m
+++ b/SmartDeviceLink/SDLReadDID.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLReadDID
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameReadDID]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithECUName:(UInt16)ecuName didLocation:(NSArray<NSNumber<SDLInt> *> *)didLocation {
     self = [self init];
@@ -31,21 +34,21 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setEcuName:(NSNumber<SDLInt> *)ecuName {
-    [parameters sdl_setObject:ecuName forName:SDLRPCParameterNameECUName];
+    [self.parameters sdl_setObject:ecuName forName:SDLRPCParameterNameECUName];
 }
 
 - (NSNumber<SDLInt> *)ecuName {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameECUName ofClass:NSNumber.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameECUName ofClass:NSNumber.class error:&error];
 }
 
 - (void)setDidLocation:(NSArray<NSNumber<SDLInt> *> *)didLocation {
-    [parameters sdl_setObject:didLocation forName:SDLRPCParameterNameDIDLocation];
+    [self.parameters sdl_setObject:didLocation forName:SDLRPCParameterNameDIDLocation];
 }
 
 - (NSArray<NSNumber<SDLInt> *> *)didLocation {
     NSError *error = nil;
-    return [parameters sdl_objectsForName:SDLRPCParameterNameDIDLocation ofClass:NSNumber.class error:&error];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameDIDLocation ofClass:NSNumber.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLReadDIDResponse.m
+++ b/SmartDeviceLink/SDLReadDIDResponse.m
@@ -13,18 +13,21 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLReadDIDResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameReadDID]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setDidResult:(nullable NSArray<SDLDIDResult *> *)didResult {
-    [parameters sdl_setObject:didResult forName:SDLRPCParameterNameDIDResult];
+    [self.parameters sdl_setObject:didResult forName:SDLRPCParameterNameDIDResult];
 }
 
 - (nullable NSArray<SDLDIDResult *> *)didResult {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameDIDResult ofClass:SDLDIDResult.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameDIDResult ofClass:SDLDIDResult.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLRectangle.m
+++ b/SmartDeviceLink/SDLRectangle.m
@@ -29,39 +29,39 @@
 }
 
 - (void)setX:(NSNumber<SDLFloat> *)x {
-    [store sdl_setObject:x forName:SDLRPCParameterNameX];
+    [self.store sdl_setObject:x forName:SDLRPCParameterNameX];
 }
 
 - (NSNumber<SDLFloat> *)x {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameX ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameX ofClass:NSNumber.class error:&error];
 }
 
 - (void)setY:(NSNumber<SDLFloat> *)y {
-    [store sdl_setObject:y forName:SDLRPCParameterNameY];
+    [self.store sdl_setObject:y forName:SDLRPCParameterNameY];
 }
 
 - (NSNumber<SDLFloat> *)y {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameY ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameY ofClass:NSNumber.class error:&error];
 }
 
 - (void)setWidth:(NSNumber<SDLFloat> *)width {
-    [store sdl_setObject:width forName:SDLRPCParameterNameWidth];
+    [self.store sdl_setObject:width forName:SDLRPCParameterNameWidth];
 }
 
 - (NSNumber<SDLFloat> *)width {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameWidth ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameWidth ofClass:NSNumber.class error:&error];
 }
 
 - (void)setHeight:(NSNumber<SDLFloat> *)height {
-    [store sdl_setObject:height forName:SDLRPCParameterNameHeight];
+    [self.store sdl_setObject:height forName:SDLRPCParameterNameHeight];
 }
 
 - (NSNumber<SDLFloat> *)height {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameHeight ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameHeight ofClass:NSNumber.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLRegisterAppInterface.m
+++ b/SmartDeviceLink/SDLRegisterAppInterface.m
@@ -23,11 +23,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Lifecycle
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameRegisterAppInterface]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithLifecycleConfiguration:(SDLLifecycleConfiguration *)lifecycleConfiguration {
     NSArray<SDLAppHMIType> *allHMITypes = lifecycleConfiguration.additionalAppTypes ? [lifecycleConfiguration.additionalAppTypes arrayByAddingObject:lifecycleConfiguration.appType] : @[lifecycleConfiguration.appType];
@@ -117,136 +120,136 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Getters and Setters
 
 - (void)setSyncMsgVersion:(SDLSyncMsgVersion *)syncMsgVersion {
-    [parameters sdl_setObject:syncMsgVersion forName:SDLRPCParameterNameSyncMessageVersion];
+    [self.parameters sdl_setObject:syncMsgVersion forName:SDLRPCParameterNameSyncMessageVersion];
 }
 
 - (SDLSyncMsgVersion *)syncMsgVersion {
-    return [parameters sdl_objectForName:SDLRPCParameterNameSyncMessageVersion ofClass:SDLSyncMsgVersion.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameSyncMessageVersion ofClass:SDLSyncMsgVersion.class error:nil];
 }
 
 - (void)setAppName:(NSString *)appName {
-    [parameters sdl_setObject:appName forName:SDLRPCParameterNameAppName];
+    [self.parameters sdl_setObject:appName forName:SDLRPCParameterNameAppName];
 }
 
 - (NSString *)appName {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameAppName ofClass:NSString.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameAppName ofClass:NSString.class error:&error];
 }
 
 - (void)setTtsName:(nullable NSArray<SDLTTSChunk *> *)ttsName {
-    [parameters sdl_setObject:ttsName forName:SDLRPCParameterNameTTSName];
+    [self.parameters sdl_setObject:ttsName forName:SDLRPCParameterNameTTSName];
 }
 
 - (nullable NSArray<SDLTTSChunk *> *)ttsName {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameTTSName ofClass:SDLTTSChunk.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameTTSName ofClass:SDLTTSChunk.class error:nil];
 }
 
 - (void)setNgnMediaScreenAppName:(nullable NSString *)ngnMediaScreenAppName {
-    [parameters sdl_setObject:ngnMediaScreenAppName forName:SDLRPCParameterNameNGNMediaScreenAppName];
+    [self.parameters sdl_setObject:ngnMediaScreenAppName forName:SDLRPCParameterNameNGNMediaScreenAppName];
 }
 
 - (nullable NSString *)ngnMediaScreenAppName {
-    return [parameters sdl_objectForName:SDLRPCParameterNameNGNMediaScreenAppName ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameNGNMediaScreenAppName ofClass:NSString.class error:nil];
 }
 
 - (void)setVrSynonyms:(nullable NSArray<NSString *> *)vrSynonyms {
-    [parameters sdl_setObject:vrSynonyms forName:SDLRPCParameterNameVRSynonyms];
+    [self.parameters sdl_setObject:vrSynonyms forName:SDLRPCParameterNameVRSynonyms];
 }
 
 - (nullable NSArray<NSString *> *)vrSynonyms {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameVRSynonyms ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameVRSynonyms ofClass:NSString.class error:nil];
 }
 
 - (void)setIsMediaApplication:(NSNumber<SDLBool> *)isMediaApplication {
-    [parameters sdl_setObject:isMediaApplication forName:SDLRPCParameterNameIsMediaApplication];
+    [self.parameters sdl_setObject:isMediaApplication forName:SDLRPCParameterNameIsMediaApplication];
 }
 
 - (NSNumber<SDLBool> *)isMediaApplication {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameIsMediaApplication ofClass:NSNumber.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameIsMediaApplication ofClass:NSNumber.class error:&error];
 }
 
 - (void)setLanguageDesired:(SDLLanguage)languageDesired {
-    [parameters sdl_setObject:languageDesired forName:SDLRPCParameterNameLanguageDesired];
+    [self.parameters sdl_setObject:languageDesired forName:SDLRPCParameterNameLanguageDesired];
 }
 
 - (SDLLanguage)languageDesired {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameLanguageDesired error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameLanguageDesired error:&error];
 }
 
 - (void)setHmiDisplayLanguageDesired:(SDLLanguage)hmiDisplayLanguageDesired {
-    [parameters sdl_setObject:hmiDisplayLanguageDesired forName:SDLRPCParameterNameHMIDisplayLanguageDesired];
+    [self.parameters sdl_setObject:hmiDisplayLanguageDesired forName:SDLRPCParameterNameHMIDisplayLanguageDesired];
 }
 
 - (SDLLanguage)hmiDisplayLanguageDesired {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameHMIDisplayLanguageDesired error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameHMIDisplayLanguageDesired error:&error];
 }
 
 - (void)setAppHMIType:(nullable NSArray<SDLAppHMIType> *)appHMIType {
-    [parameters sdl_setObject:appHMIType forName:SDLRPCParameterNameAppHMIType];
+    [self.parameters sdl_setObject:appHMIType forName:SDLRPCParameterNameAppHMIType];
 }
 
 - (nullable NSArray<SDLAppHMIType> *)appHMIType {
-    return [parameters sdl_enumsForName:SDLRPCParameterNameAppHMIType error:nil];
+    return [self.parameters sdl_enumsForName:SDLRPCParameterNameAppHMIType error:nil];
 }
 
 - (void)setHashID:(nullable NSString *)hashID {
-    [parameters sdl_setObject:hashID forName:SDLRPCParameterNameHashId];
+    [self.parameters sdl_setObject:hashID forName:SDLRPCParameterNameHashId];
 }
 
 - (nullable NSString *)hashID {
-    return [parameters sdl_objectForName:SDLRPCParameterNameHashId ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameHashId ofClass:NSString.class error:nil];
 }
 
 - (void)setDeviceInfo:(nullable SDLDeviceInfo *)deviceInfo {
-    [parameters sdl_setObject:deviceInfo forName:SDLRPCParameterNameDeviceInfo];
+    [self.parameters sdl_setObject:deviceInfo forName:SDLRPCParameterNameDeviceInfo];
 }
 
 - (nullable SDLDeviceInfo *)deviceInfo {
-    return [parameters sdl_objectForName:SDLRPCParameterNameDeviceInfo ofClass:SDLDeviceInfo.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameDeviceInfo ofClass:SDLDeviceInfo.class error:nil];
 }
 
 - (void)setAppID:(NSString *)appID {
-    [parameters sdl_setObject:appID forName:SDLRPCParameterNameAppId];
+    [self.parameters sdl_setObject:appID forName:SDLRPCParameterNameAppId];
 }
 
 - (NSString *)appID {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameAppId ofClass:NSString.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameAppId ofClass:NSString.class error:&error];
 }
 
 - (void)setFullAppID:(nullable NSString *)fullAppID {
-    [parameters sdl_setObject:fullAppID forName:SDLRPCParameterNameFullAppID];
+    [self.parameters sdl_setObject:fullAppID forName:SDLRPCParameterNameFullAppID];
 }
 
 - (nullable NSString *)fullAppID {
-    return [parameters sdl_objectForName:SDLRPCParameterNameFullAppID ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameFullAppID ofClass:NSString.class error:nil];
 }
 
 - (void)setAppInfo:(nullable SDLAppInfo *)appInfo {
-    [parameters sdl_setObject:appInfo forName:SDLRPCParameterNameAppInfo];
+    [self.parameters sdl_setObject:appInfo forName:SDLRPCParameterNameAppInfo];
 }
 
 - (nullable SDLAppInfo *)appInfo {
-    return [parameters sdl_objectForName:SDLRPCParameterNameAppInfo ofClass:SDLAppInfo.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameAppInfo ofClass:SDLAppInfo.class error:nil];
 }
 
 - (void)setDayColorScheme:(nullable SDLTemplateColorScheme *)dayColorScheme {
-    [parameters sdl_setObject:dayColorScheme forName:SDLRPCParameterNameDayColorScheme];
+    [self.parameters sdl_setObject:dayColorScheme forName:SDLRPCParameterNameDayColorScheme];
 }
 
 - (nullable SDLTemplateColorScheme *)dayColorScheme {
-    return [parameters sdl_objectForName:SDLRPCParameterNameDayColorScheme ofClass:SDLTemplateColorScheme.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameDayColorScheme ofClass:SDLTemplateColorScheme.class error:nil];
 }
 
 - (void)setNightColorScheme:(nullable SDLTemplateColorScheme *)nightColorScheme {
-    [parameters sdl_setObject:nightColorScheme forName:SDLRPCParameterNameNightColorScheme];
+    [self.parameters sdl_setObject:nightColorScheme forName:SDLRPCParameterNameNightColorScheme];
 }
 
 - (nullable SDLTemplateColorScheme *)nightColorScheme {
-    return [parameters sdl_objectForName:SDLRPCParameterNameNightColorScheme ofClass:SDLTemplateColorScheme.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameNightColorScheme ofClass:SDLTemplateColorScheme.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLRegisterAppInterfaceResponse.m
+++ b/SmartDeviceLink/SDLRegisterAppInterfaceResponse.m
@@ -21,162 +21,165 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLRegisterAppInterfaceResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameRegisterAppInterface]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setSyncMsgVersion:(nullable SDLSyncMsgVersion *)syncMsgVersion {
-    [parameters sdl_setObject:syncMsgVersion forName:SDLRPCParameterNameSyncMessageVersion];
+    [self.parameters sdl_setObject:syncMsgVersion forName:SDLRPCParameterNameSyncMessageVersion];
 }
 
 - (nullable SDLSyncMsgVersion *)syncMsgVersion {
-    return [parameters sdl_objectForName:SDLRPCParameterNameSyncMessageVersion ofClass:SDLSyncMsgVersion.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameSyncMessageVersion ofClass:SDLSyncMsgVersion.class error:nil];
 }
 
 - (void)setLanguage:(nullable SDLLanguage)language {
-    [parameters sdl_setObject:language forName:SDLRPCParameterNameLanguage];
+    [self.parameters sdl_setObject:language forName:SDLRPCParameterNameLanguage];
 }
 
 - (nullable SDLLanguage)language {
-    return [parameters sdl_enumForName:SDLRPCParameterNameLanguage error:nil];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameLanguage error:nil];
 }
 
 - (void)setHmiDisplayLanguage:(nullable SDLLanguage)hmiDisplayLanguage {
-    [parameters sdl_setObject:hmiDisplayLanguage forName:SDLRPCParameterNameHMIDisplayLanguage];
+    [self.parameters sdl_setObject:hmiDisplayLanguage forName:SDLRPCParameterNameHMIDisplayLanguage];
 }
 
 - (nullable SDLLanguage)hmiDisplayLanguage {
-    return [parameters sdl_enumForName:SDLRPCParameterNameHMIDisplayLanguage error:nil];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameHMIDisplayLanguage error:nil];
 }
 
 - (void)setDisplayCapabilities:(nullable SDLDisplayCapabilities *)displayCapabilities {
-    [parameters sdl_setObject:displayCapabilities forName:SDLRPCParameterNameDisplayCapabilities];
+    [self.parameters sdl_setObject:displayCapabilities forName:SDLRPCParameterNameDisplayCapabilities];
 }
 
 - (nullable SDLDisplayCapabilities *)displayCapabilities {
-    return [parameters sdl_objectForName:SDLRPCParameterNameDisplayCapabilities ofClass:SDLDisplayCapabilities.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameDisplayCapabilities ofClass:SDLDisplayCapabilities.class error:nil];
 }
 
 - (void)setButtonCapabilities:(nullable NSArray<SDLButtonCapabilities *> *)buttonCapabilities {
-    [parameters sdl_setObject:buttonCapabilities forName:SDLRPCParameterNameButtonCapabilities];
+    [self.parameters sdl_setObject:buttonCapabilities forName:SDLRPCParameterNameButtonCapabilities];
 }
 
 - (nullable NSArray<SDLButtonCapabilities *> *)buttonCapabilities {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameButtonCapabilities ofClass:SDLButtonCapabilities.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameButtonCapabilities ofClass:SDLButtonCapabilities.class error:nil];
 }
 
 - (void)setSoftButtonCapabilities:(nullable NSArray<SDLSoftButtonCapabilities *> *)softButtonCapabilities {
-    [parameters sdl_setObject:softButtonCapabilities forName:SDLRPCParameterNameSoftButtonCapabilities];
+    [self.parameters sdl_setObject:softButtonCapabilities forName:SDLRPCParameterNameSoftButtonCapabilities];
 }
 
 - (nullable NSArray<SDLSoftButtonCapabilities *> *)softButtonCapabilities {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameSoftButtonCapabilities ofClass:SDLSoftButtonCapabilities.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameSoftButtonCapabilities ofClass:SDLSoftButtonCapabilities.class error:nil];
 }
 
 - (void)setPresetBankCapabilities:(nullable SDLPresetBankCapabilities *)presetBankCapabilities {
-    [parameters sdl_setObject:presetBankCapabilities forName:SDLRPCParameterNamePresetBankCapabilities];
+    [self.parameters sdl_setObject:presetBankCapabilities forName:SDLRPCParameterNamePresetBankCapabilities];
 }
 
 - (nullable SDLPresetBankCapabilities *)presetBankCapabilities {
-    return [parameters sdl_objectForName:SDLRPCParameterNamePresetBankCapabilities ofClass:SDLPresetBankCapabilities.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNamePresetBankCapabilities ofClass:SDLPresetBankCapabilities.class error:nil];
 }
 
 - (void)setHmiZoneCapabilities:(nullable NSArray<SDLHMIZoneCapabilities> *)hmiZoneCapabilities {
-    [parameters sdl_setObject:hmiZoneCapabilities forName:SDLRPCParameterNameHMIZoneCapabilities];
+    [self.parameters sdl_setObject:hmiZoneCapabilities forName:SDLRPCParameterNameHMIZoneCapabilities];
 }
 
 - (nullable NSArray<SDLHMIZoneCapabilities> *)hmiZoneCapabilities {
-    return [parameters sdl_enumsForName:SDLRPCParameterNameHMIZoneCapabilities error:nil];
+    return [self.parameters sdl_enumsForName:SDLRPCParameterNameHMIZoneCapabilities error:nil];
 }
 
 - (void)setSpeechCapabilities:(nullable NSArray<SDLSpeechCapabilities> *)speechCapabilities {
-    [parameters sdl_setObject:speechCapabilities forName:SDLRPCParameterNameSpeechCapabilities];
+    [self.parameters sdl_setObject:speechCapabilities forName:SDLRPCParameterNameSpeechCapabilities];
 }
 
 - (nullable NSArray<SDLSpeechCapabilities> *)speechCapabilities {
-    return [parameters sdl_enumsForName:SDLRPCParameterNameSpeechCapabilities error:nil];
+    return [self.parameters sdl_enumsForName:SDLRPCParameterNameSpeechCapabilities error:nil];
 }
 
 - (void)setPrerecordedSpeech:(nullable NSArray<SDLPrerecordedSpeech> *)prerecordedSpeech {
-    [parameters sdl_setObject:prerecordedSpeech forName:SDLRPCParameterNamePrerecordedSpeech];
+    [self.parameters sdl_setObject:prerecordedSpeech forName:SDLRPCParameterNamePrerecordedSpeech];
 }
 
 - (nullable NSArray<SDLPrerecordedSpeech> *)prerecordedSpeech {
-    return [parameters sdl_enumsForName:SDLRPCParameterNamePrerecordedSpeech error:nil];
+    return [self.parameters sdl_enumsForName:SDLRPCParameterNamePrerecordedSpeech error:nil];
 }
 
 - (void)setVrCapabilities:(nullable NSArray<SDLVRCapabilities> *)vrCapabilities {
-    [parameters sdl_setObject:vrCapabilities forName:SDLRPCParameterNameVRCapabilities];
+    [self.parameters sdl_setObject:vrCapabilities forName:SDLRPCParameterNameVRCapabilities];
 }
 
 - (nullable NSArray<SDLVRCapabilities> *)vrCapabilities {
-    return [parameters sdl_enumsForName:SDLRPCParameterNameVRCapabilities error:nil];
+    return [self.parameters sdl_enumsForName:SDLRPCParameterNameVRCapabilities error:nil];
 }
 
 - (void)setAudioPassThruCapabilities:(nullable NSArray<SDLAudioPassThruCapabilities *> *)audioPassThruCapabilities {
-    [parameters sdl_setObject:audioPassThruCapabilities forName:SDLRPCParameterNameAudioPassThruCapabilities];
+    [self.parameters sdl_setObject:audioPassThruCapabilities forName:SDLRPCParameterNameAudioPassThruCapabilities];
 }
 
 - (nullable NSArray<SDLAudioPassThruCapabilities *> *)audioPassThruCapabilities {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameAudioPassThruCapabilities ofClass:SDLAudioPassThruCapabilities.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameAudioPassThruCapabilities ofClass:SDLAudioPassThruCapabilities.class error:nil];
 }
 
 - (void)setPcmStreamCapabilities:(nullable SDLAudioPassThruCapabilities *)pcmStreamCapabilities {
-    [parameters sdl_setObject:pcmStreamCapabilities forName:SDLRPCParameterNamePCMStreamCapabilities];
+    [self.parameters sdl_setObject:pcmStreamCapabilities forName:SDLRPCParameterNamePCMStreamCapabilities];
 }
 
 - (nullable SDLAudioPassThruCapabilities *)pcmStreamCapabilities {
-    return [parameters sdl_objectForName:SDLRPCParameterNamePCMStreamCapabilities ofClass:SDLAudioPassThruCapabilities.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNamePCMStreamCapabilities ofClass:SDLAudioPassThruCapabilities.class error:nil];
 }
 
 - (void)setVehicleType:(nullable SDLVehicleType *)vehicleType {
-    [parameters sdl_setObject:vehicleType forName:SDLRPCParameterNameVehicleType];
+    [self.parameters sdl_setObject:vehicleType forName:SDLRPCParameterNameVehicleType];
 }
 
 - (nullable SDLVehicleType *)vehicleType {
-    return [parameters sdl_objectForName:SDLRPCParameterNameVehicleType ofClass:SDLVehicleType.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameVehicleType ofClass:SDLVehicleType.class error:nil];
 }
 
 - (void)setSupportedDiagModes:(nullable NSArray<NSNumber<SDLInt> *> *)supportedDiagModes {
-    [parameters sdl_setObject:supportedDiagModes forName:SDLRPCParameterNameSupportedDiagnosticModes];
+    [self.parameters sdl_setObject:supportedDiagModes forName:SDLRPCParameterNameSupportedDiagnosticModes];
 }
 
 - (nullable NSArray<NSNumber<SDLInt> *> *)supportedDiagModes {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameSupportedDiagnosticModes ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameSupportedDiagnosticModes ofClass:NSNumber.class error:nil];
 }
 
 - (void)setHmiCapabilities:(nullable SDLHMICapabilities *)hmiCapabilities {
-    [parameters sdl_setObject:hmiCapabilities forName:SDLRPCParameterNameHMICapabilities];
+    [self.parameters sdl_setObject:hmiCapabilities forName:SDLRPCParameterNameHMICapabilities];
 }
 
 - (nullable SDLHMICapabilities *)hmiCapabilities {
-    return [parameters sdl_objectForName:SDLRPCParameterNameHMICapabilities ofClass:SDLHMICapabilities.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameHMICapabilities ofClass:SDLHMICapabilities.class error:nil];
 }
 
 - (void)setSdlVersion:(nullable NSString *)sdlVersion {
-    [parameters sdl_setObject:sdlVersion forName:SDLRPCParameterNameSDLVersion];
+    [self.parameters sdl_setObject:sdlVersion forName:SDLRPCParameterNameSDLVersion];
 }
 
 - (nullable NSString *)sdlVersion {
-    return [parameters sdl_objectForName:SDLRPCParameterNameSDLVersion ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameSDLVersion ofClass:NSString.class error:nil];
 }
 
 - (void)setSystemSoftwareVersion:(nullable NSString *)systemSoftwareVersion {
-    [parameters sdl_setObject:systemSoftwareVersion forName:SDLRPCParameterNameSystemSoftwareVersion];
+    [self.parameters sdl_setObject:systemSoftwareVersion forName:SDLRPCParameterNameSystemSoftwareVersion];
 }
 
 - (nullable NSString *)systemSoftwareVersion {
-    return [parameters sdl_objectForName:SDLRPCParameterNameSystemSoftwareVersion ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameSystemSoftwareVersion ofClass:NSString.class error:nil];
 }
 
 - (void)setIconResumed:(nullable NSNumber<SDLBool> *)iconResumed {
-    [parameters sdl_setObject:iconResumed forName:SDLRPCParameterNameIconResumed];
+    [self.parameters sdl_setObject:iconResumed forName:SDLRPCParameterNameIconResumed];
 }
 
 - (nullable NSNumber<SDLBool> *)iconResumed {
-    return [parameters sdl_objectForName:SDLRPCParameterNameIconResumed ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameIconResumed ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLRemoteControlCapabilities.m
+++ b/SmartDeviceLink/SDLRemoteControlCapabilities.m
@@ -40,59 +40,59 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setClimateControlCapabilities:(nullable NSArray<SDLClimateControlCapabilities *> *)climateControlCapabilities {
-    [store sdl_setObject:climateControlCapabilities forName:SDLRPCParameterNameClimateControlCapabilities];
+    [self.store sdl_setObject:climateControlCapabilities forName:SDLRPCParameterNameClimateControlCapabilities];
 }
 
 - (nullable NSArray<SDLClimateControlCapabilities *> *)climateControlCapabilities {
-    return [store sdl_objectsForName:SDLRPCParameterNameClimateControlCapabilities ofClass:SDLClimateControlCapabilities.class error:nil];
+    return [self.store sdl_objectsForName:SDLRPCParameterNameClimateControlCapabilities ofClass:SDLClimateControlCapabilities.class error:nil];
 }
 
 -(void)setRadioControlCapabilities:(nullable NSArray<SDLRadioControlCapabilities *> *)radioControlCapabilities {
-    [store sdl_setObject:radioControlCapabilities forName:SDLRPCParameterNameRadioControlCapabilities ];
+    [self.store sdl_setObject:radioControlCapabilities forName:SDLRPCParameterNameRadioControlCapabilities ];
 }
 
 - (nullable NSArray<SDLRadioControlCapabilities *> *)radioControlCapabilities {
-    return [store sdl_objectsForName:SDLRPCParameterNameRadioControlCapabilities ofClass:SDLRadioControlCapabilities.class error:nil];
+    return [self.store sdl_objectsForName:SDLRPCParameterNameRadioControlCapabilities ofClass:SDLRadioControlCapabilities.class error:nil];
 }
 
 - (void)setButtonCapabilities:(nullable NSArray<SDLButtonCapabilities *> *)buttonCapabilities {
-    [store sdl_setObject:buttonCapabilities forName:SDLRPCParameterNameButtonCapabilities];}
+    [self.store sdl_setObject:buttonCapabilities forName:SDLRPCParameterNameButtonCapabilities];}
 
 - (nullable NSArray<SDLButtonCapabilities *> *)buttonCapabilities {
-    return [store sdl_objectsForName:SDLRPCParameterNameButtonCapabilities ofClass:SDLButtonCapabilities.class error:nil];
+    return [self.store sdl_objectsForName:SDLRPCParameterNameButtonCapabilities ofClass:SDLButtonCapabilities.class error:nil];
 }
 
 - (void)setSeatControlCapabilities:(nullable NSArray<SDLSeatControlCapabilities *> *)seatControlCapabilities {
-    [store sdl_setObject:seatControlCapabilities forName:SDLRPCParameterNameSeatControlCapabilities];
+    [self.store sdl_setObject:seatControlCapabilities forName:SDLRPCParameterNameSeatControlCapabilities];
 }
 
 - (nullable NSArray<SDLSeatControlCapabilities *> *)seatControlCapabilities {
-    return [store sdl_objectsForName:SDLRPCParameterNameSeatControlCapabilities ofClass:SDLSeatControlCapabilities.class error:nil];
+    return [self.store sdl_objectsForName:SDLRPCParameterNameSeatControlCapabilities ofClass:SDLSeatControlCapabilities.class error:nil];
 }
 
 - (void)setAudioControlCapabilities:(nullable NSArray<SDLAudioControlCapabilities *> *)audioControlCapabilities {
-    [store sdl_setObject:audioControlCapabilities forName:SDLRPCParameterNameAudioControlCapabilities];
+    [self.store sdl_setObject:audioControlCapabilities forName:SDLRPCParameterNameAudioControlCapabilities];
 }
 
 - (nullable NSArray<SDLAudioControlCapabilities *> *)audioControlCapabilities {
-    return [store sdl_objectsForName:SDLRPCParameterNameAudioControlCapabilities ofClass:SDLAudioControlCapabilities.class error:nil];
+    return [self.store sdl_objectsForName:SDLRPCParameterNameAudioControlCapabilities ofClass:SDLAudioControlCapabilities.class error:nil];
 
 }
 
 - (void)setHmiSettingsControlCapabilities:(nullable NSArray<SDLHMISettingsControlCapabilities *> *)hmiSettingsControlCapabilities {
-    [store sdl_setObject:hmiSettingsControlCapabilities forName:SDLRPCParameterNameHmiSettingsControlCapabilities];
+    [self.store sdl_setObject:hmiSettingsControlCapabilities forName:SDLRPCParameterNameHmiSettingsControlCapabilities];
 }
 
 - (nullable NSArray<SDLHMISettingsControlCapabilities *> *)hmiSettingsControlCapabilities {
-    return [store sdl_objectsForName:SDLRPCParameterNameHmiSettingsControlCapabilities ofClass:SDLHMISettingsControlCapabilities.class error:nil];
+    return [self.store sdl_objectsForName:SDLRPCParameterNameHmiSettingsControlCapabilities ofClass:SDLHMISettingsControlCapabilities.class error:nil];
 }
 
 - (void)setLightControlCapabilities:(nullable NSArray<SDLLightControlCapabilities *> *)lightControlCapabilities {
-    [store sdl_setObject:lightControlCapabilities forName:SDLRPCParameterNameLightControlCapabilities];
+    [self.store sdl_setObject:lightControlCapabilities forName:SDLRPCParameterNameLightControlCapabilities];
 }
 
 - (nullable NSArray<SDLLightControlCapabilities *> *)lightControlCapabilities {
-    return [store sdl_objectsForName:SDLRPCParameterNameLightControlCapabilities ofClass:SDLLightControlCapabilities.class error:nil];
+    return [self.store sdl_objectsForName:SDLRPCParameterNameLightControlCapabilities ofClass:SDLLightControlCapabilities.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLResetGlobalProperties.m
+++ b/SmartDeviceLink/SDLResetGlobalProperties.m
@@ -13,11 +13,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLResetGlobalProperties
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameResetGlobalProperties]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithProperties:(NSArray<SDLGlobalProperty> *)properties {
     self = [self init];
@@ -31,12 +34,12 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setProperties:(NSArray<SDLGlobalProperty> *)properties {
-    [parameters sdl_setObject:properties forName:SDLRPCParameterNameProperties];
+    [self.parameters sdl_setObject:properties forName:SDLRPCParameterNameProperties];
 }
 
 - (NSArray<SDLGlobalProperty> *)properties {
     NSError *error = nil;
-    return [parameters sdl_enumsForName:SDLRPCParameterNameProperties error:&error];
+    return [self.parameters sdl_enumsForName:SDLRPCParameterNameProperties error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLResetGlobalPropertiesResponse.m
+++ b/SmartDeviceLink/SDLResetGlobalPropertiesResponse.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLResetGlobalPropertiesResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameResetGlobalProperties]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLSISData.m
+++ b/SmartDeviceLink/SDLSISData.m
@@ -28,43 +28,43 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setStationShortName:(nullable NSString *)stationShortName {
-    [store sdl_setObject:stationShortName forName:SDLRPCParameterNameStationShortName];
+    [self.store sdl_setObject:stationShortName forName:SDLRPCParameterNameStationShortName];
 }
 
 - (nullable NSString *)stationShortName {
-    return [store sdl_objectForName:SDLRPCParameterNameStationShortName ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameStationShortName ofClass:NSString.class error:nil];
 }
 
 - (void)setStationIDNumber:(nullable SDLStationIDNumber *)stationIDNumber {
-    [store sdl_setObject:stationIDNumber forName:SDLRPCParameterNameStationIDNumber];
+    [self.store sdl_setObject:stationIDNumber forName:SDLRPCParameterNameStationIDNumber];
 }
 
 - (nullable SDLStationIDNumber *)stationIDNumber {
-    return [store sdl_objectForName:SDLRPCParameterNameStationIDNumber ofClass:SDLStationIDNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameStationIDNumber ofClass:SDLStationIDNumber.class error:nil];
 }
 
 - (void)setStationLongName:(nullable NSString *)stationLongName {
-    [store sdl_setObject:stationLongName forName:SDLRPCParameterNameStationLongName];
+    [self.store sdl_setObject:stationLongName forName:SDLRPCParameterNameStationLongName];
 }
 
 - (nullable NSString *)stationLongName {
-    return [store sdl_objectForName:SDLRPCParameterNameStationLongName ofClass:NSString.class error:nil];;
+    return [self.store sdl_objectForName:SDLRPCParameterNameStationLongName ofClass:NSString.class error:nil];;
 }
 
 - (void)setStationLocation:(nullable SDLGPSData *)stationLocation {
-    [store sdl_setObject:stationLocation forName:SDLRPCParameterNameStationLocation];
+    [self.store sdl_setObject:stationLocation forName:SDLRPCParameterNameStationLocation];
 }
 
 - (nullable SDLGPSData *)stationLocation {
-    return [store sdl_objectForName:SDLRPCParameterNameStationLocation ofClass:SDLGPSData.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameStationLocation ofClass:SDLGPSData.class error:nil];
 }
 
 - (void)setStationMessage:(nullable NSString *)stationMessage {
-    [store sdl_setObject:stationMessage forName:SDLRPCParameterNameStationMessage];
+    [self.store sdl_setObject:stationMessage forName:SDLRPCParameterNameStationMessage];
 }
 
 - (nullable NSString *)stationMessage {
-    return [store sdl_objectForName:SDLRPCParameterNameStationMessage ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameStationMessage ofClass:NSString.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLScreenParams.m
+++ b/SmartDeviceLink/SDLScreenParams.m
@@ -13,20 +13,20 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation SDLScreenParams
 
 - (void)setResolution:(SDLImageResolution *)resolution {
-    [store sdl_setObject:resolution forName:SDLRPCParameterNameResolution];
+    [self.store sdl_setObject:resolution forName:SDLRPCParameterNameResolution];
 }
 
 - (SDLImageResolution *)resolution {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameResolution ofClass:SDLImageResolution.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameResolution ofClass:SDLImageResolution.class error:&error];
 }
 
 - (void)setTouchEventAvailable:(nullable SDLTouchEventCapabilities *)touchEventAvailable {
-    [store sdl_setObject:touchEventAvailable forName:SDLRPCParameterNameTouchEventAvailable];
+    [self.store sdl_setObject:touchEventAvailable forName:SDLRPCParameterNameTouchEventAvailable];
 }
 
 - (nullable SDLTouchEventCapabilities *)touchEventAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameTouchEventAvailable ofClass:SDLTouchEventCapabilities.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameTouchEventAvailable ofClass:SDLTouchEventCapabilities.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLScrollableMessage.m
+++ b/SmartDeviceLink/SDLScrollableMessage.m
@@ -13,11 +13,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLScrollableMessage
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameScrollableMessage]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithMessage:(NSString *)message timeout:(UInt16)timeout softButtons:(nullable NSArray<SDLSoftButton *> *)softButtons {
     self = [self initWithMessage:message];
@@ -43,28 +46,28 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setScrollableMessageBody:(NSString *)scrollableMessageBody {
-    [parameters sdl_setObject:scrollableMessageBody forName:SDLRPCParameterNameScrollableMessageBody];
+    [self.parameters sdl_setObject:scrollableMessageBody forName:SDLRPCParameterNameScrollableMessageBody];
 }
 
 - (NSString *)scrollableMessageBody {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameScrollableMessageBody ofClass:NSString.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameScrollableMessageBody ofClass:NSString.class error:&error];
 }
 
 - (void)setTimeout:(nullable NSNumber<SDLInt> *)timeout {
-    [parameters sdl_setObject:timeout forName:SDLRPCParameterNameTimeout];
+    [self.parameters sdl_setObject:timeout forName:SDLRPCParameterNameTimeout];
 }
 
 - (nullable NSNumber<SDLInt> *)timeout {
-    return [parameters sdl_objectForName:SDLRPCParameterNameTimeout ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameTimeout ofClass:NSNumber.class error:nil];
 }
 
 - (void)setSoftButtons:(nullable NSArray<SDLSoftButton *> *)softButtons {
-    [parameters sdl_setObject:softButtons forName:SDLRPCParameterNameSoftButtons];
+    [self.parameters sdl_setObject:softButtons forName:SDLRPCParameterNameSoftButtons];
 }
 
 - (nullable NSArray<SDLSoftButton *> *)softButtons {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameSoftButtons ofClass:SDLSoftButton.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameSoftButtons ofClass:SDLSoftButton.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLScrollableMessageResponse.m
+++ b/SmartDeviceLink/SDLScrollableMessageResponse.m
@@ -10,10 +10,13 @@
 
 @implementation SDLScrollableMessageResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameScrollableMessage]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end

--- a/SmartDeviceLink/SDLSeatControlCapabilities.m
+++ b/SmartDeviceLink/SDLSeatControlCapabilities.m
@@ -44,159 +44,159 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setModuleName:(NSString *)moduleName {
-    [store sdl_setObject:moduleName forName:SDLRPCParameterNameModuleName];
+    [self.store sdl_setObject:moduleName forName:SDLRPCParameterNameModuleName];
 }
 
 - (NSString *)moduleName {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameModuleName ofClass:NSString.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameModuleName ofClass:NSString.class error:&error];
 }
 
 - (void)setHeatingEnabledAvailable:(nullable NSNumber<SDLBool> *)heatingEnabledAvailable {
-    [store sdl_setObject:heatingEnabledAvailable forName:SDLRPCParameterNameHeatingEnabledAvailable];
+    [self.store sdl_setObject:heatingEnabledAvailable forName:SDLRPCParameterNameHeatingEnabledAvailable];
 }
 
 - (nullable NSNumber<SDLBool> *)heatingEnabledAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameHeatingEnabledAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameHeatingEnabledAvailable ofClass:NSNumber.class error:nil];
 }
 
 - (void)setCoolingEnabledAvailable:(nullable NSNumber<SDLBool> *)coolingEnabledAvailable {
-    [store sdl_setObject:coolingEnabledAvailable forName:SDLRPCParameterNameCoolingEnabledAvailable];
+    [self.store sdl_setObject:coolingEnabledAvailable forName:SDLRPCParameterNameCoolingEnabledAvailable];
 
 }
 
 - (nullable NSNumber<SDLBool> *)coolingEnabledAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameCoolingEnabledAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameCoolingEnabledAvailable ofClass:NSNumber.class error:nil];
 
 }
 
 - (void)setHeatingLevelAvailable:(nullable NSNumber<SDLBool> *)heatingLevelAvailable {
-    [store sdl_setObject:heatingLevelAvailable forName:SDLRPCParameterNameHeatingLevelAvailable];
+    [self.store sdl_setObject:heatingLevelAvailable forName:SDLRPCParameterNameHeatingLevelAvailable];
 
 }
 
 - (nullable NSNumber<SDLBool> *)heatingLevelAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameHeatingLevelAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameHeatingLevelAvailable ofClass:NSNumber.class error:nil];
 
 }
 
 - (void)setCoolingLevelAvailable:(nullable NSNumber<SDLBool> *)coolingLevelAvailable {
-    [store sdl_setObject:coolingLevelAvailable forName:SDLRPCParameterNameCoolingLevelAvailable];
+    [self.store sdl_setObject:coolingLevelAvailable forName:SDLRPCParameterNameCoolingLevelAvailable];
 
 }
 
 - (nullable NSNumber<SDLBool> *)coolingLevelAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameCoolingLevelAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameCoolingLevelAvailable ofClass:NSNumber.class error:nil];
 
 }
 
 - (void)setHorizontalPositionAvailable:(nullable NSNumber<SDLBool> *)horizontalPositionAvailable {
-    [store sdl_setObject:horizontalPositionAvailable forName:SDLRPCParameterNameHorizontalPositionAvailable];
+    [self.store sdl_setObject:horizontalPositionAvailable forName:SDLRPCParameterNameHorizontalPositionAvailable];
 
 }
 
 - (nullable NSNumber<SDLBool> *)horizontalPositionAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameHorizontalPositionAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameHorizontalPositionAvailable ofClass:NSNumber.class error:nil];
 
 }
 
 - (void)setVerticalPositionAvailable:(nullable NSNumber<SDLBool> *)verticalPositionAvailable {
-    [store sdl_setObject:verticalPositionAvailable forName:SDLRPCParameterNameVerticalPositionAvailable];
+    [self.store sdl_setObject:verticalPositionAvailable forName:SDLRPCParameterNameVerticalPositionAvailable];
 
 }
 
 - (nullable NSNumber<SDLBool> *)verticalPositionAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameVerticalPositionAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameVerticalPositionAvailable ofClass:NSNumber.class error:nil];
 
 }
 
 - (void)setFrontVerticalPositionAvailable:(nullable NSNumber<SDLBool> *)frontVerticalPositionAvailable {
-    [store sdl_setObject:frontVerticalPositionAvailable forName:SDLRPCParameterNameFrontVerticalPositionAvailable];
+    [self.store sdl_setObject:frontVerticalPositionAvailable forName:SDLRPCParameterNameFrontVerticalPositionAvailable];
 
 }
 
 - (nullable NSNumber<SDLBool> *)frontVerticalPositionAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameFrontVerticalPositionAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameFrontVerticalPositionAvailable ofClass:NSNumber.class error:nil];
 
 }
 
 - (void)setBackVerticalPositionAvailable:(nullable NSNumber<SDLBool> *)backVerticalPositionAvailable {
-    [store sdl_setObject:backVerticalPositionAvailable forName:SDLRPCParameterNameBackVerticalPositionAvailable];
+    [self.store sdl_setObject:backVerticalPositionAvailable forName:SDLRPCParameterNameBackVerticalPositionAvailable];
 
 }
 
 - (nullable NSNumber<SDLBool> *)backVerticalPositionAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameBackVerticalPositionAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameBackVerticalPositionAvailable ofClass:NSNumber.class error:nil];
 
 }
 
 - (void)setBackTiltAngleAvailable:(nullable NSNumber<SDLBool> *)backTiltAngleAvailable {
-    [store sdl_setObject:backTiltAngleAvailable forName:SDLRPCParameterNameBackTiltAngleAvailable];
+    [self.store sdl_setObject:backTiltAngleAvailable forName:SDLRPCParameterNameBackTiltAngleAvailable];
 
 }
 
 - (nullable NSNumber<SDLBool> *)backTiltAngleAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameBackTiltAngleAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameBackTiltAngleAvailable ofClass:NSNumber.class error:nil];
 
 }
 
 - (void)setHeadSupportHorizontalPositionAvailable:(nullable NSNumber<SDLBool> *)headSupportHorizontalPositionAvailable {
-    [store sdl_setObject:headSupportHorizontalPositionAvailable forName:SDLRPCParameterNameHeadSupportHorizontalPositionAvailable];
+    [self.store sdl_setObject:headSupportHorizontalPositionAvailable forName:SDLRPCParameterNameHeadSupportHorizontalPositionAvailable];
 
 }
 
 - (nullable NSNumber<SDLBool> *)headSupportHorizontalPositionAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameHeadSupportHorizontalPositionAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameHeadSupportHorizontalPositionAvailable ofClass:NSNumber.class error:nil];
 
 }
 
 - (void)setHeadSupportVerticalPositionAvailable:(nullable NSNumber<SDLBool> *)headSupportVerticalPositionAvailable {
-    [store sdl_setObject:headSupportVerticalPositionAvailable forName:SDLRPCParameterNameHeadSupportVerticalPositionAvailable];
+    [self.store sdl_setObject:headSupportVerticalPositionAvailable forName:SDLRPCParameterNameHeadSupportVerticalPositionAvailable];
 
 }
 
 - (nullable NSNumber<SDLBool> *)headSupportVerticalPositionAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameHeadSupportVerticalPositionAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameHeadSupportVerticalPositionAvailable ofClass:NSNumber.class error:nil];
 
 }
 
 - (void)setMassageEnabledAvailable:(nullable NSNumber<SDLBool> *)massageEnabledAvailable {
-    [store sdl_setObject:massageEnabledAvailable forName:SDLRPCParameterNameMassageEnabledAvailable];
+    [self.store sdl_setObject:massageEnabledAvailable forName:SDLRPCParameterNameMassageEnabledAvailable];
 
 }
 
 - (nullable NSNumber<SDLBool> *)massageEnabledAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameMassageEnabledAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameMassageEnabledAvailable ofClass:NSNumber.class error:nil];
 
 }
 
 - (void)setMassageModeAvailable:(nullable NSNumber<SDLBool> *)massageModeAvailable {
-    [store sdl_setObject:massageModeAvailable forName:SDLRPCParameterNameMassageModeAvailable];
+    [self.store sdl_setObject:massageModeAvailable forName:SDLRPCParameterNameMassageModeAvailable];
 
 }
 
 - (nullable NSNumber<SDLBool> *)massageModeAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameMassageModeAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameMassageModeAvailable ofClass:NSNumber.class error:nil];
 
 }
 
 - (void)setMassageCushionFirmnessAvailable:(nullable NSNumber<SDLBool> *)massageCushionFirmnessAvailable {
-    [store sdl_setObject:massageCushionFirmnessAvailable forName:SDLRPCParameterNameMassageCushionFirmnessAvailable];
+    [self.store sdl_setObject:massageCushionFirmnessAvailable forName:SDLRPCParameterNameMassageCushionFirmnessAvailable];
 
 }
 
 - (nullable NSNumber<SDLBool> *)massageCushionFirmnessAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameMassageCushionFirmnessAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameMassageCushionFirmnessAvailable ofClass:NSNumber.class error:nil];
 
 }
 
 - (void)setMemoryAvailable:(nullable NSNumber<SDLBool> *)memoryAvailable {
-    [store sdl_setObject:memoryAvailable forName:SDLRPCParameterNameMemoryAvailable];
+    [self.store sdl_setObject:memoryAvailable forName:SDLRPCParameterNameMemoryAvailable];
 
 }
 
 - (nullable NSNumber<SDLBool> *)memoryAvailable {
-    return [store sdl_objectForName:SDLRPCParameterNameMemoryAvailable ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameMemoryAvailable ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLSeatControlData.m
+++ b/SmartDeviceLink/SDLSeatControlData.m
@@ -54,133 +54,133 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setId:(SDLSupportedSeat)id {
-    [store sdl_setObject:id forName:SDLRPCParameterNameId];
+    [self.store sdl_setObject:id forName:SDLRPCParameterNameId];
 }
 
 - (SDLSupportedSeat)id {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameId error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameId error:&error];
 }
 
 - (void)setHeatingEnabled:(nullable NSNumber<SDLBool> *)heatingEnabled {
-    [store sdl_setObject:heatingEnabled forName:SDLRPCParameterNameHeatingEnabled];
+    [self.store sdl_setObject:heatingEnabled forName:SDLRPCParameterNameHeatingEnabled];
 }
 
 - (nullable NSNumber<SDLBool> *)heatingEnabled {
-    return [store sdl_objectForName:SDLRPCParameterNameHeatingEnabled ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameHeatingEnabled ofClass:NSNumber.class error:nil];
 }
 
 - (void)setCoolingEnabled:(nullable NSNumber<SDLBool> *)coolingEnabled {
-    [store sdl_setObject:coolingEnabled forName:SDLRPCParameterNameCoolingEnabled];
+    [self.store sdl_setObject:coolingEnabled forName:SDLRPCParameterNameCoolingEnabled];
 }
 
 - (nullable NSNumber<SDLBool> *)coolingEnabled {
-    return [store sdl_objectForName:SDLRPCParameterNameCoolingEnabled ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameCoolingEnabled ofClass:NSNumber.class error:nil];
 }
 
 - (void)setHeatingLevel:(nullable NSNumber<SDLInt> *)heatingLevel {
-    [store sdl_setObject:heatingLevel forName:SDLRPCParameterNameHeatingLevel];
+    [self.store sdl_setObject:heatingLevel forName:SDLRPCParameterNameHeatingLevel];
 }
 
 - (nullable NSNumber<SDLInt> *)heatingLevel {
-    return [store sdl_objectForName:SDLRPCParameterNameHeatingLevel ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameHeatingLevel ofClass:NSNumber.class error:nil];
 }
 
 - (void)setCoolingLevel:(nullable NSNumber<SDLInt> *)coolingLevel {
-    [store sdl_setObject:coolingLevel forName:SDLRPCParameterNameCoolingLevel];
+    [self.store sdl_setObject:coolingLevel forName:SDLRPCParameterNameCoolingLevel];
 }
 
 - (nullable NSNumber<SDLInt> *)coolingLevel {
-    return [store sdl_objectForName:SDLRPCParameterNameCoolingLevel ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameCoolingLevel ofClass:NSNumber.class error:nil];
 }
 
 - (void)setHorizontalPosition:(nullable NSNumber<SDLInt> *)horizontalPosition {
-    [store sdl_setObject:horizontalPosition forName:SDLRPCParameterNameHorizontalPosition];
+    [self.store sdl_setObject:horizontalPosition forName:SDLRPCParameterNameHorizontalPosition];
 }
 
 - (nullable NSNumber<SDLInt> *)horizontalPosition {
-    return [store sdl_objectForName:SDLRPCParameterNameHorizontalPosition ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameHorizontalPosition ofClass:NSNumber.class error:nil];
 }
 
 - (void)setVerticalPosition:(nullable NSNumber<SDLInt> *)verticalPosition {
-    [store sdl_setObject:verticalPosition forName:SDLRPCParameterNameVerticalPosition];
+    [self.store sdl_setObject:verticalPosition forName:SDLRPCParameterNameVerticalPosition];
 }
 
 - (nullable NSNumber<SDLInt> *)verticalPosition {
-    return [store sdl_objectForName:SDLRPCParameterNameVerticalPosition ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameVerticalPosition ofClass:NSNumber.class error:nil];
 }
 
 - (void)setFrontVerticalPosition:(nullable NSNumber<SDLInt> *)frontVerticalPosition {
-    [store sdl_setObject:frontVerticalPosition forName:SDLRPCParameterNameFrontVerticalPosition];
+    [self.store sdl_setObject:frontVerticalPosition forName:SDLRPCParameterNameFrontVerticalPosition];
 }
 
 - (nullable NSNumber<SDLInt> *)frontVerticalPosition {
-    return [store sdl_objectForName:SDLRPCParameterNameFrontVerticalPosition ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameFrontVerticalPosition ofClass:NSNumber.class error:nil];
 }
 
 - (void)setBackVerticalPosition:(nullable NSNumber<SDLInt> *)backVerticalPosition {
-    [store sdl_setObject:backVerticalPosition forName:SDLRPCParameterNameBackVerticalPosition];
+    [self.store sdl_setObject:backVerticalPosition forName:SDLRPCParameterNameBackVerticalPosition];
 }
 
 - (nullable NSNumber<SDLInt> *)backVerticalPosition {
-    return [store sdl_objectForName:SDLRPCParameterNameBackVerticalPosition ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameBackVerticalPosition ofClass:NSNumber.class error:nil];
 }
 
 - (void)setBackTiltAngle:(nullable NSNumber<SDLInt> *)backTiltAngle {
-    [store sdl_setObject:backTiltAngle forName:SDLRPCParameterNameBackTiltAngle];
+    [self.store sdl_setObject:backTiltAngle forName:SDLRPCParameterNameBackTiltAngle];
 }
 
 - (nullable NSNumber<SDLInt> *)backTiltAngle {
-    return [store sdl_objectForName:SDLRPCParameterNameBackTiltAngle ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameBackTiltAngle ofClass:NSNumber.class error:nil];
 }
 
 -  (void)setHeadSupportHorizontalPosition:(nullable NSNumber<SDLInt> *)headSupportHorizontalPosition {
-    [store sdl_setObject:headSupportHorizontalPosition forName:SDLRPCParameterNameHeadSupportHorizontalPosition];
+    [self.store sdl_setObject:headSupportHorizontalPosition forName:SDLRPCParameterNameHeadSupportHorizontalPosition];
 }
 
 - (nullable NSNumber<SDLInt> *)headSupportHorizontalPosition {
-    return [store sdl_objectForName:SDLRPCParameterNameHeadSupportHorizontalPosition ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameHeadSupportHorizontalPosition ofClass:NSNumber.class error:nil];
 }
 
 -(void)setHeadSupportVerticalPosition:(nullable NSNumber<SDLInt> *)headSupportVerticalPosition {
-    [store sdl_setObject:headSupportVerticalPosition forName:SDLRPCParameterNameHeadSupportVerticalPosition];
+    [self.store sdl_setObject:headSupportVerticalPosition forName:SDLRPCParameterNameHeadSupportVerticalPosition];
 }
 
 - (nullable NSNumber<SDLInt> *)headSupportVerticalPosition {
-    return [store sdl_objectForName:SDLRPCParameterNameHeadSupportVerticalPosition ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameHeadSupportVerticalPosition ofClass:NSNumber.class error:nil];
 }
 
 - (void)setMassageEnabled:(nullable NSNumber<SDLBool> *)massageEnabled {
-    [store sdl_setObject:massageEnabled forName:SDLRPCParameterNameMassageEnabled];
+    [self.store sdl_setObject:massageEnabled forName:SDLRPCParameterNameMassageEnabled];
 }
 
 - (nullable NSNumber<SDLBool> *)massageEnabled {
-    return [store sdl_objectForName:SDLRPCParameterNameMassageEnabled ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameMassageEnabled ofClass:NSNumber.class error:nil];
 
 }
 
 - (void)setMassageMode:(nullable NSArray<SDLMassageModeData *> *)massageMode {
-    [store sdl_setObject:massageMode forName:SDLRPCParameterNameMassageMode];
+    [self.store sdl_setObject:massageMode forName:SDLRPCParameterNameMassageMode];
 }
 
 - (nullable NSArray<SDLMassageModeData *> *)massageMode {
-   return [store sdl_objectsForName:SDLRPCParameterNameMassageMode ofClass:SDLMassageModeData.class error:nil];
+   return [self.store sdl_objectsForName:SDLRPCParameterNameMassageMode ofClass:SDLMassageModeData.class error:nil];
 }
 
 - (void)setMassageCushionFirmness:(nullable NSArray<SDLMassageCushionFirmness *> *)massageCushionFirmness {
-    [store sdl_setObject:massageCushionFirmness forName:SDLRPCParameterNameMassageCushionFirmness];
+    [self.store sdl_setObject:massageCushionFirmness forName:SDLRPCParameterNameMassageCushionFirmness];
 }
 
 - (nullable NSArray<SDLMassageCushionFirmness *> *)massageCushionFirmness {
-    return [store sdl_objectsForName:SDLRPCParameterNameMassageCushionFirmness ofClass:SDLMassageCushionFirmness.class error:nil];
+    return [self.store sdl_objectsForName:SDLRPCParameterNameMassageCushionFirmness ofClass:SDLMassageCushionFirmness.class error:nil];
 }
 
 - (void)setMemory:(nullable SDLSeatMemoryAction *)memory {
-    [store sdl_setObject:memory forName:SDLRPCParameterNameMemory];
+    [self.store sdl_setObject:memory forName:SDLRPCParameterNameMemory];
 }
 
 - (nullable SDLSeatMemoryAction *)memory {
-    return [store sdl_objectForName:SDLRPCParameterNameMemory ofClass:SDLSeatMemoryAction.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameMemory ofClass:SDLSeatMemoryAction.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLSeatMemoryAction.m
+++ b/SmartDeviceLink/SDLSeatMemoryAction.m
@@ -32,29 +32,29 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setId:(NSNumber<SDLInt> *)id {
-    [store sdl_setObject:id forName:SDLRPCParameterNameId];
+    [self.store sdl_setObject:id forName:SDLRPCParameterNameId];
 }
 
 - (NSNumber<SDLInt> *)id {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameId ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameId ofClass:NSNumber.class error:&error];
 }
 
 - (void)setLabel:(nullable NSString *)label {
-    [store sdl_setObject:label forName:SDLRPCParameterNameLabel];
+    [self.store sdl_setObject:label forName:SDLRPCParameterNameLabel];
 }
 
 - (nullable NSString *)label {
-    return [store sdl_objectForName:SDLRPCParameterNameLabel ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameLabel ofClass:NSString.class error:nil];
 }
 
 - (void)setAction:(SDLSeatMemoryActionType)action {
-    [store sdl_setObject:action forName:SDLRPCParameterNameAction];
+    [self.store sdl_setObject:action forName:SDLRPCParameterNameAction];
 }
 
 - (SDLSeatMemoryActionType)action {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameAction error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameAction error:&error];
 }
 @end
 

--- a/SmartDeviceLink/SDLSendHapticData.m
+++ b/SmartDeviceLink/SDLSendHapticData.m
@@ -16,11 +16,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLSendHapticData
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameSendHapticData]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithHapticRectData:(NSArray<SDLHapticRect *> *)hapticRectData {
     self = [self init];
@@ -34,11 +37,11 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setHapticRectData:(nullable NSArray<SDLHapticRect *> *)hapticRectData {
-    [parameters sdl_setObject:hapticRectData forName:SDLRPCParameterNameHapticRectData];
+    [self.parameters sdl_setObject:hapticRectData forName:SDLRPCParameterNameHapticRectData];
 }
 
 - (nullable NSArray<SDLHapticRect *> *)hapticRectData {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameHapticRectData ofClass:SDLHapticRect.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameHapticRectData ofClass:SDLHapticRect.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLSendHapticDataResponse.m
+++ b/SmartDeviceLink/SDLSendHapticDataResponse.m
@@ -15,11 +15,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLSendHapticDataResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameSendHapticData]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLSendLocation.m
+++ b/SmartDeviceLink/SDLSendLocation.m
@@ -12,6 +12,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLSendLocation
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     self = [super initWithName:SDLRPCFunctionNameSendLocation];
     if (!self) {
@@ -20,6 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithAddress:(SDLOasisAddress *)address addressLines:(nullable NSArray<NSString *> *)addressLines locationName:(nullable NSString *)locationName locationDescription:(nullable NSString *)locationDescription phoneNumber:(nullable NSString *)phoneNumber image:(nullable SDLImage *)image deliveryMode:(nullable SDLDeliveryMode)deliveryMode timeStamp:(nullable SDLDateTime *)timeStamp {
     self = [self init];
@@ -62,83 +65,83 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setLongitudeDegrees:(nullable NSNumber<SDLFloat> *)longitudeDegrees {
-    [parameters sdl_setObject:longitudeDegrees forName:SDLRPCParameterNameLongitudeDegrees];
+    [self.parameters sdl_setObject:longitudeDegrees forName:SDLRPCParameterNameLongitudeDegrees];
 }
 
 - (nullable NSNumber<SDLFloat> *)longitudeDegrees {
-    return [parameters sdl_objectForName:SDLRPCParameterNameLongitudeDegrees ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameLongitudeDegrees ofClass:NSNumber.class error:nil];
 }
 
 - (void)setLatitudeDegrees:(nullable NSNumber<SDLFloat> *)latitudeDegrees {
-    [parameters sdl_setObject:latitudeDegrees forName:SDLRPCParameterNameLatitudeDegrees];
+    [self.parameters sdl_setObject:latitudeDegrees forName:SDLRPCParameterNameLatitudeDegrees];
 }
 
 - (nullable NSNumber<SDLFloat> *)latitudeDegrees {
-    return [parameters sdl_objectForName:SDLRPCParameterNameLatitudeDegrees ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameLatitudeDegrees ofClass:NSNumber.class error:nil];
 }
 
 - (void)setLocationName:(nullable NSString *)locationName {
-    [parameters sdl_setObject:locationName forName:SDLRPCParameterNameLocationName];
+    [self.parameters sdl_setObject:locationName forName:SDLRPCParameterNameLocationName];
 }
 
 - (nullable NSString *)locationName {
-    return [parameters sdl_objectForName:SDLRPCParameterNameLocationName ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameLocationName ofClass:NSString.class error:nil];
 }
 
 - (void)setAddressLines:(nullable NSArray<NSString *> *)addressLines {
-    [parameters sdl_setObject:addressLines forName:SDLRPCParameterNameAddressLines];
+    [self.parameters sdl_setObject:addressLines forName:SDLRPCParameterNameAddressLines];
 }
 
 - (nullable NSString *)locationDescription {
-    return [parameters sdl_objectForName:SDLRPCParameterNameLocationDescription ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameLocationDescription ofClass:NSString.class error:nil];
 }
 
 - (void)setLocationDescription:(nullable NSString *)locationDescription {
-    [parameters sdl_setObject:locationDescription forName:SDLRPCParameterNameLocationDescription];
+    [self.parameters sdl_setObject:locationDescription forName:SDLRPCParameterNameLocationDescription];
 }
 
 - (nullable NSArray<NSString *> *)addressLines {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameAddressLines ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameAddressLines ofClass:NSString.class error:nil];
 }
 
 - (void)setPhoneNumber:(nullable NSString *)phoneNumber {
-    [parameters sdl_setObject:phoneNumber forName:SDLRPCParameterNamePhoneNumber];
+    [self.parameters sdl_setObject:phoneNumber forName:SDLRPCParameterNamePhoneNumber];
 }
 
 - (nullable NSString *)phoneNumber {
-    return [parameters sdl_objectForName:SDLRPCParameterNamePhoneNumber ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNamePhoneNumber ofClass:NSString.class error:nil];
 }
 
 - (void)setLocationImage:(nullable SDLImage *)locationImage {
-    [parameters sdl_setObject:locationImage forName:SDLRPCParameterNameLocationImage];
+    [self.parameters sdl_setObject:locationImage forName:SDLRPCParameterNameLocationImage];
 }
 
 - (nullable SDLImage *)locationImage {
-    return [parameters sdl_objectForName:SDLRPCParameterNameLocationImage ofClass:SDLImage.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameLocationImage ofClass:SDLImage.class error:nil];
 }
 
 - (void)setDeliveryMode:(nullable SDLDeliveryMode)deliveryMode {
-    [parameters sdl_setObject:deliveryMode forName:SDLRPCParameterNameDeliveryMode];
+    [self.parameters sdl_setObject:deliveryMode forName:SDLRPCParameterNameDeliveryMode];
 }
 
 - (nullable SDLDeliveryMode)deliveryMode {
-    return [parameters sdl_enumForName:SDLRPCParameterNameDeliveryMode error:nil];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameDeliveryMode error:nil];
 }
 
 - (void)setTimeStamp:(nullable SDLDateTime *)timeStamp {
-    [parameters sdl_setObject:timeStamp forName:SDLRPCParameterNameTimeStamp];
+    [self.parameters sdl_setObject:timeStamp forName:SDLRPCParameterNameTimeStamp];
 }
 
 - (nullable SDLDateTime *)timeStamp {
-    return [parameters sdl_objectForName:SDLRPCParameterNameTimeStamp ofClass:SDLDateTime.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameTimeStamp ofClass:SDLDateTime.class error:nil];
 }
 
 - (void)setAddress:(nullable SDLOasisAddress *)address {
-    [parameters sdl_setObject:address forName:SDLRPCParameterNameAddress];
+    [self.parameters sdl_setObject:address forName:SDLRPCParameterNameAddress];
 }
 
 - (nullable SDLOasisAddress *)address {
-    return [parameters sdl_objectForName:SDLRPCParameterNameAddress ofClass:SDLOasisAddress.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameAddress ofClass:SDLOasisAddress.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLSendLocationResponse.m
+++ b/SmartDeviceLink/SDLSendLocationResponse.m
@@ -12,6 +12,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLSendLocationResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     self = [super initWithName:SDLRPCFunctionNameSendLocation];
     if (!self) {
@@ -20,6 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLSetAppIcon.m
+++ b/SmartDeviceLink/SDLSetAppIcon.m
@@ -10,11 +10,14 @@
 
 @implementation SDLSetAppIcon
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameSetAppIcon]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithFileName:(NSString *)fileName {
     self = [self init];
@@ -28,12 +31,12 @@
 }
 
 - (void)setSyncFileName:(NSString *)syncFileName {
-    [parameters sdl_setObject:syncFileName forName:SDLRPCParameterNameSyncFileName];
+    [self.parameters sdl_setObject:syncFileName forName:SDLRPCParameterNameSyncFileName];
 }
 
 - (NSString *)syncFileName {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameSyncFileName ofClass:NSString.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameSyncFileName ofClass:NSString.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLSetAppIconResponse.m
+++ b/SmartDeviceLink/SDLSetAppIconResponse.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLSetAppIconResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameSetAppIcon]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLSetCloudAppProperties.m
+++ b/SmartDeviceLink/SDLSetCloudAppProperties.m
@@ -18,11 +18,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLSetCloudAppProperties
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameSetCloudAppProperties]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithProperties:(SDLCloudAppProperties *)properties {
     self = [self init];
@@ -36,12 +39,12 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setProperties:(SDLCloudAppProperties *)properties {
-    [parameters sdl_setObject:properties forName:SDLRPCParameterNameProperties];
+    [self.parameters sdl_setObject:properties forName:SDLRPCParameterNameProperties];
 }
 
 - (SDLCloudAppProperties *)properties {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameProperties ofClass:SDLCloudAppProperties.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameProperties ofClass:SDLCloudAppProperties.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLSetCloudAppPropertiesResponse.m
+++ b/SmartDeviceLink/SDLSetCloudAppPropertiesResponse.m
@@ -14,11 +14,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLSetCloudAppPropertiesResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameSetCloudAppProperties]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLSetDisplayLayout.m
+++ b/SmartDeviceLink/SDLSetDisplayLayout.m
@@ -13,11 +13,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLSetDisplayLayout
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameSetDisplayLayout]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithPredefinedLayout:(SDLPredefinedLayout)predefinedLayout {
     return [self initWithLayout:predefinedLayout];
@@ -45,28 +48,28 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setDisplayLayout:(NSString *)displayLayout {
-    [parameters sdl_setObject:displayLayout forName:SDLRPCParameterNameDisplayLayout];
+    [self.parameters sdl_setObject:displayLayout forName:SDLRPCParameterNameDisplayLayout];
 }
 
 - (NSString *)displayLayout {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameDisplayLayout ofClass:NSString.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameDisplayLayout ofClass:NSString.class error:&error];
 }
 
 - (void)setDayColorScheme:(nullable SDLTemplateColorScheme *)dayColorScheme {
-    [parameters sdl_setObject:dayColorScheme forName:SDLRPCParameterNameDayColorScheme];
+    [self.parameters sdl_setObject:dayColorScheme forName:SDLRPCParameterNameDayColorScheme];
 }
 
 - (nullable SDLTemplateColorScheme *)dayColorScheme {
-    return [parameters sdl_objectForName:SDLRPCParameterNameDayColorScheme ofClass:SDLTemplateColorScheme.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameDayColorScheme ofClass:SDLTemplateColorScheme.class error:nil];
 }
 
 - (void)setNightColorScheme:(nullable SDLTemplateColorScheme *)nightColorScheme {
-    [parameters sdl_setObject:nightColorScheme forName:SDLRPCParameterNameNightColorScheme];
+    [self.parameters sdl_setObject:nightColorScheme forName:SDLRPCParameterNameNightColorScheme];
 }
 
 - (nullable SDLTemplateColorScheme *)nightColorScheme {
-    return [parameters sdl_objectForName:SDLRPCParameterNameNightColorScheme ofClass:SDLTemplateColorScheme.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameNightColorScheme ofClass:SDLTemplateColorScheme.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLSetDisplayLayoutResponse.m
+++ b/SmartDeviceLink/SDLSetDisplayLayoutResponse.m
@@ -16,42 +16,45 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLSetDisplayLayoutResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameSetDisplayLayout]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setDisplayCapabilities:(nullable SDLDisplayCapabilities *)displayCapabilities {
-    [parameters sdl_setObject:displayCapabilities forName:SDLRPCParameterNameDisplayCapabilities];
+    [self.parameters sdl_setObject:displayCapabilities forName:SDLRPCParameterNameDisplayCapabilities];
 }
 
 - (nullable SDLDisplayCapabilities *)displayCapabilities {
-    return [parameters sdl_objectForName:SDLRPCParameterNameDisplayCapabilities ofClass:SDLDisplayCapabilities.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameDisplayCapabilities ofClass:SDLDisplayCapabilities.class error:nil];
 }
 
 - (void)setButtonCapabilities:(nullable NSArray<SDLButtonCapabilities *> *)buttonCapabilities {
-    [parameters sdl_setObject:buttonCapabilities forName:SDLRPCParameterNameButtonCapabilities];
+    [self.parameters sdl_setObject:buttonCapabilities forName:SDLRPCParameterNameButtonCapabilities];
 }
 
 - (nullable NSArray<SDLButtonCapabilities *> *)buttonCapabilities {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameButtonCapabilities ofClass:SDLButtonCapabilities.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameButtonCapabilities ofClass:SDLButtonCapabilities.class error:nil];
 }
 
 - (void)setSoftButtonCapabilities:(nullable NSArray<SDLSoftButtonCapabilities *> *)softButtonCapabilities {
-    [parameters sdl_setObject:softButtonCapabilities forName:SDLRPCParameterNameSoftButtonCapabilities];
+    [self.parameters sdl_setObject:softButtonCapabilities forName:SDLRPCParameterNameSoftButtonCapabilities];
 }
 
 - (nullable NSArray<SDLSoftButtonCapabilities *> *)softButtonCapabilities {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameSoftButtonCapabilities ofClass:SDLSoftButtonCapabilities.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameSoftButtonCapabilities ofClass:SDLSoftButtonCapabilities.class error:nil];
 }
 
 - (void)setPresetBankCapabilities:(nullable SDLPresetBankCapabilities *)presetBankCapabilities {
-    [parameters sdl_setObject:presetBankCapabilities forName:SDLRPCParameterNamePresetBankCapabilities];
+    [self.parameters sdl_setObject:presetBankCapabilities forName:SDLRPCParameterNamePresetBankCapabilities];
 }
 
 - (nullable SDLPresetBankCapabilities *)presetBankCapabilities {
-    return [parameters sdl_objectForName:SDLRPCParameterNamePresetBankCapabilities ofClass:SDLPresetBankCapabilities.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNamePresetBankCapabilities ofClass:SDLPresetBankCapabilities.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLSetGlobalProperties.m
+++ b/SmartDeviceLink/SDLSetGlobalProperties.m
@@ -16,11 +16,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLSetGlobalProperties
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameSetGlobalProperties]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithHelpText:(nullable NSString *)helpText timeoutText:(nullable NSString *)timeoutText {
     return [self initWithHelpText:helpText timeoutText:timeoutText vrHelpTitle:nil vrHelp:nil];
@@ -48,59 +51,59 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setHelpPrompt:(nullable NSArray<SDLTTSChunk *> *)helpPrompt {
-    [parameters sdl_setObject:helpPrompt forName:SDLRPCParameterNameHelpPrompt];
+    [self.parameters sdl_setObject:helpPrompt forName:SDLRPCParameterNameHelpPrompt];
 }
 
 - (nullable NSArray<SDLTTSChunk *> *)helpPrompt {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameHelpPrompt ofClass:SDLTTSChunk.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameHelpPrompt ofClass:SDLTTSChunk.class error:nil];
 }
 
 - (void)setTimeoutPrompt:(nullable NSArray<SDLTTSChunk *> *)timeoutPrompt {
-    [parameters sdl_setObject:timeoutPrompt forName:SDLRPCParameterNameTimeoutPrompt];
+    [self.parameters sdl_setObject:timeoutPrompt forName:SDLRPCParameterNameTimeoutPrompt];
 }
 
 - (nullable NSArray<SDLTTSChunk *> *)timeoutPrompt {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameTimeoutPrompt ofClass:SDLTTSChunk.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameTimeoutPrompt ofClass:SDLTTSChunk.class error:nil];
 }
 
 - (void)setVrHelpTitle:(nullable NSString *)vrHelpTitle {
-    [parameters sdl_setObject:vrHelpTitle forName:SDLRPCParameterNameVRHelpTitle];
+    [self.parameters sdl_setObject:vrHelpTitle forName:SDLRPCParameterNameVRHelpTitle];
 }
 
 - (nullable NSString *)vrHelpTitle {
-    return [parameters sdl_objectForName:SDLRPCParameterNameVRHelpTitle ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameVRHelpTitle ofClass:NSString.class error:nil];
 }
 
 - (void)setVrHelp:(nullable NSArray<SDLVRHelpItem *> *)vrHelp {
-    [parameters sdl_setObject:vrHelp forName:SDLRPCParameterNameVRHelp];
+    [self.parameters sdl_setObject:vrHelp forName:SDLRPCParameterNameVRHelp];
 }
 
 - (nullable NSArray<SDLVRHelpItem *> *)vrHelp {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameVRHelp ofClass:SDLVRHelpItem.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameVRHelp ofClass:SDLVRHelpItem.class error:nil];
 }
 
 - (void)setMenuTitle:(nullable NSString *)menuTitle {
-    [parameters sdl_setObject:menuTitle forName:SDLRPCParameterNameMenuTitle];
+    [self.parameters sdl_setObject:menuTitle forName:SDLRPCParameterNameMenuTitle];
 }
 
 - (nullable NSString *)menuTitle {
-    return [parameters sdl_objectForName:SDLRPCParameterNameMenuTitle ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameMenuTitle ofClass:NSString.class error:nil];
 }
 
 - (void)setMenuIcon:(nullable SDLImage *)menuIcon {
-    [parameters sdl_setObject:menuIcon forName:SDLRPCParameterNameMenuIcon];
+    [self.parameters sdl_setObject:menuIcon forName:SDLRPCParameterNameMenuIcon];
 }
 
 - (nullable SDLImage *)menuIcon {
-    return [parameters sdl_objectForName:SDLRPCParameterNameMenuIcon ofClass:SDLImage.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameMenuIcon ofClass:SDLImage.class error:nil];
 }
 
 - (void)setKeyboardProperties:(nullable SDLKeyboardProperties *)keyboardProperties {
-    [parameters sdl_setObject:keyboardProperties forName:SDLRPCParameterNameKeyboardProperties];
+    [self.parameters sdl_setObject:keyboardProperties forName:SDLRPCParameterNameKeyboardProperties];
 }
 
 - (nullable SDLKeyboardProperties *)keyboardProperties {
-    return [parameters sdl_objectForName:SDLRPCParameterNameKeyboardProperties ofClass:SDLKeyboardProperties.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameKeyboardProperties ofClass:SDLKeyboardProperties.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLSetGlobalPropertiesResponse.m
+++ b/SmartDeviceLink/SDLSetGlobalPropertiesResponse.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLSetGlobalPropertiesResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameSetGlobalProperties]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLSetInteriorVehicleData.m
+++ b/SmartDeviceLink/SDLSetInteriorVehicleData.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLSetInteriorVehicleData
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameSetInteriorVehicleData]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithModuleData:(SDLModuleData *)moduleData {
     self = [self init];
@@ -30,12 +33,12 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setModuleData:(SDLModuleData *)moduleData {
-    [parameters sdl_setObject:moduleData forName:SDLRPCParameterNameModuleData];
+    [self.parameters sdl_setObject:moduleData forName:SDLRPCParameterNameModuleData];
 }
 
 - (SDLModuleData *)moduleData {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameModuleData ofClass:SDLModuleData.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameModuleData ofClass:SDLModuleData.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLSetInteriorVehicleDataResponse.m
+++ b/SmartDeviceLink/SDLSetInteriorVehicleDataResponse.m
@@ -12,19 +12,22 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLSetInteriorVehicleDataResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameSetInteriorVehicleData]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setModuleData:(SDLModuleData *)moduleData {
-    [parameters sdl_setObject:moduleData forName:SDLRPCParameterNameModuleData];
+    [self.parameters sdl_setObject:moduleData forName:SDLRPCParameterNameModuleData];
 }
 
 - (SDLModuleData *)moduleData {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameModuleData ofClass:SDLModuleData.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameModuleData ofClass:SDLModuleData.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLSetMediaClockTimer.m
+++ b/SmartDeviceLink/SDLSetMediaClockTimer.m
@@ -13,11 +13,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLSetMediaClockTimer
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameSetMediaClockTimer]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithUpdateMode:(SDLUpdateMode)updateMode startTime:(nullable SDLStartTime *)startTime endTime:(nullable SDLStartTime *)endTime playPauseIndicator:(nullable SDLAudioStreamingIndicator)playPauseIndicator {
     self = [self init];
@@ -110,36 +113,36 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setStartTime:(nullable SDLStartTime *)startTime {
-    [parameters sdl_setObject:startTime forName:SDLRPCParameterNameStartTime];
+    [self.parameters sdl_setObject:startTime forName:SDLRPCParameterNameStartTime];
 }
 
 - (nullable SDLStartTime *)startTime {
-    return [parameters sdl_objectForName:SDLRPCParameterNameStartTime ofClass:SDLStartTime.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameStartTime ofClass:SDLStartTime.class error:nil];
 }
 
 - (void)setEndTime:(nullable SDLStartTime *)endTime {
-    [parameters sdl_setObject:endTime forName:SDLRPCParameterNameEndTime];
+    [self.parameters sdl_setObject:endTime forName:SDLRPCParameterNameEndTime];
 }
 
 - (nullable SDLStartTime *)endTime {
-    return [parameters sdl_objectForName:SDLRPCParameterNameEndTime ofClass:SDLStartTime.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameEndTime ofClass:SDLStartTime.class error:nil];
 }
 
 - (void)setUpdateMode:(SDLUpdateMode)updateMode {
-    [parameters sdl_setObject:updateMode forName:SDLRPCParameterNameUpdateMode];
+    [self.parameters sdl_setObject:updateMode forName:SDLRPCParameterNameUpdateMode];
 }
 
 - (SDLUpdateMode)updateMode {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameUpdateMode error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameUpdateMode error:&error];
 }
 
 - (void)setAudioStreamingIndicator:(nullable SDLAudioStreamingIndicator)audioStreamingIndicator {
-    [parameters sdl_setObject:audioStreamingIndicator forName:SDLRPCParameterNameAudioStreamingIndicator];
+    [self.parameters sdl_setObject:audioStreamingIndicator forName:SDLRPCParameterNameAudioStreamingIndicator];
 }
 
 - (nullable SDLAudioStreamingIndicator)audioStreamingIndicator {
-    return [parameters sdl_enumForName:SDLRPCParameterNameAudioStreamingIndicator error:nil];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameAudioStreamingIndicator error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLSetMediaClockTimerResponse.m
+++ b/SmartDeviceLink/SDLSetMediaClockTimerResponse.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLSetMediaClockTimerResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameSetMediaClockTimer]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLShow.m
+++ b/SmartDeviceLink/SDLShow.m
@@ -16,11 +16,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLShow
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameShow]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithMainField1:(nullable NSString *)mainField1 mainField2:(nullable NSString *)mainField2 alignment:(nullable SDLTextAlignment)alignment {
     return [self initWithMainField1:mainField1 mainField2:mainField2 mainField3:nil mainField4:nil alignment:alignment];
@@ -98,107 +101,107 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setMainField1:(nullable NSString *)mainField1 {
-    [parameters sdl_setObject:mainField1 forName:SDLRPCParameterNameMainField1];
+    [self.parameters sdl_setObject:mainField1 forName:SDLRPCParameterNameMainField1];
 }
 
 - (nullable NSString *)mainField1 {
-    return [parameters sdl_objectForName:SDLRPCParameterNameMainField1 ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameMainField1 ofClass:NSString.class error:nil];
 }
 
 - (void)setMainField2:(nullable NSString *)mainField2 {
-    [parameters sdl_setObject:mainField2 forName:SDLRPCParameterNameMainField2];
+    [self.parameters sdl_setObject:mainField2 forName:SDLRPCParameterNameMainField2];
 }
 
 - (nullable NSString *)mainField2 {
-    return [parameters sdl_objectForName:SDLRPCParameterNameMainField2 ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameMainField2 ofClass:NSString.class error:nil];
 }
 
 - (void)setMainField3:(nullable NSString *)mainField3 {
-    [parameters sdl_setObject:mainField3 forName:SDLRPCParameterNameMainField3];
+    [self.parameters sdl_setObject:mainField3 forName:SDLRPCParameterNameMainField3];
 }
 
 - (nullable NSString *)mainField3 {
-    return [parameters sdl_objectForName:SDLRPCParameterNameMainField3 ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameMainField3 ofClass:NSString.class error:nil];
 }
 
 - (void)setMainField4:(nullable NSString *)mainField4 {
-    [parameters sdl_setObject:mainField4 forName:SDLRPCParameterNameMainField4];
+    [self.parameters sdl_setObject:mainField4 forName:SDLRPCParameterNameMainField4];
 }
 
 - (nullable NSString *)mainField4 {
-    return [parameters sdl_objectForName:SDLRPCParameterNameMainField4 ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameMainField4 ofClass:NSString.class error:nil];
 }
 
 - (void)setAlignment:(nullable SDLTextAlignment)alignment {
-    [parameters sdl_setObject:alignment forName:SDLRPCParameterNameAlignment];
+    [self.parameters sdl_setObject:alignment forName:SDLRPCParameterNameAlignment];
 }
 
 - (nullable SDLTextAlignment)alignment {
-    return [parameters sdl_enumForName:SDLRPCParameterNameAlignment error:nil];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameAlignment error:nil];
 }
 
 - (void)setStatusBar:(nullable NSString *)statusBar {
-    [parameters sdl_setObject:statusBar forName:SDLRPCParameterNameStatusBar];
+    [self.parameters sdl_setObject:statusBar forName:SDLRPCParameterNameStatusBar];
 }
 
 - (nullable NSString *)statusBar {
-    return [parameters sdl_objectForName:SDLRPCParameterNameStatusBar ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameStatusBar ofClass:NSString.class error:nil];
 }
 
 - (void)setMediaClock:(nullable NSString *)mediaClock {
-    [parameters sdl_setObject:mediaClock forName:SDLRPCParameterNameMediaClock];
+    [self.parameters sdl_setObject:mediaClock forName:SDLRPCParameterNameMediaClock];
 }
 
 - (nullable NSString *)mediaClock {
-    return [parameters sdl_objectForName:SDLRPCParameterNameMediaClock ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameMediaClock ofClass:NSString.class error:nil];
 }
 
 - (void)setMediaTrack:(nullable NSString *)mediaTrack {
-    [parameters sdl_setObject:mediaTrack forName:SDLRPCParameterNameMediaTrack];
+    [self.parameters sdl_setObject:mediaTrack forName:SDLRPCParameterNameMediaTrack];
 }
 
 - (nullable NSString *)mediaTrack {
-    return [parameters sdl_objectForName:SDLRPCParameterNameMediaTrack ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameMediaTrack ofClass:NSString.class error:nil];
 }
 
 - (void)setGraphic:(nullable SDLImage *)graphic {
-    [parameters sdl_setObject:graphic forName:SDLRPCParameterNameGraphic];
+    [self.parameters sdl_setObject:graphic forName:SDLRPCParameterNameGraphic];
 }
 
 - (nullable SDLImage *)graphic {
-    return [parameters sdl_objectForName:SDLRPCParameterNameGraphic ofClass:SDLImage.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameGraphic ofClass:SDLImage.class error:nil];
 }
 
 - (void)setSecondaryGraphic:(nullable SDLImage *)secondaryGraphic {
-    [parameters sdl_setObject:secondaryGraphic forName:SDLRPCParameterNameSecondaryGraphic];
+    [self.parameters sdl_setObject:secondaryGraphic forName:SDLRPCParameterNameSecondaryGraphic];
 }
 
 - (nullable SDLImage *)secondaryGraphic {
-    return [parameters sdl_objectForName:SDLRPCParameterNameSecondaryGraphic ofClass:SDLImage.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameSecondaryGraphic ofClass:SDLImage.class error:nil];
 }
 
 - (void)setSoftButtons:(nullable NSArray<SDLSoftButton *> *)softButtons {
-    [parameters sdl_setObject:softButtons forName:SDLRPCParameterNameSoftButtons];
+    [self.parameters sdl_setObject:softButtons forName:SDLRPCParameterNameSoftButtons];
 }
 
 - (nullable NSArray<SDLSoftButton *> *)softButtons {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameSoftButtons ofClass:SDLSoftButton.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameSoftButtons ofClass:SDLSoftButton.class error:nil];
 }
 
 - (void)setCustomPresets:(nullable NSArray<NSString *> *)customPresets {
-    [parameters sdl_setObject:customPresets forName:SDLRPCParameterNameCustomPresets];
+    [self.parameters sdl_setObject:customPresets forName:SDLRPCParameterNameCustomPresets];
 }
 
 - (nullable NSArray<NSString *> *)customPresets {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameCustomPresets ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameCustomPresets ofClass:NSString.class error:nil];
 }
 
 - (void)setMetadataTags:(nullable SDLMetadataTags *)metadataTags {
-    [parameters sdl_setObject:metadataTags forName:SDLRPCParameterNameMetadataTags];
+    [self.parameters sdl_setObject:metadataTags forName:SDLRPCParameterNameMetadataTags];
 }
 
 - (nullable SDLMetadataTags *)metadataTags {
-    return [parameters sdl_objectForName:SDLRPCParameterNameMetadataTags ofClass:SDLMetadataTags.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameMetadataTags ofClass:SDLMetadataTags.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLShowConstantTBT.m
+++ b/SmartDeviceLink/SDLShowConstantTBT.m
@@ -14,11 +14,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLShowConstantTBT
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameShowConstantTBT]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithNavigationText1:(nullable NSString *)navigationText1 navigationText2:(nullable NSString *)navigationText2 eta:(nullable NSString *)eta timeToDestination:(nullable NSString *)timeToDestination totalDistance:(nullable NSString *)totalDistance turnIcon:(nullable SDLImage *)turnIcon nextTurnIcon:(nullable SDLImage *)nextTurnIcon distanceToManeuver:(double)distanceToManeuver distanceToManeuverScale:(double)distanceToManeuverScale maneuverComplete:(BOOL)maneuverComplete softButtons:(nullable NSArray<SDLSoftButton *> *)softButtons {
     self = [self init];
@@ -42,91 +45,91 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setNavigationText1:(nullable NSString *)navigationText1 {
-    [parameters sdl_setObject:navigationText1 forName:SDLRPCParameterNameNavigationText1];
+    [self.parameters sdl_setObject:navigationText1 forName:SDLRPCParameterNameNavigationText1];
 }
 
 - (nullable NSString *)navigationText1 {
-    return [parameters sdl_objectForName:SDLRPCParameterNameNavigationText1 ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameNavigationText1 ofClass:NSString.class error:nil];
 }
 
 - (void)setNavigationText2:(nullable NSString *)navigationText2 {
-    [parameters sdl_setObject:navigationText2 forName:SDLRPCParameterNameNavigationText2];
+    [self.parameters sdl_setObject:navigationText2 forName:SDLRPCParameterNameNavigationText2];
 }
 
 - (nullable NSString *)navigationText2 {
-    return [parameters sdl_objectForName:SDLRPCParameterNameNavigationText2 ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameNavigationText2 ofClass:NSString.class error:nil];
 }
 
 - (void)setEta:(nullable NSString *)eta {
-    [parameters sdl_setObject:eta forName:SDLRPCParameterNameETA];
+    [self.parameters sdl_setObject:eta forName:SDLRPCParameterNameETA];
 }
 
 - (nullable NSString *)eta {
-    return [parameters sdl_objectForName:SDLRPCParameterNameETA ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameETA ofClass:NSString.class error:nil];
 }
 
 - (void)setTimeToDestination:(nullable NSString *)timeToDestination {
-    [parameters sdl_setObject:timeToDestination forName:SDLRPCParameterNameTimeToDestination];
+    [self.parameters sdl_setObject:timeToDestination forName:SDLRPCParameterNameTimeToDestination];
 }
 
 - (nullable NSString *)timeToDestination {
-    return [parameters sdl_objectForName:SDLRPCParameterNameTimeToDestination ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameTimeToDestination ofClass:NSString.class error:nil];
 }
 
 - (void)setTotalDistance:(nullable NSString *)totalDistance {
-    [parameters sdl_setObject:totalDistance forName:SDLRPCParameterNameTotalDistance];
+    [self.parameters sdl_setObject:totalDistance forName:SDLRPCParameterNameTotalDistance];
 }
 
 - (nullable NSString *)totalDistance {
-    return [parameters sdl_objectForName:SDLRPCParameterNameTotalDistance ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameTotalDistance ofClass:NSString.class error:nil];
 }
 
 - (void)setTurnIcon:(nullable SDLImage *)turnIcon {
-    [parameters sdl_setObject:turnIcon forName:SDLRPCParameterNameTurnIcon];
+    [self.parameters sdl_setObject:turnIcon forName:SDLRPCParameterNameTurnIcon];
 }
 
 - (nullable SDLImage *)turnIcon {
-    return [parameters sdl_objectForName:SDLRPCParameterNameTurnIcon ofClass:SDLImage.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameTurnIcon ofClass:SDLImage.class error:nil];
 }
 
 - (void)setNextTurnIcon:(nullable SDLImage *)nextTurnIcon {
-    [parameters sdl_setObject:nextTurnIcon forName:SDLRPCParameterNameNextTurnIcon];
+    [self.parameters sdl_setObject:nextTurnIcon forName:SDLRPCParameterNameNextTurnIcon];
 }
 
 - (nullable SDLImage *)nextTurnIcon {
-    return [parameters sdl_objectForName:SDLRPCParameterNameNextTurnIcon ofClass:SDLImage.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameNextTurnIcon ofClass:SDLImage.class error:nil];
 }
 
 - (void)setDistanceToManeuver:(nullable NSNumber<SDLFloat> *)distanceToManeuver {
-    [parameters sdl_setObject:distanceToManeuver forName:SDLRPCParameterNameDistanceToManeuver];
+    [self.parameters sdl_setObject:distanceToManeuver forName:SDLRPCParameterNameDistanceToManeuver];
 }
 
 - (nullable NSNumber<SDLFloat> *)distanceToManeuver {
-    return [parameters sdl_objectForName:SDLRPCParameterNameDistanceToManeuver ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameDistanceToManeuver ofClass:NSNumber.class error:nil];
 }
 
 - (void)setDistanceToManeuverScale:(nullable NSNumber<SDLFloat> *)distanceToManeuverScale {
-    [parameters sdl_setObject:distanceToManeuverScale forName:SDLRPCParameterNameDistanceToManeuverScale];
+    [self.parameters sdl_setObject:distanceToManeuverScale forName:SDLRPCParameterNameDistanceToManeuverScale];
 }
 
 - (nullable NSNumber<SDLFloat> *)distanceToManeuverScale {
-    return [parameters sdl_objectForName:SDLRPCParameterNameDistanceToManeuverScale ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameDistanceToManeuverScale ofClass:NSNumber.class error:nil];
 }
 
 - (void)setManeuverComplete:(nullable NSNumber<SDLBool> *)maneuverComplete {
-    [parameters sdl_setObject:maneuverComplete forName:SDLRPCParameterNameManeuverComplete];
+    [self.parameters sdl_setObject:maneuverComplete forName:SDLRPCParameterNameManeuverComplete];
 }
 
 - (nullable NSNumber<SDLBool> *)maneuverComplete {
-    return [parameters sdl_objectForName:SDLRPCParameterNameManeuverComplete ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameManeuverComplete ofClass:NSNumber.class error:nil];
 }
 
 - (void)setSoftButtons:(nullable NSArray<SDLSoftButton *> *)softButtons {
-    [parameters sdl_setObject:softButtons forName:SDLRPCParameterNameSoftButtons];
+    [self.parameters sdl_setObject:softButtons forName:SDLRPCParameterNameSoftButtons];
 }
 
 - (nullable NSArray<SDLSoftButton *> *)softButtons {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameSoftButtons ofClass:SDLSoftButton.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameSoftButtons ofClass:SDLSoftButton.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLShowConstantTBTResponse.m
+++ b/SmartDeviceLink/SDLShowConstantTBTResponse.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLShowConstantTBTResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameShowConstantTBT]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLShowResponse.m
+++ b/SmartDeviceLink/SDLShowResponse.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLShowResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameShow]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLSingleTireStatus.m
+++ b/SmartDeviceLink/SDLSingleTireStatus.m
@@ -12,28 +12,28 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation SDLSingleTireStatus
 
 - (void)setStatus:(SDLComponentVolumeStatus)status {
-    [store sdl_setObject:status forName:SDLRPCParameterNameStatus];
+    [self.store sdl_setObject:status forName:SDLRPCParameterNameStatus];
 }
 
 - (SDLComponentVolumeStatus)status {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameStatus error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameStatus error:&error];
 }
 
 - (void)setMonitoringSystemStatus:(nullable SDLTPMS)monitoringSystemStatus {
-    [store sdl_setObject:monitoringSystemStatus forName:SDLRPCParameterNameTPMS];
+    [self.store sdl_setObject:monitoringSystemStatus forName:SDLRPCParameterNameTPMS];
 }
 
 - (nullable SDLTPMS)monitoringSystemStatus {
-    return [store sdl_enumForName:SDLRPCParameterNameTPMS error:nil];
+    return [self.store sdl_enumForName:SDLRPCParameterNameTPMS error:nil];
 }
 
 - (void)setPressure:(nullable NSNumber<SDLFloat> *)pressure {
-    [store sdl_setObject:pressure forName:SDLRPCParameterNamePressure];
+    [self.store sdl_setObject:pressure forName:SDLRPCParameterNamePressure];
 }
 
 - (nullable NSNumber<SDLFloat> *)pressure {
-    return [store sdl_objectForName:SDLRPCParameterNamePressure ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNamePressure ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLSlider.m
+++ b/SmartDeviceLink/SDLSlider.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLSlider
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameSlider]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithNumTicks:(UInt8)numTicks position:(UInt8)position sliderHeader:(NSString *)sliderHeader sliderFooter:(nullable NSString *)sliderFooter timeout:(UInt16)timeout {
     NSArray<NSString *> *footer = nil;
@@ -53,46 +56,46 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setNumTicks:(NSNumber<SDLInt> *)numTicks {
-    [parameters sdl_setObject:numTicks forName:SDLRPCParameterNameNumberTicks];
+    [self.parameters sdl_setObject:numTicks forName:SDLRPCParameterNameNumberTicks];
 }
 
 - (NSNumber<SDLInt> *)numTicks {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameNumberTicks ofClass:NSNumber.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameNumberTicks ofClass:NSNumber.class error:&error];
 }
 
 - (void)setPosition:(NSNumber<SDLInt> *)position {
-    [parameters sdl_setObject:position forName:SDLRPCParameterNamePosition];
+    [self.parameters sdl_setObject:position forName:SDLRPCParameterNamePosition];
 }
 
 - (NSNumber<SDLInt> *)position {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNamePosition ofClass:NSNumber.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNamePosition ofClass:NSNumber.class error:&error];
 }
 
 - (void)setSliderHeader:(NSString *)sliderHeader {
-    [parameters sdl_setObject:sliderHeader forName:SDLRPCParameterNameSliderHeader];
+    [self.parameters sdl_setObject:sliderHeader forName:SDLRPCParameterNameSliderHeader];
 }
 
 - (NSString *)sliderHeader {
     NSError *error = nil;
-    return [parameters sdl_objectForName:SDLRPCParameterNameSliderHeader ofClass:NSString.class error:&error];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameSliderHeader ofClass:NSString.class error:&error];
 }
 
 - (void)setSliderFooter:(nullable NSArray<NSString *> *)sliderFooter {
-    [parameters sdl_setObject:sliderFooter forName:SDLRPCParameterNameSliderFooter];
+    [self.parameters sdl_setObject:sliderFooter forName:SDLRPCParameterNameSliderFooter];
 }
 
 - (nullable NSArray<NSString *> *)sliderFooter {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameSliderFooter ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameSliderFooter ofClass:NSString.class error:nil];
 }
 
 - (void)setTimeout:(nullable NSNumber<SDLInt> *)timeout {
-    [parameters sdl_setObject:timeout forName:SDLRPCParameterNameTimeout];
+    [self.parameters sdl_setObject:timeout forName:SDLRPCParameterNameTimeout];
 }
 
 - (nullable NSNumber<SDLInt> *)timeout {
-    return [parameters sdl_objectForName:SDLRPCParameterNameTimeout ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameTimeout ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLSliderResponse.m
+++ b/SmartDeviceLink/SDLSliderResponse.m
@@ -12,18 +12,21 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLSliderResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameSlider]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setSliderPosition:(nullable NSNumber<SDLInt> *)sliderPosition {
-    [parameters sdl_setObject:sliderPosition forName:SDLRPCParameterNameSliderPosition];
+    [self.parameters sdl_setObject:sliderPosition forName:SDLRPCParameterNameSliderPosition];
 }
 
 - (nullable NSNumber<SDLInt> *)sliderPosition {
-    return [parameters sdl_objectForName:SDLRPCParameterNameSliderPosition ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameSliderPosition ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLSoftButton.m
+++ b/SmartDeviceLink/SDLSoftButton.m
@@ -40,53 +40,53 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setType:(SDLSoftButtonType)type {
-    [store sdl_setObject:type forName:SDLRPCParameterNameType];
+    [self.store sdl_setObject:type forName:SDLRPCParameterNameType];
 }
 
 - (SDLSoftButtonType)type {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameType error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameType error:&error];
 }
 
 - (void)setText:(nullable NSString *)text {
-    [store sdl_setObject:text forName:SDLRPCParameterNameText];
+    [self.store sdl_setObject:text forName:SDLRPCParameterNameText];
 }
 
 - (nullable NSString *)text {
-    return [store sdl_objectForName:SDLRPCParameterNameText ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameText ofClass:NSString.class error:nil];
 }
 
 - (void)setImage:(nullable SDLImage *)image {
-    [store sdl_setObject:image forName:SDLRPCParameterNameImage];
+    [self.store sdl_setObject:image forName:SDLRPCParameterNameImage];
 }
 
 - (nullable SDLImage *)image {
-    return [store sdl_objectForName:SDLRPCParameterNameImage ofClass:SDLImage.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameImage ofClass:SDLImage.class error:nil];
 }
 
 - (void)setIsHighlighted:(nullable NSNumber<SDLBool> *)isHighlighted {
-    [store sdl_setObject:isHighlighted forName:SDLRPCParameterNameIsHighlighted];
+    [self.store sdl_setObject:isHighlighted forName:SDLRPCParameterNameIsHighlighted];
 }
 
 - (nullable NSNumber<SDLBool> *)isHighlighted {
-    return [store sdl_objectForName:SDLRPCParameterNameIsHighlighted ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameIsHighlighted ofClass:NSNumber.class error:nil];
 }
 
 - (void)setSoftButtonID:(NSNumber<SDLInt> *)softButtonID {
-    [store sdl_setObject:softButtonID forName:SDLRPCParameterNameSoftButtonId];
+    [self.store sdl_setObject:softButtonID forName:SDLRPCParameterNameSoftButtonId];
 }
 
 - (NSNumber<SDLInt> *)softButtonID {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameSoftButtonId ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameSoftButtonId ofClass:NSNumber.class error:&error];
 }
 
 - (void)setSystemAction:(nullable SDLSystemAction)systemAction {
-    [store sdl_setObject:systemAction forName:SDLRPCParameterNameSystemAction];
+    [self.store sdl_setObject:systemAction forName:SDLRPCParameterNameSystemAction];
 }
 
 - (nullable SDLSystemAction)systemAction {
-    return [store sdl_enumForName:SDLRPCParameterNameSystemAction error:nil];
+    return [self.store sdl_enumForName:SDLRPCParameterNameSystemAction error:nil];
 }
 
 -(id)copyWithZone:(nullable NSZone *)zone {

--- a/SmartDeviceLink/SDLSoftButtonCapabilities.m
+++ b/SmartDeviceLink/SDLSoftButtonCapabilities.m
@@ -12,39 +12,39 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation SDLSoftButtonCapabilities
 
 - (void)setShortPressAvailable:(NSNumber<SDLBool> *)shortPressAvailable {
-    [store sdl_setObject:shortPressAvailable forName:SDLRPCParameterNameShortPressAvailable];
+    [self.store sdl_setObject:shortPressAvailable forName:SDLRPCParameterNameShortPressAvailable];
 }
 
 - (NSNumber<SDLBool> *)shortPressAvailable {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameShortPressAvailable ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameShortPressAvailable ofClass:NSNumber.class error:&error];
 }
 
 - (void)setLongPressAvailable:(NSNumber<SDLBool> *)longPressAvailable {
-    [store sdl_setObject:longPressAvailable forName:SDLRPCParameterNameLongPressAvailable];
+    [self.store sdl_setObject:longPressAvailable forName:SDLRPCParameterNameLongPressAvailable];
 }
 
 - (NSNumber<SDLBool> *)longPressAvailable {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameLongPressAvailable ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameLongPressAvailable ofClass:NSNumber.class error:&error];
 }
 
 - (void)setUpDownAvailable:(NSNumber<SDLBool> *)upDownAvailable {
-    [store sdl_setObject:upDownAvailable forName:SDLRPCParameterNameUpDownAvailable];
+    [self.store sdl_setObject:upDownAvailable forName:SDLRPCParameterNameUpDownAvailable];
 }
 
 - (NSNumber<SDLBool> *)upDownAvailable {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameUpDownAvailable ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameUpDownAvailable ofClass:NSNumber.class error:&error];
 }
 
 - (void)setImageSupported:(NSNumber<SDLBool> *)imageSupported {
-    [store sdl_setObject:imageSupported forName:SDLRPCParameterNameImageSupported];
+    [self.store sdl_setObject:imageSupported forName:SDLRPCParameterNameImageSupported];
 }
 
 - (NSNumber<SDLBool> *)imageSupported {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameImageSupported ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameImageSupported ofClass:NSNumber.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLSpeak.m
+++ b/SmartDeviceLink/SDLSpeak.m
@@ -13,11 +13,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLSpeak
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameSpeak]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithTTS:(NSString *)ttsText {
     NSArray *ttsChunks = [SDLTTSChunk textChunksFromString:ttsText];
@@ -36,12 +39,12 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setTtsChunks:(NSArray<SDLTTSChunk *> *)ttsChunks {
-    [parameters sdl_setObject:ttsChunks forName:SDLRPCParameterNameTTSChunks];
+    [self.parameters sdl_setObject:ttsChunks forName:SDLRPCParameterNameTTSChunks];
 }
 
 - (NSArray<SDLTTSChunk *> *)ttsChunks {
     NSError *error = nil;
-    return [parameters sdl_objectsForName:SDLRPCParameterNameTTSChunks ofClass:SDLTTSChunk.class error:&error];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameTTSChunks ofClass:SDLTTSChunk.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLSpeakResponse.m
+++ b/SmartDeviceLink/SDLSpeakResponse.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLSpeakResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameSpeak]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLStartTime.m
+++ b/SmartDeviceLink/SDLStartTime.m
@@ -38,30 +38,30 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setHours:(NSNumber<SDLInt> *)hours {
-    [store sdl_setObject:hours forName:SDLRPCParameterNameHours];
+    [self.store sdl_setObject:hours forName:SDLRPCParameterNameHours];
 }
 
 - (NSNumber<SDLInt> *)hours {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameHours ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameHours ofClass:NSNumber.class error:&error];
 }
 
 - (void)setMinutes:(NSNumber<SDLInt> *)minutes {
-    [store sdl_setObject:minutes forName:SDLRPCParameterNameMinutes];
+    [self.store sdl_setObject:minutes forName:SDLRPCParameterNameMinutes];
 }
 
 - (NSNumber<SDLInt> *)minutes {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameMinutes ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameMinutes ofClass:NSNumber.class error:&error];
 }
 
 - (void)setSeconds:(NSNumber<SDLInt> *)seconds {
-    [store sdl_setObject:seconds forName:SDLRPCParameterNameSeconds];
+    [self.store sdl_setObject:seconds forName:SDLRPCParameterNameSeconds];
 }
 
 - (NSNumber<SDLInt> *)seconds {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameSeconds ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameSeconds ofClass:NSNumber.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLStationIDNumber.m
+++ b/SmartDeviceLink/SDLStationIDNumber.m
@@ -22,20 +22,20 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setCountryCode:(nullable NSNumber<SDLInt> *)countryCode {
-    [store sdl_setObject:countryCode forName:SDLRPCParameterNameCountryCode];
+    [self.store sdl_setObject:countryCode forName:SDLRPCParameterNameCountryCode];
 }
 
 - (nullable NSNumber<SDLInt> *)countryCode {
-    return [store sdl_objectForName:SDLRPCParameterNameCountryCode ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameCountryCode ofClass:NSNumber.class error:nil];
 }
 
 
 - (void)setFccFacilityId:(nullable NSNumber<SDLInt> *)fccFacilityId {
-    [store sdl_setObject:fccFacilityId forName:SDLRPCParameterNameFCCFacilityId];
+    [self.store sdl_setObject:fccFacilityId forName:SDLRPCParameterNameFCCFacilityId];
 }
 
 - (nullable NSNumber<SDLInt> *)fccFacilityId {
-    return [store sdl_objectForName:SDLRPCParameterNameFCCFacilityId ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameFCCFacilityId ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLSubscribeButton.m
+++ b/SmartDeviceLink/SDLSubscribeButton.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLSubscribeButton
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameSubscribeButton]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithHandler:(nullable SDLRPCButtonNotificationHandler)handler {
     self = [self init];
@@ -42,12 +45,12 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setButtonName:(SDLButtonName)buttonName {
-    [parameters sdl_setObject:buttonName forName:SDLRPCParameterNameButtonName];
+    [self.parameters sdl_setObject:buttonName forName:SDLRPCParameterNameButtonName];
 }
 
 - (SDLButtonName)buttonName {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameButtonName error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameButtonName error:&error];
 }
 
 -(id)copyWithZone:(nullable NSZone *)zone {

--- a/SmartDeviceLink/SDLSubscribeButtonResponse.m
+++ b/SmartDeviceLink/SDLSubscribeButtonResponse.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLSubscribeButtonResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameSubscribeButton]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLSubscribeVehicleData.m
+++ b/SmartDeviceLink/SDLSubscribeVehicleData.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLSubscribeVehicleData
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameSubscribeVehicleData]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithAccelerationPedalPosition:(BOOL)accelerationPedalPosition airbagStatus:(BOOL)airbagStatus beltStatus:(BOOL)beltStatus bodyInformation:(BOOL)bodyInformation clusterModeStatus:(BOOL)clusterModeStatus deviceStatus:(BOOL)deviceStatus driverBraking:(BOOL)driverBraking eCallInfo:(BOOL)eCallInfo emergencyEvent:(BOOL)emergencyEvent engineTorque:(BOOL)engineTorque externalTemperature:(BOOL)externalTemperature fuelLevel:(BOOL)fuelLevel fuelLevelState:(BOOL)fuelLevelState gps:(BOOL)gps headLampStatus:(BOOL)headLampStatus instantFuelConsumption:(BOOL)instantFuelConsumption myKey:(BOOL)myKey odometer:(BOOL)odometer prndl:(BOOL)prndl rpm:(BOOL)rpm speed:(BOOL)speed steeringWheelAngle:(BOOL)steeringWheelAngle tirePressure:(BOOL)tirePressure wiperStatus:(BOOL)wiperStatus {
     return [self initWithAccelerationPedalPosition:accelerationPedalPosition airbagStatus:airbagStatus beltStatus:beltStatus bodyInformation:bodyInformation clusterModeStatus:clusterModeStatus deviceStatus:deviceStatus driverBraking:driverBraking eCallInfo:eCallInfo electronicParkBrakeStatus:NO emergencyEvent:emergencyEvent engineOilLife:NO engineTorque:engineTorque externalTemperature:externalTemperature fuelLevel:fuelLevel fuelLevelState:fuelLevelState fuelRange:NO gps:gps headLampStatus:headLampStatus instantFuelConsumption:instantFuelConsumption myKey:myKey odometer:odometer prndl:prndl rpm:rpm speed:speed steeringWheelAngle:steeringWheelAngle tirePressure:tirePressure turnSignal:NO wiperStatus:wiperStatus];
@@ -66,235 +69,235 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setGps:(nullable NSNumber<SDLBool> *)gps {
-    [parameters sdl_setObject:gps forName:SDLRPCParameterNameGPS];
+    [self.parameters sdl_setObject:gps forName:SDLRPCParameterNameGPS];
 }
 
 - (nullable NSNumber<SDLBool> *)gps {
-    return [parameters sdl_objectForName:SDLRPCParameterNameGPS ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameGPS ofClass:NSNumber.class error:nil];
 }
 
 - (void)setSpeed:(nullable NSNumber<SDLBool> *)speed {
-    [parameters sdl_setObject:speed forName:SDLRPCParameterNameSpeed];
+    [self.parameters sdl_setObject:speed forName:SDLRPCParameterNameSpeed];
 }
 
 - (nullable NSNumber<SDLBool> *)speed {
-    return [parameters sdl_objectForName:SDLRPCParameterNameSpeed ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameSpeed ofClass:NSNumber.class error:nil];
 }
 
 - (void)setRpm:(nullable NSNumber<SDLBool> *)rpm {
-    [parameters sdl_setObject:rpm forName:SDLRPCParameterNameRPM];
+    [self.parameters sdl_setObject:rpm forName:SDLRPCParameterNameRPM];
 }
 
 - (nullable NSNumber<SDLBool> *)rpm {
-    return [parameters sdl_objectForName:SDLRPCParameterNameRPM ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameRPM ofClass:NSNumber.class error:nil];
 }
 
 - (void)setFuelLevel:(nullable NSNumber<SDLBool> *)fuelLevel {
-    [parameters sdl_setObject:fuelLevel forName:SDLRPCParameterNameFuelLevel];
+    [self.parameters sdl_setObject:fuelLevel forName:SDLRPCParameterNameFuelLevel];
 }
 
 - (nullable NSNumber<SDLBool> *)fuelLevel {
-    return [parameters sdl_objectForName:SDLRPCParameterNameFuelLevel ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameFuelLevel ofClass:NSNumber.class error:nil];
 }
 
 - (void)setFuelLevel_State:(nullable NSNumber<SDLBool> *)fuelLevel_State {
-    [parameters sdl_setObject:fuelLevel_State forName:SDLRPCParameterNameFuelLevelState];
+    [self.parameters sdl_setObject:fuelLevel_State forName:SDLRPCParameterNameFuelLevelState];
 }
 
 - (nullable NSNumber<SDLBool> *)fuelLevel_State {
-    return [parameters sdl_objectForName:SDLRPCParameterNameFuelLevelState ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameFuelLevelState ofClass:NSNumber.class error:nil];
 }
 
 - (void)setFuelRange:(nullable NSNumber<SDLBool> *)fuelRange {
-    [parameters sdl_setObject:fuelRange forName:SDLRPCParameterNameFuelRange];
+    [self.parameters sdl_setObject:fuelRange forName:SDLRPCParameterNameFuelRange];
 }
 
 - (nullable NSNumber<SDLBool> *)fuelRange {
-    return [parameters sdl_objectForName:SDLRPCParameterNameFuelRange ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameFuelRange ofClass:NSNumber.class error:nil];
 }
 
 - (void)setInstantFuelConsumption:(nullable NSNumber<SDLBool> *)instantFuelConsumption {
-    [parameters sdl_setObject:instantFuelConsumption forName:SDLRPCParameterNameInstantFuelConsumption];
+    [self.parameters sdl_setObject:instantFuelConsumption forName:SDLRPCParameterNameInstantFuelConsumption];
 }
 
 - (nullable NSNumber<SDLBool> *)instantFuelConsumption {
-    return [parameters sdl_objectForName:SDLRPCParameterNameInstantFuelConsumption ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameInstantFuelConsumption ofClass:NSNumber.class error:nil];
 }
 
 - (void)setExternalTemperature:(nullable NSNumber<SDLBool> *)externalTemperature {
-    [parameters sdl_setObject:externalTemperature forName:SDLRPCParameterNameExternalTemperature];
+    [self.parameters sdl_setObject:externalTemperature forName:SDLRPCParameterNameExternalTemperature];
 }
 
 - (nullable NSNumber<SDLBool> *)externalTemperature {
-    return [parameters sdl_objectForName:SDLRPCParameterNameExternalTemperature ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameExternalTemperature ofClass:NSNumber.class error:nil];
 }
 
 - (void)setPrndl:(nullable NSNumber<SDLBool> *)prndl {
-    [parameters sdl_setObject:prndl forName:SDLRPCParameterNamePRNDL];
+    [self.parameters sdl_setObject:prndl forName:SDLRPCParameterNamePRNDL];
 }
 
 - (nullable NSNumber<SDLBool> *)prndl {
-    return [parameters sdl_objectForName:SDLRPCParameterNamePRNDL ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNamePRNDL ofClass:NSNumber.class error:nil];
 }
 
 - (void)setTirePressure:(nullable NSNumber<SDLBool> *)tirePressure {
-    [parameters sdl_setObject:tirePressure forName:SDLRPCParameterNameTirePressure];
+    [self.parameters sdl_setObject:tirePressure forName:SDLRPCParameterNameTirePressure];
 }
 
 - (nullable NSNumber<SDLBool> *)tirePressure {
-    return [parameters sdl_objectForName:SDLRPCParameterNameTirePressure ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameTirePressure ofClass:NSNumber.class error:nil];
 }
 
 - (void)setOdometer:(nullable NSNumber<SDLBool> *)odometer {
-    [parameters sdl_setObject:odometer forName:SDLRPCParameterNameOdometer];
+    [self.parameters sdl_setObject:odometer forName:SDLRPCParameterNameOdometer];
 }
 
 - (nullable NSNumber<SDLBool> *)odometer {
-    return [parameters sdl_objectForName:SDLRPCParameterNameOdometer ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameOdometer ofClass:NSNumber.class error:nil];
 }
 
 - (void)setBeltStatus:(nullable NSNumber<SDLBool> *)beltStatus {
-    [parameters sdl_setObject:beltStatus forName:SDLRPCParameterNameBeltStatus];
+    [self.parameters sdl_setObject:beltStatus forName:SDLRPCParameterNameBeltStatus];
 }
 
 - (nullable NSNumber<SDLBool> *)beltStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameBeltStatus ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameBeltStatus ofClass:NSNumber.class error:nil];
 }
 
 - (void)setBodyInformation:(nullable NSNumber<SDLBool> *)bodyInformation {
-    [parameters sdl_setObject:bodyInformation forName:SDLRPCParameterNameBodyInformation];
+    [self.parameters sdl_setObject:bodyInformation forName:SDLRPCParameterNameBodyInformation];
 }
 
 - (nullable NSNumber<SDLBool> *)bodyInformation {
-    return [parameters sdl_objectForName:SDLRPCParameterNameBodyInformation ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameBodyInformation ofClass:NSNumber.class error:nil];
 }
 
 - (void)setDeviceStatus:(nullable NSNumber<SDLBool> *)deviceStatus {
-    [parameters sdl_setObject:deviceStatus forName:SDLRPCParameterNameDeviceStatus];
+    [self.parameters sdl_setObject:deviceStatus forName:SDLRPCParameterNameDeviceStatus];
 }
 
 - (nullable NSNumber<SDLBool> *)deviceStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameDeviceStatus ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameDeviceStatus ofClass:NSNumber.class error:nil];
 }
 
 - (void)setDriverBraking:(nullable NSNumber<SDLBool> *)driverBraking {
-    [parameters sdl_setObject:driverBraking forName:SDLRPCParameterNameDriverBraking];
+    [self.parameters sdl_setObject:driverBraking forName:SDLRPCParameterNameDriverBraking];
 }
 
 - (nullable NSNumber<SDLBool> *)driverBraking {
-    return [parameters sdl_objectForName:SDLRPCParameterNameDriverBraking ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameDriverBraking ofClass:NSNumber.class error:nil];
 }
 
 - (void)setWiperStatus:(nullable NSNumber<SDLBool> *)wiperStatus {
-    [parameters sdl_setObject:wiperStatus forName:SDLRPCParameterNameWiperStatus];
+    [self.parameters sdl_setObject:wiperStatus forName:SDLRPCParameterNameWiperStatus];
 }
 
 - (nullable NSNumber<SDLBool> *)wiperStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameWiperStatus ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameWiperStatus ofClass:NSNumber.class error:nil];
 }
 
 - (void)setHeadLampStatus:(nullable NSNumber<SDLBool> *)headLampStatus {
-    [parameters sdl_setObject:headLampStatus forName:SDLRPCParameterNameHeadLampStatus];
+    [self.parameters sdl_setObject:headLampStatus forName:SDLRPCParameterNameHeadLampStatus];
 }
 
 - (nullable NSNumber<SDLBool> *)headLampStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameHeadLampStatus ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameHeadLampStatus ofClass:NSNumber.class error:nil];
 }
 
 - (void)setEngineOilLife:(nullable NSNumber<SDLBool> *)engineOilLife {
-    [parameters sdl_setObject:engineOilLife forName:SDLRPCParameterNameEngineOilLife];
+    [self.parameters sdl_setObject:engineOilLife forName:SDLRPCParameterNameEngineOilLife];
 }
 
 - (nullable NSNumber<SDLBool> *)engineOilLife {
-    return [parameters sdl_objectForName:SDLRPCParameterNameEngineOilLife ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameEngineOilLife ofClass:NSNumber.class error:nil];
 }
 
 - (void)setEngineTorque:(nullable NSNumber<SDLBool> *)engineTorque {
-    [parameters sdl_setObject:engineTorque forName:SDLRPCParameterNameEngineTorque];
+    [self.parameters sdl_setObject:engineTorque forName:SDLRPCParameterNameEngineTorque];
 }
 
 - (nullable NSNumber<SDLBool> *)engineTorque {
-    return [parameters sdl_objectForName:SDLRPCParameterNameEngineTorque ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameEngineTorque ofClass:NSNumber.class error:nil];
 }
 
 - (void)setAccPedalPosition:(nullable NSNumber<SDLBool> *)accPedalPosition {
-    [parameters sdl_setObject:accPedalPosition forName:SDLRPCParameterNameAccelerationPedalPosition];
+    [self.parameters sdl_setObject:accPedalPosition forName:SDLRPCParameterNameAccelerationPedalPosition];
 }
 
 - (nullable NSNumber<SDLBool> *)accPedalPosition {
-    return [parameters sdl_objectForName:SDLRPCParameterNameAccelerationPedalPosition ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameAccelerationPedalPosition ofClass:NSNumber.class error:nil];
 }
 
 - (void)setSteeringWheelAngle:(nullable NSNumber<SDLBool> *)steeringWheelAngle {
-    [parameters sdl_setObject:steeringWheelAngle forName:SDLRPCParameterNameSteeringWheelAngle];
+    [self.parameters sdl_setObject:steeringWheelAngle forName:SDLRPCParameterNameSteeringWheelAngle];
 }
 
 - (nullable NSNumber<SDLBool> *)steeringWheelAngle {
-    return [parameters sdl_objectForName:SDLRPCParameterNameSteeringWheelAngle ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameSteeringWheelAngle ofClass:NSNumber.class error:nil];
 }
 
 - (void)setECallInfo:(nullable NSNumber<SDLBool> *)eCallInfo {
-    [parameters sdl_setObject:eCallInfo forName:SDLRPCParameterNameECallInfo];
+    [self.parameters sdl_setObject:eCallInfo forName:SDLRPCParameterNameECallInfo];
 }
 
 - (nullable NSNumber<SDLBool> *)eCallInfo {
-    return [parameters sdl_objectForName:SDLRPCParameterNameECallInfo ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameECallInfo ofClass:NSNumber.class error:nil];
 }
 
 - (void)setAirbagStatus:(nullable NSNumber<SDLBool> *)airbagStatus {
-    [parameters sdl_setObject:airbagStatus forName:SDLRPCParameterNameAirbagStatus];
+    [self.parameters sdl_setObject:airbagStatus forName:SDLRPCParameterNameAirbagStatus];
 }
 
 - (nullable NSNumber<SDLBool> *)airbagStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameAirbagStatus ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameAirbagStatus ofClass:NSNumber.class error:nil];
 }
 
 - (void)setEmergencyEvent:(nullable NSNumber<SDLBool> *)emergencyEvent {
-    [parameters sdl_setObject:emergencyEvent forName:SDLRPCParameterNameEmergencyEvent];
+    [self.parameters sdl_setObject:emergencyEvent forName:SDLRPCParameterNameEmergencyEvent];
 }
 
 - (nullable NSNumber<SDLBool> *)emergencyEvent {
-    return [parameters sdl_objectForName:SDLRPCParameterNameEmergencyEvent ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameEmergencyEvent ofClass:NSNumber.class error:nil];
 }
 
 - (void)setClusterModeStatus:(nullable NSNumber<SDLBool> *)clusterModeStatus {
-    [parameters sdl_setObject:clusterModeStatus forName:SDLRPCParameterNameClusterModeStatus];
+    [self.parameters sdl_setObject:clusterModeStatus forName:SDLRPCParameterNameClusterModeStatus];
 }
 
 - (nullable NSNumber<SDLBool> *)clusterModeStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameClusterModeStatus ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameClusterModeStatus ofClass:NSNumber.class error:nil];
 }
 
 - (void)setMyKey:(nullable NSNumber<SDLBool> *)myKey {
-    [parameters sdl_setObject:myKey forName:SDLRPCParameterNameMyKey];
+    [self.parameters sdl_setObject:myKey forName:SDLRPCParameterNameMyKey];
 }
 
 - (nullable NSNumber<SDLBool> *)myKey {
-    return [parameters sdl_objectForName:SDLRPCParameterNameMyKey ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameMyKey ofClass:NSNumber.class error:nil];
 }
 
 - (void)setElectronicParkBrakeStatus:(nullable NSNumber<SDLBool> *)electronicParkBrakeStatus {
-    [parameters sdl_setObject:electronicParkBrakeStatus forName:SDLRPCParameterNameElectronicParkBrakeStatus];
+    [self.parameters sdl_setObject:electronicParkBrakeStatus forName:SDLRPCParameterNameElectronicParkBrakeStatus];
 }
 
 - (nullable NSNumber<SDLBool> *)electronicParkBrakeStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameElectronicParkBrakeStatus ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameElectronicParkBrakeStatus ofClass:NSNumber.class error:nil];
 }
 
 - (void)setTurnSignal:(nullable NSNumber<SDLBool> *)turnSignal {
-    [parameters sdl_setObject:turnSignal forName:SDLRPCParameterNameTurnSignal];
+    [self.parameters sdl_setObject:turnSignal forName:SDLRPCParameterNameTurnSignal];
 }
 
 - (nullable NSNumber<SDLBool> *)turnSignal {
-    return [parameters sdl_objectForName:SDLRPCParameterNameTurnSignal ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameTurnSignal ofClass:NSNumber.class error:nil];
 }
 
 - (void)setCloudAppVehicleID:(nullable NSNumber<SDLBool> *)cloudAppVehicleID {
-    [parameters sdl_setObject:cloudAppVehicleID forName:SDLRPCParameterNameCloudAppVehicleID];
+    [self.parameters sdl_setObject:cloudAppVehicleID forName:SDLRPCParameterNameCloudAppVehicleID];
 }
 
 - (nullable NSNumber<SDLBool> *)cloudAppVehicleID {
-    return [parameters sdl_objectForName:SDLRPCParameterNameCloudAppVehicleID ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameCloudAppVehicleID ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLSubscribeVehicleDataResponse.m
+++ b/SmartDeviceLink/SDLSubscribeVehicleDataResponse.m
@@ -13,242 +13,245 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLSubscribeVehicleDataResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameSubscribeVehicleData]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setGps:(nullable SDLVehicleDataResult *)gps {
-    [parameters sdl_setObject:gps forName:SDLRPCParameterNameGPS];
+    [self.parameters sdl_setObject:gps forName:SDLRPCParameterNameGPS];
 }
 
 - (nullable SDLVehicleDataResult *)gps {
-    return [parameters sdl_objectForName:SDLRPCParameterNameGPS ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameGPS ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setSpeed:(nullable SDLVehicleDataResult *)speed {
-    [parameters sdl_setObject:speed forName:SDLRPCParameterNameSpeed];
+    [self.parameters sdl_setObject:speed forName:SDLRPCParameterNameSpeed];
 }
 
 - (nullable SDLVehicleDataResult *)speed {
-    return [parameters sdl_objectForName:SDLRPCParameterNameSpeed ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameSpeed ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setRpm:(nullable SDLVehicleDataResult *)rpm {
-    [parameters sdl_setObject:rpm forName:SDLRPCParameterNameRPM];
+    [self.parameters sdl_setObject:rpm forName:SDLRPCParameterNameRPM];
 }
 
 - (nullable SDLVehicleDataResult *)rpm {
-    return [parameters sdl_objectForName:SDLRPCParameterNameRPM ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameRPM ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setFuelLevel:(nullable SDLVehicleDataResult *)fuelLevel {
-    [parameters sdl_setObject:fuelLevel forName:SDLRPCParameterNameFuelLevel];
+    [self.parameters sdl_setObject:fuelLevel forName:SDLRPCParameterNameFuelLevel];
 }
 
 - (nullable SDLVehicleDataResult *)fuelLevel {
-    return [parameters sdl_objectForName:SDLRPCParameterNameFuelLevel ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameFuelLevel ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setFuelLevel_State:(nullable SDLVehicleDataResult *)fuelLevel_State {
-    [parameters sdl_setObject:fuelLevel_State forName:SDLRPCParameterNameFuelLevelState];
+    [self.parameters sdl_setObject:fuelLevel_State forName:SDLRPCParameterNameFuelLevelState];
 }
 
 - (nullable SDLVehicleDataResult *)fuelLevel_State {
-    return [parameters sdl_objectForName:SDLRPCParameterNameFuelLevelState ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameFuelLevelState ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setFuelRange:(nullable SDLVehicleDataResult *)fuelRange {
-    [parameters sdl_setObject:fuelRange forName:SDLRPCParameterNameFuelRange];
+    [self.parameters sdl_setObject:fuelRange forName:SDLRPCParameterNameFuelRange];
 }
 
 - (nullable SDLVehicleDataResult *)fuelRange {
-    return [parameters sdl_objectForName:SDLRPCParameterNameFuelRange ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameFuelRange ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setInstantFuelConsumption:(nullable SDLVehicleDataResult *)instantFuelConsumption {
-    [parameters sdl_setObject:instantFuelConsumption forName:SDLRPCParameterNameInstantFuelConsumption];
+    [self.parameters sdl_setObject:instantFuelConsumption forName:SDLRPCParameterNameInstantFuelConsumption];
 }
 
 - (nullable SDLVehicleDataResult *)instantFuelConsumption {
-    return [parameters sdl_objectForName:SDLRPCParameterNameInstantFuelConsumption ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameInstantFuelConsumption ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setExternalTemperature:(nullable SDLVehicleDataResult *)externalTemperature {
-    [parameters sdl_setObject:externalTemperature forName:SDLRPCParameterNameExternalTemperature];
+    [self.parameters sdl_setObject:externalTemperature forName:SDLRPCParameterNameExternalTemperature];
 }
 
 - (nullable SDLVehicleDataResult *)externalTemperature {
-    return [parameters sdl_objectForName:SDLRPCParameterNameExternalTemperature ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameExternalTemperature ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setPrndl:(nullable SDLVehicleDataResult *)prndl {
-    [parameters sdl_setObject:prndl forName:SDLRPCParameterNamePRNDL];
+    [self.parameters sdl_setObject:prndl forName:SDLRPCParameterNamePRNDL];
 }
 
 - (nullable SDLVehicleDataResult *)prndl {
-    return [parameters sdl_objectForName:SDLRPCParameterNamePRNDL ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNamePRNDL ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setTirePressure:(nullable SDLVehicleDataResult *)tirePressure {
-    [parameters sdl_setObject:tirePressure forName:SDLRPCParameterNameTirePressure];
+    [self.parameters sdl_setObject:tirePressure forName:SDLRPCParameterNameTirePressure];
 }
 
 - (nullable SDLVehicleDataResult *)tirePressure {
-    return [parameters sdl_objectForName:SDLRPCParameterNameTirePressure ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameTirePressure ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setOdometer:(nullable SDLVehicleDataResult *)odometer {
-    [parameters sdl_setObject:odometer forName:SDLRPCParameterNameOdometer];
+    [self.parameters sdl_setObject:odometer forName:SDLRPCParameterNameOdometer];
 }
 
 - (nullable SDLVehicleDataResult *)odometer {
-    return [parameters sdl_objectForName:SDLRPCParameterNameOdometer ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameOdometer ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setBeltStatus:(nullable SDLVehicleDataResult *)beltStatus {
-    [parameters sdl_setObject:beltStatus forName:SDLRPCParameterNameBeltStatus];
+    [self.parameters sdl_setObject:beltStatus forName:SDLRPCParameterNameBeltStatus];
 }
 
 - (nullable SDLVehicleDataResult *)beltStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameBeltStatus ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameBeltStatus ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setBodyInformation:(nullable SDLVehicleDataResult *)bodyInformation {
-    [parameters sdl_setObject:bodyInformation forName:SDLRPCParameterNameBodyInformation];
+    [self.parameters sdl_setObject:bodyInformation forName:SDLRPCParameterNameBodyInformation];
 }
 
 - (nullable SDLVehicleDataResult *)bodyInformation {
-    return [parameters sdl_objectForName:SDLRPCParameterNameBodyInformation ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameBodyInformation ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setDeviceStatus:(nullable SDLVehicleDataResult *)deviceStatus {
-    [parameters sdl_setObject:deviceStatus forName:SDLRPCParameterNameDeviceStatus];
+    [self.parameters sdl_setObject:deviceStatus forName:SDLRPCParameterNameDeviceStatus];
 }
 
 - (nullable SDLVehicleDataResult *)deviceStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameDeviceStatus ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameDeviceStatus ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setDriverBraking:(nullable SDLVehicleDataResult *)driverBraking {
-    [parameters sdl_setObject:driverBraking forName:SDLRPCParameterNameDriverBraking];
+    [self.parameters sdl_setObject:driverBraking forName:SDLRPCParameterNameDriverBraking];
 }
 
 - (nullable SDLVehicleDataResult *)driverBraking {
-    return [parameters sdl_objectForName:SDLRPCParameterNameDriverBraking ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameDriverBraking ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setWiperStatus:(nullable SDLVehicleDataResult *)wiperStatus {
-    [parameters sdl_setObject:wiperStatus forName:SDLRPCParameterNameWiperStatus];
+    [self.parameters sdl_setObject:wiperStatus forName:SDLRPCParameterNameWiperStatus];
 }
 
 - (nullable SDLVehicleDataResult *)wiperStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameWiperStatus ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameWiperStatus ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setHeadLampStatus:(nullable SDLVehicleDataResult *)headLampStatus {
-    [parameters sdl_setObject:headLampStatus forName:SDLRPCParameterNameHeadLampStatus];
+    [self.parameters sdl_setObject:headLampStatus forName:SDLRPCParameterNameHeadLampStatus];
 }
 
 - (nullable SDLVehicleDataResult *)headLampStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameHeadLampStatus ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameHeadLampStatus ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setEngineOilLife:(nullable SDLVehicleDataResult *)engineOilLife {
-    [parameters sdl_setObject:engineOilLife forName:SDLRPCParameterNameEngineOilLife];
+    [self.parameters sdl_setObject:engineOilLife forName:SDLRPCParameterNameEngineOilLife];
 }
 
 - (nullable SDLVehicleDataResult *)engineOilLife {
-    return [parameters sdl_objectForName:SDLRPCParameterNameEngineOilLife ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameEngineOilLife ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setEngineTorque:(nullable SDLVehicleDataResult *)engineTorque {
-    [parameters sdl_setObject:engineTorque forName:SDLRPCParameterNameEngineTorque];
+    [self.parameters sdl_setObject:engineTorque forName:SDLRPCParameterNameEngineTorque];
 }
 
 - (nullable SDLVehicleDataResult *)engineTorque {
-    return [parameters sdl_objectForName:SDLRPCParameterNameEngineTorque ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameEngineTorque ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setAccPedalPosition:(nullable SDLVehicleDataResult *)accPedalPosition {
-    [parameters sdl_setObject:accPedalPosition forName:SDLRPCParameterNameAccelerationPedalPosition];
+    [self.parameters sdl_setObject:accPedalPosition forName:SDLRPCParameterNameAccelerationPedalPosition];
 }
 
 - (nullable SDLVehicleDataResult *)accPedalPosition {
-    return [parameters sdl_objectForName:SDLRPCParameterNameAccelerationPedalPosition ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameAccelerationPedalPosition ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setSteeringWheelAngle:(nullable SDLVehicleDataResult *)steeringWheelAngle {
-    [parameters sdl_setObject:steeringWheelAngle forName:SDLRPCParameterNameSteeringWheelAngle];
+    [self.parameters sdl_setObject:steeringWheelAngle forName:SDLRPCParameterNameSteeringWheelAngle];
 }
 
 - (nullable SDLVehicleDataResult *)steeringWheelAngle {
-    return [parameters sdl_objectForName:SDLRPCParameterNameSteeringWheelAngle ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameSteeringWheelAngle ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setECallInfo:(nullable SDLVehicleDataResult *)eCallInfo {
-    [parameters sdl_setObject:eCallInfo forName:SDLRPCParameterNameECallInfo];
+    [self.parameters sdl_setObject:eCallInfo forName:SDLRPCParameterNameECallInfo];
 }
 
 - (nullable SDLVehicleDataResult *)eCallInfo {
-    return [parameters sdl_objectForName:SDLRPCParameterNameECallInfo ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameECallInfo ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setAirbagStatus:(nullable SDLVehicleDataResult *)airbagStatus {
-    [parameters sdl_setObject:airbagStatus forName:SDLRPCParameterNameAirbagStatus];
+    [self.parameters sdl_setObject:airbagStatus forName:SDLRPCParameterNameAirbagStatus];
 }
 
 - (nullable SDLVehicleDataResult *)airbagStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameAirbagStatus ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameAirbagStatus ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setEmergencyEvent:(nullable SDLVehicleDataResult *)emergencyEvent {
-    [parameters sdl_setObject:emergencyEvent forName:SDLRPCParameterNameEmergencyEvent];
+    [self.parameters sdl_setObject:emergencyEvent forName:SDLRPCParameterNameEmergencyEvent];
 }
 
 - (nullable SDLVehicleDataResult *)emergencyEvent {
-    return [parameters sdl_objectForName:SDLRPCParameterNameEmergencyEvent ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameEmergencyEvent ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setClusterModes:(nullable SDLVehicleDataResult *)clusterModes {
-    [parameters sdl_setObject:clusterModes forName:SDLRPCParameterNameClusterModes];
+    [self.parameters sdl_setObject:clusterModes forName:SDLRPCParameterNameClusterModes];
 }
 
 - (nullable SDLVehicleDataResult *)clusterModes {
-    return [parameters sdl_objectForName:SDLRPCParameterNameClusterModes ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameClusterModes ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setMyKey:(nullable SDLVehicleDataResult *)myKey {
-    [parameters sdl_setObject:myKey forName:SDLRPCParameterNameMyKey];
+    [self.parameters sdl_setObject:myKey forName:SDLRPCParameterNameMyKey];
 }
 
 - (nullable SDLVehicleDataResult *)myKey {
-    return [parameters sdl_objectForName:SDLRPCParameterNameMyKey ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameMyKey ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setElectronicParkBrakeStatus:(nullable SDLVehicleDataResult *)electronicParkBrakeStatus {
-    [parameters sdl_setObject:electronicParkBrakeStatus forName:SDLRPCParameterNameElectronicParkBrakeStatus];
+    [self.parameters sdl_setObject:electronicParkBrakeStatus forName:SDLRPCParameterNameElectronicParkBrakeStatus];
 }
 
 - (nullable SDLVehicleDataResult *)electronicParkBrakeStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameElectronicParkBrakeStatus ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameElectronicParkBrakeStatus ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setTurnSignal:(nullable SDLVehicleDataResult *)turnSignal {
-    [parameters sdl_setObject:turnSignal forName:SDLRPCParameterNameTurnSignal];
+    [self.parameters sdl_setObject:turnSignal forName:SDLRPCParameterNameTurnSignal];
 }
 
 - (nullable SDLVehicleDataResult *)turnSignal {
-    return [parameters sdl_objectForName:SDLRPCParameterNameTurnSignal ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameTurnSignal ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setCloudAppVehicleID:(nullable SDLVehicleDataResult *)cloudAppVehicleID {
-    [parameters sdl_setObject:cloudAppVehicleID forName:SDLRPCParameterNameCloudAppVehicleID];
+    [self.parameters sdl_setObject:cloudAppVehicleID forName:SDLRPCParameterNameCloudAppVehicleID];
 }
 
 - (nullable SDLVehicleDataResult *)cloudAppVehicleID {
-    return [parameters sdl_objectForName:SDLRPCParameterNameCloudAppVehicleID ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameCloudAppVehicleID ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLSubscribeWayPoints.m
+++ b/SmartDeviceLink/SDLSubscribeWayPoints.m
@@ -11,11 +11,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLSubscribeWayPoints
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameSubscribeWayPoints]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLSubscribeWayPointsResponse.m
+++ b/SmartDeviceLink/SDLSubscribeWayPointsResponse.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLSubscribeWayPointsResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameSubscribeWayPoints]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLSyncMsgVersion.m
+++ b/SmartDeviceLink/SDLSyncMsgVersion.m
@@ -25,29 +25,29 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setMajorVersion:(NSNumber<SDLInt> *)majorVersion {
-    [store sdl_setObject:majorVersion forName:SDLRPCParameterNameMajorVersion];
+    [self.store sdl_setObject:majorVersion forName:SDLRPCParameterNameMajorVersion];
 }
 
 - (NSNumber<SDLInt> *)majorVersion {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameMajorVersion ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameMajorVersion ofClass:NSNumber.class error:&error];
 }
 
 - (void)setMinorVersion:(NSNumber<SDLInt> *)minorVersion {
-    [store sdl_setObject:minorVersion forName:SDLRPCParameterNameMinorVersion];
+    [self.store sdl_setObject:minorVersion forName:SDLRPCParameterNameMinorVersion];
 }
 
 - (NSNumber<SDLInt> *)minorVersion {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameMinorVersion ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameMinorVersion ofClass:NSNumber.class error:&error];
 }
 
 - (void)setPatchVersion:(nullable NSNumber<SDLInt> *)patchVersion {
-    [store sdl_setObject:patchVersion forName:SDLRPCParameterNamePatchVersion];
+    [self.store sdl_setObject:patchVersion forName:SDLRPCParameterNamePatchVersion];
 }
 
 - (nullable NSNumber<SDLInt> *)patchVersion {
-    return [store sdl_objectForName:SDLRPCParameterNamePatchVersion ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNamePatchVersion ofClass:NSNumber.class error:nil];
 }
 
 - (NSString *)description {

--- a/SmartDeviceLink/SDLSyncPData.m
+++ b/SmartDeviceLink/SDLSyncPData.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLSyncPData
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameSyncPData]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLSyncPDataResponse.m
+++ b/SmartDeviceLink/SDLSyncPDataResponse.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLSyncPDataResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameSyncPData]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLSystemCapability.m
+++ b/SmartDeviceLink/SDLSystemCapability.m
@@ -82,52 +82,52 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setSystemCapabilityType:(SDLSystemCapabilityType)type {
-    [store sdl_setObject:type forName:SDLRPCParameterNameSystemCapabilityType];
+    [self.store sdl_setObject:type forName:SDLRPCParameterNameSystemCapabilityType];
 }
 
 - (SDLSystemCapabilityType)systemCapabilityType {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameSystemCapabilityType error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameSystemCapabilityType error:&error];
 }
 
 - (void)setAppServicesCapabilities:(nullable SDLAppServicesCapabilities *)appServicesCapabilities {
-    [store sdl_setObject:appServicesCapabilities forName:SDLRPCParameterNameAppServicesCapabilities];
+    [self.store sdl_setObject:appServicesCapabilities forName:SDLRPCParameterNameAppServicesCapabilities];
 }
 
 - (nullable SDLAppServicesCapabilities *)appServicesCapabilities {
-    return [store sdl_objectForName:SDLRPCParameterNameAppServicesCapabilities ofClass:SDLAppServicesCapabilities.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameAppServicesCapabilities ofClass:SDLAppServicesCapabilities.class error:nil];
 }
 
 - (void)setNavigationCapability:(nullable SDLNavigationCapability *)navigationCapability {
-    [store sdl_setObject:navigationCapability forName:SDLRPCParameterNameNavigationCapability];
+    [self.store sdl_setObject:navigationCapability forName:SDLRPCParameterNameNavigationCapability];
 }
 
 - (nullable SDLNavigationCapability *)navigationCapability {
-    return [store sdl_objectForName:SDLRPCParameterNameNavigationCapability ofClass:SDLNavigationCapability.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameNavigationCapability ofClass:SDLNavigationCapability.class error:nil];
 }
 
 - (void)setPhoneCapability:(nullable SDLPhoneCapability *)phoneCapability {
-    [store sdl_setObject:phoneCapability forName:SDLRPCParameterNamePhoneCapability];
+    [self.store sdl_setObject:phoneCapability forName:SDLRPCParameterNamePhoneCapability];
 }
 
 - (nullable SDLPhoneCapability *)phoneCapability {
-    return [store sdl_objectForName:SDLRPCParameterNamePhoneCapability ofClass:SDLPhoneCapability.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNamePhoneCapability ofClass:SDLPhoneCapability.class error:nil];
 }
 
 - (void)setVideoStreamingCapability:(nullable SDLVideoStreamingCapability *)videoStreamingCapability {
-    [store sdl_setObject:videoStreamingCapability forName:SDLRPCParameterNameVideoStreamingCapability];
+    [self.store sdl_setObject:videoStreamingCapability forName:SDLRPCParameterNameVideoStreamingCapability];
 }
 
 - (nullable SDLVideoStreamingCapability *)videoStreamingCapability {
-    return [store sdl_objectForName:SDLRPCParameterNameVideoStreamingCapability ofClass:SDLVideoStreamingCapability.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameVideoStreamingCapability ofClass:SDLVideoStreamingCapability.class error:nil];
 }
 
 - (void)setRemoteControlCapability:(nullable SDLRemoteControlCapabilities *)remoteControlCapability {
-    [store sdl_setObject:remoteControlCapability forName:SDLRPCParameterNameRemoteControlCapability];
+    [self.store sdl_setObject:remoteControlCapability forName:SDLRPCParameterNameRemoteControlCapability];
 }
 
 - (nullable SDLRemoteControlCapabilities *)remoteControlCapability {
-    return [store sdl_objectForName:SDLRPCParameterNameRemoteControlCapability ofClass:SDLRemoteControlCapabilities.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameRemoteControlCapability ofClass:SDLRemoteControlCapabilities.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLSystemRequest.m
+++ b/SmartDeviceLink/SDLSystemRequest.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLSystemRequest
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameSystemRequest]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithType:(SDLRequestType)requestType fileName:(nullable NSString *)fileName {
     self = [self init];
@@ -42,28 +45,28 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setRequestType:(SDLRequestType)requestType {
-    [parameters sdl_setObject:requestType forName:SDLRPCParameterNameRequestType];
+    [self.parameters sdl_setObject:requestType forName:SDLRPCParameterNameRequestType];
 }
 
 - (SDLRequestType)requestType {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameRequestType error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameRequestType error:&error];
 }
 
 - (void)setRequestSubType:(nullable NSString *)requestSubType {
-    [parameters sdl_setObject:requestSubType forName:SDLRPCParameterNameRequestSubType];
+    [self.parameters sdl_setObject:requestSubType forName:SDLRPCParameterNameRequestSubType];
 }
 
 - (nullable NSString *)requestSubType {
-    return [parameters sdl_objectForName:SDLRPCParameterNameRequestSubType ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameRequestSubType ofClass:NSString.class error:nil];
 }
 
 - (void)setFileName:(nullable NSString *)fileName {
-    [parameters sdl_setObject:fileName forName:SDLRPCParameterNameFilename];
+    [self.parameters sdl_setObject:fileName forName:SDLRPCParameterNameFilename];
 }
 
 - (nullable NSString *)fileName {
-    return [parameters sdl_objectForName:SDLRPCParameterNameFilename ofClass:NSString.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameFilename ofClass:NSString.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLSystemRequestResponse.m
+++ b/SmartDeviceLink/SDLSystemRequestResponse.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLSystemRequestResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameSystemRequest]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLTTSChunk.m
+++ b/SmartDeviceLink/SDLTTSChunk.m
@@ -55,21 +55,21 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setText:(NSString *)text {
-    [store sdl_setObject:text forName:SDLRPCParameterNameText];
+    [self.store sdl_setObject:text forName:SDLRPCParameterNameText];
 }
 
 - (NSString *)text {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameText ofClass:NSString.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameText ofClass:NSString.class error:&error];
 }
 
 - (void)setType:(SDLSpeechCapabilities)type {
-    [store sdl_setObject:type forName:SDLRPCParameterNameType];
+    [self.store sdl_setObject:type forName:SDLRPCParameterNameType];
 }
 
 - (SDLSpeechCapabilities)type {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameType error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameType error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLTemperature.m
+++ b/SmartDeviceLink/SDLTemperature.m
@@ -31,21 +31,21 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setUnit:(SDLTemperatureUnit)unit {
-    [store sdl_setObject:unit forName:SDLRPCParameterNameUnit];
+    [self.store sdl_setObject:unit forName:SDLRPCParameterNameUnit];
 }
 
 - (SDLTemperatureUnit)unit {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameUnit error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameUnit error:&error];
 }
 
 - (void)setValue:(NSNumber<SDLFloat> *)value {
-    [store sdl_setObject:value forName:SDLRPCParameterNameValue];
+    [self.store sdl_setObject:value forName:SDLRPCParameterNameValue];
 }
 
 - (NSNumber<SDLFloat> *)value {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameValue ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameValue ofClass:NSNumber.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLTemplateColorScheme.m
+++ b/SmartDeviceLink/SDLTemplateColorScheme.m
@@ -39,27 +39,27 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setPrimaryColor:(nullable SDLRGBColor *)primaryColor {
-    [store sdl_setObject:primaryColor forName:SDLRPCParameterNamePrimaryColor];
+    [self.store sdl_setObject:primaryColor forName:SDLRPCParameterNamePrimaryColor];
 }
 
 - (nullable SDLRGBColor *)primaryColor {
-    return [store sdl_objectForName:SDLRPCParameterNamePrimaryColor ofClass:SDLRGBColor.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNamePrimaryColor ofClass:SDLRGBColor.class error:nil];
 }
 
 - (void)setSecondaryColor:(nullable SDLRGBColor *)secondaryColor {
-    [store sdl_setObject:secondaryColor forName:SDLRPCParameterNameSecondaryColor];
+    [self.store sdl_setObject:secondaryColor forName:SDLRPCParameterNameSecondaryColor];
 }
 
 - (nullable SDLRGBColor *)secondaryColor {
-    return [store sdl_objectForName:SDLRPCParameterNameSecondaryColor ofClass:SDLRGBColor.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameSecondaryColor ofClass:SDLRGBColor.class error:nil];
 }
 
 - (void)setBackgroundColor:(nullable SDLRGBColor *)backgroundColor {
-    [store sdl_setObject:backgroundColor forName:SDLRPCParameterNameBackgroundColor];
+    [self.store sdl_setObject:backgroundColor forName:SDLRPCParameterNameBackgroundColor];
 }
 
 - (nullable SDLRGBColor *)backgroundColor {
-    return [store sdl_objectForName:SDLRPCParameterNameBackgroundColor ofClass:SDLRGBColor.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameBackgroundColor ofClass:SDLRGBColor.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLTextField.m
+++ b/SmartDeviceLink/SDLTextField.m
@@ -13,39 +13,39 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation SDLTextField
 
 - (void)setName:(SDLTextFieldName)name {
-    [store sdl_setObject:name forName:SDLRPCParameterNameName];
+    [self.store sdl_setObject:name forName:SDLRPCParameterNameName];
 }
 
 - (SDLTextFieldName)name {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameName error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameName error:&error];
 }
 
 - (void)setCharacterSet:(SDLCharacterSet)characterSet {
-    [store sdl_setObject:characterSet forName:SDLRPCParameterNameCharacterSet];
+    [self.store sdl_setObject:characterSet forName:SDLRPCParameterNameCharacterSet];
 }
 
 - (SDLCharacterSet)characterSet {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameCharacterSet error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameCharacterSet error:&error];
 }
 
 - (void)setWidth:(NSNumber<SDLInt> *)width {
-    [store sdl_setObject:width forName:SDLRPCParameterNameWidth];
+    [self.store sdl_setObject:width forName:SDLRPCParameterNameWidth];
 }
 
 - (NSNumber<SDLInt> *)width {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameWidth ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameWidth ofClass:NSNumber.class error:&error];
 }
 
 - (void)setRows:(NSNumber<SDLInt> *)rows {
-    [store sdl_setObject:rows forName:SDLRPCParameterNameRows];
+    [self.store sdl_setObject:rows forName:SDLRPCParameterNameRows];
 }
 
 - (NSNumber<SDLInt> *)rows {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameRows ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameRows ofClass:NSNumber.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLTireStatus.m
+++ b/SmartDeviceLink/SDLTireStatus.m
@@ -12,66 +12,66 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation SDLTireStatus
 
 - (void)setPressureTelltale:(SDLWarningLightStatus)pressureTelltale {
-    [store sdl_setObject:pressureTelltale forName:SDLRPCParameterNamePressureTelltale];
+    [self.store sdl_setObject:pressureTelltale forName:SDLRPCParameterNamePressureTelltale];
 }
 
 - (SDLWarningLightStatus)pressureTelltale {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNamePressureTelltale error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNamePressureTelltale error:&error];
 }
 
 - (void)setLeftFront:(SDLSingleTireStatus *)leftFront {
-    [store sdl_setObject:leftFront forName:SDLRPCParameterNameLeftFront];
+    [self.store sdl_setObject:leftFront forName:SDLRPCParameterNameLeftFront];
 }
 
 - (SDLSingleTireStatus *)leftFront {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameLeftFront ofClass:SDLSingleTireStatus.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameLeftFront ofClass:SDLSingleTireStatus.class error:&error];
 }
 
 - (void)setRightFront:(SDLSingleTireStatus *)rightFront {
-    [store sdl_setObject:rightFront forName:SDLRPCParameterNameRightFront];
+    [self.store sdl_setObject:rightFront forName:SDLRPCParameterNameRightFront];
 }
 
 - (SDLSingleTireStatus *)rightFront {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameRightFront ofClass:SDLSingleTireStatus.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameRightFront ofClass:SDLSingleTireStatus.class error:&error];
 }
 
 - (void)setLeftRear:(SDLSingleTireStatus *)leftRear {
-    [store sdl_setObject:leftRear forName:SDLRPCParameterNameLeftRear];
+    [self.store sdl_setObject:leftRear forName:SDLRPCParameterNameLeftRear];
 }
 
 - (SDLSingleTireStatus *)leftRear {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameLeftRear ofClass:SDLSingleTireStatus.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameLeftRear ofClass:SDLSingleTireStatus.class error:&error];
 }
 
 - (void)setRightRear:(SDLSingleTireStatus *)rightRear {
-    [store sdl_setObject:rightRear forName:SDLRPCParameterNameRightRear];
+    [self.store sdl_setObject:rightRear forName:SDLRPCParameterNameRightRear];
 }
 
 - (SDLSingleTireStatus *)rightRear {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameRightRear ofClass:SDLSingleTireStatus.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameRightRear ofClass:SDLSingleTireStatus.class error:&error];
 }
 
 - (void)setInnerLeftRear:(SDLSingleTireStatus *)innerLeftRear {
-    [store sdl_setObject:innerLeftRear forName:SDLRPCParameterNameInnerLeftRear];
+    [self.store sdl_setObject:innerLeftRear forName:SDLRPCParameterNameInnerLeftRear];
 }
 
 - (SDLSingleTireStatus *)innerLeftRear {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameInnerLeftRear ofClass:SDLSingleTireStatus.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameInnerLeftRear ofClass:SDLSingleTireStatus.class error:&error];
 }
 
 - (void)setInnerRightRear:(SDLSingleTireStatus *)innerRightRear {
-    [store sdl_setObject:innerRightRear forName:SDLRPCParameterNameInnerRightRear];
+    [self.store sdl_setObject:innerRightRear forName:SDLRPCParameterNameInnerRightRear];
 }
 
 - (SDLSingleTireStatus *)innerRightRear {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameInnerRightRear ofClass:SDLSingleTireStatus.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameInnerRightRear ofClass:SDLSingleTireStatus.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLTouchCoord.m
+++ b/SmartDeviceLink/SDLTouchCoord.m
@@ -12,21 +12,21 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation SDLTouchCoord
 
 - (void)setX:(NSNumber<SDLFloat> *)x {
-    [store sdl_setObject:x forName:SDLRPCParameterNameX];
+    [self.store sdl_setObject:x forName:SDLRPCParameterNameX];
 }
 
 - (NSNumber<SDLFloat> *)x {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameX ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameX ofClass:NSNumber.class error:&error];
 }
 
 - (void)setY:(NSNumber<SDLFloat> *)y {
-    [store sdl_setObject:y forName:SDLRPCParameterNameY];
+    [self.store sdl_setObject:y forName:SDLRPCParameterNameY];
 }
 
 - (NSNumber<SDLFloat> *)y {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameY ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameY ofClass:NSNumber.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLTouchEvent.m
+++ b/SmartDeviceLink/SDLTouchEvent.m
@@ -13,30 +13,30 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation SDLTouchEvent
 
 - (void)setTouchEventId:(NSNumber<SDLInt> *)touchEventId {
-    [store sdl_setObject:touchEventId forName:SDLRPCParameterNameId];
+    [self.store sdl_setObject:touchEventId forName:SDLRPCParameterNameId];
 }
 
 - (NSNumber<SDLInt> *)touchEventId {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameId ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameId ofClass:NSNumber.class error:&error];
 }
 
 - (void)setTimeStamp:(NSArray<NSNumber<SDLInt> *> *)timeStamp {
-    [store sdl_setObject:timeStamp forName:SDLRPCParameterNameTS];
+    [self.store sdl_setObject:timeStamp forName:SDLRPCParameterNameTS];
 }
 
 - (NSArray<NSNumber<SDLInt> *> *)timeStamp {
     NSError *error = nil;
-    return [store sdl_objectsForName:SDLRPCParameterNameTS ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectsForName:SDLRPCParameterNameTS ofClass:NSNumber.class error:&error];
 }
 
 - (void)setCoord:(NSArray<SDLTouchCoord *> *)coord {
-    [store sdl_setObject:coord forName:SDLRPCParameterNameCoordinate];
+    [self.store sdl_setObject:coord forName:SDLRPCParameterNameCoordinate];
 }
 
 - (NSArray<SDLTouchCoord *> *)coord {
     NSError *error = nil;
-    return [store sdl_objectsForName:SDLRPCParameterNameCoordinate ofClass:SDLTouchCoord.class error:&error];
+    return [self.store sdl_objectsForName:SDLRPCParameterNameCoordinate ofClass:SDLTouchCoord.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLTouchEventCapabilities.m
+++ b/SmartDeviceLink/SDLTouchEventCapabilities.m
@@ -12,30 +12,30 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation SDLTouchEventCapabilities
 
 - (void)setPressAvailable:(NSNumber<SDLBool> *)pressAvailable {
-    [store sdl_setObject:pressAvailable forName:SDLRPCParameterNamePressAvailable];
+    [self.store sdl_setObject:pressAvailable forName:SDLRPCParameterNamePressAvailable];
 }
 
 - (NSNumber<SDLBool> *)pressAvailable {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNamePressAvailable ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNamePressAvailable ofClass:NSNumber.class error:&error];
 }
 
 - (void)setMultiTouchAvailable:(NSNumber<SDLBool> *)multiTouchAvailable {
-    [store sdl_setObject:multiTouchAvailable forName:SDLRPCParameterNameMultiTouchAvailable];
+    [self.store sdl_setObject:multiTouchAvailable forName:SDLRPCParameterNameMultiTouchAvailable];
 }
 
 - (NSNumber<SDLBool> *)multiTouchAvailable {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameMultiTouchAvailable ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameMultiTouchAvailable ofClass:NSNumber.class error:&error];
 }
 
 - (void)setDoublePressAvailable:(NSNumber<SDLBool> *)doublePressAvailable {
-    [store sdl_setObject:doublePressAvailable forName:SDLRPCParameterNameDoublePressAvailable];
+    [self.store sdl_setObject:doublePressAvailable forName:SDLRPCParameterNameDoublePressAvailable];
 }
 
 - (NSNumber<SDLBool> *)doublePressAvailable {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameDoublePressAvailable ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameDoublePressAvailable ofClass:NSNumber.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLTurn.m
+++ b/SmartDeviceLink/SDLTurn.m
@@ -24,19 +24,19 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setNavigationText:(nullable NSString *)navigationText {
-    [store sdl_setObject:navigationText forName:SDLRPCParameterNameNavigationText];
+    [self.store sdl_setObject:navigationText forName:SDLRPCParameterNameNavigationText];
 }
 
 - (nullable NSString *)navigationText {
-    return [store sdl_objectForName:SDLRPCParameterNameNavigationText ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameNavigationText ofClass:NSString.class error:nil];
 }
 
 - (void)setTurnIcon:(nullable SDLImage *)turnIcon {
-    [store sdl_setObject:turnIcon forName:SDLRPCParameterNameTurnIcon];
+    [self.store sdl_setObject:turnIcon forName:SDLRPCParameterNameTurnIcon];
 }
 
 - (nullable SDLImage *)turnIcon {
-    return [store sdl_objectForName:SDLRPCParameterNameTurnIcon ofClass:SDLImage.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameTurnIcon ofClass:SDLImage.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLUnregisterAppInterface.m
+++ b/SmartDeviceLink/SDLUnregisterAppInterface.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLUnregisterAppInterface
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameUnregisterAppInterface]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLUnregisterAppInterfaceResponse.m
+++ b/SmartDeviceLink/SDLUnregisterAppInterfaceResponse.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLUnregisterAppInterfaceResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameUnregisterAppInterface]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLUnsubscribeButton.m
+++ b/SmartDeviceLink/SDLUnsubscribeButton.m
@@ -13,11 +13,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLUnsubscribeButton
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameUnsubscribeButton]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithButtonName:(SDLButtonName)buttonName {
     self = [self init];
@@ -31,12 +34,12 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setButtonName:(SDLButtonName)buttonName {
-    [parameters sdl_setObject:buttonName forName:SDLRPCParameterNameButtonName];
+    [self.parameters sdl_setObject:buttonName forName:SDLRPCParameterNameButtonName];
 }
 
 - (SDLButtonName)buttonName {
     NSError *error = nil;
-    return [parameters sdl_enumForName:SDLRPCParameterNameButtonName error:&error];
+    return [self.parameters sdl_enumForName:SDLRPCParameterNameButtonName error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLUnsubscribeButtonResponse.m
+++ b/SmartDeviceLink/SDLUnsubscribeButtonResponse.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLUnsubscribeButtonResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameUnsubscribeButton]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLUnsubscribeVehicleData.m
+++ b/SmartDeviceLink/SDLUnsubscribeVehicleData.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLUnsubscribeVehicleData
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameUnsubscribeVehicleData]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithAccelerationPedalPosition:(BOOL)accelerationPedalPosition airbagStatus:(BOOL)airbagStatus beltStatus:(BOOL)beltStatus bodyInformation:(BOOL)bodyInformation clusterModeStatus:(BOOL)clusterModeStatus deviceStatus:(BOOL)deviceStatus driverBraking:(BOOL)driverBraking eCallInfo:(BOOL)eCallInfo emergencyEvent:(BOOL)emergencyEvent engineTorque:(BOOL)engineTorque externalTemperature:(BOOL)externalTemperature fuelLevel:(BOOL)fuelLevel fuelLevelState:(BOOL)fuelLevelState gps:(BOOL)gps headLampStatus:(BOOL)headLampStatus instantFuelConsumption:(BOOL)instantFuelConsumption myKey:(BOOL)myKey odometer:(BOOL)odometer prndl:(BOOL)prndl rpm:(BOOL)rpm speed:(BOOL)speed steeringWheelAngle:(BOOL)steeringWheelAngle tirePressure:(BOOL)tirePressure wiperStatus:(BOOL)wiperStatus {
     return [self initWithAccelerationPedalPosition:accelerationPedalPosition airbagStatus:airbagStatus beltStatus:beltStatus bodyInformation:bodyInformation clusterModeStatus:clusterModeStatus deviceStatus:deviceStatus driverBraking:driverBraking eCallInfo:eCallInfo electronicParkBrakeStatus:NO emergencyEvent:emergencyEvent engineOilLife:NO engineTorque:engineTorque externalTemperature:externalTemperature fuelLevel:fuelLevel fuelLevelState:fuelLevelState fuelRange:NO gps:gps headLampStatus:headLampStatus instantFuelConsumption:instantFuelConsumption myKey:myKey odometer:odometer prndl:prndl rpm:rpm speed:speed steeringWheelAngle:steeringWheelAngle tirePressure:tirePressure turnSignal:NO wiperStatus:wiperStatus];
@@ -66,235 +69,235 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setGps:(nullable NSNumber<SDLBool> *)gps {
-    [parameters sdl_setObject:gps forName:SDLRPCParameterNameGPS];
+    [self.parameters sdl_setObject:gps forName:SDLRPCParameterNameGPS];
 }
 
 - (nullable NSNumber<SDLBool> *)gps {
-    return [parameters sdl_objectForName:SDLRPCParameterNameGPS ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameGPS ofClass:NSNumber.class error:nil];
 }
 
 - (void)setSpeed:(nullable NSNumber<SDLBool> *)speed {
-    [parameters sdl_setObject:speed forName:SDLRPCParameterNameSpeed];
+    [self.parameters sdl_setObject:speed forName:SDLRPCParameterNameSpeed];
 }
 
 - (nullable NSNumber<SDLBool> *)speed {
-    return [parameters sdl_objectForName:SDLRPCParameterNameSpeed ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameSpeed ofClass:NSNumber.class error:nil];
 }
 
 - (void)setRpm:(nullable NSNumber<SDLBool> *)rpm {
-    [parameters sdl_setObject:rpm forName:SDLRPCParameterNameRPM];
+    [self.parameters sdl_setObject:rpm forName:SDLRPCParameterNameRPM];
 }
 
 - (nullable NSNumber<SDLBool> *)rpm {
-    return [parameters sdl_objectForName:SDLRPCParameterNameRPM ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameRPM ofClass:NSNumber.class error:nil];
 }
 
 - (void)setFuelLevel:(nullable NSNumber<SDLBool> *)fuelLevel {
-    [parameters sdl_setObject:fuelLevel forName:SDLRPCParameterNameFuelLevel];
+    [self.parameters sdl_setObject:fuelLevel forName:SDLRPCParameterNameFuelLevel];
 }
 
 - (nullable NSNumber<SDLBool> *)fuelLevel {
-    return [parameters sdl_objectForName:SDLRPCParameterNameFuelLevel ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameFuelLevel ofClass:NSNumber.class error:nil];
 }
 
 - (void)setFuelLevel_State:(nullable NSNumber<SDLBool> *)fuelLevel_State {
-    [parameters sdl_setObject:fuelLevel_State forName:SDLRPCParameterNameFuelLevelState];
+    [self.parameters sdl_setObject:fuelLevel_State forName:SDLRPCParameterNameFuelLevelState];
 }
 
 - (nullable NSNumber<SDLBool> *)fuelLevel_State {
-    return [parameters sdl_objectForName:SDLRPCParameterNameFuelLevelState ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameFuelLevelState ofClass:NSNumber.class error:nil];
 }
 
 - (void)setFuelRange:(nullable NSNumber<SDLBool> *)fuelRange {
-    [parameters sdl_setObject:fuelRange forName:SDLRPCParameterNameFuelRange];
+    [self.parameters sdl_setObject:fuelRange forName:SDLRPCParameterNameFuelRange];
 }
 
 - (nullable NSNumber<SDLBool> *)fuelRange {
-    return [parameters sdl_objectForName:SDLRPCParameterNameFuelRange ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameFuelRange ofClass:NSNumber.class error:nil];
 }
 
 - (void)setInstantFuelConsumption:(nullable NSNumber<SDLBool> *)instantFuelConsumption {
-    [parameters sdl_setObject:instantFuelConsumption forName:SDLRPCParameterNameInstantFuelConsumption];
+    [self.parameters sdl_setObject:instantFuelConsumption forName:SDLRPCParameterNameInstantFuelConsumption];
 }
 
 - (nullable NSNumber<SDLBool> *)instantFuelConsumption {
-    return [parameters sdl_objectForName:SDLRPCParameterNameInstantFuelConsumption ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameInstantFuelConsumption ofClass:NSNumber.class error:nil];
 }
 
 - (void)setExternalTemperature:(nullable NSNumber<SDLBool> *)externalTemperature {
-    [parameters sdl_setObject:externalTemperature forName:SDLRPCParameterNameExternalTemperature];
+    [self.parameters sdl_setObject:externalTemperature forName:SDLRPCParameterNameExternalTemperature];
 }
 
 - (nullable NSNumber<SDLBool> *)externalTemperature {
-    return [parameters sdl_objectForName:SDLRPCParameterNameExternalTemperature ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameExternalTemperature ofClass:NSNumber.class error:nil];
 }
 
 - (void)setPrndl:(nullable NSNumber<SDLBool> *)prndl {
-    [parameters sdl_setObject:prndl forName:SDLRPCParameterNamePRNDL];
+    [self.parameters sdl_setObject:prndl forName:SDLRPCParameterNamePRNDL];
 }
 
 - (nullable NSNumber<SDLBool> *)prndl {
-    return [parameters sdl_objectForName:SDLRPCParameterNamePRNDL ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNamePRNDL ofClass:NSNumber.class error:nil];
 }
 
 - (void)setTirePressure:(nullable NSNumber<SDLBool> *)tirePressure {
-    [parameters sdl_setObject:tirePressure forName:SDLRPCParameterNameTirePressure];
+    [self.parameters sdl_setObject:tirePressure forName:SDLRPCParameterNameTirePressure];
 }
 
 - (nullable NSNumber<SDLBool> *)tirePressure {
-    return [parameters sdl_objectForName:SDLRPCParameterNameTirePressure ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameTirePressure ofClass:NSNumber.class error:nil];
 }
 
 - (void)setOdometer:(nullable NSNumber<SDLBool> *)odometer {
-    [parameters sdl_setObject:odometer forName:SDLRPCParameterNameOdometer];
+    [self.parameters sdl_setObject:odometer forName:SDLRPCParameterNameOdometer];
 }
 
 - (nullable NSNumber<SDLBool> *)odometer {
-    return [parameters sdl_objectForName:SDLRPCParameterNameOdometer ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameOdometer ofClass:NSNumber.class error:nil];
 }
 
 - (void)setBeltStatus:(nullable NSNumber<SDLBool> *)beltStatus {
-    [parameters sdl_setObject:beltStatus forName:SDLRPCParameterNameBeltStatus];
+    [self.parameters sdl_setObject:beltStatus forName:SDLRPCParameterNameBeltStatus];
 }
 
 - (nullable NSNumber<SDLBool> *)beltStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameBeltStatus ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameBeltStatus ofClass:NSNumber.class error:nil];
 }
 
 - (void)setBodyInformation:(nullable NSNumber<SDLBool> *)bodyInformation {
-    [parameters sdl_setObject:bodyInformation forName:SDLRPCParameterNameBodyInformation];
+    [self.parameters sdl_setObject:bodyInformation forName:SDLRPCParameterNameBodyInformation];
 }
 
 - (nullable NSNumber<SDLBool> *)bodyInformation {
-    return [parameters sdl_objectForName:SDLRPCParameterNameBodyInformation ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameBodyInformation ofClass:NSNumber.class error:nil];
 }
 
 - (void)setDeviceStatus:(nullable NSNumber<SDLBool> *)deviceStatus {
-    [parameters sdl_setObject:deviceStatus forName:SDLRPCParameterNameDeviceStatus];
+    [self.parameters sdl_setObject:deviceStatus forName:SDLRPCParameterNameDeviceStatus];
 }
 
 - (nullable NSNumber<SDLBool> *)deviceStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameDeviceStatus ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameDeviceStatus ofClass:NSNumber.class error:nil];
 }
 
 - (void)setDriverBraking:(nullable NSNumber<SDLBool> *)driverBraking {
-    [parameters sdl_setObject:driverBraking forName:SDLRPCParameterNameDriverBraking];
+    [self.parameters sdl_setObject:driverBraking forName:SDLRPCParameterNameDriverBraking];
 }
 
 - (nullable NSNumber<SDLBool> *)driverBraking {
-    return [parameters sdl_objectForName:SDLRPCParameterNameDriverBraking ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameDriverBraking ofClass:NSNumber.class error:nil];
 }
 
 - (void)setWiperStatus:(nullable NSNumber<SDLBool> *)wiperStatus {
-    [parameters sdl_setObject:wiperStatus forName:SDLRPCParameterNameWiperStatus];
+    [self.parameters sdl_setObject:wiperStatus forName:SDLRPCParameterNameWiperStatus];
 }
 
 - (nullable NSNumber<SDLBool> *)wiperStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameWiperStatus ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameWiperStatus ofClass:NSNumber.class error:nil];
 }
 
 - (void)setHeadLampStatus:(nullable NSNumber<SDLBool> *)headLampStatus {
-    [parameters sdl_setObject:headLampStatus forName:SDLRPCParameterNameHeadLampStatus];
+    [self.parameters sdl_setObject:headLampStatus forName:SDLRPCParameterNameHeadLampStatus];
 }
 
 - (nullable NSNumber<SDLBool> *)headLampStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameHeadLampStatus ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameHeadLampStatus ofClass:NSNumber.class error:nil];
 }
 
 - (void)setEngineOilLife:(nullable NSNumber<SDLBool> *)engineOilLife {
-    [parameters sdl_setObject:engineOilLife forName:SDLRPCParameterNameEngineOilLife];
+    [self.parameters sdl_setObject:engineOilLife forName:SDLRPCParameterNameEngineOilLife];
 }
 
 - (nullable NSNumber<SDLBool> *)engineOilLife {
-    return [parameters sdl_objectForName:SDLRPCParameterNameEngineOilLife ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameEngineOilLife ofClass:NSNumber.class error:nil];
 }
 
 - (void)setEngineTorque:(nullable NSNumber<SDLBool> *)engineTorque {
-    [parameters sdl_setObject:engineTorque forName:SDLRPCParameterNameEngineTorque];
+    [self.parameters sdl_setObject:engineTorque forName:SDLRPCParameterNameEngineTorque];
 }
 
 - (nullable NSNumber<SDLBool> *)engineTorque {
-    return [parameters sdl_objectForName:SDLRPCParameterNameEngineTorque ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameEngineTorque ofClass:NSNumber.class error:nil];
 }
 
 - (void)setAccPedalPosition:(nullable NSNumber<SDLBool> *)accPedalPosition {
-    [parameters sdl_setObject:accPedalPosition forName:SDLRPCParameterNameAccelerationPedalPosition];
+    [self.parameters sdl_setObject:accPedalPosition forName:SDLRPCParameterNameAccelerationPedalPosition];
 }
 
 - (nullable NSNumber<SDLBool> *)accPedalPosition {
-    return [parameters sdl_objectForName:SDLRPCParameterNameAccelerationPedalPosition ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameAccelerationPedalPosition ofClass:NSNumber.class error:nil];
 }
 
 - (void)setSteeringWheelAngle:(nullable NSNumber<SDLBool> *)steeringWheelAngle {
-    [parameters sdl_setObject:steeringWheelAngle forName:SDLRPCParameterNameSteeringWheelAngle];
+    [self.parameters sdl_setObject:steeringWheelAngle forName:SDLRPCParameterNameSteeringWheelAngle];
 }
 
 - (nullable NSNumber<SDLBool> *)steeringWheelAngle {
-    return [parameters sdl_objectForName:SDLRPCParameterNameSteeringWheelAngle ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameSteeringWheelAngle ofClass:NSNumber.class error:nil];
 }
 
 - (void)setECallInfo:(nullable NSNumber<SDLBool> *)eCallInfo {
-    [parameters sdl_setObject:eCallInfo forName:SDLRPCParameterNameECallInfo];
+    [self.parameters sdl_setObject:eCallInfo forName:SDLRPCParameterNameECallInfo];
 }
 
 - (nullable NSNumber<SDLBool> *)eCallInfo {
-    return [parameters sdl_objectForName:SDLRPCParameterNameECallInfo ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameECallInfo ofClass:NSNumber.class error:nil];
 }
 
 - (void)setAirbagStatus:(nullable NSNumber<SDLBool> *)airbagStatus {
-    [parameters sdl_setObject:airbagStatus forName:SDLRPCParameterNameAirbagStatus];
+    [self.parameters sdl_setObject:airbagStatus forName:SDLRPCParameterNameAirbagStatus];
 }
 
 - (nullable NSNumber<SDLBool> *)airbagStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameAirbagStatus ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameAirbagStatus ofClass:NSNumber.class error:nil];
 }
 
 - (void)setEmergencyEvent:(nullable NSNumber<SDLBool> *)emergencyEvent {
-    [parameters sdl_setObject:emergencyEvent forName:SDLRPCParameterNameEmergencyEvent];
+    [self.parameters sdl_setObject:emergencyEvent forName:SDLRPCParameterNameEmergencyEvent];
 }
 
 - (nullable NSNumber<SDLBool> *)emergencyEvent {
-    return [parameters sdl_objectForName:SDLRPCParameterNameEmergencyEvent ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameEmergencyEvent ofClass:NSNumber.class error:nil];
 }
 
 - (void)setClusterModeStatus:(nullable NSNumber<SDLBool> *)clusterModeStatus {
-    [parameters sdl_setObject:clusterModeStatus forName:SDLRPCParameterNameClusterModeStatus];
+    [self.parameters sdl_setObject:clusterModeStatus forName:SDLRPCParameterNameClusterModeStatus];
 }
 
 - (nullable NSNumber<SDLBool> *)clusterModeStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameClusterModeStatus ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameClusterModeStatus ofClass:NSNumber.class error:nil];
 }
 
 - (void)setMyKey:(nullable NSNumber<SDLBool> *)myKey {
-    [parameters sdl_setObject:myKey forName:SDLRPCParameterNameMyKey];
+    [self.parameters sdl_setObject:myKey forName:SDLRPCParameterNameMyKey];
 }
 
 - (nullable NSNumber<SDLBool> *)myKey {
-    return [parameters sdl_objectForName:SDLRPCParameterNameMyKey ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameMyKey ofClass:NSNumber.class error:nil];
 }
 
 - (void)setElectronicParkBrakeStatus:(nullable NSNumber<SDLBool> *)electronicParkBrakeStatus {
-    [parameters sdl_setObject:electronicParkBrakeStatus forName:SDLRPCParameterNameElectronicParkBrakeStatus];
+    [self.parameters sdl_setObject:electronicParkBrakeStatus forName:SDLRPCParameterNameElectronicParkBrakeStatus];
 }
 
 - (nullable NSNumber<SDLBool> *)electronicParkBrakeStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameElectronicParkBrakeStatus ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameElectronicParkBrakeStatus ofClass:NSNumber.class error:nil];
 }
 
 - (void)setTurnSignal:(nullable NSNumber<SDLBool> *)turnSignal {
-    [parameters sdl_setObject:turnSignal forName:SDLRPCParameterNameTurnSignal];
+    [self.parameters sdl_setObject:turnSignal forName:SDLRPCParameterNameTurnSignal];
 }
 
 - (nullable NSNumber<SDLBool> *)turnSignal {
-    return [parameters sdl_objectForName:SDLRPCParameterNameTurnSignal ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameTurnSignal ofClass:NSNumber.class error:nil];
 }
 
 - (void)setCloudAppVehicleID:(nullable NSNumber<SDLBool> *)cloudAppVehicleID {
-    [parameters sdl_setObject:cloudAppVehicleID forName:SDLRPCParameterNameCloudAppVehicleID];
+    [self.parameters sdl_setObject:cloudAppVehicleID forName:SDLRPCParameterNameCloudAppVehicleID];
 }
 
 - (nullable NSNumber<SDLBool> *)cloudAppVehicleID {
-    return [parameters sdl_objectForName:SDLRPCParameterNameCloudAppVehicleID ofClass:NSNumber.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameCloudAppVehicleID ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLUnsubscribeVehicleDataResponse.m
+++ b/SmartDeviceLink/SDLUnsubscribeVehicleDataResponse.m
@@ -13,242 +13,245 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLUnsubscribeVehicleDataResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameUnsubscribeVehicleData]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (void)setGps:(nullable SDLVehicleDataResult *)gps {
-    [parameters sdl_setObject:gps forName:SDLRPCParameterNameGPS];
+    [self.parameters sdl_setObject:gps forName:SDLRPCParameterNameGPS];
 }
 
 - (nullable SDLVehicleDataResult *)gps {
-    return [parameters sdl_objectForName:SDLRPCParameterNameGPS ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameGPS ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setSpeed:(nullable SDLVehicleDataResult *)speed {
-    [parameters sdl_setObject:speed forName:SDLRPCParameterNameSpeed];
+    [self.parameters sdl_setObject:speed forName:SDLRPCParameterNameSpeed];
 }
 
 - (nullable SDLVehicleDataResult *)speed {
-    return [parameters sdl_objectForName:SDLRPCParameterNameSpeed ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameSpeed ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setRpm:(nullable SDLVehicleDataResult *)rpm {
-    [parameters sdl_setObject:rpm forName:SDLRPCParameterNameRPM];
+    [self.parameters sdl_setObject:rpm forName:SDLRPCParameterNameRPM];
 }
 
 - (nullable SDLVehicleDataResult *)rpm {
-    return [parameters sdl_objectForName:SDLRPCParameterNameRPM ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameRPM ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setFuelLevel:(nullable SDLVehicleDataResult *)fuelLevel {
-    [parameters sdl_setObject:fuelLevel forName:SDLRPCParameterNameFuelLevel];
+    [self.parameters sdl_setObject:fuelLevel forName:SDLRPCParameterNameFuelLevel];
 }
 
 - (nullable SDLVehicleDataResult *)fuelLevel {
-    return [parameters sdl_objectForName:SDLRPCParameterNameFuelLevel ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameFuelLevel ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setFuelLevel_State:(nullable SDLVehicleDataResult *)fuelLevel_State {
-    [parameters sdl_setObject:fuelLevel_State forName:SDLRPCParameterNameFuelLevelState];
+    [self.parameters sdl_setObject:fuelLevel_State forName:SDLRPCParameterNameFuelLevelState];
 }
 
 - (nullable SDLVehicleDataResult *)fuelLevel_State {
-    return [parameters sdl_objectForName:SDLRPCParameterNameFuelLevelState ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameFuelLevelState ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setFuelRange:(nullable SDLVehicleDataResult *)fuelRange {
-    [parameters sdl_setObject:fuelRange forName:SDLRPCParameterNameFuelRange];
+    [self.parameters sdl_setObject:fuelRange forName:SDLRPCParameterNameFuelRange];
 }
 
 - (nullable SDLVehicleDataResult *)fuelRange {
-    return [parameters sdl_objectForName:SDLRPCParameterNameFuelRange ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameFuelRange ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setInstantFuelConsumption:(nullable SDLVehicleDataResult *)instantFuelConsumption {
-    [parameters sdl_setObject:instantFuelConsumption forName:SDLRPCParameterNameInstantFuelConsumption];
+    [self.parameters sdl_setObject:instantFuelConsumption forName:SDLRPCParameterNameInstantFuelConsumption];
 }
 
 - (nullable SDLVehicleDataResult *)instantFuelConsumption {
-    return [parameters sdl_objectForName:SDLRPCParameterNameInstantFuelConsumption ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameInstantFuelConsumption ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setExternalTemperature:(nullable SDLVehicleDataResult *)externalTemperature {
-    [parameters sdl_setObject:externalTemperature forName:SDLRPCParameterNameExternalTemperature];
+    [self.parameters sdl_setObject:externalTemperature forName:SDLRPCParameterNameExternalTemperature];
 }
 
 - (nullable SDLVehicleDataResult *)externalTemperature {
-    return [parameters sdl_objectForName:SDLRPCParameterNameExternalTemperature ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameExternalTemperature ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setPrndl:(nullable SDLVehicleDataResult *)prndl {
-    [parameters sdl_setObject:prndl forName:SDLRPCParameterNamePRNDL];
+    [self.parameters sdl_setObject:prndl forName:SDLRPCParameterNamePRNDL];
 }
 
 - (nullable SDLVehicleDataResult *)prndl {
-    return [parameters sdl_objectForName:SDLRPCParameterNamePRNDL ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNamePRNDL ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setTirePressure:(nullable SDLVehicleDataResult *)tirePressure {
-    [parameters sdl_setObject:tirePressure forName:SDLRPCParameterNameTirePressure];
+    [self.parameters sdl_setObject:tirePressure forName:SDLRPCParameterNameTirePressure];
 }
 
 - (nullable SDLVehicleDataResult *)tirePressure {
-    return [parameters sdl_objectForName:SDLRPCParameterNameTirePressure ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameTirePressure ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setOdometer:(nullable SDLVehicleDataResult *)odometer {
-    [parameters sdl_setObject:odometer forName:SDLRPCParameterNameOdometer];
+    [self.parameters sdl_setObject:odometer forName:SDLRPCParameterNameOdometer];
 }
 
 - (nullable SDLVehicleDataResult *)odometer {
-    return [parameters sdl_objectForName:SDLRPCParameterNameOdometer ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameOdometer ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setBeltStatus:(nullable SDLVehicleDataResult *)beltStatus {
-    [parameters sdl_setObject:beltStatus forName:SDLRPCParameterNameBeltStatus];
+    [self.parameters sdl_setObject:beltStatus forName:SDLRPCParameterNameBeltStatus];
 }
 
 - (nullable SDLVehicleDataResult *)beltStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameBeltStatus ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameBeltStatus ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setBodyInformation:(nullable SDLVehicleDataResult *)bodyInformation {
-    [parameters sdl_setObject:bodyInformation forName:SDLRPCParameterNameBodyInformation];
+    [self.parameters sdl_setObject:bodyInformation forName:SDLRPCParameterNameBodyInformation];
 }
 
 - (nullable SDLVehicleDataResult *)bodyInformation {
-    return [parameters sdl_objectForName:SDLRPCParameterNameBodyInformation ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameBodyInformation ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setDeviceStatus:(nullable SDLVehicleDataResult *)deviceStatus {
-    [parameters sdl_setObject:deviceStatus forName:SDLRPCParameterNameDeviceStatus];
+    [self.parameters sdl_setObject:deviceStatus forName:SDLRPCParameterNameDeviceStatus];
 }
 
 - (nullable SDLVehicleDataResult *)deviceStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameDeviceStatus ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameDeviceStatus ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setDriverBraking:(nullable SDLVehicleDataResult *)driverBraking {
-    [parameters sdl_setObject:driverBraking forName:SDLRPCParameterNameDriverBraking];
+    [self.parameters sdl_setObject:driverBraking forName:SDLRPCParameterNameDriverBraking];
 }
 
 - (nullable SDLVehicleDataResult *)driverBraking {
-    return [parameters sdl_objectForName:SDLRPCParameterNameDriverBraking ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameDriverBraking ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setWiperStatus:(nullable SDLVehicleDataResult *)wiperStatus {
-    [parameters sdl_setObject:wiperStatus forName:SDLRPCParameterNameWiperStatus];
+    [self.parameters sdl_setObject:wiperStatus forName:SDLRPCParameterNameWiperStatus];
 }
 
 - (nullable SDLVehicleDataResult *)wiperStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameWiperStatus ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameWiperStatus ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setHeadLampStatus:(nullable SDLVehicleDataResult *)headLampStatus {
-    [parameters sdl_setObject:headLampStatus forName:SDLRPCParameterNameHeadLampStatus];
+    [self.parameters sdl_setObject:headLampStatus forName:SDLRPCParameterNameHeadLampStatus];
 }
 
 - (nullable SDLVehicleDataResult *)headLampStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameHeadLampStatus ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameHeadLampStatus ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setEngineOilLife:(nullable SDLVehicleDataResult *)engineOilLife {
-    [parameters sdl_setObject:engineOilLife forName:SDLRPCParameterNameEngineOilLife];
+    [self.parameters sdl_setObject:engineOilLife forName:SDLRPCParameterNameEngineOilLife];
 }
 
 - (nullable SDLVehicleDataResult *)engineOilLife {
-    return [parameters sdl_objectForName:SDLRPCParameterNameEngineOilLife ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameEngineOilLife ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setEngineTorque:(nullable SDLVehicleDataResult *)engineTorque {
-    [parameters sdl_setObject:engineTorque forName:SDLRPCParameterNameEngineTorque];
+    [self.parameters sdl_setObject:engineTorque forName:SDLRPCParameterNameEngineTorque];
 }
 
 - (nullable SDLVehicleDataResult *)engineTorque {
-    return [parameters sdl_objectForName:SDLRPCParameterNameEngineTorque ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameEngineTorque ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setAccPedalPosition:(nullable SDLVehicleDataResult *)accPedalPosition {
-    [parameters sdl_setObject:accPedalPosition forName:SDLRPCParameterNameAccelerationPedalPosition];
+    [self.parameters sdl_setObject:accPedalPosition forName:SDLRPCParameterNameAccelerationPedalPosition];
 }
 
 - (nullable SDLVehicleDataResult *)accPedalPosition {
-    return [parameters sdl_objectForName:SDLRPCParameterNameAccelerationPedalPosition ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameAccelerationPedalPosition ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setSteeringWheelAngle:(nullable SDLVehicleDataResult *)steeringWheelAngle {
-    [parameters sdl_setObject:steeringWheelAngle forName:SDLRPCParameterNameSteeringWheelAngle];
+    [self.parameters sdl_setObject:steeringWheelAngle forName:SDLRPCParameterNameSteeringWheelAngle];
 }
 
 - (nullable SDLVehicleDataResult *)steeringWheelAngle {
-    return [parameters sdl_objectForName:SDLRPCParameterNameSteeringWheelAngle ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameSteeringWheelAngle ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setECallInfo:(nullable SDLVehicleDataResult *)eCallInfo {
-    [parameters sdl_setObject:eCallInfo forName:SDLRPCParameterNameECallInfo];
+    [self.parameters sdl_setObject:eCallInfo forName:SDLRPCParameterNameECallInfo];
 }
 
 - (nullable SDLVehicleDataResult *)eCallInfo {
-    return [parameters sdl_objectForName:SDLRPCParameterNameECallInfo ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameECallInfo ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setAirbagStatus:(nullable SDLVehicleDataResult *)airbagStatus {
-    [parameters sdl_setObject:airbagStatus forName:SDLRPCParameterNameAirbagStatus];
+    [self.parameters sdl_setObject:airbagStatus forName:SDLRPCParameterNameAirbagStatus];
 }
 
 - (nullable SDLVehicleDataResult *)airbagStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameAirbagStatus ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameAirbagStatus ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setEmergencyEvent:(nullable SDLVehicleDataResult *)emergencyEvent {
-    [parameters sdl_setObject:emergencyEvent forName:SDLRPCParameterNameEmergencyEvent];
+    [self.parameters sdl_setObject:emergencyEvent forName:SDLRPCParameterNameEmergencyEvent];
 }
 
 - (nullable SDLVehicleDataResult *)emergencyEvent {
-    return [parameters sdl_objectForName:SDLRPCParameterNameEmergencyEvent ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameEmergencyEvent ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setClusterModes:(nullable SDLVehicleDataResult *)clusterModes {
-    [parameters sdl_setObject:clusterModes forName:SDLRPCParameterNameClusterModes];
+    [self.parameters sdl_setObject:clusterModes forName:SDLRPCParameterNameClusterModes];
 }
 
 - (nullable SDLVehicleDataResult *)clusterModes {
-    return [parameters sdl_objectForName:SDLRPCParameterNameClusterModes ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameClusterModes ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setMyKey:(nullable SDLVehicleDataResult *)myKey {
-    [parameters sdl_setObject:myKey forName:SDLRPCParameterNameMyKey];
+    [self.parameters sdl_setObject:myKey forName:SDLRPCParameterNameMyKey];
 }
 
 - (nullable SDLVehicleDataResult *)myKey {
-    return [parameters sdl_objectForName:SDLRPCParameterNameMyKey ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameMyKey ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setElectronicParkBrakeStatus:(nullable SDLVehicleDataResult *)electronicParkBrakeStatus {
-    [parameters sdl_setObject:electronicParkBrakeStatus forName:SDLRPCParameterNameElectronicParkBrakeStatus];
+    [self.parameters sdl_setObject:electronicParkBrakeStatus forName:SDLRPCParameterNameElectronicParkBrakeStatus];
 }
 
 - (nullable SDLVehicleDataResult *)electronicParkBrakeStatus {
-    return [parameters sdl_objectForName:SDLRPCParameterNameElectronicParkBrakeStatus ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameElectronicParkBrakeStatus ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setTurnSignal:(nullable SDLVehicleDataResult *)turnSignal {
-    [parameters sdl_setObject:turnSignal forName:SDLRPCParameterNameTurnSignal];
+    [self.parameters sdl_setObject:turnSignal forName:SDLRPCParameterNameTurnSignal];
 }
 
 - (nullable SDLVehicleDataResult *)turnSignal {
-    return [parameters sdl_objectForName:SDLRPCParameterNameTurnSignal ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameTurnSignal ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 - (void)setCloudAppVehicleID:(nullable SDLVehicleDataResult *)cloudAppVehicleID {
-    [parameters sdl_setObject:cloudAppVehicleID forName:SDLRPCParameterNameCloudAppVehicleID];
+    [self.parameters sdl_setObject:cloudAppVehicleID forName:SDLRPCParameterNameCloudAppVehicleID];
 }
 
 - (nullable SDLVehicleDataResult *)cloudAppVehicleID {
-    return [parameters sdl_objectForName:SDLRPCParameterNameCloudAppVehicleID ofClass:SDLVehicleDataResult.class error:nil];
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameCloudAppVehicleID ofClass:SDLVehicleDataResult.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLUnsubscribeWayPoints.m
+++ b/SmartDeviceLink/SDLUnsubscribeWayPoints.m
@@ -11,11 +11,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLUnsubscribeWayPoints
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameUnsubscribeWayPoints]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLUnsubscribeWayPointsResponse.m
+++ b/SmartDeviceLink/SDLUnsubscribeWayPointsResponse.m
@@ -11,11 +11,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLUnsubscribeWayPointsResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameUnsubscribeWayPoints]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLUpdateTurnList.m
+++ b/SmartDeviceLink/SDLUpdateTurnList.m
@@ -14,11 +14,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLUpdateTurnList
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameUpdateTurnList]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 - (instancetype)initWithTurnList:(nullable NSArray<SDLTurn *> *)turnList softButtons:(nullable NSArray<SDLSoftButton *> *)softButtons {
     self = [self init];
@@ -33,19 +36,19 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setTurnList:(nullable NSArray<SDLTurn *> *)turnList {
-    [parameters sdl_setObject:turnList forName:SDLRPCParameterNameTurnList];
+    [self.parameters sdl_setObject:turnList forName:SDLRPCParameterNameTurnList];
 }
 
 - (nullable NSArray<SDLTurn *> *)turnList {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameTurnList ofClass:SDLTurn.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameTurnList ofClass:SDLTurn.class error:nil];
 }
 
 - (void)setSoftButtons:(nullable NSArray<SDLSoftButton *> *)softButtons {
-    [parameters sdl_setObject:softButtons forName:SDLRPCParameterNameSoftButtons];
+    [self.parameters sdl_setObject:softButtons forName:SDLRPCParameterNameSoftButtons];
 }
 
 - (nullable NSArray<SDLSoftButton *> *)softButtons {
-    return [parameters sdl_objectsForName:SDLRPCParameterNameSoftButtons ofClass:SDLSoftButton.class error:nil];
+    return [self.parameters sdl_objectsForName:SDLRPCParameterNameSoftButtons ofClass:SDLSoftButton.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLUpdateTurnListResponse.m
+++ b/SmartDeviceLink/SDLUpdateTurnListResponse.m
@@ -12,11 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLUpdateTurnListResponse
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     if (self = [super initWithName:SDLRPCFunctionNameUpdateTurnList]) {
     }
     return self;
 }
+#pragma clang diagnostic pop
 
 @end
 

--- a/SmartDeviceLink/SDLVehicleDataResult.m
+++ b/SmartDeviceLink/SDLVehicleDataResult.m
@@ -11,21 +11,21 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation SDLVehicleDataResult
 
 - (void)setDataType:(SDLVehicleDataType)dataType {
-    [store sdl_setObject:dataType forName:SDLRPCParameterNameDataType];
+    [self.store sdl_setObject:dataType forName:SDLRPCParameterNameDataType];
 }
 
 - (SDLVehicleDataType)dataType {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameDataType error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameDataType error:&error];
 }
 
 - (void)setResultCode:(SDLVehicleDataResultCode)resultCode {
-    [store sdl_setObject:resultCode forName:SDLRPCParameterNameResultCode];
+    [self.store sdl_setObject:resultCode forName:SDLRPCParameterNameResultCode];
 }
 
 - (SDLVehicleDataResultCode)resultCode {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameResultCode error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameResultCode error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLVehicleType.m
+++ b/SmartDeviceLink/SDLVehicleType.m
@@ -12,35 +12,35 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation SDLVehicleType
 
 - (void)setMake:(nullable NSString *)make {
-    [store sdl_setObject:make forName:SDLRPCParameterNameMake];
+    [self.store sdl_setObject:make forName:SDLRPCParameterNameMake];
 }
 
 - (nullable NSString *)make {
-    return [store sdl_objectForName:SDLRPCParameterNameMake ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameMake ofClass:NSString.class error:nil];
 }
 
 - (void)setModel:(nullable NSString *)model {
-    [store sdl_setObject:model forName:SDLRPCParameterNameModel];
+    [self.store sdl_setObject:model forName:SDLRPCParameterNameModel];
 }
 
 - (nullable NSString *)model {
-    return [store sdl_objectForName:SDLRPCParameterNameModel ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameModel ofClass:NSString.class error:nil];
 }
 
 - (void)setModelYear:(nullable NSString *)modelYear {
-    [store sdl_setObject:modelYear forName:SDLRPCParameterNameModelYear];
+    [self.store sdl_setObject:modelYear forName:SDLRPCParameterNameModelYear];
 }
 
 - (nullable NSString *)modelYear {
-    return [store sdl_objectForName:SDLRPCParameterNameModelYear ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameModelYear ofClass:NSString.class error:nil];
 }
 
 - (void)setTrim:(nullable NSString *)trim {
-    [store sdl_setObject:trim forName:SDLRPCParameterNameTrim];
+    [self.store sdl_setObject:trim forName:SDLRPCParameterNameTrim];
 }
 
 - (nullable NSString *)trim {
-    return [store sdl_objectForName:SDLRPCParameterNameTrim ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameTrim ofClass:NSString.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLVideoStreamingCapability.m
+++ b/SmartDeviceLink/SDLVideoStreamingCapability.m
@@ -32,35 +32,35 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setPreferredResolution:(nullable SDLImageResolution *)preferredResolution {
-    [store sdl_setObject:preferredResolution forName:SDLRPCParameterNamePreferredResolution];
+    [self.store sdl_setObject:preferredResolution forName:SDLRPCParameterNamePreferredResolution];
 }
 
 - (nullable SDLImageResolution *)preferredResolution {
-    return [store sdl_objectForName:SDLRPCParameterNamePreferredResolution ofClass:SDLImageResolution.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNamePreferredResolution ofClass:SDLImageResolution.class error:nil];
 }
 
 - (void)setMaxBitrate:(nullable NSNumber<SDLInt> *)maxBitrate {
-    [store sdl_setObject:maxBitrate forName:SDLRPCParameterNameMaxBitrate];
+    [self.store sdl_setObject:maxBitrate forName:SDLRPCParameterNameMaxBitrate];
 }
 
 - (nullable NSNumber<SDLInt> *)maxBitrate {
-    return [store sdl_objectForName:SDLRPCParameterNameMaxBitrate ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameMaxBitrate ofClass:NSNumber.class error:nil];
 }
 
 - (void)setSupportedFormats:(nullable NSArray<SDLVideoStreamingFormat *> *)supportedFormats {
-    [store sdl_setObject:supportedFormats forName:SDLRPCParameterNameSupportedFormats];
+    [self.store sdl_setObject:supportedFormats forName:SDLRPCParameterNameSupportedFormats];
 }
 
 - (nullable NSArray<SDLVideoStreamingFormat *> *)supportedFormats {
-    return [store sdl_objectsForName:SDLRPCParameterNameSupportedFormats ofClass:SDLVideoStreamingFormat.class error:nil];
+    return [self.store sdl_objectsForName:SDLRPCParameterNameSupportedFormats ofClass:SDLVideoStreamingFormat.class error:nil];
 }
 
 - (void)setHapticSpatialDataSupported:(nullable NSNumber<SDLBool> *)hapticSpatialDataSupported {
-    [store sdl_setObject:hapticSpatialDataSupported forName:SDLRPCParameterNameHapticSpatialDataSupported];
+    [self.store sdl_setObject:hapticSpatialDataSupported forName:SDLRPCParameterNameHapticSpatialDataSupported];
 }
 
 - (nullable NSNumber<SDLBool> *)hapticSpatialDataSupported {
-    return [store sdl_objectForName:SDLRPCParameterNameHapticSpatialDataSupported ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameHapticSpatialDataSupported ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLVideoStreamingFormat.m
+++ b/SmartDeviceLink/SDLVideoStreamingFormat.m
@@ -26,20 +26,20 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (SDLVideoStreamingProtocol)protocol {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameVideoProtocol error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameVideoProtocol error:&error];
 }
 
 - (void)setProtocol:(SDLVideoStreamingProtocol)protocol {
-    [store sdl_setObject:protocol forName:SDLRPCParameterNameVideoProtocol];
+    [self.store sdl_setObject:protocol forName:SDLRPCParameterNameVideoProtocol];
 }
 
 - (SDLVideoStreamingCodec)codec {
     NSError *error = nil;
-    return [store sdl_enumForName:SDLRPCParameterNameVideoCodec error:&error];
+    return [self.store sdl_enumForName:SDLRPCParameterNameVideoCodec error:&error];
 }
 
 - (void)setCodec:(SDLVideoStreamingCodec)codec {
-    [store sdl_setObject:codec forName:SDLRPCParameterNameVideoCodec];
+    [self.store sdl_setObject:codec forName:SDLRPCParameterNameVideoCodec];
 }
 
 @end

--- a/SmartDeviceLink/SDLVrHelpItem.m
+++ b/SmartDeviceLink/SDLVrHelpItem.m
@@ -36,29 +36,29 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setText:(NSString *)text {
-    [store sdl_setObject:text forName:SDLRPCParameterNameText];
+    [self.store sdl_setObject:text forName:SDLRPCParameterNameText];
 }
 
 - (NSString *)text {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameText ofClass:NSString.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameText ofClass:NSString.class error:&error];
 }
 
 - (void)setImage:(nullable SDLImage *)image {
-    [store sdl_setObject:image forName:SDLRPCParameterNameImage];
+    [self.store sdl_setObject:image forName:SDLRPCParameterNameImage];
 }
 
 - (nullable SDLImage *)image {
-    return [store sdl_objectForName:SDLRPCParameterNameImage ofClass:SDLImage.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameImage ofClass:SDLImage.class error:nil];
 }
 
 - (void)setPosition:(NSNumber<SDLInt> *)position {
-    [store sdl_setObject:position forName:SDLRPCParameterNamePosition];
+    [self.store sdl_setObject:position forName:SDLRPCParameterNamePosition];
 }
 
 - (NSNumber<SDLInt> *)position {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNamePosition ofClass:NSNumber.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNamePosition ofClass:NSNumber.class error:&error];
 }
 
 @end

--- a/SmartDeviceLink/SDLWeatherAlert.m
+++ b/SmartDeviceLink/SDLWeatherAlert.m
@@ -32,51 +32,51 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setTitle:(nullable NSString *)title {
-    [store sdl_setObject:title forName:SDLRPCParameterNameTitle];
+    [self.store sdl_setObject:title forName:SDLRPCParameterNameTitle];
 }
 
 - (nullable NSString *)title {
-    return [store sdl_objectForName:SDLRPCParameterNameTitle ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameTitle ofClass:NSString.class error:nil];
 }
 
 - (void)setSummary:(nullable NSString *)summary {
-    [store sdl_setObject:summary forName:SDLRPCParameterNameSummary];
+    [self.store sdl_setObject:summary forName:SDLRPCParameterNameSummary];
 }
 
 - (nullable NSString *)summary {
-    return [store sdl_objectForName:SDLRPCParameterNameSummary ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameSummary ofClass:NSString.class error:nil];
 }
 
 - (void)setExpires:(nullable SDLDateTime *)expires {
-    [store sdl_setObject:expires forName:SDLRPCParameterNameExpires];
+    [self.store sdl_setObject:expires forName:SDLRPCParameterNameExpires];
 }
 
 - (nullable SDLDateTime *)expires {
-    return [store sdl_objectForName:SDLRPCParameterNameExpires ofClass:SDLDateTime.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameExpires ofClass:SDLDateTime.class error:nil];
 }
 
 - (void)setRegions:(nullable NSArray<NSString *> *)regions {
-    [store sdl_setObject:regions forName:SDLRPCParameterNameRegions];
+    [self.store sdl_setObject:regions forName:SDLRPCParameterNameRegions];
 }
 
 - (nullable NSArray<NSString *> *)regions {
-    return [store sdl_objectsForName:SDLRPCParameterNameRegions ofClass:NSString.class error:nil];
+    return [self.store sdl_objectsForName:SDLRPCParameterNameRegions ofClass:NSString.class error:nil];
 }
 
 - (void)setSeverity:(nullable NSString *)severity {
-    [store sdl_setObject:severity forName:SDLRPCParameterNameSeverity];
+    [self.store sdl_setObject:severity forName:SDLRPCParameterNameSeverity];
 }
 
 - (nullable NSString *)severity {
-    return [store sdl_objectForName:SDLRPCParameterNameSeverity ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameSeverity ofClass:NSString.class error:nil];
 }
 
 - (void)setTimeIssued:(nullable SDLDateTime *)timeIssued {
-    [store sdl_setObject:timeIssued forName:SDLRPCParameterNameTimeIssued];
+    [self.store sdl_setObject:timeIssued forName:SDLRPCParameterNameTimeIssued];
 }
 
 - (nullable SDLDateTime *)timeIssued {
-    return [store sdl_objectForName:SDLRPCParameterNameTimeIssued ofClass:SDLDateTime.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameTimeIssued ofClass:SDLDateTime.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLWeatherData.m
+++ b/SmartDeviceLink/SDLWeatherData.m
@@ -51,179 +51,179 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setCurrentTemperature:(nullable SDLTemperature *)currentTemperature {
-    [store sdl_setObject:currentTemperature forName:SDLRPCParameterNameCurrentTemperature];
+    [self.store sdl_setObject:currentTemperature forName:SDLRPCParameterNameCurrentTemperature];
 }
 
 - (nullable SDLTemperature *)currentTemperature {
-    return [store sdl_objectForName:SDLRPCParameterNameCurrentTemperature ofClass:SDLTemperature.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameCurrentTemperature ofClass:SDLTemperature.class error:nil];
 }
 
 - (void)setTemperatureHigh:(nullable SDLTemperature *)temperatureHigh {
-    [store sdl_setObject:temperatureHigh forName:SDLRPCParameterNameTemperatureHigh];
+    [self.store sdl_setObject:temperatureHigh forName:SDLRPCParameterNameTemperatureHigh];
 }
 
 - (nullable SDLTemperature *)temperatureHigh {
-    return [store sdl_objectForName:SDLRPCParameterNameTemperatureHigh ofClass:SDLTemperature.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameTemperatureHigh ofClass:SDLTemperature.class error:nil];
 }
 
 - (void)setTemperatureLow:(nullable SDLTemperature *)temperatureLow {
-    [store sdl_setObject:temperatureLow forName:SDLRPCParameterNameTemperatureLow];
+    [self.store sdl_setObject:temperatureLow forName:SDLRPCParameterNameTemperatureLow];
 }
 
 - (nullable SDLTemperature *)temperatureLow {
-    return [store sdl_objectForName:SDLRPCParameterNameTemperatureLow ofClass:SDLTemperature.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameTemperatureLow ofClass:SDLTemperature.class error:nil];
 }
 
 - (void)setApparentTemperature:(nullable SDLTemperature *)apparentTemperature {
-    [store sdl_setObject:apparentTemperature forName:SDLRPCParameterNameApparentTemperature];
+    [self.store sdl_setObject:apparentTemperature forName:SDLRPCParameterNameApparentTemperature];
 }
 
 - (nullable SDLTemperature *)apparentTemperature {
-    return [store sdl_objectForName:SDLRPCParameterNameApparentTemperature ofClass:SDLTemperature.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameApparentTemperature ofClass:SDLTemperature.class error:nil];
 }
 
 - (void)setApparentTemperatureHigh:(nullable SDLTemperature *)apparentTemperatureHigh {
-    [store sdl_setObject:apparentTemperatureHigh forName:SDLRPCParameterNameApparentTemperatureHigh];
+    [self.store sdl_setObject:apparentTemperatureHigh forName:SDLRPCParameterNameApparentTemperatureHigh];
 }
 
 - (nullable SDLTemperature *)apparentTemperatureHigh {
-    return [store sdl_objectForName:SDLRPCParameterNameApparentTemperatureHigh ofClass:SDLTemperature.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameApparentTemperatureHigh ofClass:SDLTemperature.class error:nil];
 }
 
 - (void)setApparentTemperatureLow:(nullable SDLTemperature *)apparentTemperatureLow {
-    [store sdl_setObject:apparentTemperatureLow forName:SDLRPCParameterNameApparentTemperatureLow];
+    [self.store sdl_setObject:apparentTemperatureLow forName:SDLRPCParameterNameApparentTemperatureLow];
 }
 
 - (nullable SDLTemperature *)apparentTemperatureLow {
-    return [store sdl_objectForName:SDLRPCParameterNameApparentTemperatureLow ofClass:SDLTemperature.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameApparentTemperatureLow ofClass:SDLTemperature.class error:nil];
 }
 
 - (void)setWeatherSummary:(nullable NSString *)weatherSummary {
-    [store sdl_setObject:weatherSummary forName:SDLRPCParameterNameWeatherSummary];
+    [self.store sdl_setObject:weatherSummary forName:SDLRPCParameterNameWeatherSummary];
 }
 
 - (nullable NSString *)weatherSummary {
-    return [store sdl_objectForName:SDLRPCParameterNameWeatherSummary ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameWeatherSummary ofClass:NSString.class error:nil];
 }
 
 - (void)setTime:(nullable SDLDateTime *)time {
-    [store sdl_setObject:time forName:SDLRPCParameterNameTime];
+    [self.store sdl_setObject:time forName:SDLRPCParameterNameTime];
 }
 
 - (nullable SDLDateTime *)time {
-    return [store sdl_objectForName:SDLRPCParameterNameTime ofClass:SDLDateTime.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameTime ofClass:SDLDateTime.class error:nil];
 }
 
 - (void)setHumidity:(nullable NSNumber<SDLFloat> *)humidity {
-    [store sdl_setObject:humidity forName:SDLRPCParameterNameHumidity];
+    [self.store sdl_setObject:humidity forName:SDLRPCParameterNameHumidity];
 }
 
 - (nullable NSNumber<SDLFloat> *)humidity {
-    return [store sdl_objectForName:SDLRPCParameterNameHumidity ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameHumidity ofClass:NSNumber.class error:nil];
 }
 
 - (void)setCloudCover:(nullable NSNumber<SDLFloat> *)cloudCover {
-    [store sdl_setObject:cloudCover forName:SDLRPCParameterNameCloudCover];
+    [self.store sdl_setObject:cloudCover forName:SDLRPCParameterNameCloudCover];
 }
 
 - (nullable NSNumber<SDLFloat> *)cloudCover {
-    return [store sdl_objectForName:SDLRPCParameterNameCloudCover ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameCloudCover ofClass:NSNumber.class error:nil];
 }
 
 - (void)setMoonPhase:(nullable NSNumber<SDLFloat> *)moonPhase {
-    [store sdl_setObject:moonPhase forName:SDLRPCParameterNameMoonPhase];
+    [self.store sdl_setObject:moonPhase forName:SDLRPCParameterNameMoonPhase];
 }
 
 - (nullable NSNumber<SDLFloat> *)moonPhase {
-    return [store sdl_objectForName:SDLRPCParameterNameMoonPhase ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameMoonPhase ofClass:NSNumber.class error:nil];
 }
 
 - (void)setWindBearing:(nullable NSNumber<SDLInt> *)windBearing {
-    [store sdl_setObject:windBearing forName:SDLRPCParameterNameWindBearing];
+    [self.store sdl_setObject:windBearing forName:SDLRPCParameterNameWindBearing];
 }
 
 - (nullable NSNumber<SDLInt> *)windBearing {
-    return [store sdl_objectForName:SDLRPCParameterNameWindBearing ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameWindBearing ofClass:NSNumber.class error:nil];
 }
 
 - (void)setWindGust:(nullable NSNumber<SDLFloat> *)windGust {
-    [store sdl_setObject:windGust forName:SDLRPCParameterNameWindGust];
+    [self.store sdl_setObject:windGust forName:SDLRPCParameterNameWindGust];
 }
 
 - (nullable NSNumber<SDLFloat> *)windGust {
-    return [store sdl_objectForName:SDLRPCParameterNameWindGust ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameWindGust ofClass:NSNumber.class error:nil];
 }
 
 - (void)setWindSpeed:(nullable NSNumber<SDLFloat> *)windSpeed {
-    [store sdl_setObject:windSpeed forName:SDLRPCParameterNameWindSpeed];
+    [self.store sdl_setObject:windSpeed forName:SDLRPCParameterNameWindSpeed];
 }
 
 - (nullable NSNumber<SDLFloat> *)windSpeed {
-    return [store sdl_objectForName:SDLRPCParameterNameWindSpeed ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameWindSpeed ofClass:NSNumber.class error:nil];
 }
 
 - (void)setNearestStormBearing:(nullable NSNumber<SDLInt> *)nearestStormBearing {
-    [store sdl_setObject:nearestStormBearing forName:SDLRPCParameterNameNearestStormBearing];
+    [self.store sdl_setObject:nearestStormBearing forName:SDLRPCParameterNameNearestStormBearing];
 }
 
 - (nullable NSNumber<SDLInt> *)nearestStormBearing {
-    return [store sdl_objectForName:SDLRPCParameterNameNearestStormBearing ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameNearestStormBearing ofClass:NSNumber.class error:nil];
 }
 
 - (void)setNearestStormDistance:(nullable NSNumber<SDLInt> *)nearestStormDistance {
-    [store sdl_setObject:nearestStormDistance forName:SDLRPCParameterNameNearestStormDistance];
+    [self.store sdl_setObject:nearestStormDistance forName:SDLRPCParameterNameNearestStormDistance];
 }
 
 - (nullable NSNumber<SDLInt> *)nearestStormDistance {
-    return [store sdl_objectForName:SDLRPCParameterNameNearestStormDistance ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameNearestStormDistance ofClass:NSNumber.class error:nil];
 }
 
 - (void)setPrecipAccumulation:(nullable NSNumber<SDLFloat> *)precipAccumulation {
-    [store sdl_setObject:precipAccumulation forName:SDLRPCParameterNamePrecipAccumulation];
+    [self.store sdl_setObject:precipAccumulation forName:SDLRPCParameterNamePrecipAccumulation];
 }
 
 - (nullable NSNumber<SDLFloat> *)precipAccumulation {
-    return [store sdl_objectForName:SDLRPCParameterNamePrecipAccumulation ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNamePrecipAccumulation ofClass:NSNumber.class error:nil];
 }
 
 - (void)setPrecipIntensity:(nullable NSNumber<SDLFloat> *)precipIntensity {
-    [store sdl_setObject:precipIntensity forName:SDLRPCParameterNamePrecipIntensity];
+    [self.store sdl_setObject:precipIntensity forName:SDLRPCParameterNamePrecipIntensity];
 }
 
 - (nullable NSNumber<SDLFloat> *)precipIntensity {
-    return [store sdl_objectForName:SDLRPCParameterNamePrecipIntensity ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNamePrecipIntensity ofClass:NSNumber.class error:nil];
 }
 
 - (void)setPrecipProbability:(nullable NSNumber<SDLFloat> *)precipProbability {
-    [store sdl_setObject:precipProbability forName:SDLRPCParameterNamePrecipProbability];
+    [self.store sdl_setObject:precipProbability forName:SDLRPCParameterNamePrecipProbability];
 }
 
 - (nullable NSNumber<SDLFloat> *)precipProbability {
-    return [store sdl_objectForName:SDLRPCParameterNamePrecipProbability ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNamePrecipProbability ofClass:NSNumber.class error:nil];
 }
 
 - (void)setPrecipType:(nullable NSString *)precipType {
-    [store sdl_setObject:precipType forName:SDLRPCParameterNamePrecipType];
+    [self.store sdl_setObject:precipType forName:SDLRPCParameterNamePrecipType];
 }
 
 - (nullable NSString *)precipType {
-    return [store sdl_objectForName:SDLRPCParameterNamePrecipType ofClass:NSString.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNamePrecipType ofClass:NSString.class error:nil];
 }
 
 - (void)setVisibility:(nullable NSNumber<SDLFloat> *)visibility {
-    [store sdl_setObject:visibility forName:SDLRPCParameterNameVisibility];
+    [self.store sdl_setObject:visibility forName:SDLRPCParameterNameVisibility];
 }
 
 - (nullable NSNumber<SDLFloat> *)visibility {
-    return [store sdl_objectForName:SDLRPCParameterNameVisibility ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameVisibility ofClass:NSNumber.class error:nil];
 }
 
 - (void)setWeatherIcon:(nullable SDLImage *)weatherIcon {
-    [store sdl_setObject:weatherIcon forName:SDLRPCParameterNameWeatherIcon];
+    [self.store sdl_setObject:weatherIcon forName:SDLRPCParameterNameWeatherIcon];
 }
 
 - (nullable SDLImage *)weatherIcon {
-    return [store sdl_objectForName:SDLRPCParameterNameWeatherIcon ofClass:SDLImage.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameWeatherIcon ofClass:SDLImage.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLWeatherServiceData.m
+++ b/SmartDeviceLink/SDLWeatherServiceData.m
@@ -42,52 +42,52 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setLocation:(SDLLocationDetails *)location {
-    [store sdl_setObject:location forName:SDLRPCParameterNameLocation];
+    [self.store sdl_setObject:location forName:SDLRPCParameterNameLocation];
 }
 
 - (SDLLocationDetails *)location {
     NSError *error = nil;
-    return [store sdl_objectForName:SDLRPCParameterNameLocation ofClass:SDLLocationDetails.class error:&error];
+    return [self.store sdl_objectForName:SDLRPCParameterNameLocation ofClass:SDLLocationDetails.class error:&error];
 }
 
 - (void)setCurrentForecast:(nullable SDLWeatherData *)currentForecast {
-    [store sdl_setObject:currentForecast forName:SDLRPCParameterNameCurrentForecast];
+    [self.store sdl_setObject:currentForecast forName:SDLRPCParameterNameCurrentForecast];
 }
 
 - (nullable SDLWeatherData *)currentForecast {
-    return [store sdl_objectForName:SDLRPCParameterNameCurrentForecast ofClass:SDLWeatherData.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameCurrentForecast ofClass:SDLWeatherData.class error:nil];
 }
 
 - (void)setMinuteForecast:(nullable NSArray<SDLWeatherData *> *)minuteForecast {
-    [store sdl_setObject:minuteForecast forName:SDLRPCParameterNameMinuteForecast];
+    [self.store sdl_setObject:minuteForecast forName:SDLRPCParameterNameMinuteForecast];
 }
 
 - (nullable NSArray<SDLWeatherData *> *)minuteForecast {
-    return [store sdl_objectsForName:SDLRPCParameterNameMinuteForecast ofClass:SDLWeatherData.class error:nil];
+    return [self.store sdl_objectsForName:SDLRPCParameterNameMinuteForecast ofClass:SDLWeatherData.class error:nil];
 }
 
 - (void)setHourlyForecast:(nullable NSArray<SDLWeatherData *> *)hourlyForecast {
-    [store sdl_setObject:hourlyForecast forName:SDLRPCParameterNameHourlyForecast];
+    [self.store sdl_setObject:hourlyForecast forName:SDLRPCParameterNameHourlyForecast];
 }
 
 - (nullable NSArray<SDLWeatherData *> *)hourlyForecast {
-    return [store sdl_objectsForName:SDLRPCParameterNameHourlyForecast ofClass:SDLWeatherData.class error:nil];
+    return [self.store sdl_objectsForName:SDLRPCParameterNameHourlyForecast ofClass:SDLWeatherData.class error:nil];
 }
 
 - (void)setMultidayForecast:(nullable NSArray<SDLWeatherData *> *)multidayForecast {
-    [store sdl_setObject:multidayForecast forName:SDLRPCParameterNameMultidayForecast];
+    [self.store sdl_setObject:multidayForecast forName:SDLRPCParameterNameMultidayForecast];
 }
 
 - (nullable NSArray<SDLWeatherData *> *)multidayForecast {
-    return [store sdl_objectsForName:SDLRPCParameterNameMultidayForecast ofClass:SDLWeatherData.class error:nil];
+    return [self.store sdl_objectsForName:SDLRPCParameterNameMultidayForecast ofClass:SDLWeatherData.class error:nil];
 }
 
 - (void)setAlerts:(nullable NSArray<SDLWeatherAlert *> *)alerts {
-    [store sdl_setObject:alerts forName:SDLRPCParameterNameAlerts];
+    [self.store sdl_setObject:alerts forName:SDLRPCParameterNameAlerts];
 }
 
 - (nullable NSArray<SDLWeatherAlert *> *)alerts {
-    return [store sdl_objectsForName:SDLRPCParameterNameAlerts ofClass:SDLWeatherAlert.class error:nil];
+    return [self.store sdl_objectsForName:SDLRPCParameterNameAlerts ofClass:SDLWeatherAlert.class error:nil];
 }
 
 @end

--- a/SmartDeviceLink/SDLWeatherServiceManifest.m
+++ b/SmartDeviceLink/SDLWeatherServiceManifest.m
@@ -31,43 +31,43 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setCurrentForecastSupported:(nullable NSNumber<SDLBool> *)currentForecastSupported {
-    [store sdl_setObject:currentForecastSupported forName:SDLRPCParameterNameCurrentForecastSupported];
+    [self.store sdl_setObject:currentForecastSupported forName:SDLRPCParameterNameCurrentForecastSupported];
 }
 
 - (nullable NSNumber<SDLBool> *)currentForecastSupported {
-    return [store sdl_objectForName:SDLRPCParameterNameCurrentForecastSupported ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameCurrentForecastSupported ofClass:NSNumber.class error:nil];
 }
 
 - (void)setMaxMultidayForecastAmount:(nullable NSNumber<SDLInt> *)maxMultidayForecastAmount {
-    [store sdl_setObject:maxMultidayForecastAmount forName:SDLRPCParameterNameMaxMultidayForecastAmount];
+    [self.store sdl_setObject:maxMultidayForecastAmount forName:SDLRPCParameterNameMaxMultidayForecastAmount];
 }
 
 - (nullable NSNumber<SDLInt> *)maxMultidayForecastAmount {
-    return [store sdl_objectForName:SDLRPCParameterNameMaxMultidayForecastAmount ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameMaxMultidayForecastAmount ofClass:NSNumber.class error:nil];
 }
 
 - (void)setMaxHourlyForecastAmount:(nullable NSNumber<SDLInt> *)maxHourlyForecastAmount {
-    [store sdl_setObject:maxHourlyForecastAmount forName:SDLRPCParameterNameMaxHourlyForecastAmount];
+    [self.store sdl_setObject:maxHourlyForecastAmount forName:SDLRPCParameterNameMaxHourlyForecastAmount];
 }
 
 - (nullable NSNumber<SDLInt> *)maxHourlyForecastAmount {
-    return [store sdl_objectForName:SDLRPCParameterNameMaxHourlyForecastAmount ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameMaxHourlyForecastAmount ofClass:NSNumber.class error:nil];
 }
 
 - (void)setMaxMinutelyForecastAmount:(nullable NSNumber<SDLInt> *)maxMinutelyForecastAmount {
-    [store sdl_setObject:maxMinutelyForecastAmount forName:SDLRPCParameterNameMaxMinutelyForecastAmount];
+    [self.store sdl_setObject:maxMinutelyForecastAmount forName:SDLRPCParameterNameMaxMinutelyForecastAmount];
 }
 
 - (nullable NSNumber<SDLInt> *)maxMinutelyForecastAmount {
-    return [store sdl_objectForName:SDLRPCParameterNameMaxMinutelyForecastAmount ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameMaxMinutelyForecastAmount ofClass:NSNumber.class error:nil];
 }
 
 - (void)setWeatherForLocationSupported:(nullable NSNumber<SDLBool> *)weatherForLocationSupported {
-    [store sdl_setObject:weatherForLocationSupported forName:SDLRPCParameterNameWeatherForLocationSupported];
+    [self.store sdl_setObject:weatherForLocationSupported forName:SDLRPCParameterNameWeatherForLocationSupported];
 }
 
 - (nullable NSNumber<SDLBool> *)weatherForLocationSupported {
-    return [store sdl_objectForName:SDLRPCParameterNameWeatherForLocationSupported ofClass:NSNumber.class error:nil];
+    return [self.store sdl_objectForName:SDLRPCParameterNameWeatherForLocationSupported ofClass:NSNumber.class error:nil];
 }
 
 @end

--- a/SmartDeviceLinkTests/DevAPISpecs/Notification Tests/SDLRPCNotificationNotificationSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/Notification Tests/SDLRPCNotificationNotificationSpec.m
@@ -21,7 +21,10 @@ describe(@"A request notification notification", ^{
     __block NSString *testName = nil;
 
     beforeEach(^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         testNotification = [[SDLOnCommand alloc] initWithName:@"testNotification"];
+#pragma clang diagnostic pop
         testName = SDLDidReceiveCommandNotification;
     });
 

--- a/SmartDeviceLinkTests/DevAPISpecs/Notification Tests/SDLRPCRequestNotificationSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/Notification Tests/SDLRPCRequestNotificationSpec.m
@@ -21,7 +21,10 @@ describe(@"A request notification", ^{
     __block NSString *testName = nil;
 
     beforeEach(^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         testRequest = [[SDLAddCommand alloc] initWithName:@"testRequest"];
+#pragma clang diagnostic pop
         testName = SDLDidReceiveAddCommandResponse;
     });
 

--- a/SmartDeviceLinkTests/DevAPISpecs/Notification Tests/SDLRPCResponseNotificationSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/Notification Tests/SDLRPCResponseNotificationSpec.m
@@ -20,7 +20,10 @@ describe(@"A response notification", ^{
     __block NSString *testName = nil;
 
     beforeEach(^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         testResponse = [[SDLAddCommandResponse alloc] initWithName:@"testResponse"];
+#pragma clang diagnostic pop
         testName = SDLDidReceiveAddCommandRequest;
     });
 

--- a/SmartDeviceLinkTests/ProtocolSpecs/MessageSpecs/SDLProtocolSpec.m
+++ b/SmartDeviceLinkTests/ProtocolSpecs/MessageSpecs/SDLProtocolSpec.m
@@ -215,7 +215,10 @@ describe(@"SendRPCRequest Tests", ^ {
     
     context(@"During V1 session", ^ {
         it(@"Should send the correct data", ^ {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             [[[[mockRequest stub] andReturn:dictionaryV1] ignoringNonObjectArgs] serializeAsDictionary:1];
+#pragma clang diagnostic pop
             
             SDLProtocol* testProtocol = [[SDLProtocol alloc] init];
             SDLV1ProtocolHeader *testHeader = [[SDLV1ProtocolHeader alloc] init];
@@ -252,9 +255,12 @@ describe(@"SendRPCRequest Tests", ^ {
     
     context(@"During V2 session", ^ {
         it(@"Should send the correct data bulk data when bulk data is available", ^ {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             [[[[mockRequest stub] andReturn:dictionaryV2] ignoringNonObjectArgs] serializeAsDictionary:2];
+#pragma clang diagnostic pop
             [[[mockRequest stub] andReturn:@0x98765] correlationID];
-            [[[mockRequest stub] andReturn:@"DeleteCommand"] getFunctionName];
+            [[[mockRequest stub] andReturn:@"DeleteCommand"] name];
             [[[mockRequest stub] andReturn:[NSData dataWithBytes:"COMMAND" length:strlen("COMMAND")]] bulkData];
             
             SDLProtocol* testProtocol = [[SDLProtocol alloc] init];

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnAppInterfaceUnregisteredSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnAppInterfaceUnregisteredSpec.m
@@ -29,7 +29,10 @@ describe(@"Getter/Setter Tests", ^ {
                                            @{SDLRPCParameterNameParameters:
                                                  @{SDLRPCParameterNameReason:SDLAppInterfaceUnregisteredReasonAppUnauthorized},
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnAppInterfaceUnregistered}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnAppInterfaceUnregistered* testNotification = [[SDLOnAppInterfaceUnregistered alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testNotification.reason).to(equal(SDLAppInterfaceUnregisteredReasonAppUnauthorized));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnAppServiceDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnAppServiceDataSpec.m
@@ -37,7 +37,10 @@ describe(@"Getter/Setter Tests", ^{
                                                SDLRPCParameterNameServiceData:testAppServiceData
                                                },
                                        SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnAppServiceData}};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnAppServiceData *testNotification = [[SDLOnAppServiceData alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testNotification.serviceData).to(equal(testAppServiceData));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnButtonEventSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnButtonEventSpec.m
@@ -37,7 +37,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                    SDLRPCParameterNameButtonEventMode:SDLButtonEventModeButtonDown,
                                                    SDLRPCParameterNameCustomButtonId:@4252},
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnButtonEvent}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnButtonEvent* testNotification = [[SDLOnButtonEvent alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testNotification.buttonName).to(equal(SDLButtonNameCustomButton));
         expect(testNotification.buttonEventMode).to(equal(SDLButtonEventModeButtonDown));

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnButtonPressSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnButtonPressSpec.m
@@ -37,7 +37,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                    SDLRPCParameterNameButtonPressMode:SDLButtonPressModeLong,
                                                    SDLRPCParameterNameCustomButtonId:@5642},
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnButtonPress}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnButtonPress* testNotification = [[SDLOnButtonPress alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testNotification.buttonName).to(equal(SDLButtonNameCustomButton));
         expect(testNotification.buttonPressMode).to(equal(SDLButtonPressModeLong));

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnCommandSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnCommandSpec.m
@@ -32,7 +32,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                  @{SDLRPCParameterNameCommandId:@5676544,
                                                    SDLRPCParameterNameTriggerSource:SDLTriggerSourceKeyboard},
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnCommand}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnCommand* testNotification = [[SDLOnCommand alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testNotification.cmdID).to(equal(@5676544));
         expect(testNotification.triggerSource).to(equal(SDLTriggerSourceKeyboard));

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnDriverDistractionSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnDriverDistractionSpec.m
@@ -29,7 +29,10 @@ describe(@"Getter/Setter Tests", ^ {
                                            @{SDLRPCParameterNameParameters:
                                                  @{SDLRPCParameterNameState:SDLDriverDistractionStateOn},
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnDriverDistraction}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnDriverDistraction* testNotification = [[SDLOnDriverDistraction alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testNotification.state).to(equal(SDLDriverDistractionStateOn));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnEncodedSyncPDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnEncodedSyncPDataSpec.m
@@ -34,7 +34,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                                    SDLRPCParameterNameURLUppercase:@"www.zombo.com",
                                                                    SDLRPCParameterNameTimeoutCapitalized:@564},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnEncodedSyncPData}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnEncodedSyncPData* testNotification = [[SDLOnEncodedSyncPData alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testNotification.data).to(equal([@[@"0"] mutableCopy]));
         expect(testNotification.URL).to(equal(@"www.zombo.com"));

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnHMIStatusSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnHMIStatusSpec.m
@@ -41,7 +41,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                    SDLRPCParameterNameSystemContext: SDLSystemContextHMIObscured,
                                                    SDLRPCParameterNameVideoStreamingState: SDLVideoStreamingStateStreamable},
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnHMIStatus}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnHMIStatus* testNotification = [[SDLOnHMIStatus alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testNotification.hmiLevel).to(equal(SDLHMILevelLimited));
         expect(testNotification.audioStreamingState).to(equal(SDLAudioStreamingStateAttenuated));

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnHashChangeSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnHashChangeSpec.m
@@ -28,7 +28,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                            @{SDLRPCParameterNameParameters:
                                                                  @{SDLRPCParameterNameHashId:@"hash"},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnHashChange}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnHashChange* testNotification = [[SDLOnHashChange alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testNotification.hashID).to(equal(@"hash"));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnInteriorVehicleDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnInteriorVehicleDataSpec.m
@@ -35,7 +35,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                            @{SDLRPCParameterNameParameters:
                                                                  @{SDLRPCParameterNameModuleData:someModuleData},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnInteriorVehicleData}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnInteriorVehicleData* testNotification = [[SDLOnInteriorVehicleData alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testNotification.moduleData).to(equal(someModuleData));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnKeyboardInputSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnKeyboardInputSpec.m
@@ -32,7 +32,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                  @{SDLRPCParameterNameEvent:SDLKeyboardEventSubmitted,
                                                    SDLRPCParameterNameData:@"qwertyg"},
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnKeyboardInput}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnKeyboardInput* testNotification = [[SDLOnKeyboardInput alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testNotification.event).to(equal(SDLKeyboardEventSubmitted));
         expect(testNotification.data).to(equal(@"qwertyg"));

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnLanguageChangeSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnLanguageChangeSpec.m
@@ -33,7 +33,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                  @{SDLRPCParameterNameLanguage:SDLLanguageEsEs,
                                                    SDLRPCParameterNameHMIDisplayLanguage:SDLLanguageDeDe},
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnLanguageChange}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnLanguageChange* testNotification = [[SDLOnLanguageChange alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testNotification.language).to(equal(SDLLanguageEsEs));
         expect(testNotification.hmiDisplayLanguage).to(equal(SDLLanguageDeDe));

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnLockScreenStatusSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnLockScreenStatusSpec.m
@@ -39,7 +39,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                    @"OnLockScreenStatus":SDLLockScreenStatusRequired,
                                                    @"hmiLevel":SDLHMILevelNone},
                                              SDLRPCParameterNameOperationName:@"OnLockScreenStatus"}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnLockScreenStatus* testNotification = [[SDLOnLockScreenStatus alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testNotification.driverDistractionStatus).to(equal(@NO));
         expect(testNotification.userSelected).to(equal(@3));

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnPermissionsChangeSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnPermissionsChangeSpec.m
@@ -31,7 +31,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                            @{SDLRPCParameterNameParameters:
                                                                  @{SDLRPCParameterNamePermissionItem:[@[item] mutableCopy]},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnPermissionsChange}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnPermissionsChange* testNotification = [[SDLOnPermissionsChange alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testNotification.permissionItem).to(equal([@[item] mutableCopy]));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnRCStatusSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnRCStatusSpec.m
@@ -36,7 +36,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                                    SDLRPCParameterNameAllowed:@YES
                                                                    },
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnRCStatus}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnRCStatus* testNotification = [[SDLOnRCStatus alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testNotification.allowed).to(equal(@YES));
         expect(testNotification.allocatedModules).to(equal([@[allocatedModule] copy]));

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnSyncPDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnSyncPDataSpec.m
@@ -31,7 +31,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                                  @{SDLRPCParameterNameURLUppercase:@"https://www.youtube.com/watch?v=ygr5AHufBN4",
                                                                    SDLRPCParameterNameTimeoutCapitalized:@8357},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnSyncPData}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnSyncPData* testNotification = [[SDLOnSyncPData alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testNotification.URL).to(equal(@"https://www.youtube.com/watch?v=ygr5AHufBN4"));
         expect(testNotification.Timeout).to(equal(@8357));

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnSystemCapabilityUpdatedSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnSystemCapabilityUpdatedSpec.m
@@ -38,7 +38,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                SDLRPCParameterNameSystemCapability:testSystemCapability
                                                },
                                        SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnSystemCapabilityUpdated}};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnSystemCapabilityUpdated *testNotification = [[SDLOnSystemCapabilityUpdated alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testNotification.systemCapability).to(equal(testSystemCapability));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnSystemRequestSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnSystemRequestSpec.m
@@ -49,7 +49,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                    SDLRPCParameterNameOffset:@2532678684,
                                                    SDLRPCParameterNameLength:@50000000000},
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnSystemRequest}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnSystemRequest* testNotification = [[SDLOnSystemRequest alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testNotification.requestType).to(equal(SDLRequestTypeFileResume));
         expect(testNotification.requestSubType).to(equal(@"subtype"));

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnTBTClientStateSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnTBTClientStateSpec.m
@@ -30,7 +30,10 @@ describe(@"Getter/Setter Tests", ^ {
                                            @{SDLRPCParameterNameParameters:
                                                  @{SDLRPCParameterNameState:SDLTBTStateETARequest},
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnTBTClientState}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnTBTClientState* testNotification = [[SDLOnTBTClientState alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testNotification.state).to(equal(SDLTBTStateETARequest));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnTouchEventSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnTouchEventSpec.m
@@ -36,7 +36,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                  @{SDLRPCParameterNameType:SDLTouchTypeBegin,
                                                    SDLRPCParameterNameEvent:[@[event] mutableCopy]},
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnTouchEvent}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnTouchEvent* testNotification = [[SDLOnTouchEvent alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testNotification.type).to(equal(SDLTouchTypeBegin));
         expect(testNotification.event).to(equal([@[event] mutableCopy]));

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnVehicleDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnVehicleDataSpec.m
@@ -146,7 +146,10 @@ describe(@"Getter/Setter Tests", ^ {
                                            SDLRPCParameterNameVIN:@"222222222722",
                                            SDLRPCParameterNameWiperStatus:SDLWiperStatusStalled},
                                      SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnVehicleData}};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnVehicleData* testNotification = [[SDLOnVehicleData alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testNotification.accPedalPosition).to(equal(@99.99999999));
         expect(testNotification.airbagStatus).to(equal(airbag));

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnWaypointChangeSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnWaypointChangeSpec.m
@@ -71,8 +71,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                    },
                                            SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnWayPointChange
                                            };
-                
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 testNotification = [[SDLOnWayPointChange alloc] initWithDictionary:[NSMutableDictionary dictionaryWithDictionary:initDict]];
+#pragma clang diagnostic pop
             });
             
             // Since all the properties are immutable, a copy should be executed as a retain, which means they should be identical
@@ -89,8 +91,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                    SDLRPCParameterNameParameters: @{}
                                                    }
                                            };
-                
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 testNotification = [[SDLOnWayPointChange alloc] initWithDictionary:[NSMutableDictionary dictionaryWithDictionary:initDict]];
+#pragma clang diagnostic pop
             });
             
             it(@"should return nil for waypoints", ^{

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLAddCommandSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLAddCommandSpec.m
@@ -42,9 +42,11 @@ describe(@"Getter/Setter Tests", ^ {
                                                                   SDLRPCParameterNameVRCommands:[@[@"name", @"anotherName"] mutableCopy],
                                                                   SDLRPCParameterNameCommandIcon:image},
                                                             SDLRPCParameterNameOperationName:SDLRPCFunctionNameAddCommand}} mutableCopy];
-
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLAddCommand* testRequest = [[SDLAddCommand alloc] initWithDictionary:dict];
-        
+#pragma clang diagnostic pop
+
         expect(testRequest.cmdID).to(equal(@434577));
         expect(testRequest.menuParams).to(equal(menu));
         expect(testRequest.vrCommands).to(equal([@[@"name", @"anotherName"] mutableCopy]));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLAddSubMenuSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLAddSubMenuSpec.m
@@ -80,7 +80,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                                            }
                                                                    },
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameAddSubMenu}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLAddSubMenu* testRequest = [[SDLAddSubMenu alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testRequest.menuID).to(equal(@(menuId)));
         expect(testRequest.position).to(equal(@(position)));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLAlertManeuverSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLAlertManeuverSpec.m
@@ -36,7 +36,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                                  @{SDLRPCParameterNameTTSChunks:[@[tts] mutableCopy],
                                                                    SDLRPCParameterNameSoftButtons:[@[button] mutableCopy]},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameAlertManeuver}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLAlertManeuver* testRequest = [[SDLAlertManeuver alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testRequest.ttsChunks).to(equal([@[tts] mutableCopy]));
         expect(testRequest.softButtons).to(equal([@[button] mutableCopy]));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLAlertSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLAlertSpec.m
@@ -54,7 +54,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                                    SDLRPCParameterNameProgressIndicator:@NO,
                                                                    SDLRPCParameterNameSoftButtons:[@[button] mutableCopy]},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameAlert}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLAlert* testRequest = [[SDLAlert alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testRequest.alertText1).to(equal(@"alert#1"));
         expect(testRequest.alertText2).to(equal(@"alert#2"));
@@ -78,7 +81,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                    SDLRPCParameterNameProgressIndicator:@NO,
                                                    SDLRPCParameterNameSoftButtons:[NSNull null]},
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameAlert}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLAlert* testRequest = [[SDLAlert alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         expectAction(^{
             NSArray<SDLSoftButton *> *softButtons = testRequest.softButtons;
         }).to(raiseException());

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLButtonPressSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLButtonPressSpec.m
@@ -38,7 +38,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                                    SDLRPCParameterNameButtonName : SDLButtonNameAC,
                                                                    SDLRPCParameterNameButtonPressMode : SDLButtonPressModeShort},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameButtonPress}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLButtonPress* testRequest = [[SDLButtonPress alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testRequest.moduleType).to(equal(SDLModuleTypeClimate));
         expect(testRequest.buttonName).to(equal(SDLButtonNameAC));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLChangeRegistrationSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLChangeRegistrationSpec.m
@@ -122,8 +122,10 @@ describe(@"change registration", ^ {
                                                                            SDLRPCParameterNameNGNMediaScreenAppName:someNGNMediaAppName,
                                                                            SDLRPCParameterNameVRSynonyms:someVRSynonyms},
                                                                      SDLRPCParameterNameOperationName:SDLRPCFunctionNameChangeRegistration}} mutableCopy];
-                
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 testRequest = [[SDLChangeRegistration alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
             });
             
             // Since the properties are immutable, a copy should be executed as a retain, so they should be identical
@@ -154,7 +156,10 @@ describe(@"change registration", ^ {
         
         context(@"when no parameters are set", ^{
             beforeEach(^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 testRequest = [[SDLChangeRegistration alloc] initWithDictionary:[NSMutableDictionary dictionary]];
+#pragma clang diagnostic pop
             });
             
             it(@"Should return nil if for language", ^ {

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLCreateInteractionChoiceSetSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLCreateInteractionChoiceSetSpec.m
@@ -34,7 +34,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                                  @{SDLRPCParameterNameInteractionChoiceSetId:@141414,
                                                                    SDLRPCParameterNameChoiceSet:[@[choice] mutableCopy]},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameCreateInteractionChoiceSet}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLCreateInteractionChoiceSet* testRequest = [[SDLCreateInteractionChoiceSet alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testRequest.interactionChoiceSetID).to(equal(@141414));
         expect(testRequest.choiceSet).to(equal([@[choice] mutableCopy]));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLDeleteCommandSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLDeleteCommandSpec.m
@@ -28,7 +28,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                            @{SDLRPCParameterNameParameters:
                                                                  @{SDLRPCParameterNameCommandId:@11223344},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameDeleteCommand}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLDeleteCommand* testRequest = [[SDLDeleteCommand alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testRequest.cmdID).to(equal(@11223344));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLDeleteFileSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLDeleteFileSpec.m
@@ -28,7 +28,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                            @{SDLRPCParameterNameParameters:
                                                                  @{SDLRPCParameterNameSyncFileName:@"synchro"},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameDeleteFile}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLDeleteFile* testRequest = [[SDLDeleteFile alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testRequest.syncFileName).to(equal(@"synchro"));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLDeleteInteractionChoiceSetSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLDeleteInteractionChoiceSetSpec.m
@@ -28,7 +28,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                            @{SDLRPCParameterNameParameters:
                                                                  @{SDLRPCParameterNameInteractionChoiceSetId:@20314},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameDeleteInteractionChoiceSet}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLDeleteInteractionChoiceSet* testRequest = [[SDLDeleteInteractionChoiceSet alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testRequest.interactionChoiceSetID).to(equal(@20314));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLDeleteSubMenuSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLDeleteSubMenuSpec.m
@@ -28,7 +28,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                            @{SDLRPCParameterNameParameters:
                                                                  @{SDLRPCParameterNameMenuId:@25614},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameDeleteSubMenu}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLDeleteSubMenu* testRequest = [[SDLDeleteSubMenu alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testRequest.menuID).to(equal(@25614));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLDiagnosticMessageSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLDiagnosticMessageSpec.m
@@ -34,7 +34,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                                    SDLRPCParameterNameMessageLength:@55555,
                                                                    SDLRPCParameterNameMessageData:[@[@1, @4, @16, @64] mutableCopy]},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameDiagnosticMessage}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLDiagnosticMessage* testRequest = [[SDLDiagnosticMessage alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testRequest.targetID).to(equal(@3562));
         expect(testRequest.messageLength).to(equal(@55555));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLDialNumberSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLDialNumberSpec.m
@@ -49,8 +49,10 @@ describe(@"Dial Number RPC", ^{
                                                        }
                                                }
                                        };
-            
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             testRequest = [[SDLDialNumber alloc] initWithDictionary:[initDict mutableCopy]];
+#pragma clang diagnostic pop
         });
         
         it(@"should get 'number' correctly", ^{
@@ -67,8 +69,10 @@ describe(@"Dial Number RPC", ^{
                                                        }
                                                }
                                        };
-            
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             testRequest = [[SDLDialNumber alloc] initWithDictionary:[initDict mutableCopy]];
+#pragma clang diagnostic pop
         });
         
         it(@"should return nil for number", ^{

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLEncodedSyncPDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLEncodedSyncPDataSpec.m
@@ -28,7 +28,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                            @{SDLRPCParameterNameParameters:
                                                                  @{SDLRPCParameterNameData:[@[@"2", @"2", @"2"] mutableCopy]},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameEncodedSyncPData}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLEncodedSyncPData* testRequest = [[SDLEncodedSyncPData alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testRequest.data).to(equal([@[@"2", @"2", @"2"] mutableCopy]));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetAppServiceDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetAppServiceDataSpec.m
@@ -43,7 +43,10 @@ describe(@"Getter/Setter Tests", ^{
                                                SDLRPCParameterNameSubscribe:@(testSubscribe)
                                                },
                                        SDLRPCParameterNameOperationName:SDLRPCFunctionNameGetAppServiceData}};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLGetAppServiceData *testRequest = [[SDLGetAppServiceData alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testRequest.serviceType).to(equal(testServiceType));
         expect(testRequest.subscribe).to(beTrue());

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetCloudAppPropertiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetCloudAppPropertiesSpec.m
@@ -37,10 +37,12 @@ describe(@"Getter/Setter Tests", ^{
                                                SDLRPCParameterNameAppId:testAppID
                                                },
                                        SDLRPCParameterNameOperationName:SDLRPCFunctionNameGetCloudAppProperties}};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLGetCloudAppProperties *testRequest = [[SDLGetCloudAppProperties alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testRequest.appID).to(equal(testAppID));
-        expect(testRequest.getFunctionName).to(equal(SDLRPCFunctionNameGetCloudAppProperties));
     });
 
     it(@"Should initialize correctly with the convenience init", ^{

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetDTCsSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetDTCsSpec.m
@@ -31,7 +31,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                                  @{SDLRPCParameterNameECUName:@4321,
                                                                    SDLRPCParameterNameDTCMask:@22},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameEndAudioPassThru}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLGetDTCs* testRequest = [[SDLGetDTCs alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testRequest.ecuName).to(equal(@4321));
         expect(testRequest.dtcMask).to(equal(@22));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetFileSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetFileSpec.m
@@ -54,7 +54,10 @@ describe(@"Getter/Setter Tests", ^{
                                                SDLRPCParameterNameLength:@(testLength)
                                                },
                                        SDLRPCParameterNameOperationName:SDLRPCFunctionNameGetFile}};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLGetFile *testRequest = [[SDLGetFile alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testRequest.fileName).to(equal(testFileName));
         expect(testRequest.appServiceId).to(equal(testAppServiceId));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetInteriorVehicleDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetInteriorVehicleDataSpec.m
@@ -31,7 +31,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                                  @{SDLRPCParameterNameModuleType : SDLModuleTypeRadio,
                                                                    SDLRPCParameterNameSubscribe : @YES},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameGetInteriorVehicleData}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLGetInteriorVehicleData* testRequest = [[SDLGetInteriorVehicleData alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testRequest.moduleType).to(equal(SDLModuleTypeRadio));
         expect(testRequest.subscribe).to(equal(@YES));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetSystemCapabilitiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetSystemCapabilitiesSpec.m
@@ -28,7 +28,10 @@ describe(@"Initialization tests", ^{
                                                }
                                        }
                                };
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLGetSystemCapability *testRequest = [[SDLGetSystemCapability alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testRequest.systemCapabilityType).to(equal(SDLSystemCapabilityTypePhoneCall));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetSystemCapabilitySpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetSystemCapabilitySpec.m
@@ -49,7 +49,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                    SDLRPCParameterNameSubscribe:@(testSubcribe)
                                                    },
                                            SDLRPCParameterNameOperationName:SDLRPCFunctionNameGetSystemCapability}};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             SDLGetSystemCapability *testRequest = [[SDLGetSystemCapability alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
             expect(testRequest.systemCapabilityType).to(equal(testSystemCapabilityType));
             expect(testRequest.subscribe).to(beFalse());

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetVehicleDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetVehicleDataSpec.m
@@ -112,7 +112,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                                    SDLRPCParameterNameTurnSignal:@NO,
                                                                    SDLRPCParameterNameWiperStatus:@YES},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameGetVehicleData}};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLGetVehicleData* testRequest = [[SDLGetVehicleData alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testRequest.accPedalPosition).to(equal(@YES));
         expect(testRequest.airbagStatus).to(equal(@YES));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetWaypointsSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetWaypointsSpec.m
@@ -28,7 +28,10 @@ describe(@"Getter/Setter Tests", ^ {
                                            @{SDLRPCParameterNameParameters:
                                                  @{SDLRPCParameterNameWayPointType:SDLWayPointTypeAll},
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameGetWayPoints}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLGetWayPoints* testRequest = [[SDLGetWayPoints alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testRequest.waypointType).to(equal(SDLWayPointTypeAll));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLPerformAppServiceInteractionSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLPerformAppServiceInteractionSpec.m
@@ -50,7 +50,10 @@ describe(@"Getter/Setter Tests", ^{
                                                SDLRPCParameterNameRequestServiceActive:@(testRequestServiceActive)
                                                },
                                        SDLRPCParameterNameOperationName:SDLRPCFunctionNamePerformAppServiceInteraction}};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLPerformAppServiceInteraction *testRequest = [[SDLPerformAppServiceInteraction alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testRequest.serviceUri).to(equal(testServiceUri));
         expect(testRequest.serviceID).to(equal(testServiceID));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLPerformAudioPassThruSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLPerformAudioPassThruSpec.m
@@ -50,7 +50,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                    SDLRPCParameterNameAudioType:SDLAudioTypePCM,
                                                    SDLRPCParameterNameMuteAudio:@NO},
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNamePerformAudioPassThru}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLPerformAudioPassThru* testRequest = [[SDLPerformAudioPassThru alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testRequest.audioPassThruDisplayText1).to(equal(@"passthru#1"));
         expect(testRequest.audioPassThruDisplayText2).to(equal(@"passthru#2"));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLPerformInteractionSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLPerformInteractionSpec.m
@@ -61,7 +61,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                    SDLRPCParameterNameVRHelp:[@[helpItem] mutableCopy],
                                                    SDLRPCParameterNameInteractionLayout:SDLLayoutModeIconWithSearch},
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNamePerformInteraction}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLPerformInteraction* testRequest = [[SDLPerformInteraction alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testRequest.initialText).to(equal(@"a"));
         expect(testRequest.initialPrompt).to(equal([@[chunk1] mutableCopy]));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLPublishAppServiceSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLPublishAppServiceSpec.m
@@ -43,7 +43,10 @@ describe(@"Getter/Setter Tests", ^{
                                                    SDLRPCParameterNameAppServiceManifest:testAppServiceManifest
                                                    },
                                            SDLRPCParameterNameOperationName:SDLRPCFunctionNamePublishAppService}};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             SDLPublishAppService *testRequest = [[SDLPublishAppService alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
             expect(testRequest.appServiceManifest).to(equal(testAppServiceManifest));
         });

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLPutFileSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLPutFileSpec.m
@@ -54,7 +54,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                     SDLRPCParameterNameLength:@123456789,
                                                    SDLRPCParameterNameCRC:@0xffffffff},
                                                     SDLRPCParameterNameOperationName:SDLRPCFunctionNamePutFile}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLPutFile* testRequest = [[SDLPutFile alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testRequest.syncFileName).to(equal(@"fileName"));
         expect(testRequest.fileType).to(equal(SDLFileTypeJPEG));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLReadDIDSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLReadDIDSpec.m
@@ -31,7 +31,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                                  @{SDLRPCParameterNameECUName:@33112,
                                                                    SDLRPCParameterNameDIDLocation:[@[@200, @201, @205] mutableCopy]},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameEndAudioPassThru}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLReadDID* testRequest = [[SDLReadDID alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testRequest.ecuName).to(equal(@33112));
         expect(testRequest.didLocation).to(equal([@[@200, @201, @205] mutableCopy]));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLRegisterAppInterfaceSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLRegisterAppInterfaceSpec.m
@@ -113,7 +113,10 @@ describe(@"RegisterAppInterface Tests", ^{
                                                    SDLRPCParameterNameNightColorScheme: colorScheme,
                                                    },
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameRegisterAppInterface}};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLRegisterAppInterface* testRegisterAppInterface = [[SDLRegisterAppInterface alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testRegisterAppInterface.syncMsgVersion).to(equal(version));
         expect(testRegisterAppInterface.appName).to(match(appName));
@@ -211,7 +214,10 @@ describe(@"RegisterAppInterface Tests", ^{
         });
 
         it(@"initWithAppName:appId:languageDesired:isMediaApp:appTypes:shortAppName:", ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             SDLRegisterAppInterface *testRegisterAppInterface = [[SDLRegisterAppInterface alloc] initWithAppName:appName appId:appId languageDesired:language isMediaApp:isMediaApp appTypes:appTypes shortAppName:shortAppName];
+#pragma clang diagnostic pop
 
             expect(testRegisterAppInterface.fullAppID).to(beNil());
             expect(testRegisterAppInterface.appID).to(match(appId));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLResetGlobalPropertiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLResetGlobalPropertiesSpec.m
@@ -29,7 +29,10 @@ describe(@"Getter/Setter Tests", ^ {
                                            @{SDLRPCParameterNameParameters:
                                                  @{SDLRPCParameterNameProperties:[@[SDLGlobalPropertyMenuName, SDLGlobalPropertyVoiceRecognitionHelpTitle] copy]},
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameResetGlobalProperties}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLResetGlobalProperties* testRequest = [[SDLResetGlobalProperties alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testRequest.properties).to(equal([@[SDLGlobalPropertyMenuName, SDLGlobalPropertyVoiceRecognitionHelpTitle] copy]));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLScrollableMessageSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLScrollableMessageSpec.m
@@ -37,7 +37,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                                    SDLRPCParameterNameTimeout:@9182,
                                                                    SDLRPCParameterNameSoftButtons:[@[button] mutableCopy]},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameScrollableMessage}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLScrollableMessage* testRequest = [[SDLScrollableMessage alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testRequest.scrollableMessageBody).to(equal(@"thatmessagebody"));
         expect(testRequest.timeout).to(equal(@9182));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSendHapticDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSendHapticDataSpec.m
@@ -41,7 +41,10 @@ describe(@"Initialization Tests", ^ {
                                                @{SDLRPCParameterNameParameters:
                                                      @{SDLRPCParameterNameHapticRectData:@[testStruct]},
                                                  SDLRPCParameterNameOperationName:SDLRPCFunctionNameSendHapticData}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             SDLSendHapticData *testRequest = [[SDLSendHapticData alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
             expect(testRequest.hapticRectData).to(equal(@[testStruct]));
         });

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSendLocationSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSendLocationSpec.m
@@ -164,8 +164,10 @@ describe(@"Send Location RPC", ^{
                                                    SDLRPCParameterNameOperationName:SDLRPCFunctionNameSendLocation
                                                    }
                                            };
-                
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 testRequest = [[SDLSendLocation alloc] initWithDictionary:[NSMutableDictionary dictionaryWithDictionary:initDict]];
+#pragma clang diagnostic pop
             });
             
             // Since all the properties are immutable, a copy should be executed as a retain, which means they should be identical
@@ -190,8 +192,10 @@ describe(@"Send Location RPC", ^{
                                                    SDLRPCParameterNameParameters: @{}
                                                    }
                                            };
-                
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 testRequest = [[SDLSendLocation alloc] initWithDictionary:[NSMutableDictionary dictionaryWithDictionary:initDict]];
+#pragma clang diagnostic pop
             });
             
             it(@"should return nil for parameters", ^{

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSetAppIconSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSetAppIconSpec.m
@@ -28,7 +28,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                            @{SDLRPCParameterNameParameters:
                                                                  @{SDLRPCParameterNameSyncFileName:@"A/File/Name"},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameSetAppIcon}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSetAppIcon* testRequest = [[SDLSetAppIcon alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testRequest.syncFileName).to(equal(@"A/File/Name"));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSetCloudAppPropertiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSetCloudAppPropertiesSpec.m
@@ -36,7 +36,10 @@ describe(@"Getter/Setter Tests", ^{
                                                SDLRPCParameterNameProperties:testProperties
                                                },
                                        SDLRPCParameterNameOperationName:SDLRPCFunctionNameSetCloudAppProperties}};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSetCloudAppProperties *testRequest = [[SDLSetCloudAppProperties alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testRequest.properties).to(equal(testProperties));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSetDisplayLayoutSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSetDisplayLayoutSpec.m
@@ -48,7 +48,10 @@ describe(@"SetDisplayLayout Tests", ^ {
                                                                @{SDLRPCParameterNameParameters:
                                                                      @{SDLRPCParameterNameDisplayLayout:@"wat"},
                                                                  SDLRPCParameterNameOperationName:SDLRPCFunctionNameSetDisplayLayout}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             SDLSetDisplayLayout* testRequest = [[SDLSetDisplayLayout alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
             expect(testRequest.displayLayout).to(equal(@"wat"));
         });

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSetGlobalPropertiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSetGlobalPropertiesSpec.m
@@ -57,7 +57,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                                    SDLRPCParameterNameMenuIcon:image,
                                                                    SDLRPCParameterNameKeyboardProperties:keyboard},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameSetGlobalProperties}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSetGlobalProperties* testRequest = [[SDLSetGlobalProperties alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testRequest.helpPrompt).to(equal([@[chunk1] mutableCopy]));
         expect(testRequest.timeoutPrompt).to(equal([@[chunk2] mutableCopy]));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSetInteriorVehicleDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSetInteriorVehicleDataSpec.m
@@ -31,7 +31,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                            @{SDLRPCParameterNameParameters:
                                                                  @{SDLRPCParameterNameModuleData : someModuleData},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameSetInteriorVehicleData}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSetInteriorVehicleData* testRequest = [[SDLSetInteriorVehicleData alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testRequest.moduleData).to(equal(someModuleData));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSetMediaClockTimerSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSetMediaClockTimerSpec.m
@@ -35,7 +35,10 @@ describe(@"SetMediaClocktimer Spec", ^ {
                                                        SDLRPCParameterNameAudioStreamingIndicator:testIndicator
                                                        },
                                                  SDLRPCParameterNameOperationName:SDLRPCFunctionNameSetMediaClockTimer}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             SDLSetMediaClockTimer* testRequest = [[SDLSetMediaClockTimer alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
             expect(testRequest.startTime).to(equal(time1));
             expect(testRequest.endTime).to(equal(time2));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLShowConstantTBTSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLShowConstantTBTSpec.m
@@ -65,7 +65,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                                    SDLRPCParameterNameManeuverComplete:@NO,
                                                                    SDLRPCParameterNameSoftButtons:[@[button] mutableCopy]},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameShowConstantTBT}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLShowConstantTBT* testRequest = [[SDLShowConstantTBT alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testRequest.navigationText1).to(equal(@"nav1"));
         expect(testRequest.navigationText2).to(equal(@"nav2"));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLShowSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLShowSpec.m
@@ -329,7 +329,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                        SDLRPCParameterNameCustomPresets:[@[@"preset1", @"preset2"] mutableCopy],
                                                        SDLRPCParameterNameMetadataTags:testMetadata},
                                                  SDLRPCParameterNameOperationName:SDLRPCFunctionNameShow}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             SDLShow* testRequest = [[SDLShow alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
             expect(testRequest.mainField1).to(equal(@"field1"));
             expect(testRequest.mainField2).to(equal(@"field2"));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSliderSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSliderSpec.m
@@ -58,7 +58,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                             SDLRPCParameterNameSliderFooter:testFooters,
                                                             SDLRPCParameterNameTimeout:@(testTimeout)},
                                                       SDLRPCParameterNameOperationName:SDLRPCFunctionNameSlider}};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         testRequest = [[SDLSlider alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testRequest.numTicks).to(equal(testNumTicks));
         expect(testRequest.position).to(equal(testPosition));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSpeakSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSpeakSpec.m
@@ -31,7 +31,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                            @{SDLRPCParameterNameParameters:
                                                                  @{SDLRPCParameterNameTTSChunks:[@[chunk] mutableCopy]},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameSpeak}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSpeak* testRequest = [[SDLSpeak alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testRequest.ttsChunks).to(equal([@[chunk] mutableCopy]));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSubscribeButtonSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSubscribeButtonSpec.m
@@ -30,7 +30,10 @@ describe(@"Getter/Setter Tests", ^ {
                                            @{SDLRPCParameterNameParameters:
                                                  @{SDLRPCParameterNameButtonName:SDLButtonNamePreset5},
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameSubscribeButton}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSubscribeButton* testRequest = [[SDLSubscribeButton alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testRequest.buttonName).to(equal(SDLButtonNamePreset5));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSubscribeVehicleDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSubscribeVehicleDataSpec.m
@@ -112,7 +112,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                            SDLRPCParameterNameTurnSignal:@NO,
                                                            SDLRPCParameterNameWiperStatus:@NO},
                                                      SDLRPCParameterNameOperationName:SDLRPCFunctionNameSubscribeVehicleData}};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSubscribeVehicleData* testRequest = [[SDLSubscribeVehicleData alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testRequest.accPedalPosition).to(equal(@YES));
         expect(testRequest.airbagStatus).to(equal(@YES));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSystemRequestSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSystemRequestSpec.m
@@ -28,7 +28,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                        SDLRPCParameterNameRequestSubType: testSubType,
                                                        SDLRPCParameterNameFilename:testFileName},
                                                  SDLRPCParameterNameOperationName:SDLRPCFunctionNameSystemRequest}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             SDLSystemRequest* testRequest = [[SDLSystemRequest alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
             expect(testRequest.requestType).to(equal(testRequestType));
             expect(testRequest.requestSubType).to(equal(testSubType));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLUnsubscribeButtonSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLUnsubscribeButtonSpec.m
@@ -30,7 +30,10 @@ describe(@"Getter/Setter Tests", ^ {
                                            @{SDLRPCParameterNameParameters:
                                                  @{SDLRPCParameterNameButtonName:SDLButtonNamePreset0},
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameUnsubscribeButton}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLUnsubscribeButton* testRequest = [[SDLUnsubscribeButton alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testRequest.buttonName).to(equal(SDLButtonNamePreset0));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLUnsubscribeVehicleDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLUnsubscribeVehicleDataSpec.m
@@ -112,7 +112,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                            SDLRPCParameterNameTurnSignal:@YES,
                                                            SDLRPCParameterNameWiperStatus:@YES},
                                                      SDLRPCParameterNameOperationName:SDLRPCFunctionNameUnsubscribeVehicleData}};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLUnsubscribeVehicleData* testRequest = [[SDLUnsubscribeVehicleData alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testRequest.accPedalPosition).to(equal(@YES));
         expect(testRequest.airbagStatus).to(equal(@YES));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLUpdateTurnListSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLUpdateTurnListSpec.m
@@ -36,7 +36,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                                  @{SDLRPCParameterNameTurnList:[@[turn] mutableCopy],
                                                                    SDLRPCParameterNameSoftButtons:[@[button] mutableCopy]},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameUpdateTurnList}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLUpdateTurnList* testRequest = [[SDLUpdateTurnList alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testRequest.turnList).to(equal([@[turn] mutableCopy]));
         expect(testRequest.softButtons).to(equal([@[button] mutableCopy]));

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLDeleteFileResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLDeleteFileResponseSpec.m
@@ -28,7 +28,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                            @{SDLRPCParameterNameParameters:
                                                                  @{SDLRPCParameterNameSpaceAvailable:@0},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameDeleteFile}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLDeleteFileResponse* testResponse = [[SDLDeleteFileResponse alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testResponse.spaceAvailable).to(equal(@0));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLDiagnosticMessageResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLDiagnosticMessageResponseSpec.m
@@ -28,7 +28,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                            @{SDLRPCParameterNameParameters:
                                                                  @{SDLRPCParameterNameMessageDataResult:@[@3, @9, @27, @81]},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameDiagnosticMessage}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLDiagnosticMessageResponse* testResponse = [[SDLDiagnosticMessageResponse alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testResponse.messageDataResult).to(equal(@[@3, @9, @27, @81]));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetAppServiceDataResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetAppServiceDataResponseSpec.m
@@ -38,7 +38,10 @@ describe(@"Getter/Setter Tests", ^{
                                                SDLRPCParameterNameServiceData:testAppServiceData
                                                },
                                        SDLRPCParameterNameOperationName:SDLRPCFunctionNameGetAppServiceData}};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLGetAppServiceDataResponse *testResponse = [[SDLGetAppServiceDataResponse alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testResponse.serviceData).to(equal(testAppServiceData));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetCloudAppPropertiesResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetCloudAppPropertiesResponseSpec.m
@@ -36,7 +36,10 @@ describe(@"Getter/Setter Tests", ^{
                                                SDLRPCParameterNameProperties:testProperties
                                                },
                                        SDLRPCParameterNameOperationName:SDLRPCFunctionNameSetCloudAppProperties}};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLGetCloudAppPropertiesResponse *testResponse = [[SDLGetCloudAppPropertiesResponse alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testResponse.properties).to(equal(testProperties));
         expect(testResponse.name).to(equal(SDLRPCFunctionNameSetCloudAppProperties));

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetDTCsResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetDTCsResponseSpec.m
@@ -31,7 +31,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                                 @{SDLRPCParameterNameECUHeader:@404,
                                                                   SDLRPCParameterNameDTC:[@[@"FFFF", @"FFFE", @"FFFD"] mutableCopy]},
                                                             SDLRPCParameterNameOperationName:SDLRPCFunctionNameGetDTCs}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLGetDTCsResponse* testResponse = [[SDLGetDTCsResponse alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testResponse.ecuHeader).to(equal(@404));
         expect(testResponse.dtc).to(equal([@[@"FFFF", @"FFFE", @"FFFD"] mutableCopy]));

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetFileResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetFileResponseSpec.m
@@ -48,7 +48,10 @@ describe(@"Getter/Setter Tests", ^{
                                                SDLRPCParameterNameCRC:@(testCrc)
                                                },
                                        SDLRPCParameterNameOperationName:SDLRPCFunctionNameGetFile}};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLGetFileResponse *testResponse = [[SDLGetFileResponse alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testResponse.offset).to(equal(testOffset));
         expect(testResponse.length).to(equal(testLength));

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetInteriorVehicleDataResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetInteriorVehicleDataResponseSpec.m
@@ -40,7 +40,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                                  @{SDLRPCParameterNameModuleData:someModuleData,
                                                                    SDLRPCParameterNameIsSubscribed:@NO},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameGetInteriorVehicleData}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLGetInteriorVehicleDataResponse* testResponse = [[SDLGetInteriorVehicleDataResponse alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testResponse.moduleData).to(equal(someModuleData));
         expect(testResponse.isSubscribed).to(equal(@NO));

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetSystemCapabilityResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetSystemCapabilityResponseSpec.m
@@ -41,7 +41,10 @@ describe(@"Initialization tests", ^{
                                        SDLRPCParameterNameOperationName:SDLRPCFunctionNameGetSystemCapability
                                        }
                                };
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLGetSystemCapabilityResponse *testResponse = [[SDLGetSystemCapabilityResponse alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testResponse.systemCapability.systemCapabilityType).to(equal(SDLSystemCapabilityTypeNavigation));
         expect(testResponse.systemCapability.navigationCapability.sendLocationEnabled).to(equal(YES));

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetVehicleDataResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetVehicleDataResponseSpec.m
@@ -149,7 +149,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                      SDLRPCParameterNameVIN:vin,
                                                      SDLRPCParameterNameWiperStatus:SDLWiperStatusAutomaticHigh},
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameGetVehicleData}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLGetVehicleDataResponse* testResponse = [[SDLGetVehicleDataResponse alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testResponse.accPedalPosition).to(equal(@0));
         expect(testResponse.airbagStatus).to(equal(airbag));

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetWaypointsResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetWaypointsResponseSpec.m
@@ -69,8 +69,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                            }
                                                    }
                                            };
-                
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 testResponse = [[SDLGetWayPointsResponse alloc] initWithDictionary:[NSMutableDictionary dictionaryWithDictionary:initDict]];
+#pragma clang diagnostic pop
             });
             
             // Since all the properties are immutable, a copy should be executed as a retain, which means they should be identical
@@ -87,8 +89,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                    SDLRPCParameterNameParameters: @{}
                                                    }
                                            };
-                
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 testResponse = [[SDLGetWayPointsResponse alloc] initWithDictionary:[NSMutableDictionary dictionaryWithDictionary:initDict]];
+#pragma clang diagnostic pop
             });
             
             it(@"should return nil for waypoints", ^{

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLListFilesResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLListFilesResponseSpec.m
@@ -31,7 +31,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                                  @{SDLRPCParameterNameFilenames:[@[@"Music/music.mp3", @"Documents/document.txt", @"Downloads/format.exe"] mutableCopy],
                                                                    SDLRPCParameterNameSpaceAvailable:@500000000},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameListFiles}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLListFilesResponse* testResponse = [[SDLListFilesResponse alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testResponse.filenames).to(equal([@[@"Music/music.mp3", @"Documents/document.txt", @"Downloads/format.exe"] mutableCopy]));
         expect(testResponse.spaceAvailable).to(equal(@500000000));

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLPerformAppServiceInteractionResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLPerformAppServiceInteractionResponseSpec.m
@@ -35,7 +35,10 @@ describe(@"Getter/Setter Tests", ^{
                                                SDLRPCParameterNameServiceSpecificResult:testServiceSpecificResult
                                                },
                                        SDLRPCParameterNameOperationName:SDLRPCFunctionNamePublishAppService}};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLPerformAppServiceInteractionResponse *testResponse = [[SDLPerformAppServiceInteractionResponse alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testResponse.serviceSpecificResult).to(equal(testServiceSpecificResult));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLPerformInteractionResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLPerformInteractionResponseSpec.m
@@ -36,7 +36,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                   SDLRPCParameterNameManualTextEntry:@"entry",
                                                   SDLRPCParameterNameTriggerSource:SDLTriggerSourceKeyboard},
                                             SDLRPCParameterNameOperationName:SDLRPCFunctionNamePerformInteraction}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLPerformInteractionResponse* testResponse = [[SDLPerformInteractionResponse alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testResponse.choiceID).to(equal(@25));
         expect(testResponse.manualTextEntry).to(equal(@"entry"));

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLPublishAppServiceResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLPublishAppServiceResponseSpec.m
@@ -37,7 +37,10 @@ describe(@"Getter/Setter Tests", ^{
                                                SDLRPCParameterNameAppServiceRecord:testAppServiceRecord
                                                },
                                        SDLRPCParameterNameOperationName:SDLRPCFunctionNamePublishAppService}};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLPublishAppServiceResponse *testResponse = [[SDLPublishAppServiceResponse alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testResponse.appServiceRecord).to(equal(testAppServiceRecord));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLPutFileResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLPutFileResponseSpec.m
@@ -29,7 +29,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                                  @{SDLRPCParameterNameSpaceAvailable:@1248,
                                                                    },
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNamePutFile}};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLPutFileResponse* testResponse = [[SDLPutFileResponse alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testResponse.spaceAvailable).to(equal(@1248));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLReadDIDResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLReadDIDResponseSpec.m
@@ -31,7 +31,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                            @{SDLRPCParameterNameParameters:
                                                                  @{SDLRPCParameterNameDIDResult:[@[result] mutableCopy]},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameReadDID}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLReadDIDResponse* testResponse = [[SDLReadDIDResponse alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testResponse.didResult).to(equal([@[result] mutableCopy]));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLRegisterAppInterfaceResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLRegisterAppInterfaceResponseSpec.m
@@ -93,7 +93,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                    SDLRPCParameterNameIconResumed: @YES,
                                                    },
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameRegisterAppInterface}};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLRegisterAppInterfaceResponse* testResponse = [[SDLRegisterAppInterfaceResponse alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testResponse.syncMsgVersion).to(equal(version));
         expect(testResponse.language).to(equal(SDLLanguageEsMx));
@@ -164,7 +167,10 @@ describe(@"Getter/Setter Tests", ^ {
                                            SDLRPCParameterNameIconResumed: NSNull.null,
                                            },
                                      SDLRPCParameterNameOperationName:SDLRPCFunctionNameRegisterAppInterface}};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLRegisterAppInterfaceResponse* testResponse = [[SDLRegisterAppInterfaceResponse alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expectAction(^{ [testResponse syncMsgVersion]; }).to(raiseException());
         expectAction(^{ [testResponse language]; }).to(raiseException());

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLSetCloudAppPropertiesResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLSetCloudAppPropertiesResponseSpec.m
@@ -26,7 +26,10 @@ describe(@"Getter/Setter Tests", ^ {
         NSDictionary *dict = @{SDLRPCParameterNameResponse:@{
                                        SDLRPCParameterNameParameters:@{},
                                        SDLRPCParameterNameOperationName:SDLRPCFunctionNameSetCloudAppProperties}};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSetCloudAppPropertiesResponse *testResponse = [[SDLSetCloudAppPropertiesResponse alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testResponse).toNot(beNil());
         expect(testResponse.name).to(equal(SDLRPCFunctionNameSetCloudAppProperties));

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLSetDisplayLayoutResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLSetDisplayLayoutResponseSpec.m
@@ -47,7 +47,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                                    SDLRPCParameterNameSoftButtonCapabilities:[@[softButton] mutableCopy],
                                                                    SDLRPCParameterNamePresetBankCapabilities:presetBank},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameSetDisplayLayout}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSetDisplayLayoutResponse* testResponse = [[SDLSetDisplayLayoutResponse alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testResponse.displayCapabilities).to(equal(info));
         expect(testResponse.buttonCapabilities).to(equal([@[button] mutableCopy]));

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLSetInteriorVehicleDataResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLSetInteriorVehicleDataResponseSpec.m
@@ -36,7 +36,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                            @{SDLRPCParameterNameParameters:
                                                                  @{SDLRPCParameterNameModuleData:someModuleData},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameSetInteriorVehicleData}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSetInteriorVehicleDataResponse* testResponse = [[SDLSetInteriorVehicleDataResponse alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testResponse.moduleData).to(equal(someModuleData));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLSliderResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLSliderResponseSpec.m
@@ -29,7 +29,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                            @{SDLRPCParameterNameParameters:
                                                                  @{SDLRPCParameterNameSliderPosition:@13},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameSlider}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSliderResponse* testResponse = [[SDLSliderResponse alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testResponse.sliderPosition).to(equal(@13));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLSubscribeVehicleDataResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLSubscribeVehicleDataResponseSpec.m
@@ -116,7 +116,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                                    SDLRPCParameterNameTurnSignal:vehicleDataResult,
                                                                    SDLRPCParameterNameWiperStatus:vehicleDataResult},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameSubscribeVehicleData}};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSubscribeVehicleDataResponse* testResponse = [[SDLSubscribeVehicleDataResponse alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testResponse.accPedalPosition).to(equal(vehicleDataResult));
         expect(testResponse.airbagStatus).to(equal(vehicleDataResult));

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLUnsubscribeVehicleDataResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLUnsubscribeVehicleDataResponseSpec.m
@@ -117,7 +117,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                                    SDLRPCParameterNameCloudAppVehicleID:vehicleDataResult
                                                                    },
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameUnsubscribeVehicleData}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLUnsubscribeVehicleDataResponse* testResponse = [[SDLUnsubscribeVehicleDataResponse alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testResponse.gps).to(equal(vehicleDataResult));
         expect(testResponse.speed).to(equal(vehicleDataResult));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLAirbagStatusSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLAirbagStatusSpec.m
@@ -47,7 +47,10 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameDriverKneeAirbagDeployed:SDLVehicleDataEventStatusNo,
                                        SDLRPCParameterNamePassengerSideAirbagDeployed:SDLVehicleDataEventStatusYes,
                                        SDLRPCParameterNamePassengerKneeAirbagDeployed:SDLVehicleDataEventStatusNoEvent} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLAirbagStatus* testStruct = [[SDLAirbagStatus alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.driverAirbagDeployed).to(equal(SDLVehicleDataEventStatusYes));
         expect(testStruct.driverSideAirbagDeployed).to(equal(SDLVehicleDataEventStatusNoEvent));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLAppInfoSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLAppInfoSpec.m
@@ -31,7 +31,10 @@ describe(@"Getter/Setter Tests", ^ {
         NSMutableDictionary<NSString *, id> *dict = [@{SDLRPCParameterNameAppDisplayName:@"display name",
                                                        SDLRPCParameterNameAppVersion:@"1.2.3.4",
                                                        SDLRPCParameterNameAppBundleId:@"com.app.bundle"} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLAppInfo* testStruct = [[SDLAppInfo alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.appDisplayName).to(equal(@"display name"));
         expect(testStruct.appVersion).to(equal(@"1.2.3.4"));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLAppServiceCapabilitySpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLAppServiceCapabilitySpec.m
@@ -21,7 +21,10 @@ describe(@"Getter/Setter Tests", ^{
 
     beforeEach(^{
         testUpdateReason = SDLServiceUpdateActivated;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         testUpdatedAppServiceRecord = [[SDLAppServiceRecord alloc] initWithDictionary:@{SDLRPCParameterNameServiceID:@"1234", SDLRPCParameterNameServicePublished:@YES}];
+#pragma clang diagnostic pop
     });
 
     it(@"Should set and get correctly", ^{
@@ -37,8 +40,10 @@ describe(@"Getter/Setter Tests", ^{
         NSDictionary *dict = @{SDLRPCParameterNameUpdateReason:testUpdateReason,
                                SDLRPCParameterNameUpdatedAppServiceRecord:testUpdatedAppServiceRecord
                                };
-
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLAppServiceCapability *testStruct = [[SDLAppServiceCapability alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         expect(testStruct.updateReason).to(equal(testUpdateReason));
         expect(testStruct.updatedAppServiceRecord).to(equal(testUpdatedAppServiceRecord));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLAppServiceDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLAppServiceDataSpec.m
@@ -57,7 +57,10 @@ describe(@"Getter/Setter Tests", ^{
                                SDLRPCParameterNameWeatherServiceData:testWeatherServiceData,
                                SDLRPCParameterNameNavigationServiceData:testNavigationServiceData
                                };
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLAppServiceData *testStruct = [[SDLAppServiceData alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.serviceType).to(equal(testServiceType));
         expect(testStruct.serviceId).to(equal(testServiceId));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLAppServiceManifestSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLAppServiceManifestSpec.m
@@ -81,7 +81,10 @@ describe(@"Getter/Setter Tests", ^ {
                                SDLRPCParameterNameMediaServiceManifest:testMediaServiceManifest,
                                SDLRPCParameterNameNavigationServiceManifest:testNavigationServiceManifest
                                };
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLAppServiceManifest *testStruct = [[SDLAppServiceManifest alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.serviceName).to(match(testServiceName));
         expect(testStruct.serviceType).to(equal(testServiceType));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLAppServiceRecordSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLAppServiceRecordSpec.m
@@ -23,7 +23,10 @@ describe(@"Getter/Setter Tests", ^{
 
     beforeEach(^{
         testServiceID = @"12345";
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         testAppServiceManifest = [[SDLAppServiceManifest alloc] initWithDictionary:@{SDLRPCParameterNameAllowAppConsumers:@NO}];
+#pragma clang diagnostic pop
         testServicePublished = @NO;
         testServiceActive = @YES;
     });
@@ -56,7 +59,10 @@ describe(@"Getter/Setter Tests", ^{
                                SDLRPCParameterNameServicePublished:testServicePublished,
                                SDLRPCParameterNameServiceActive:testServiceActive
                                     };
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLAppServiceRecord *testStruct = [[SDLAppServiceRecord alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.serviceID).to(match(testServiceID));
         expect(testStruct.serviceManifest).to(equal(testAppServiceManifest));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLAppServicesCapabilitiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLAppServicesCapabilitiesSpec.m
@@ -19,7 +19,10 @@ describe(@"Getter/Setter Tests", ^{
     __block NSArray<SDLAppServiceCapability *> *testAppServices = nil;
 
     beforeEach(^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         testAppServices = @[[[SDLAppServiceCapability alloc] initWithDictionary:@{SDLRPCParameterNameUpdateReason:SDLServiceUpdateRemoved}]];
+#pragma clang diagnostic pop
     });
 
     it(@"Should set and get correctly", ^{
@@ -38,7 +41,10 @@ describe(@"Getter/Setter Tests", ^{
     it(@"Should get correctly when initialized with a dictionary", ^{
         NSDictionary *dict = @{SDLRPCParameterNameAppServices:testAppServices
                                };
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLAppServicesCapabilities *testStruct = [[SDLAppServicesCapabilities alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.appServices).to(equal(testAppServices));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLAudioControlCapabilitiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLAudioControlCapabilitiesSpec.m
@@ -63,7 +63,10 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameEqualizerAvailable:@(NO),
                                        SDLRPCParameterNameEqualizerMaxChannelId:@12
                                        } mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLAudioControlCapabilities* testStruct = [[SDLAudioControlCapabilities alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.moduleName).to(equal(@"module"));
         expect(testStruct.sourceAvailable).to(equal(@(NO)));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLAudioControlDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLAudioControlDataSpec.m
@@ -48,7 +48,10 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameVolume:@(NO),
                                        SDLRPCParameterNameEqualizerSettings:[@[someEqualizerSettings] copy]
                                        } mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLAudioControlData* testStruct = [[SDLAudioControlData alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.source).to(equal(SDLPrimaryAudioSourceCD));
         expect(testStruct.keepContext).to(equal(@(NO)));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLAudioPassThruCapabilitiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLAudioPassThruCapabilitiesSpec.m
@@ -34,7 +34,10 @@ describe(@"Getter/Setter Tests", ^ {
         NSMutableDictionary* dict = [@{SDLRPCParameterNameSamplingRate:SDLSamplingRate22KHZ,
                                        SDLRPCParameterNameBitsPerSample:SDLBitsPerSample8Bit,
                                        SDLRPCParameterNameAudioType:SDLAudioTypePCM} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLAudioPassThruCapabilities* testStruct = [[SDLAudioPassThruCapabilities alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.samplingRate).to(equal(SDLSamplingRate22KHZ));
         expect(testStruct.bitsPerSample).to(equal(SDLBitsPerSample8Bit));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLBeltStatusSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLBeltStatusSpec.m
@@ -68,7 +68,10 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameRightRearInflatableBelted:SDLVehicleDataEventStatusFault,
                                        SDLRPCParameterNameMiddleRow1BeltDeployed:SDLVehicleDataEventStatusNoEvent,
                                        SDLRPCParameterNameMiddleRow1BuckleBelted:SDLVehicleDataEventStatusNotSupported} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLBeltStatus* testStruct = [[SDLBeltStatus alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.driverBeltDeployed).to(equal(SDLVehicleDataEventStatusNoEvent));
         expect(testStruct.passengerBeltDeployed).to(equal(SDLVehicleDataEventStatusYes));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLBodyInformationSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLBodyInformationSpec.m
@@ -44,7 +44,10 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNamePassengerDoorAjar:@NO,
                                        SDLRPCParameterNameRearLeftDoorAjar:@NO,
                                        SDLRPCParameterNameRearRightDoorAjar:@YES} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLBodyInformation* testStruct = [[SDLBodyInformation alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.parkBrakeActive).to(equal(@YES));
         expect(testStruct.ignitionStableStatus).to(equal(SDLIgnitionStableStatusNotStable));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLButtonCapabilitiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLButtonCapabilitiesSpec.m
@@ -35,7 +35,10 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameShortPressAvailable:@YES,
                                        SDLRPCParameterNameLongPressAvailable:@YES,
                                        SDLRPCParameterNameUpDownAvailable:@NO} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLButtonCapabilities* testStruct = [[SDLButtonCapabilities alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.name).to(equal(SDLButtonNameCustomButton));
         expect(testStruct.shortPressAvailable).to(equal(@YES));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLChoiceSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLChoiceSpec.m
@@ -47,7 +47,10 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameSecondaryText:@"Arbitrary",
                                        SDLRPCParameterNameTertiaryText:@"qwerty",
                                        SDLRPCParameterNameSecondaryImage:secondaryImage} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLChoice* testStruct = [[SDLChoice alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.choiceID).to(equal(@3));
         expect(testStruct.menuName).to(equal(@"Hello"));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLClimateControlCapabilitiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLClimateControlCapabilitiesSpec.m
@@ -74,7 +74,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                            SDLRPCParameterNameHeatedRearWindowAvailable:@YES,
                                                        SDLRPCParameterNameHeatedMirrorsAvailable:@NO
                                                        } mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLClimateControlCapabilities* testStruct = [[SDLClimateControlCapabilities alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.moduleName).to(equal(@"Name"));
         expect(testStruct.fanSpeedAvailable).to(equal(@YES));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLClimateControlDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLClimateControlDataSpec.m
@@ -115,8 +115,11 @@ describe(@"Getter/Setter Tests", ^ {
                                                        SDLRPCParameterNameHeatedRearWindowEnable:@NO,
                                                        SDLRPCParameterNameHeatedMirrorsEnable:@YES,
                                                        } mutableCopy];
-        
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLClimateControlData* testStruct = [[SDLClimateControlData alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.fanSpeed).to(equal(@43));
         expect(testStruct.currentTemperature).to(equal(currentTemp));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLCloudAppPropertiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLCloudAppPropertiesSpec.m
@@ -63,7 +63,10 @@ describe(@"Getter/Setter Tests", ^{
                                SDLRPCParameterNameHybridAppPreference:testHybridAppPreference,
                                SDLRPCParameterNameEndpoint:testEndpoint
                                };
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLCloudAppProperties *testStruct = [[SDLCloudAppProperties alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.nicknames).to(equal(testNicknames));
         expect(testStruct.appID).to(equal(testAppID));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLClusterModeStatusSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLClusterModeStatusSpec.m
@@ -36,7 +36,10 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNamePowerModeQualificationStatus:SDLPowerModeQualificationStatusOk,
                                        SDLRPCParameterNameCarModeStatus:SDLCarModeStatusCrash,
                                        SDLRPCParameterNamePowerModeStatus:SDLPowerModeStatusKeyOut} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLClusterModeStatus* testStruct = [[SDLClusterModeStatus alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.powerModeActive).to(equal(@NO));
         expect(testStruct.powerModeQualificationStatus).to(equal(SDLPowerModeQualificationStatusOk));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLDIDResult.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLDIDResult.m
@@ -32,7 +32,10 @@ describe(@"Getter/Setter Tests", ^ {
         NSMutableDictionary* dict = [@{SDLRPCParameterNameResultCode:SDLVehicleDataResultCodeDataNotSubscribed,
                                        SDLRPCParameterNameDIDLocation:@300,
                                        SDLRPCParameterNameData:@"gertwydhty4235tdhedt4tue"} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLDIDResult* testStruct = [[SDLDIDResult alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.resultCode).to(equal(SDLVehicleDataResultCodeDataNotSubscribed));
         expect(testStruct.didLocation).to(equal(@300));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLDateTimeSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLDateTimeSpec.m
@@ -51,7 +51,10 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameYear:@4000,
                                        SDLRPCParameterNameTimezoneMinuteOffset:@0,
                                        SDLRPCParameterNameTimezoneHourOffset:@1000} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLDateTime* testStruct = [[SDLDateTime alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.millisecond).to(equal(@100));
         expect(testStruct.second).to(equal(@4));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLDeviceInfoSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLDeviceInfoSpec.m
@@ -39,7 +39,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                        SDLRPCParameterNameOSVersion:@"9.9",
                                                        SDLRPCParameterNameCarrier:@"ThatOneWirelessCompany",
                                                        SDLRPCParameterNameMaxNumberRFCOMMPorts:@20} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLDeviceInfo* testStruct = [[SDLDeviceInfo alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.hardware).to(equal(@"GDFR34F"));
         expect(testStruct.firmwareRev).to(equal(@"4.2a"));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLDeviceStatusSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLDeviceStatusSpec.m
@@ -57,7 +57,10 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameSignalLevelStatus:SDLDeviceLevelStatusTwoBars,
                                        SDLRPCParameterNamePrimaryAudioSource:SDLPrimaryAudioSourceBluetoothStereo,
                                        SDLRPCParameterNameECallEventActive:@NO} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLDeviceStatus* testStruct = [[SDLDeviceStatus alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.voiceRecOn).to(equal(@NO));
         expect(testStruct.btIconOn).to(equal(@NO));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLECallInfoSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLECallInfoSpec.m
@@ -33,7 +33,10 @@ describe(@"Getter/Setter Tests", ^ {
         NSMutableDictionary* dict = [@{SDLRPCParameterNameECallNotificationStatus:SDLVehicleDataNotificationStatusNormal,
                                        SDLRPCParameterNameAuxECallNotificationStatus:SDLVehicleDataNotificationStatusActive,
                                        SDLRPCParameterNameECallConfirmationStatus:SDLECallConfirmationStatusInProgress} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLECallInfo* testStruct = [[SDLECallInfo alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.eCallNotificationStatus).to(equal(SDLVehicleDataNotificationStatusNormal));
         expect(testStruct.auxECallNotificationStatus).to(equal(SDLVehicleDataNotificationStatusActive));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLEmergencyEventSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLEmergencyEventSpec.m
@@ -40,7 +40,10 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameRolloverEvent:SDLVehicleDataEventStatusYes,
                                        SDLRPCParameterNameMaximumChangeVelocity:@33,
                                        SDLRPCParameterNameMultipleEvents:SDLVehicleDataEventStatusNo} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLEmergencyEvent* testStruct = [[SDLEmergencyEvent alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.emergencyEventType).to(equal(SDLEmergencyEventTypeFrontal));
         expect(testStruct.fuelCutoffStatus).to(equal(SDLFuelCutoffStatusNormalOperation));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLEqualizerSettingsSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLEqualizerSettingsSpec.m
@@ -39,7 +39,10 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameChannelName:@"channel",
                                        SDLRPCParameterNameChannelSetting:@45
                                        } mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLEqualizerSettings* testStruct = [[SDLEqualizerSettings alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.channelId).to(equal(@2));
         expect(testStruct.channelName).to(equal(@"channel"));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLFuelRangeSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLFuelRangeSpec.m
@@ -31,8 +31,10 @@ describe(@"Getter/Setter Tests", ^ {
         NSDictionary *dict = @{SDLRPCParameterNameType:SDLFuelTypeLPG,
                                 SDLRPCParameterNameRange:@23
                                 };
-
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLFuelRange *testStruct = [[SDLFuelRange alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.type).to(equal(SDLFuelTypeLPG));
         expect(testStruct.range).to(equal(@23));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLGPSDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLGPSDataSpec.m
@@ -78,7 +78,10 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameAltitude:@3000,
                                        SDLRPCParameterNameHeading:@96,
                                        SDLRPCParameterNameSpeed:@64} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLGPSData* testStruct = [[SDLGPSData alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.longitudeDegrees).to(equal(@31.41592653589793));
         expect(testStruct.latitudeDegrees).to(equal(@45));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLHMICapabilitiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLHMICapabilitiesSpec.m
@@ -46,7 +46,10 @@ describe(@"SDLHMICapabilities struct", ^{
                                              SDLRPCParameterNamePhoneCall: somePhoneCallState,
                                              SDLRPCParameterNameVideoStreaming: someVideoStreamState
                                              };
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             testStruct = [[SDLHMICapabilities alloc] initWithDictionary:[structInitDict mutableCopy]];
+#pragma clang diagnostic pop
         });
         
         it(@"should properly set phone call", ^{

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLHMIPermissionsSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLHMIPermissionsSpec.m
@@ -28,7 +28,10 @@ describe(@"Getter/Setter Tests", ^ {
     it(@"Should get correctly when initialized", ^ {
         NSMutableDictionary* dict = [@{SDLRPCParameterNameAllowed:[@[SDLHMILevelBackground, SDLHMILevelFull] copy],
                                        SDLRPCParameterNameUserDisallowed:[@[SDLHMILevelNone, SDLHMILevelLimited] copy]} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLHMIPermissions* testStruct = [[SDLHMIPermissions alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.allowed).to(equal([@[SDLHMILevelBackground, SDLHMILevelFull] copy]));
         expect(testStruct.userDisallowed).to(equal([@[SDLHMILevelNone, SDLHMILevelLimited] copy]));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLHMISettingsControlCapabilitiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLHMISettingsControlCapabilitiesSpec.m
@@ -53,7 +53,10 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameDistanceUnitAvailable:@(YES),
                                        SDLRPCParameterNameDisplayModeUnitAvailable:@(NO)
                                        } mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLHMISettingsControlCapabilities* testStruct = [[SDLHMISettingsControlCapabilities alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.moduleName).to(equal(@"temperatureUnit"));
         expect(testStruct.distanceUnitAvailable).to(equal(@(YES)));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLHMISettingsControlDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLHMISettingsControlDataSpec.m
@@ -37,7 +37,10 @@ describe(@"Getter/Setter Tests", ^ {
             NSMutableDictionary* dict = [@{SDLRPCParameterNameDisplayMode:SDLDisplayModeAuto,
                                            SDLRPCParameterNameTemperatureUnit:SDLTemperatureUnitCelsius,
                                            SDLRPCParameterNameDistanceUnit:SDLDistanceUnitKilometers} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             SDLHMISettingsControlData* testStruct = [[SDLHMISettingsControlData alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
             expect(testStruct.displayMode).to(equal(SDLDisplayModeAuto));
             expect(testStruct.temperatureUnit).to(equal(SDLTemperatureUnitCelsius));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLHapticRectSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLHapticRectSpec.m
@@ -49,7 +49,10 @@ describe(@"Getter/Setter Tests", ^{
                                                SDLRPCParameterNameHeight:@3000
                                                }
                                        } mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLHapticRect *testStruct = [[SDLHapticRect alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.id).to(equal(@2));
         expect(testStruct.rect.x).to(equal(@20));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLHeadLampStatusSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLHeadLampStatusSpec.m
@@ -32,7 +32,10 @@ describe(@"Getter/Setter Tests", ^ {
         NSMutableDictionary* dict = [@{SDLRPCParameterNameLowBeamsOn:@YES,
                                        SDLRPCParameterNameHighBeamsOn:@NO,
                                        SDLRPCParameterNameAmbientLightSensorStatus:SDLAmbientLightStatusTwilight3} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLHeadLampStatus* testStruct = [[SDLHeadLampStatus alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.lowBeamsOn).to(equal(@YES));
         expect(testStruct.highBeamsOn).to(equal(@NO));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLImageFieldSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLImageFieldSpec.m
@@ -36,7 +36,10 @@ describe(@"Getter/Setter Tests", ^ {
         NSMutableDictionary* dict = [@{SDLRPCParameterNameName:SDLImageFieldNameTurnIcon,
                                        SDLRPCParameterNameImageTypeSupported:[@[SDLFileTypePNG, SDLFileTypeJPEG] copy],
                                        SDLRPCParameterNameImageResolution:resolution} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLImageField* testStruct = [[SDLImageField alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.name).to(equal(SDLImageFieldNameTurnIcon));
         expect(testStruct.imageTypeSupported).to(equal([@[SDLFileTypePNG, SDLFileTypeJPEG] copy]));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLImageResolutionSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLImageResolutionSpec.m
@@ -28,7 +28,10 @@ describe(@"Getter/Setter Tests", ^ {
         NSDictionary *dict = @{SDLRPCParameterNameResolutionHeight:@69,
                                        SDLRPCParameterNameResolutionWidth:@869,
                                        };
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLImageResolution *testStruct = [[SDLImageResolution alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.resolutionWidth).to(equal(@869));
         expect(testStruct.resolutionHeight).to(equal(@69));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLImageSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLImageSpec.m
@@ -51,7 +51,10 @@ describe(@"Getter/Setter Tests", ^{
                                            SDLRPCParameterNameImageType:imageType,
                                            SDLRPCParameterNameImageTemplate:@YES
                                            } mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             testSDLImage = [[SDLImage alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
             expectedValue = value;
             expectedImageType = imageType;

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLKeyboardPropertiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLKeyboardPropertiesSpec.m
@@ -40,7 +40,10 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameKeypressMode:SDLKeypressModeResendCurrentEntry,
                                        SDLRPCParameterNameLimitedCharacterList:[@[@"s", @"r", @"f", @"q"] mutableCopy],
                                        SDLRPCParameterNameAutoCompleteText:@"Auto Carrot"} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLKeyboardProperties* testStruct = [[SDLKeyboardProperties alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.language).to(equal(SDLLanguageDaDk));
         expect(testStruct.keyboardLayout).to(equal(SDLKeyboardLayoutQWERTZ));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLLightCapabilitiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLLightCapabilitiesSpec.m
@@ -42,7 +42,10 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameRGBColorSpaceAvailable:@NO
                                        } mutableCopy];
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLLightCapabilities* testStruct = [[SDLLightCapabilities alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.name).to(equal(SDLLightNameFogLights));
         expect(testStruct.densityAvailable).to(equal(@YES));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLLightControlCapabilitiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLLightControlCapabilitiesSpec.m
@@ -40,8 +40,10 @@ describe(@"Getter/Setter Tests", ^ {
         NSMutableDictionary* dict = [@{SDLRPCParameterNameModuleName:@"moduleName",
                                        SDLRPCParameterNameSupportedLights:[@[somelightCapabilities] copy]
                                        } mutableCopy];
-
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLLightControlCapabilities* testStruct = [[SDLLightControlCapabilities alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.moduleName).to(equal(@"moduleName"));
         expect(testStruct.supportedLights).to(equal([@[somelightCapabilities] copy]));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLLightControlDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLLightControlDataSpec.m
@@ -32,8 +32,10 @@ describe(@"Getter/Setter Tests", ^ {
 
     it(@"Should get correctly when initialized", ^ {
         NSMutableDictionary* dict = [@{SDLRPCParameterNameLightState:[@[someLightState] copy]} mutableCopy];
-
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLLightControlData* testStruct = [[SDLLightControlData alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.lightState).to(equal([@[someLightState] copy]));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLLightStateSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLLightStateSpec.m
@@ -68,7 +68,10 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameDensity:@(0.5),
                                        SDLRPCParameterNameColor:someRGBColor} mutableCopy];
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLLightState* testStruct = [[SDLLightState alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.id).to(equal(SDLLightNameFogLights));
         expect(testStruct.status).to(equal(SDLLightStatusOn));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLLocationCoordinateSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLLocationCoordinateSpec.m
@@ -54,8 +54,10 @@ describe(@"Getter/Setter Tests", ^ {
                                            SDLRPCParameterNameLongitudeDegrees: someLongitude,
                                            SDLRPCParameterNameLatitudeDegrees: someLatitude,
                                            };
-                
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 testStruct = [[SDLLocationCoordinate alloc] initWithDictionary:[NSMutableDictionary dictionaryWithDictionary:initDict]];
+#pragma clang diagnostic pop
             });
             
             // Since all the properties are immutable, a copy should be executed as a retain, which means they should be identical
@@ -85,8 +87,10 @@ describe(@"Getter/Setter Tests", ^ {
             beforeEach(^{
                 NSDictionary *initDict = @{
                                            };
-                
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 testStruct = [[SDLLocationCoordinate alloc] initWithDictionary:[NSMutableDictionary dictionaryWithDictionary:initDict]];
+#pragma clang diagnostic pop
             });
             
             it(@"should return nil for longitude", ^{

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLLocationDetailsSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLLocationDetailsSpec.m
@@ -152,8 +152,10 @@ describe(@"Getter/Setter Tests", ^ {
                                            SDLRPCParameterNameLocationImage: someImage,
                                            SDLRPCParameterNameSearchAddress: someAddress
                                            };
-                
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 testStruct = [[SDLLocationDetails alloc] initWithDictionary:[NSMutableDictionary dictionaryWithDictionary:initDict]];
+#pragma clang diagnostic pop
             });
             
             // Since all the properties are immutable, a copy should be executed as a retain, which means they should be identical
@@ -200,8 +202,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                    SDLRPCParameterNameParameters: @{}
                                                    }
                                            };
-                
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 testStruct = [[SDLLocationDetails alloc] initWithDictionary:[NSMutableDictionary dictionaryWithDictionary:initDict]];
+#pragma clang diagnostic pop
             });
             
             it(@"should return nil for coordinate", ^{

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLMassageCushionFirmnessSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLMassageCushionFirmnessSpec.m
@@ -34,7 +34,10 @@ describe(@"Getter/Setter Tests", ^ {
         NSMutableDictionary* dict = [@{SDLRPCParameterNameCushion:SDLMassageCushionSeatBolsters,
                                        SDLRPCParameterNameFirmness:@12
                                        } mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLMassageCushionFirmness* testStruct = [[SDLMassageCushionFirmness alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.cushion).to(equal(SDLMassageCushionSeatBolsters));
         expect(testStruct.firmness).to(equal(@12));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLMassageModeDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLMassageModeDataSpec.m
@@ -35,7 +35,10 @@ describe(@"Getter/Setter Tests", ^ {
         NSMutableDictionary* dict = [@{SDLRPCParameterNameMassageMode:SDLMassageModeLow,
                                        SDLRPCParameterNameMassageZone:SDLMassageZoneLumbar
                                        } mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLMassageModeData* testStruct = [[SDLMassageModeData alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.massageZone).to(equal(SDLMassageZoneLumbar));
         expect(testStruct.massageMode).to(equal(SDLMassageModeLow));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLMediaServiceDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLMediaServiceDataSpec.m
@@ -81,7 +81,10 @@ describe(@"Getter/Setter Tests", ^{
                                SDLRPCParameterNameQueueCurrentTrackNumber:@(testQueueCurrentTrackNumber),
                                SDLRPCParameterNameQueueTotalTrackCount:@(testQueueTotalTrackCount)
                                };
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLMediaServiceData *testStruct = [[SDLMediaServiceData alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.mediaType).to(equal(testMediaType));
         expect(testStruct.mediaTitle).to(equal(testMediaTitle));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLMediaServiceManifestSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLMediaServiceManifestSpec.m
@@ -23,7 +23,10 @@ describe(@"Getter/Setter Tests", ^{
 
     it(@"Should get correctly when initialized with a dictionary", ^{
         NSDictionary *dict = @{};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLMediaServiceManifest *testStruct = [[SDLMediaServiceManifest alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         // no parameters to test
         expect(testStruct).toNot(beNil());

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLMenuParamsSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLMenuParamsSpec.m
@@ -30,7 +30,10 @@ describe(@"Initialization tests", ^{
         NSMutableDictionary* dict = [@{SDLRPCParameterNameParentId:@(testParentId),
                                        SDLRPCParameterNamePosition:@(testPosition),
                                        SDLRPCParameterNameMenuName:testMenuName} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLMenuParams* testStruct = [[SDLMenuParams alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.parentID).to(equal(@(testParentId)));
         expect(testStruct.position).to(equal(@(testPosition)));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLModuleDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLModuleDataSpec.m
@@ -50,7 +50,10 @@ describe(@"Initialization tests", ^{
                                        SDLRPCParameterNameAudioControlData:someAudioData,
                                        SDLRPCParameterNameLightControlData:someLightData,
                                        SDLRPCParameterNameHmiSettingsControlData:someHMISettingsData} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLModuleData* testStruct = [[SDLModuleData alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.moduleType).to(equal(SDLModuleTypeRadio));
         expect(testStruct.radioControlData).to(equal(someRadioData));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLMyKeySpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLMyKeySpec.m
@@ -26,7 +26,10 @@ describe(@"Getter/Setter Tests", ^ {
     
     it(@"Should get correctly when initialized", ^ {
         NSMutableDictionary* dict = [@{SDLRPCParameterNameE911Override:SDLVehicleDataStatusOn} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLMyKey* testStruct = [[SDLMyKey alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.e911Override).to(equal(SDLVehicleDataStatusOn));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLNavigationCapabilitySpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLNavigationCapabilitySpec.m
@@ -25,7 +25,10 @@ describe(@"Initialization tests", ^{
     it(@"Should get correctly when initialized with a dictionary", ^ {
         NSDictionary *dict = @{SDLRPCParameterNameGetWayPointsEnabled: @(YES),
                                        SDLRPCParameterNameSendLocationEnabled: @(YES)};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLNavigationCapability* testStruct = [[SDLNavigationCapability alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.getWayPointsEnabled).to(equal(YES));
         expect(testStruct.sendLocationEnabled).to(equal(YES));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLNavigationInstructionSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLNavigationInstructionSpec.m
@@ -68,7 +68,10 @@ describe(@"Getter/Setter Tests", ^{
                                SDLRPCParameterNameDetails:testDetails,
                                SDLRPCParameterNameImage:testImage
                                };
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLNavigationInstruction *testStruct = [[SDLNavigationInstruction alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.locationDetails).to(equal(testLocationDetails));
         expect(testStruct.action).to(equal(testAction));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLNavigationServiceDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLNavigationServiceDataSpec.m
@@ -73,7 +73,10 @@ describe(@"Getter/Setter Tests", ^{
                                SDLRPCParameterNameNextInstructionDistanceScale:@(testNextInstructionDistanceScale),
                                SDLRPCParameterNamePrompt:testPrompt
                                };
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLNavigationServiceData *testStruct = [[SDLNavigationServiceData alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.timestamp).to(equal(testTimestamp));
         expect(testStruct.origin).to(equal(testOrigin));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLNavigationServiceManifestSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLNavigationServiceManifestSpec.m
@@ -30,7 +30,10 @@ describe(@"Getter/Setter Tests", ^{
 
     it(@"Should get correctly when initialized with a dictionary", ^{
         NSDictionary *dict = @{SDLRPCParameterNameAcceptsWayPoints:@(testAcceptsWayPoints)};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLNavigationServiceManifest *testStruct = [[SDLNavigationServiceManifest alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.acceptsWayPoints).to(equal(testAcceptsWayPoints));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLOasisAddressSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLOasisAddressSpec.m
@@ -47,7 +47,10 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameSubLocality:@"18",
                                        SDLRPCParameterNameThoroughfare:@"Candy Lane",
                                        SDLRPCParameterNameSubThoroughfare:@"123"} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOasisAddress* testStruct = [[SDLOasisAddress alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.countryName).to(equal(@"United States"));
         expect(testStruct.countryCode).to(equal(@"US"));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLParameterPermissionsSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLParameterPermissionsSpec.m
@@ -28,7 +28,10 @@ describe(@"Getter/Setter Tests", ^ {
     it(@"Should get correctly when initialized", ^ {
         NSMutableDictionary* dict = [@{SDLRPCParameterNameAllowed:[@[SDLHMILevelBackground, SDLHMILevelFull] copy],
                                        SDLRPCParameterNameUserDisallowed:[@[SDLHMILevelNone, SDLHMILevelLimited] copy]} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLParameterPermissions* testStruct = [[SDLParameterPermissions alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.allowed).to(equal([@[SDLHMILevelBackground, SDLHMILevelFull] copy]));
         expect(testStruct.userDisallowed).to(equal([@[SDLHMILevelNone, SDLHMILevelLimited] copy]));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLPermissionItemSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLPermissionItemSpec.m
@@ -35,7 +35,10 @@ describe(@"Getter/Setter Tests", ^ {
         NSMutableDictionary<NSString *, id> *dict = [@{SDLRPCParameterNameRPCName:@"RPCNameThing",
                                                        SDLRPCParameterNameHMIPermissions:hmiPermissions,
                                                        SDLRPCParameterNameParameterPermissions:parameterPermissions} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLPermissionItem* testStruct = [[SDLPermissionItem alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.rpcName).to(equal(@"RPCNameThing"));
         expect(testStruct.hmiPermissions).to(equal(hmiPermissions));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLPhoneCapabilitySpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLPhoneCapabilitySpec.m
@@ -21,7 +21,10 @@ describe(@"Getter/Setter Tests", ^ {
 describe(@"Initialization tests", ^{
     it(@"Should get correctly when initialized with a dictionary", ^ {
         NSDictionary *dict = @{SDLRPCParameterNameDialNumberEnabled: @(YES)};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLPhoneCapability *testStruct = [[SDLPhoneCapability alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.dialNumberEnabled).to(equal(YES));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLPresetBankCapabilitiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLPresetBankCapabilitiesSpec.m
@@ -24,7 +24,10 @@ describe(@"Getter/Setter Tests", ^ {
     
     it(@"Should get correctly when initialized", ^ {
         NSMutableDictionary<NSString *, id> *dict = [@{SDLRPCParameterNameOnScreenPresetsAvailable:@YES} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLPresetBankCapabilities* testStruct = [[SDLPresetBankCapabilities alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.onScreenPresetsAvailable).to(equal(@YES));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLRDSDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLRDSDataSpec.m
@@ -38,8 +38,12 @@ describe(@"Initialization tests", ^{
                                        SDLRPCParameterNameTrafficProgramIdentification : @NO,
                                        SDLRPCParameterNameTrafficAnnouncementIdentification : @YES,
                                        SDLRPCParameterNameRegion : @"reg"} mutableCopy];
-        SDLRDSData* testStruct = [[SDLRDSData alloc] initWithDictionary:dict];
         
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        SDLRDSData* testStruct = [[SDLRDSData alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
+
         expect(testStruct.programService).to(equal(@"ps"));
         expect(testStruct.radioText).to(equal(@"rt"));
         expect(testStruct.clockText).to(equal(@"2017-07-25T19:20:30-5:00"));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLRGBColorSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLRGBColorSpec.m
@@ -41,7 +41,10 @@ describe(@"RGBColor Tests", ^{
         NSDictionary *dict = @{SDLRPCParameterNameRed: @0,
                                SDLRPCParameterNameGreen: @100,
                                SDLRPCParameterNameBlue: @255};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLRGBColor *testStruct = [[SDLRGBColor alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.red).to(equal(@0));
         expect(testStruct.green).to(equal(@100));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLRadioControlCapabilitiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLRadioControlCapabilitiesSpec.m
@@ -50,7 +50,10 @@ describe(@"Initialization tests", ^{
                                        SDLRPCParameterNameSiriusXMRadioAvailable : @NO,
                                        SDLRPCParameterNameSISDataAvailable:@YES
                                        } mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLRadioControlCapabilities* testStruct = [[SDLRadioControlCapabilities alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.moduleName).to(equal(@"someName"));
         expect(testStruct.radioEnableAvailable).to(equal(@YES));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLRadioControlDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLRadioControlDataSpec.m
@@ -49,7 +49,10 @@ describe(@"Initialization tests", ^{
                                        SDLRPCParameterNameState : SDLRadioStateNotFound,
                                        SDLRPCParameterNameHDRadioEnable : @NO
                                        } mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLRadioControlData* testStruct = [[SDLRadioControlData alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.frequencyInteger).to(equal(@101));
         expect(testStruct.frequencyFraction).to(equal(@7));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLRectangleSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLRectangleSpec.m
@@ -37,7 +37,10 @@ describe(@"Rectangle Tests", ^{
                                 SDLRPCParameterNameY:@200,
                                 SDLRPCParameterNameWidth:@2000,
                                 SDLRPCParameterNameHeight:@3000};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLRectangle *testStruct = [[SDLRectangle alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.x).to(equal(@20));
         expect(testStruct.y).to(equal(@200));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLRemoteControlCapabilitiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLRemoteControlCapabilitiesSpec.m
@@ -57,7 +57,10 @@ describe(@"Initialization tests", ^{
                                        SDLRPCParameterNameLightControlCapabilities :[@[someLightControlCapabilities] copy],
                                        SDLRPCParameterNameHmiSettingsControlCapabilities : [@[someHMISettingsControlCapabilities] copy]
                                        } mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLRemoteControlCapabilities* testStruct = [[SDLRemoteControlCapabilities alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.seatControlCapabilities).to(equal([@[someSeatControlCapabilities] copy]));
         expect(testStruct.climateControlCapabilities).to(equal([@[someClimateControlCapabilities] copy]));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLSISDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLSISDataSpec.m
@@ -54,8 +54,10 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameStationIDNumber:someID,
                                        SDLRPCParameterNameStationMessage:@"message"
                                        } mutableCopy];
-
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSISData* testStruct = [[SDLSISData alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.stationShortName).to(equal(@"short"));
         expect(testStruct.stationIDNumber).to(equal(someID));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLScreenParamsSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLScreenParamsSpec.m
@@ -33,7 +33,10 @@ describe(@"Getter/Setter Tests", ^ {
     it(@"Should get correctly when initialized", ^ {
         NSMutableDictionary<NSString *, id> *dict = [@{SDLRPCParameterNameResolution:resolution,
                                                        SDLRPCParameterNameTouchEventAvailable:capabilities} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLScreenParams* testStruct = [[SDLScreenParams alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.resolution).to(equal(resolution));
         expect(testStruct.touchEventAvailable).to(equal(capabilities));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLSeatControlCapabilitiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLSeatControlCapabilitiesSpec.m
@@ -117,7 +117,10 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameMassageCushionFirmnessAvailable:@NO,
                                        SDLRPCParameterNameMemoryAvailable:@NO
                                        } mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSeatControlCapabilities *testStruct = [[SDLSeatControlCapabilities alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.moduleName).to(equal(@"moduleName"));
         expect(testStruct.heatingEnabledAvailable).to(equal(@YES));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLSeatControlDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLSeatControlDataSpec.m
@@ -126,7 +126,10 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameMassageCushionFirmness:[@[massageCushionFirmness] mutableCopy],
                                        SDLRPCParameterNameMemory:seatMemoryAction
                                        } mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSeatControlData *testStruct = [[SDLSeatControlData alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.id).to(equal(SDLSupportedSeatDriver));
         expect(testStruct.heatingEnabled).to(equal(@NO));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLSeatMemoryActionSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLSeatMemoryActionSpec.m
@@ -41,7 +41,10 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameLabel:@"none",
                                        SDLRPCParameterNameAction: SDLSeatMemoryActionTypeNone
                                        } mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSeatMemoryAction *testStruct = [[SDLSeatMemoryAction alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.id).to(equal(@54));
         expect(testStruct.action).to(equal(SDLSeatMemoryActionTypeNone));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLSingleTireStatusSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLSingleTireStatusSpec.m
@@ -33,7 +33,10 @@ describe(@"Getter/Setter Tests", ^ {
                                SDLRPCParameterNameTPMS: SDLTPMSLow,
                                SDLRPCParameterNamePressure: @67.78
                                };
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSingleTireStatus* testStruct = [[SDLSingleTireStatus alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.status).to(equal(SDLComponentVolumeStatusLow));
         expect(testStruct.monitoringSystemStatus).to(equal(SDLTPMSLow));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLSoftButtonCapabilitiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLSoftButtonCapabilitiesSpec.m
@@ -33,7 +33,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                        SDLRPCParameterNameLongPressAvailable:@YES,
                                                        SDLRPCParameterNameUpDownAvailable:@NO,
                                                        SDLRPCParameterNameImageSupported:@NO} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSoftButtonCapabilities* testStruct = [[SDLSoftButtonCapabilities alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.shortPressAvailable).to(equal(@NO));
         expect(testStruct.longPressAvailable).to(equal(@YES));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLSoftButtonSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLSoftButtonSpec.m
@@ -45,7 +45,10 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameIsHighlighted:@YES,
                                        SDLRPCParameterNameSoftButtonId:@5423,
                                        SDLRPCParameterNameSystemAction:SDLSystemActionKeepContext} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSoftButton* testStruct = [[SDLSoftButton alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.type).to(equal(SDLSoftButtonTypeImage));
         expect(testStruct.text).to(equal(@"Button"));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLStartTimeSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLStartTimeSpec.m
@@ -33,7 +33,10 @@ describe(@"StartTime Spec", ^ {
             NSDictionary<NSString *, id> *dict = @{SDLRPCParameterNameHours:@(testHours),
                                                    SDLRPCParameterNameMinutes:@(testMinutes),
                                                    SDLRPCParameterNameSeconds:@(testSeconds)};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             SDLStartTime *testStruct = [[SDLStartTime alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
             expect(testStruct.hours).to(equal(@(testHours)));
             expect(testStruct.minutes).to(equal(@(testMinutes)));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLStationIDNumberSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLStationIDNumberSpec.m
@@ -36,8 +36,10 @@ describe(@"Getter/Setter Tests", ^ {
         NSMutableDictionary* dict = [@{SDLRPCParameterNameCountryCode:@91,
                                        SDLRPCParameterNameFCCFacilityId:@23
                                        } mutableCopy];
-
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLStationIDNumber* testStruct = [[SDLStationIDNumber alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.countryCode).to(equal(@91));
         expect(testStruct.fccFacilityId).to(equal(@23));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLSyncMsgVersionSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLSyncMsgVersionSpec.m
@@ -30,7 +30,10 @@ describe(@"Getter/Setter Tests", ^ {
         NSMutableDictionary* dict = [@{SDLRPCParameterNameMajorVersion:@4,
                                        SDLRPCParameterNameMinorVersion:@532,
                                        SDLRPCParameterNamePatchVersion:@12} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSyncMsgVersion* testStruct = [[SDLSyncMsgVersion alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.majorVersion).to(equal(@4));
         expect(testStruct.minorVersion).to(equal(@532));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLSystemCapabilitySpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLSystemCapabilitySpec.m
@@ -62,7 +62,10 @@ describe(@"Getter/Setter Tests", ^ {
                                SDLRPCParameterNameRemoteControlCapability:testRemoteControlCapabilities,
                                SDLRPCParameterNameVideoStreamingCapability:testVideoStreamingCapability
                                };
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSystemCapability *testStruct = [[SDLSystemCapability alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.systemCapabilityType).to(equal(SDLSystemCapabilityTypeNavigation));
         expect(testStruct.appServicesCapabilities).to(equal(testAppServicesCapabilities));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTTSChunkSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTTSChunkSpec.m
@@ -32,7 +32,10 @@ describe(@"TTS Chunk Tests", ^{
         it(@"should correctly initialize with initWithDictionary", ^{
             NSDictionary* dict = @{SDLRPCParameterNameText: testText,
                                    SDLRPCParameterNameType: testCapabilities};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             testStruct = [[SDLTTSChunk alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
             expect(testStruct.text).to(equal(testText));
             expect(testStruct.type).to(equal(testCapabilities));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTemperatureSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTemperatureSpec.m
@@ -27,7 +27,10 @@ describe(@"Initialization tests", ^{
         
         NSMutableDictionary* dict = [@{SDLRPCParameterNameUnit : SDLTemperatureUnitCelsius ,
                                            SDLRPCParameterNameValue:@30 } mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLTemperature* testStruct = [[SDLTemperature alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.unit).to(equal(SDLTemperatureUnitCelsius));
         expect(testStruct.value).to(equal(@30));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTemplateColorSchemeSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTemplateColorSchemeSpec.m
@@ -54,7 +54,10 @@ describe(@"TemplateColor Tests", ^{
         NSDictionary *dict = @{SDLRPCParameterNameRed: @0,
                                SDLRPCParameterNameGreen: @100,
                                SDLRPCParameterNameBlue: @255};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLRGBColor *testStruct = [[SDLRGBColor alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.red).to(equal(@0));
         expect(testStruct.green).to(equal(@100));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTextFieldSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTextFieldSpec.m
@@ -36,7 +36,10 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameCharacterSet:SDLCharacterSetType5,
                                        SDLRPCParameterNameWidth:@111,
                                        SDLRPCParameterNameRows:@4} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLTextField* testStruct = [[SDLTextField alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.name).to(equal(SDLTextFieldNameTertiaryText));
         expect(testStruct.characterSet).to(equal(SDLCharacterSetType5));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTireStatusSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTireStatusSpec.m
@@ -51,7 +51,10 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameRightRear:tire4,
                                        SDLRPCParameterNameInnerLeftRear:tire5,
                                        SDLRPCParameterNameInnerRightRear:tire6} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLTireStatus* testStruct = [[SDLTireStatus alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.pressureTelltale).to(equal(SDLWarningLightStatusOff));
         expect(testStruct.leftFront).to(equal(tire1));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTouchCoordSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTouchCoordSpec.m
@@ -27,7 +27,10 @@ describe(@"Getter/Setter Tests", ^ {
     it(@"Should get correctly when initialized", ^ {
         NSMutableDictionary<NSString *, id> *dict = [@{SDLRPCParameterNameX:@67,
                                                        SDLRPCParameterNameY:@362} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLTouchCoord* testStruct = [[SDLTouchCoord alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.x).to(equal(@67));
         expect(testStruct.y).to(equal(@362));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTouchEventCapabilitiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTouchEventCapabilitiesSpec.m
@@ -30,7 +30,10 @@ describe(@"Getter/Setter Tests", ^ {
         NSMutableDictionary<NSString *, id> *dict = [@{SDLRPCParameterNamePressAvailable:@YES,
                                                        SDLRPCParameterNameMultiTouchAvailable:@NO,
                                                        SDLRPCParameterNameDoublePressAvailable:@NO} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLTouchEventCapabilities* testStruct = [[SDLTouchEventCapabilities alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.pressAvailable).to(equal(@YES));
         expect(testStruct.multiTouchAvailable).to(equal(@NO));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTouchEventSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTouchEventSpec.m
@@ -33,7 +33,10 @@ describe(@"Getter/Setter Tests", ^ {
         NSMutableDictionary<NSString *, id> *dict = [@{SDLRPCParameterNameId:@3,
                                                        SDLRPCParameterNameTS:[@[@23, @52, @41345234] mutableCopy],
                                                        SDLRPCParameterNameCoordinate:[@[coord] mutableCopy]} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLTouchEvent* testStruct = [[SDLTouchEvent alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.touchEventId).to(equal(@3));
         expect(testStruct.timeStamp).to(equal([@[@23, @52, @41345234] mutableCopy]));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTurnSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTurnSpec.m
@@ -30,7 +30,10 @@ describe(@"Getter/Setter Tests", ^ {
     it(@"Should get correctly when initialized", ^ {
         NSMutableDictionary<NSString *, id> *dict = [@{SDLRPCParameterNameNavigationText:@"NAVTEXT",
                                                        SDLRPCParameterNameTurnIcon:image} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLTurn* testStruct = [[SDLTurn alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.navigationText).to(equal(@"NAVTEXT"));
         expect(testStruct.turnIcon).to(equal(image));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLVehicleDataResultSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLVehicleDataResultSpec.m
@@ -29,7 +29,10 @@ describe(@"Getter/Setter Tests", ^ {
     it(@"Should get correctly when initialized", ^ {
         NSMutableDictionary* dict = [@{SDLRPCParameterNameDataType:SDLVehicleDataTypeAirbagStatus,
                                        SDLRPCParameterNameResultCode:SDLVehicleDataResultCodeDisallowed} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLVehicleDataResult* testStruct = [[SDLVehicleDataResult alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.dataType).to(equal(SDLVehicleDataTypeAirbagStatus));
         expect(testStruct.resultCode).to(equal(SDLVehicleDataResultCodeDisallowed));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLVehicleTypeSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLVehicleTypeSpec.m
@@ -33,7 +33,10 @@ describe(@"Getter/Setter Tests", ^ {
                                                        SDLRPCParameterNameModel:@"Model",
                                                        SDLRPCParameterNameModelYear:@"3.141*10^36",
                                                        SDLRPCParameterNameTrim:@"AE"} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLVehicleType* testStruct = [[SDLVehicleType alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.make).to(equal(@"Make"));
         expect(testStruct.model).to(equal(@"Model"));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLVideoStreamingCapabilitySpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLVideoStreamingCapabilitySpec.m
@@ -43,8 +43,10 @@ describe(@"Initialization tests", ^{
                                        SDLRPCParameterNameMaxBitrate: maxBitrate,
                                        SDLRPCParameterNameSupportedFormats: formatArray,
                                        SDLRPCParameterNameHapticSpatialDataSupported: hapticDataSupported} mutableCopy];
-
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLVideoStreamingCapability* testStruct = [[SDLVideoStreamingCapability alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.preferredResolution).to(equal(resolution));
         expect(testStruct.maxBitrate).to(equal(maxBitrate));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLVideoStreamingFormatSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLVideoStreamingFormatSpec.m
@@ -22,7 +22,10 @@ describe(@"Initialization tests", ^{
     it(@"Should get correctly when initialized with a dictionary", ^ {
         NSMutableDictionary* dict = [@{SDLRPCParameterNameVideoProtocol: SDLVideoStreamingProtocolRAW,
                                        SDLRPCParameterNameVideoCodec: SDLVideoStreamingCodecH264} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLVideoStreamingFormat* testStruct = [[SDLVideoStreamingFormat alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.protocol).to(equal(SDLVideoStreamingProtocolRAW));
         expect(testStruct.codec).to(equal(SDLVideoStreamingCodecH264));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLVrHelpItemSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLVrHelpItemSpec.m
@@ -34,7 +34,10 @@ describe(@"Getter/Setter Tests", ^ {
         NSMutableDictionary<NSString *, id> *dict = [@{SDLRPCParameterNameText:@"DON'T PANIC",
                                                        SDLRPCParameterNameImage:image,
                                                        SDLRPCParameterNamePosition:@42} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLVRHelpItem* testStruct = [[SDLVRHelpItem alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
         expect(testStruct.text).to(equal(@"DON'T PANIC"));
         expect(testStruct.image).to(equal(image));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLWeatherAlertSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLWeatherAlertSpec.m
@@ -57,7 +57,10 @@ describe(@"Getter/Setter Tests", ^{
                                SDLRPCParameterNameSeverity:testSeverity,
                                SDLRPCParameterNameTimeIssued:testTimeIssued
                                };
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLWeatherAlert *testStruct = [[SDLWeatherAlert alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.title).to(equal(testTitle));
         expect(testStruct.summary).to(equal(testSummary));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLWeatherDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLWeatherDataSpec.m
@@ -127,7 +127,10 @@ describe(@"Getter/Setter Tests", ^{
                                SDLRPCParameterNameVisibility:@(testVisibility),
                                SDLRPCParameterNameWeatherIcon:testWeatherIcon
                                };
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLWeatherData *testStruct = [[SDLWeatherData alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.currentTemperature).to(equal(testCurrentTemp));
         expect(testStruct.temperatureHigh).to(equal(testTempHigh));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLWeatherServiceDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLWeatherServiceDataSpec.m
@@ -29,6 +29,8 @@ describe(@"Getter/Setter Tests", ^{
         testLocation = [[SDLLocationDetails alloc] init];
         testLocation.locationName = @"testLocationName";
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLWeatherData *testWeatherDataA = [[SDLWeatherData alloc] initWithDictionary:@{SDLRPCParameterNameWeatherSummary:@"testWeatherDataA"}];
         SDLWeatherData *testWeatherDataB = [[SDLWeatherData alloc] initWithDictionary:@{SDLRPCParameterNameWeatherSummary:@"testWeatherDataB"}];
         SDLWeatherData *testWeatherDataC = [[SDLWeatherData alloc] initWithDictionary:@{SDLRPCParameterNameWeatherSummary:@"testWeatherDataC"}];
@@ -38,6 +40,7 @@ describe(@"Getter/Setter Tests", ^{
         testMultidayForecast = @[testWeatherDataA, testWeatherDataC];
 
         SDLWeatherAlert *testWeatherAlertA = [[SDLWeatherAlert alloc] initWithDictionary:@{SDLRPCParameterNameTitle:@"testWeatherAlertA"}];
+#pragma clang diagnostic pop
         testAlerts = @[testWeatherAlertA];
     });
 
@@ -66,7 +69,10 @@ describe(@"Getter/Setter Tests", ^{
                                SDLRPCParameterNameMultidayForecast:testMultidayForecast,
                                SDLRPCParameterNameAlerts:testAlerts
                                };
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLWeatherServiceData *testStruct = [[SDLWeatherServiceData alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.location).to(equal(testLocation));
         expect(testStruct.currentForecast).to(equal(testCurrentForecast));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLWeatherServiceManifestSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLWeatherServiceManifestSpec.m
@@ -48,7 +48,10 @@ describe(@"Getter/Setter Tests", ^{
                                SDLRPCParameterNameMaxMinutelyForecastAmount:@(testMaxMinutelyForecastAmount),
                                SDLRPCParameterNameWeatherForLocationSupported:@(testWeatherForLocationSupported)
                                };
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLWeatherServiceManifest *testStruct = [[SDLWeatherServiceManifest alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
 
         expect(testStruct.currentForecastSupported).to(equal(testCurrentForecastSupported));
         expect(testStruct.maxMultidayForecastAmount).to(equal(testMaxMultidayForecastAmount));

--- a/SmartDeviceLinkTests/RPCSpecs/SuperclassSpecs/SDLRPCMessageSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/SuperclassSpecs/SDLRPCMessageSpec.m
@@ -15,16 +15,22 @@ QuickSpecBegin(SDLRPCMessageSpec)
 
 describe(@"Readonly Property Tests", ^ {
     it(@"Should get name correctly when initialized with name", ^ {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLRPCMessage* testMessage = [[SDLRPCMessage alloc] initWithName:@"Poorly Named"];
+#pragma clang diagnostic pop
         
         expect(testMessage.name).to(equal(@"Poorly Named"));
     });
     
     it(@"Should get correctly when initialized with dictionary", ^ {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLRPCMessage* testMessage = [[SDLRPCMessage alloc] initWithDictionary:[@{SDLRPCParameterNameNotification:
                                                                                       @{SDLRPCParameterNameParameters:
                                                                                             @{@"name":@"George"},
                                                                                         SDLRPCParameterNameOperationName:@"Poorly Named"}} mutableCopy]];
+#pragma clang diagnostic pop
         
         expect(testMessage.name).to(equal(@"Poorly Named"));
         expect(testMessage.messageType).to(equal(SDLRPCParameterNameNotification));
@@ -33,62 +39,86 @@ describe(@"Readonly Property Tests", ^ {
 
 describe(@"Parameter Tests", ^ {
     it(@"Should set and get correctly", ^ {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLRPCMessage* testMessage = [[SDLRPCMessage alloc] initWithName:@""];
         
         [testMessage setParameters:@"ADogAPanicInAPagoda" value:@"adogaPAnIcinaPAgoDA"];
+#pragma clang diagnostic pop
         
-        expect([testMessage getParameters:@"ADogAPanicInAPagoda"]).to(equal(@"adogaPAnIcinaPAgoDA"));
+        expect(testMessage.parameters[@"ADogAPanicInAPagoda"]).to(equal(@"adogaPAnIcinaPAgoDA"));
     });
     
     it(@"Should get correctly when initialized", ^ {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLRPCMessage* testMessage = [[SDLRPCMessage alloc] initWithDictionary:[@{SDLRPCParameterNameResponse:
                                                                                       @{SDLRPCParameterNameParameters:
                                                                                             @{@"age":@25},
                                                                                         SDLRPCParameterNameOperationName:@"Nameless"}} mutableCopy]];
+#pragma clang diagnostic pop
         
-        expect([testMessage getParameters:@"age"]).to(equal(@25));
+        expect(testMessage.parameters[@"age"]).to(equal(@25));
     });
     
     it(@"Should be nil if not set", ^ {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLRPCMessage* testMessage = [[SDLRPCMessage alloc] initWithName:@""];
         
-        expect([testMessage getParameters:@"ADogAPanicInAPagoda"]).to(beNil());
+        expect(testMessage.parameters[@"ADogAPanicInAPagoda"]).to(beNil());
+#pragma clang diagnostic pop
     });
 });
 
 describe(@"FunctionName Tests", ^ {
     it(@"Should set and get correctly", ^ {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLRPCMessage* testMessage = [[SDLRPCMessage alloc] initWithName:@""];
         
         [testMessage setFunctionName:@"Functioning"];
+#pragma clang diagnostic pop
         
-        expect([testMessage getFunctionName]).to(equal(@"Functioning"));
+        expect(testMessage.name).to(equal(@"Functioning"));
     });
     
     it(@"Should get correctly when initialized", ^ {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLRPCMessage* testMessage = [[SDLRPCMessage alloc] initWithDictionary:[@{SDLRPCParameterNameRequest:
                                                                                       @{SDLRPCParameterNameParameters:
                                                                                             @{@"age":@25},
                                                                                         SDLRPCParameterNameOperationName:@"DoNothing"}} mutableCopy]];
+#pragma clang diagnostic pop
         
-        expect([testMessage getFunctionName]).to(equal(@"DoNothing"));
-        
+        expect(testMessage.name).to(equal(@"DoNothing"));
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         testMessage = [[SDLRPCMessage alloc] initWithName:@"DoSomething"];
+#pragma clang diagnostic pop
         
-        expect([testMessage getFunctionName]).to(equal(@"DoSomething"));
+        expect(testMessage.name).to(equal(@"DoSomething"));
     });
     
     it(@"Should be nil if not set", ^ {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLRPCMessage* testMessage = [[SDLRPCMessage alloc] initWithDictionary:[@{SDLRPCParameterNameNotification:
                                                                                       @{SDLRPCParameterNameParameters:
                                                                                             @{}}} mutableCopy]];
-        expect([testMessage getFunctionName]).to(beNil());
+#pragma clang diagnostic pop
+        expect(testMessage.name).to(beNil());
     });
 });
 
 describe(@"BulkDataTests", ^ {
     it(@"Should set and get correctly", ^ {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLRPCMessage* testMessage = [[SDLRPCMessage alloc] initWithName:@""];
+#pragma clang diagnostic pop
         
         const char* testString = "ImportantData";
         testMessage.bulkData = [NSData dataWithBytes:testString length:strlen(testString)];
@@ -97,16 +127,22 @@ describe(@"BulkDataTests", ^ {
     });
     
     it(@"Should get correctly when initialized", ^ {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLRPCMessage* testMessage = [[SDLRPCMessage alloc] initWithDictionary:[@{SDLRPCParameterNameNotification:
                                                                                       @{SDLRPCParameterNameParameters:
                                                                                             @{}},
                                                                                   SDLRPCParameterNameBulkData:[NSData dataWithBytes:"ImageData" length:strlen("ImageData")]} mutableCopy]];
+#pragma clang diagnostic pop
         
         expect(testMessage.bulkData).to(equal([NSData dataWithBytes:"ImageData" length:strlen("ImageData")]));
     });
     
     it(@"Should be nil if not set", ^ {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLRPCMessage* testMessage = [[SDLRPCMessage alloc] initWithName:@""];
+#pragma clang diagnostic pop
         
         expect(testMessage.bulkData).to(beNil());
     });

--- a/SmartDeviceLinkTests/RPCSpecs/SuperclassSpecs/SDLRPCMessageSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/SuperclassSpecs/SDLRPCMessageSpec.m
@@ -44,8 +44,9 @@ describe(@"Parameter Tests", ^ {
         SDLRPCMessage* testMessage = [[SDLRPCMessage alloc] initWithName:@""];
         
         [testMessage setParameters:@"ADogAPanicInAPagoda" value:@"adogaPAnIcinaPAgoDA"];
+        expect([testMessage getParameters:@"ADogAPanicInAPagoda"]).to(equal(@"adogaPAnIcinaPAgoDA"));
 #pragma clang diagnostic pop
-        
+
         expect(testMessage.parameters[@"ADogAPanicInAPagoda"]).to(equal(@"adogaPAnIcinaPAgoDA"));
     });
     

--- a/SmartDeviceLinkTests/RPCSpecs/SuperclassSpecs/SDLRPCRequestSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/SuperclassSpecs/SDLRPCRequestSpec.m
@@ -14,7 +14,10 @@ QuickSpecBegin(SDLRPCRequestSpec)
 
 describe(@"Getter/Setter Tests",  ^ {
     it(@"Should set and get correctly", ^ {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLRPCRequest* testRequest = [[SDLRPCRequest alloc] initWithName:@"A Legitimate Request"];
+#pragma clang diagnostic pop
         
         testRequest.correlationID = @14641;
         

--- a/SmartDeviceLinkTests/RPCSpecs/SuperclassSpecs/SDLRPCResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/SuperclassSpecs/SDLRPCResponseSpec.m
@@ -17,7 +17,10 @@ QuickSpecBegin(SDLRPCResponseSpec)
 
 describe(@"Getter/Setter Tests",  ^ {
     it(@"Should set and get correctly", ^ {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLRPCResponse* response = [[SDLRPCResponse alloc] initWithName:@"A Legitimate Response"];
+#pragma clang diagnostic pop
         
         response.correlationID = @14641;
         response.success = @YES;
@@ -38,9 +41,12 @@ describe(@"Getter/Setter Tests",  ^ {
                                                    SDLRPCParameterNameInfo:@"Test Info"},
                                              SDLRPCParameterNameCorrelationId:@1004,
                                              SDLRPCParameterNameOperationName:SDLRPCParameterNameResponse}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLRPCResponse* testResponse = [[SDLRPCResponse alloc] initWithDictionary:dict];
+#pragma clang diagnostic pop
         
-        expect(testResponse.getFunctionName).to(equal(SDLRPCParameterNameResponse));
+        expect(testResponse.name).to(equal(SDLRPCParameterNameResponse));
         expect(testResponse.correlationID).to(equal(@1004));
         expect(testResponse.success).to(equal(@YES));
         expect(testResponse.resultCode).to(equal(SDLRPCParameterNameSuccess));

--- a/SmartDeviceLinkTests/RPCSpecs/SuperclassSpecs/SDLRPCStructSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/SuperclassSpecs/SDLRPCStructSpec.m
@@ -14,10 +14,13 @@ QuickSpecBegin(SDLRPCStructSpec)
 
 describe(@"SerializeAsDictionary Tests", ^ {
     it(@"Should serialize correctly", ^ {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         NSMutableDictionary<NSString *, id> *dict = [@{@"Key":@"Value", @"Answer":@42, @"Struct":[[SDLRPCStruct alloc] initWithDictionary:[@{@"Array":@[@1, @1, @1, @1]} mutableCopy]]} mutableCopy];
         SDLRPCStruct* testStruct = [[SDLRPCStruct alloc] initWithDictionary:dict];
         
         expect([testStruct serializeAsDictionary:2]).to(equal([@{@"Key":@"Value", @"Answer":@42, @"Struct":@{@"Array":@[@1, @1, @1, @1]}} mutableCopy]));
+#pragma clang diagnostic pop
     });
 });
 


### PR DESCRIPTION
Fixes #1204 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Unit testing and smoke testing

### Summary
This PR deprecates RPC superclass initializers so that they are not clearly available for developers to use, which can be confusing. Ideally, these methods would be "protected" methods and not be available at all, but because they were publicly available, they have to be deprecated until the next major version.

### Changelog
##### Bug Fixes
* Deprecate RPC superclass methods to reduce confusion for developers.

### Tasks Remaining:
- [x] Fix unit tests
- [x] Smoke test

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
