### PR TITLE
Implement SDL-0226: SDLManager RPC Subscription Helper Methods

### DIFF
--- a/Example Apps/Example ObjC/VehicleDataManager.m
+++ b/Example Apps/Example ObjC/VehicleDataManager.m
@@ -106,13 +106,13 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @param notification A SDLOnVehicleData notification
  */
-- (void)vehicleDataNotification:(SDLRPCMessage *)notification {
-    if (![notification isKindOfClass:SDLOnVehicleData.class]) {
+- (void)vehicleDataNotification:(SDLRPCNotificationNotification *)notification {
+    if (![notification.notification isKindOfClass:SDLOnVehicleData.class]) {
         return;
     }
 
     SDLOnVehicleData *onVehicleData = (SDLOnVehicleData *)notification;
-    self.vehicleOdometerData = [NSString stringWithFormat:@"%@: %@ kph", VehicleDataOdometerName, onVehicleData.odometer];
+    self.vehicleOdometerData = [NSString stringWithFormat:@"%@: %@ km", VehicleDataOdometerName, onVehicleData.odometer];
 
     if (!self.refreshUIHandler) { return; }
     self.refreshUIHandler();

--- a/Example Apps/Example ObjC/VehicleDataManager.m
+++ b/Example Apps/Example ObjC/VehicleDataManager.m
@@ -111,7 +111,7 @@ NS_ASSUME_NONNULL_BEGIN
         return;
     }
 
-    SDLOnVehicleData *onVehicleData = (SDLOnVehicleData *)notification;
+    SDLOnVehicleData *onVehicleData = (SDLOnVehicleData *)notification.notification;
     self.vehicleOdometerData = [NSString stringWithFormat:@"%@: %@ km", VehicleDataOdometerName, onVehicleData.odometer];
 
     if (!self.refreshUIHandler) { return; }

--- a/Example Apps/Example ObjC/VehicleDataManager.m
+++ b/Example Apps/Example ObjC/VehicleDataManager.m
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
     _refreshUIHandler = refreshUIHandler;
     _vehicleOdometerData = @"";
 
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(vehicleDataNotification:) name:SDLDidReceiveVehicleDataNotification object:nil];
+    [_sdlManager subscribeToRPC:SDLDidReceiveVehicleDataNotification withObserver:self selector:@selector(vehicleDataNotification:)];
     [self sdlex_resetOdometer];
 
     return self;
@@ -106,12 +106,12 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @param notification A SDLOnVehicleData notification
  */
-- (void)vehicleDataNotification:(SDLRPCNotificationNotification *)notification {
-    if (![notification.notification isKindOfClass:SDLOnVehicleData.class]) {
+- (void)vehicleDataNotification:(SDLRPCMessage *)notification {
+    if (![notification isKindOfClass:SDLOnVehicleData.class]) {
         return;
     }
 
-    SDLOnVehicleData *onVehicleData = (SDLOnVehicleData *)notification.notification;
+    SDLOnVehicleData *onVehicleData = (SDLOnVehicleData *)notification;
     self.vehicleOdometerData = [NSString stringWithFormat:@"%@: %@ kph", VehicleDataOdometerName, onVehicleData.odometer];
 
     if (!self.refreshUIHandler) { return; }

--- a/Example Apps/Example Swift/VehicleDataManager.swift
+++ b/Example Apps/Example Swift/VehicleDataManager.swift
@@ -23,7 +23,7 @@ class VehicleDataManager: NSObject {
         super.init()
 
         resetOdometer()
-        NotificationCenter.default.addObserver(self, selector: #selector(vehicleDataNotification(_:)), name: .SDLDidReceiveVehicleData, object: nil)
+        self.sdlManager.subscribe(to: .SDLDidReceiveVehicleData, observer: self, selector: #selector(vehicleDataNotification(_:)))
     }
 }
 

--- a/SmartDeviceLink/SDLManager.h
+++ b/SmartDeviceLink/SDLManager.h
@@ -178,6 +178,46 @@ typedef void (^SDLManagerReadyBlock)(BOOL success, NSError *_Nullable error);
  */
 - (void)sendSequentialRequests:(NSArray<SDLRPCRequest *> *)requests progressHandler:(nullable SDLMultipleSequentialRequestProgressHandler)progressHandler completionHandler:(nullable SDLMultipleRequestCompletionHandler)completionHandler NS_SWIFT_NAME(sendSequential(requests:progressHandler:completionHandler:));
 
+
+#pragma mark - RPC Subscriptions
+
+typedef void (^SDLRPCUpdatedBlock) (__kindof SDLRPCMessage *);
+
+/**
+ * Subscribe to callbacks about a particular RPC request, notification, or response with a block callback.
+ *
+ * @param rpcName The name of the RPC request, response, or notification to subscribe to.
+ * @param block The block that will be called every time an RPC of the name and type specified is received.
+ * @return An object that can be passed to `unsubscribeFromRPC:ofType:withObserver:` to unsubscribe the block.
+ */
+- (id)subscribeToRPC:(SDLNotificationName)rpcName withBlock:(SDLRPCUpdatedBlock)block NS_SWIFT_NAME(subscribe(to:block:));
+
+/**
+ * Subscribe to callbacks about a particular RPC request, notification, or response with a selector callback.
+ *
+ * The selector supports the following parameters:
+ *
+ * 1. One parameter e.g. `- (void)registerAppInterfaceResponse:(SDLRegisterAppInterfaceResponse *)response;`
+ * 2. Two parameters e.g. `- (void)registerAppInterfaceResponse:(SDLRegisterAppInterfaceResponse *)response error:(nullable NSError *)error;`
+ *
+ * Note that using this method to get a response instead of the `sendRequest:withResponseHandler:` method of getting a response, you will not be notifed of any `SDLGenericResponse` errors where the head unit doesn't understand the request.
+ *
+ * The error will be called if `response.success` is `NO` and will be filled with the info field.
+ *
+ * @param rpcName The name of the RPC request, response, or notification to subscribe to.
+ * @param observer The object that will have its selector called every time an RPC of the name and type specified is received.
+ * @param selector The selector on `observer` that will be called every time an RPC of the name and type specified is received.
+ */
+- (void)subscribeToRPC:(SDLNotificationName)rpcName withObserver:(id)observer selector:(SEL)selector NS_SWIFT_NAME(subscribe(to:observer:selector:));
+
+/**
+ * Unsubscribe to callbacks about a particular RPC request, notification, or response.
+ *
+ * @param rpcName The name of the RPC request, response, or notification to unsubscribe from.
+ * @param observer The object representing a block callback or selector callback to be unsubscribed
+ */
+- (void)unsubscribeFromRPC:(SDLNotificationName)rpcName withObserver:(id)observer NS_SWIFT_NAME(unsubscribe(from:observer:));
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLManager.m
+++ b/SmartDeviceLink/SDLManager.m
@@ -17,6 +17,9 @@
 #import "SDLManagerDelegate.h"
 #import "SDLNotificationDispatcher.h"
 #import "SDLResponseDispatcher.h"
+#import "SDLRPCRequestNotification.h"
+#import "SDLRPCResponseNotification.h"
+#import "SDLRPCNotificationNotification.h"
 #import "SDLSoftButtonManager.h"
 #import "SDLStateMachine.h"
 #import "SDLTextAndGraphicManager.h"
@@ -141,6 +144,24 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)sendSequentialRequests:(NSArray<SDLRPCRequest *> *)requests progressHandler:(nullable SDLMultipleSequentialRequestProgressHandler)progressHandler completionHandler:(nullable SDLMultipleRequestCompletionHandler)completionHandler {
     [self.lifecycleManager sendSequentialRequests:requests progressHandler:progressHandler completionHandler:completionHandler];
+}
+
+
+#pragma mark - RPC Subscriptions
+
+- (id)subscribeToRPC:(SDLNotificationName)rpcName withBlock:(SDLRPCUpdatedBlock)block {
+    return [[NSNotificationCenter defaultCenter] addObserverForName:rpcName object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification * _Nonnull note) {
+        SDLRPCMessage *message = note.userInfo[SDLNotificationUserInfoObject];
+        block(message);
+    }];
+}
+
+- (void)subscribeToRPC:(SDLNotificationName)rpcName withObserver:(id)observer selector:(SEL)selector {
+    [[NSNotificationCenter defaultCenter] addObserver:observer selector:selector name:rpcName object:nil];
+}
+
+- (void)unsubscribeFromRPC:(SDLNotificationName)rpcName withObserver:(id)observer {
+    [[NSNotificationCenter defaultCenter] removeObserver:observer name:rpcName object:nil];
 }
 
 @end


### PR DESCRIPTION
Fixes #1257

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Smoke tests have been performed

### Summary
This PR adds helper methods to subscribe and unsubscribe to RPC notifications. This is already possible with `NSNotificationCenter`, but it isn't clearly exposed. This simply wraps calling `NSNotificationCenter`.

### Changelog
##### Enhancements
* Add helper methods onto `SDLManager` that wrap existing `NSNotificationCenter` APIs for subscribing to RPCs.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
