### PR TITLE
Fixed file manager race condition

### DIFF
--- a/SmartDeviceLink/SDLFileManager.m
+++ b/SmartDeviceLink/SDLFileManager.m
@@ -404,8 +404,6 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
             if ([self sdl_canFileBeUploadedAgain:file maxUploadCount:maxUploadCount failedFileUploadsCount:self.failedFileUploadsCount]) {
                 SDLLogD(@"Attempting to resend file with name %@ after a failed upload attempt", file.name);
                 return [self sdl_uploadFile:file completionHandler:handler];
-            } else {
-                SDLLogE(@"File named %@ failed to upload. Max number of upload attempts reached", file.name);
             }
         }
 
@@ -526,11 +524,28 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
  *  @return                 True if the file still needs to be (re)sent to Core; false if not.
  */
 - (BOOL)sdl_canFileBeUploadedAgain:(nullable SDLFile *)file maxUploadCount:(UInt8)maxUploadCount failedFileUploadsCount:(NSMutableDictionary<SDLFileName *, NSNumber<SDLUInt> *> *)failedFileUploadsCount {
-    if (!file || [self hasUploadedFile:file]) {
+    if (![self.currentState isEqualToString:SDLFileManagerStateReady]) {
+        SDLLogE(@"File named %@ failed to upload. The file manager has shutdown so the file will not be sent again.", file.name);
         return NO;
     }
+
+    if (!file) {
+        SDLLogE(@"File named %@ can not be uploaded because it is not a valid file.", file.name);
+        return NO;
+    }
+
+    if ([self hasUploadedFile:file]) {
+        SDLLogE(@"File named %@ has already been uploaded.", file.name);
+        return NO;
+    }
+
     NSNumber *failedUploadCount = failedFileUploadsCount[file.name];
-    return (failedUploadCount == nil) ? YES : (failedUploadCount.integerValue < maxUploadCount);
+    BOOL canFileBeUploadedAgain = (failedUploadCount == nil) ? YES : (failedUploadCount.integerValue < maxUploadCount);
+    if (!canFileBeUploadedAgain) {
+        SDLLogE(@"File named %@ failed to upload. Max number of upload attempts reached.", file.name);
+    }
+
+    return canFileBeUploadedAgain;
 }
 
 /**

--- a/SmartDeviceLink/SDLFileManager.m
+++ b/SmartDeviceLink/SDLFileManager.m
@@ -525,17 +525,17 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
  */
 - (BOOL)sdl_canFileBeUploadedAgain:(nullable SDLFile *)file maxUploadCount:(UInt8)maxUploadCount failedFileUploadsCount:(NSMutableDictionary<SDLFileName *, NSNumber<SDLUInt> *> *)failedFileUploadsCount {
     if (![self.currentState isEqualToString:SDLFileManagerStateReady]) {
-        SDLLogE(@"File named %@ failed to upload. The file manager has shutdown so the file will not be sent again.", file.name);
+        SDLLogW(@"File named %@ failed to upload. The file manager has shutdown so the file upload will not retry.", file.name);
         return NO;
     }
 
     if (!file) {
-        SDLLogE(@"File named %@ can not be uploaded because it is not a valid file.", file.name);
+        SDLLogE(@"File can not be uploaded because it is not a valid file.");
         return NO;
     }
 
     if ([self hasUploadedFile:file]) {
-        SDLLogE(@"File named %@ has already been uploaded.", file.name);
+        SDLLogD(@"File named %@ has already been uploaded.", file.name);
         return NO;
     }
 


### PR DESCRIPTION
Fixes #1264 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
* Unit tests added

### Summary
* Fixed the file manager adding file uploads to the transaction queue after the file manager transitioned to state shutdown. The operation would never finish so any uploads added after the file manager transitioned back to the ready state would not run. 

### Changelog
##### Breaking Changes
* n/a

##### Bug Fixes
* Fixed the file manager adding file uploads to the transaction queue after the file manager has shutdown. 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)