### PR TITLE
Support SDLSystemCapabilityManager Subscriptions

### DIFF
--- a/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
+++ b/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
@@ -1004,6 +1004,9 @@
 		5D6F7A351BC5B9B60070BF37 /* SDLLockScreenViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D6F7A331BC5B9B60070BF37 /* SDLLockScreenViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5D6F7A361BC5B9B60070BF37 /* SDLLockScreenViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D6F7A341BC5B9B60070BF37 /* SDLLockScreenViewController.m */; };
 		5D6F7A3E1BC811FC0070BF37 /* SDLAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5D6F7A3D1BC811FC0070BF37 /* SDLAssets.xcassets */; };
+		5D75960D22972F830013207C /* TestSystemCapabilityObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D75960C22972F830013207C /* TestSystemCapabilityObserver.m */; };
+		5D75961122972FCA0013207C /* SDLSystemCapabilityObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D75960F22972FCA0013207C /* SDLSystemCapabilityObserver.h */; };
+		5D75961222972FCA0013207C /* SDLSystemCapabilityObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D75961022972FCA0013207C /* SDLSystemCapabilityObserver.m */; };
 		5D76E31C1D3805FF00647CFA /* SDLLockScreenManagerSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D76E31B1D3805FF00647CFA /* SDLLockScreenManagerSpec.m */; };
 		5D76E3211D39742300647CFA /* SDLViewControllerPresentable.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D76E3201D39742300647CFA /* SDLViewControllerPresentable.h */; };
 		5D76E3241D39767000647CFA /* SDLLockScreenPresenter.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D76E3221D39767000647CFA /* SDLLockScreenPresenter.h */; };
@@ -2632,6 +2635,10 @@
 		5D6F7A331BC5B9B60070BF37 /* SDLLockScreenViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDLLockScreenViewController.h; sourceTree = "<group>"; };
 		5D6F7A341BC5B9B60070BF37 /* SDLLockScreenViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLLockScreenViewController.m; sourceTree = "<group>"; };
 		5D6F7A3D1BC811FC0070BF37 /* SDLAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = SDLAssets.xcassets; path = Assets/SDLAssets.xcassets; sourceTree = "<group>"; };
+		5D75960B22972F830013207C /* TestSystemCapabilityObserver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = TestSystemCapabilityObserver.h; path = DevAPISpecs/TestSystemCapabilityObserver.h; sourceTree = "<group>"; };
+		5D75960C22972F830013207C /* TestSystemCapabilityObserver.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = TestSystemCapabilityObserver.m; path = DevAPISpecs/TestSystemCapabilityObserver.m; sourceTree = "<group>"; };
+		5D75960F22972FCA0013207C /* SDLSystemCapabilityObserver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDLSystemCapabilityObserver.h; sourceTree = "<group>"; };
+		5D75961022972FCA0013207C /* SDLSystemCapabilityObserver.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLSystemCapabilityObserver.m; sourceTree = "<group>"; };
 		5D76E31B1D3805FF00647CFA /* SDLLockScreenManagerSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SDLLockScreenManagerSpec.m; path = DevAPISpecs/SDLLockScreenManagerSpec.m; sourceTree = "<group>"; };
 		5D76E3201D39742300647CFA /* SDLViewControllerPresentable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDLViewControllerPresentable.h; sourceTree = "<group>"; };
 		5D76E3221D39767000647CFA /* SDLLockScreenPresenter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDLLockScreenPresenter.h; sourceTree = "<group>"; };
@@ -5050,6 +5057,24 @@
 			name = "Lock Screen UI";
 			sourceTree = "<group>";
 		};
+		5D75960A22972F620013207C /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				5D75960B22972F830013207C /* TestSystemCapabilityObserver.h */,
+				5D75960C22972F830013207C /* TestSystemCapabilityObserver.m */,
+			);
+			name = Utilities;
+			sourceTree = "<group>";
+		};
+		5D75960E22972FB90013207C /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				5D75960F22972FCA0013207C /* SDLSystemCapabilityObserver.h */,
+				5D75961022972FCA0013207C /* SDLSystemCapabilityObserver.m */,
+			);
+			name = Utilities;
+			sourceTree = "<group>";
+		};
 		5D76E31A1D3805E600647CFA /* LockScreen */ = {
 			isa = PBXGroup;
 			children = (
@@ -5740,6 +5765,7 @@
 		880E35B12088F73400181259 /* System Capabilities */ = {
 			isa = PBXGroup;
 			children = (
+				5D75960E22972FB90013207C /* Utilities */,
 				880E35B32088F75A00181259 /* SDLSystemCapabilityManager.h */,
 				880E35B22088F75A00181259 /* SDLSystemCapabilityManager.m */,
 			);
@@ -5749,6 +5775,7 @@
 		880E35B62088F77C00181259 /* System Capabilities */ = {
 			isa = PBXGroup;
 			children = (
+				5D75960A22972F620013207C /* Utilities */,
 				880E35B72088F78E00181259 /* SDLSystemCapabilityManagerSpec.m */,
 			);
 			name = "System Capabilities";
@@ -6272,6 +6299,7 @@
 				5D61FDB11A84238C00846EE7 /* SDLSubscribeVehicleData.h in Headers */,
 				5DB996601F28C6ED002D8795 /* SDLControlFramePayloadVideoStartServiceAck.h in Headers */,
 				5DCF76F51ACDBAD300BB647B /* SDLSendLocation.h in Headers */,
+				5D75961122972FCA0013207C /* SDLSystemCapabilityObserver.h in Headers */,
 				5D61FC9E1A84238C00846EE7 /* SDLEncodedSyncPData.h in Headers */,
 				1FF7DABA1F75B2A800B46C30 /* SDLFocusableItemLocator.h in Headers */,
 				5D019276214994AC003500F6 /* NSMutableArray+Safe.h in Headers */,
@@ -7025,6 +7053,7 @@
 				88EEC5BC220A327B005AA2F9 /* SDLPublishAppServiceResponse.m in Sources */,
 				5D61FC951A84238C00846EE7 /* SDLDriverDistractionState.m in Sources */,
 				5DB996611F28C6ED002D8795 /* SDLControlFramePayloadVideoStartServiceAck.m in Sources */,
+				5D75961222972FCA0013207C /* SDLSystemCapabilityObserver.m in Sources */,
 				884E702021FB983F008D53BA /* SDLAppServiceManifest.m in Sources */,
 				5D61FD961A84238C00846EE7 /* SDLShowResponse.m in Sources */,
 				5D61FD981A84238C00846EE7 /* SDLSingleTireStatus.m in Sources */,
@@ -7369,6 +7398,7 @@
 				162E837E1A9BDE8B00906325 /* SDLGPSDataSpec.m in Sources */,
 				5DAE06731BDEC6C000F9B498 /* SDLFileSpec.m in Sources */,
 				162E82E11A9BDE8B00906325 /* SDLHMIZoneCapabilitiesSpec.m in Sources */,
+				5D75960D22972F830013207C /* TestSystemCapabilityObserver.m in Sources */,
 				88B58DBD222042500011B063 /* SDLDirectionSpec.m in Sources */,
 				162E83721A9BDE8B00906325 /* SDLAudioPassThruCapabilitiesSpec.m in Sources */,
 				162E83681A9BDE8B00906325 /* SDLSpeakResponseSpec.m in Sources */,

--- a/SmartDeviceLink/SDLError.h
+++ b/SmartDeviceLink/SDLError.h
@@ -90,6 +90,7 @@ extern SDLErrorDomain *const SDLErrorDomainRPCStore;
 + (NSException *)sdl_invalidSoftButtonStateException;
 + (NSException *)sdl_carWindowOrientationException;
 + (NSException *)sdl_invalidLockscreenSetupException;
++ (NSException *)sdl_invalidSelectorExceptionWithSelector:(SEL)selector;
 
 @end
 

--- a/SmartDeviceLink/SDLError.m
+++ b/SmartDeviceLink/SDLError.m
@@ -328,6 +328,12 @@ SDLErrorDomain *const SDLErrorDomainRPCStore = @"com.sdl.rpcStore.error";
                                  userInfo:nil];
 }
 
++ (NSException *)sdl_invalidSelectorExceptionWithSelector:(SEL)selector {
+    return [NSException exceptionWithName:@"com.sdl.systemCapabilityManager.selectorException"
+                                   reason:[NSString stringWithFormat:@"Capability observation selector: %@ does not match possible selectors, which must have either 0 or 1 parameters", NSStringFromSelector(selector)]
+                                 userInfo:nil];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -385,6 +385,7 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
     dispatch_group_enter(managerGroup);
     SDLLogD(@"Setting up assistant managers");
     [self.lockScreenManager start];
+    [self.systemCapabilityManager start];
 
     dispatch_group_enter(managerGroup);
     [self.fileManager startWithCompletionHandler:^(BOOL success, NSError *_Nullable error) {

--- a/SmartDeviceLink/SDLSystemCapabilityManager.h
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.h
@@ -43,11 +43,13 @@ typedef void (^SDLUpdateCapabilityHandler)(NSError * _Nullable error, SDLSystemC
 /**
  An observer block whenever a subscription is called.
 
- @param systemCapabilityManager This manager. The user of the handler can then use the manager to pull the newest data.
+ @param capability The capability that was updated.
  */
-typedef void (^SDLCapabilityUpdateHandler)(SDLSystemCapabilityManager *systemCapabilityManager);
+typedef void (^SDLCapabilityUpdateHandler)(SDLSystemCapability *capability);
 
-
+/**
+ A manager that handles updating and subscribing to SDL capabilities.
+ */
 @interface SDLSystemCapabilityManager : NSObject
 
 /**

--- a/SmartDeviceLink/SDLSystemCapabilityManager.h
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.h
@@ -41,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 typedef void (^SDLUpdateCapabilityHandler)(NSError * _Nullable error, SDLSystemCapabilityManager *systemCapabilityManager);
 
 /**
- An observer block whenever a subscription is called.
+ An observer block for whenever a subscription is called.
 
  @param capability The capability that was updated.
  */
@@ -51,6 +51,11 @@ typedef void (^SDLCapabilityUpdateHandler)(SDLSystemCapability *capability);
  A manager that handles updating and subscribing to SDL capabilities.
  */
 @interface SDLSystemCapabilityManager : NSObject
+
+/**
+ YES if subscriptions are available on the connected head unit. If NO, calls to `subscribeToCapabilityType:withBlock` and `subscribeToCapabilityType:withObserver:selector` will fail.
+ */
+@property (assign, nonatomic, readonly) BOOL supportsSubscriptions;
 
 /**
  * @see SDLDisplayCapabilities

--- a/SmartDeviceLink/SDLSystemCapabilityManager.h
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.h
@@ -141,59 +141,64 @@ typedef void (^SDLCapabilityUpdateHandler)(SDLSystemCapabilityManager *systemCap
 @property (nullable, strong, nonatomic, readonly) SDLAppServicesCapabilities *appServicesCapabilities;
 
 /**
- * If returned, the platform supports navigation
- *
- * @see SDLNavigationCapability
- *
- * Optional
+ If returned, the platform supports navigation
+
+ @see SDLNavigationCapability
+
+ Optional
  */
 @property (nullable, strong, nonatomic, readonly) SDLNavigationCapability *navigationCapability;
 
 /**
- * If returned, the platform supports making phone calls
- *
- * @see SDLPhoneCapability
- *
- * Optional
+ If returned, the platform supports making phone calls
+
+ @see SDLPhoneCapability
+
+ Optional
  */
 @property (nullable, strong, nonatomic, readonly) SDLPhoneCapability *phoneCapability;
 
 /**
- * If returned, the platform supports video streaming
- *
- * @see SDLVideoStreamingCapability
- *
- * Optional
+ If returned, the platform supports video streaming
+
+ @see SDLVideoStreamingCapability
+
+ Optional
  */
 @property (nullable, strong, nonatomic, readonly) SDLVideoStreamingCapability *videoStreamingCapability;
 
 /**
- * If returned, the platform supports remote control capabilities
- *
- * @see SDLRemoteControlCapabilities
- *
- * Optional
+ If returned, the platform supports remote control capabilities
+
+ @see SDLRemoteControlCapabilities
+
+ Optional
  */
 @property (nullable, strong, nonatomic, readonly) SDLRemoteControlCapabilities *remoteControlCapability;
 
 /**
- *  Init is unavailable. Dependencies must be injected using initWithConnectionManager:
- *
- *  @return nil
+ Init is unavailable. Dependencies must be injected using initWithConnectionManager:
+
+ @return nil
  */
 - (instancetype)init NS_UNAVAILABLE;
 
 /**
- *  Creates a new system capability manager with a specified connection manager
- *
- *  @param manager A connection manager to use to forward on RPCs
- *
- *  @return An instance of SDLSystemCapabilityManager
+ Creates a new system capability manager with a specified connection manager
+
+ @param manager A connection manager to use to forward on RPCs
+
+ @return An instance of SDLSystemCapabilityManager
  */
 - (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)manager NS_DESIGNATED_INITIALIZER;
 
 /**
- *  Stops the manager. This method is used internally.
+ Starts the manager. This method is used internally.
+ */
+- (void)start;
+
+/**
+ Stops the manager. This method is used internally.
  */
 - (void)stop;
 
@@ -210,9 +215,9 @@ typedef void (^SDLCapabilityUpdateHandler)(SDLSystemCapabilityManager *systemCap
 
  @param type The type of capability to subscribe to
  @param block The block to be called when the capability is updated
- @return An object that can be used to unsubscribe the block using unsubscribeFromCapabilityType:withObserver: by passing it in the observer callback
+ @return An object that can be used to unsubscribe the block using unsubscribeFromCapabilityType:withObserver: by passing it in the observer callback, or nil if subscriptions aren't available on this head unit
  */
-- (id<NSObject>)subscribeToCapabilityType:(SDLSystemCapabilityType)type usingBlock:(SDLCapabilityUpdateHandler)block;
+- (nullable id<NSObject>)subscribeToCapabilityType:(SDLSystemCapabilityType)type usingBlock:(SDLCapabilityUpdateHandler)block;
 
 /**
  * Subscribe to a particular capability type with a selector callback. The selector supports the following parameters:

--- a/SmartDeviceLink/SDLSystemCapabilityObserver.h
+++ b/SmartDeviceLink/SDLSystemCapabilityObserver.h
@@ -1,0 +1,33 @@
+//
+//  SDLSystemCapabilityObserver.h
+//  SmartDeviceLink
+//
+//  Created by Joel Fischer on 5/23/19.
+//  Copyright © 2019 smartdevicelink. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@class SDLSystemCapabilityManager;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ An observer block whenever a subscription is called.
+
+ @param systemCapabilityManager This manager. The user of the handler can then use the manager to pull the newest data.
+ */
+typedef void (^SDLCapabilityUpdateHandler)(SDLSystemCapabilityManager *systemCapabilityManager);
+
+@interface SDLSystemCapabilityObserver : NSObject
+
+@property (strong, nonatomic) id<NSObject> observer;
+@property (assign, nonatomic) SEL selector;
+@property (copy, nonatomic) SDLCapabilityUpdateHandler block;
+
+- (instancetype)initWithObserver:(id<NSObject>)observer selector:(SEL)selector;
+- (instancetype)initWithObserver:(id<NSObject>)observer block:(SDLCapabilityUpdateHandler)block;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLSystemCapabilityObserver.h
+++ b/SmartDeviceLink/SDLSystemCapabilityObserver.h
@@ -8,24 +8,48 @@
 
 #import <Foundation/Foundation.h>
 
-@class SDLSystemCapabilityManager;
+@class SDLSystemCapability;
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef void (^SDLCapabilityUpdateHandler)(SDLSystemCapability *capability);
+
 /**
- An observer block whenever a subscription is called.
-
- @param systemCapabilityManager This manager. The user of the handler can then use the manager to pull the newest data.
+ An observer object for SDLSystemCapabilityManager
  */
-typedef void (^SDLCapabilityUpdateHandler)(SDLSystemCapabilityManager *systemCapabilityManager);
-
 @interface SDLSystemCapabilityObserver : NSObject
 
+/**
+ The object that will be used to call the selector if available, and to unsubscribe this observer
+ */
 @property (strong, nonatomic) id<NSObject> observer;
+
+/**
+ A selector called when the observer is triggered
+ */
 @property (assign, nonatomic) SEL selector;
+
+/**
+ A block called when the observer is triggered
+ */
 @property (copy, nonatomic) SDLCapabilityUpdateHandler block;
 
+/**
+ Create an observer using an object and a selector on that object
+
+ @param observer The object to be called when the subscription triggers
+ @param selector The selector to be called when the subscription triggers
+ @return The observer
+ */
 - (instancetype)initWithObserver:(id<NSObject>)observer selector:(SEL)selector;
+
+/**
+ Create an observer using an object and a callback block
+
+ @param observer The object that can be used to unsubscribe the block
+ @param block The block that will be called when the subscription triggers
+ @return The observer
+ */
 - (instancetype)initWithObserver:(id<NSObject>)observer block:(SDLCapabilityUpdateHandler)block;
 
 @end

--- a/SmartDeviceLink/SDLSystemCapabilityObserver.m
+++ b/SmartDeviceLink/SDLSystemCapabilityObserver.m
@@ -1,0 +1,37 @@
+//
+//  SDLSystemCapabilityObserver.m
+//  SmartDeviceLink
+//
+//  Created by Joel Fischer on 5/23/19.
+//  Copyright © 2019 smartdevicelink. All rights reserved.
+//
+
+#import "SDLSystemCapabilityObserver.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation SDLSystemCapabilityObserver
+
+- (instancetype)initWithObserver:(id<NSObject>)observer selector:(SEL)selector {
+    self = [super init];
+    if (!self) { return nil; }
+
+    _observer = observer;
+    _selector = selector;
+
+    return self;
+}
+
+- (instancetype)initWithObserver:(id<NSObject>)observer block:(SDLCapabilityUpdateHandler)block {
+    self = [super init];
+    if (!self) { return nil; }
+
+    _observer = observer;
+    _block = block;
+
+    return self;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SmartDeviceLinkTests/DevAPISpecs/TestSystemCapabilityObserver.h
+++ b/SmartDeviceLinkTests/DevAPISpecs/TestSystemCapabilityObserver.h
@@ -1,0 +1,22 @@
+//
+//  TestSystemCapabilityObserver.h
+//  SmartDeviceLinkTests
+//
+//  Created by Joel Fischer on 5/23/19.
+//  Copyright © 2019 smartdevicelink. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface TestSystemCapabilityObserver : NSObject
+
+@property (assign, nonatomic) NSUInteger selectorCalledCount;
+
+- (void)capabilityUpdated;
+- (void)capabilityUpdatedWithNotification:(SDLSystemCapabilityManager *)capabilityManager;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SmartDeviceLinkTests/DevAPISpecs/TestSystemCapabilityObserver.h
+++ b/SmartDeviceLinkTests/DevAPISpecs/TestSystemCapabilityObserver.h
@@ -8,6 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
+@class SDLSystemCapabilityManager;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface TestSystemCapabilityObserver : NSObject

--- a/SmartDeviceLinkTests/DevAPISpecs/TestSystemCapabilityObserver.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/TestSystemCapabilityObserver.m
@@ -1,0 +1,30 @@
+//
+//  TestSystemCapabilityObserver.m
+//  SmartDeviceLinkTests
+//
+//  Created by Joel Fischer on 5/23/19.
+//  Copyright © 2019 smartdevicelink. All rights reserved.
+//
+
+#import "TestSystemCapabilityObserver.h"
+
+@implementation TestSystemCapabilityObserver
+
+- (instancetype)init {
+    self = [super init];
+    if (!self) { return nil; }
+
+    _selectorCalledCount = 0;
+
+    return self;
+}
+
+- (void)capabilityUpdated {
+    self.selectorCalledCount++;
+}
+
+- (void)capabilityUpdatedWithNotification:(SDLSystemCapabilityManager *)capabilityManager {
+    self.selectorCalledCount++;
+}
+
+@end

--- a/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
+++ b/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
@@ -34,7 +34,7 @@
 
 @interface SDLSystemCapabilityManager ()
 
-@property (assign, nonatomic) BOOL supportsObservers;
+@property (assign, nonatomic, readwrite) BOOL supportsSubscriptions;
 
 @end
 
@@ -372,7 +372,7 @@ describe(@"System capability manager", ^{
 
         beforeEach(^{
             blockObserverTriggeredCount = 0;
-            testSystemCapabilityManager.supportsObservers = YES;
+            testSystemCapabilityManager.supportsSubscriptions = YES;
 
             phoneObserver = [[TestSystemCapabilityObserver alloc] init];
             [testSystemCapabilityManager subscribeToCapabilityType:SDLSystemCapabilityTypePhoneCall withObserver:phoneObserver selector:@selector(capabilityUpdatedWithNotification:)];
@@ -384,7 +384,7 @@ describe(@"System capability manager", ^{
             __block BOOL observationSuccess = NO;
 
             beforeEach(^{
-                testSystemCapabilityManager.supportsObservers = NO;
+                testSystemCapabilityManager.supportsSubscriptions = NO;
 
                 observationSuccess = [testSystemCapabilityManager subscribeToCapabilityType:SDLSystemCapabilityTypePhoneCall withObserver:phoneObserver selector:@selector(capabilityUpdatedWithNotification:)];
             });

--- a/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
+++ b/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
@@ -29,6 +29,7 @@
 #import "SDLSystemCapabilityManager.h"
 #import "SDLVideoStreamingCapability.h"
 #import "TestConnectionManager.h"
+#import "TestSystemCapabilityObserver.h"
 
 
 @interface SDLSystemCapabilityManager ()
@@ -397,7 +398,7 @@ describe(@"System capability manager", ^{
             __block id blockObserver = nil;
 
             beforeEach(^{
-                blockObserver = [testSystemCapabilityManager subscribeToCapabilityType:SDLSystemCapabilityTypePhoneCall usingBlock:^(SDLSystemCapabilityManager * _Nonnull systemCapabilityManager) {
+                blockObserver = [testSystemCapabilityManager subscribeToCapabilityType:SDLSystemCapabilityTypePhoneCall usingBlock:^(SDLSystemCapability * _Nonnull systemCapability) {
                     blockObserverTriggeredCount++;
                 }];
 
@@ -438,7 +439,7 @@ describe(@"System capability manager", ^{
             __block id blockObserver = nil;
 
             beforeEach(^{
-                blockObserver = [testSystemCapabilityManager subscribeToCapabilityType:SDLSystemCapabilityTypePhoneCall usingBlock:^(SDLSystemCapabilityManager * _Nonnull systemCapabilityManager) {
+                blockObserver = [testSystemCapabilityManager subscribeToCapabilityType:SDLSystemCapabilityTypePhoneCall usingBlock:^(SDLSystemCapability * _Nonnull systemCapability) {
                     blockObserverTriggeredCount++;
                 }];
 

--- a/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
+++ b/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
@@ -31,6 +31,13 @@
 #import "TestConnectionManager.h"
 
 
+@interface SDLSystemCapabilityManager ()
+
+@property (assign, nonatomic) BOOL supportsObservers;
+
+@end
+
+
 QuickSpecBegin(SDLSystemCapabilityManagerSpec)
 
 describe(@"System capability manager", ^{
@@ -181,7 +188,7 @@ describe(@"System capability manager", ^{
         });
     });
 
-    context(@"When notified of a Set Display Layout Response", ^ {
+    context(@"When notified of a SetDisplayLayout Response", ^ {
         __block SDLSetDisplayLayoutResponse *testSetDisplayLayoutResponse = nil;
         __block SDLDisplayCapabilities *testDisplayCapabilities = nil;
         __block NSArray<SDLSoftButtonCapabilities *> *testSoftButtonCapabilities = nil;
@@ -216,7 +223,7 @@ describe(@"System capability manager", ^{
             testSetDisplayLayoutResponse.presetBankCapabilities = testPresetBankCapabilities;
         });
 
-        describe(@"If the Set Display Layout request fails", ^{
+        describe(@"If the SetDisplayLayout request fails", ^{
             beforeEach(^{
                 testSetDisplayLayoutResponse.success = @NO;
                 SDLRPCResponseNotification *notification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveSetDisplayLayoutResponse object:self rpcResponse:testSetDisplayLayoutResponse];
@@ -231,7 +238,7 @@ describe(@"System capability manager", ^{
             });
         });
 
-        describe(@"If the Set Display Layout request succeeds", ^{
+        describe(@"If the SetDisplayLayout request succeeds", ^{
             beforeEach(^{
                 testSetDisplayLayoutResponse.success = @YES;
                 SDLRPCResponseNotification *notification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveSetDisplayLayoutResponse object:self rpcResponse:testSetDisplayLayoutResponse];
@@ -263,8 +270,8 @@ describe(@"System capability manager", ^{
         });
     });
 
-    context(@"When sending a Get System Capability request", ^{
-        __block SDLGetSystemCapabilityResponse *testGetSystemCapabilityResponse;
+    context(@"When sending a GetSystemCapability request", ^{
+        __block SDLGetSystemCapabilityResponse *testGetSystemCapabilityResponse = nil;
         __block SDLPhoneCapability *testPhoneCapability = nil;
 
         beforeEach(^{
@@ -347,11 +354,124 @@ describe(@"System capability manager", ^{
             SDLSystemCapability *newCapability = [[SDLSystemCapability alloc] initWithPhoneCapability:phoneCapability];
             SDLOnSystemCapabilityUpdated *update = [[SDLOnSystemCapabilityUpdated alloc] initWithSystemCapability:newCapability];
             SDLRPCNotificationNotification *notification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidReceiveSystemCapabilityUpdatedNotification object:nil rpcNotification:update];
+
             [[NSNotificationCenter defaultCenter] postNotification:notification];
         });
 
         it(@"should properly update phone capability", ^{
             expect(testSystemCapabilityManager.phoneCapability).toEventually(equal(phoneCapability));
+        });
+    });
+
+    describe(@"subscribing to capability types", ^{
+        __block TestSystemCapabilityObserver *phoneObserver = nil;
+        __block TestSystemCapabilityObserver *navigationObserver = nil;
+
+        __block NSUInteger blockObserverTriggeredCount = 0;
+
+        beforeEach(^{
+            blockObserverTriggeredCount = 0;
+            testSystemCapabilityManager.supportsObservers = YES;
+
+            phoneObserver = [[TestSystemCapabilityObserver alloc] init];
+            [testSystemCapabilityManager subscribeToCapabilityType:SDLSystemCapabilityTypePhoneCall withObserver:phoneObserver selector:@selector(capabilityUpdatedWithNotification:)];
+            navigationObserver = [[TestSystemCapabilityObserver alloc] init];
+            [testSystemCapabilityManager subscribeToCapabilityType:SDLSystemCapabilityTypeNavigation withObserver:navigationObserver selector:@selector(capabilityUpdatedWithNotification:)];
+        });
+
+        describe(@"when observers aren't supported", ^{
+            __block BOOL observationSuccess = NO;
+
+            beforeEach(^{
+                testSystemCapabilityManager.supportsObservers = NO;
+
+                observationSuccess = [testSystemCapabilityManager subscribeToCapabilityType:SDLSystemCapabilityTypePhoneCall withObserver:phoneObserver selector:@selector(capabilityUpdatedWithNotification:)];
+            });
+
+            it(@"should fail to subscribe", ^{
+                expect(observationSuccess).to(beFalse());
+            });
+        });
+
+        context(@"from a GetSystemCapabilitiesResponse", ^{
+            __block id blockObserver = nil;
+
+            beforeEach(^{
+                blockObserver = [testSystemCapabilityManager subscribeToCapabilityType:SDLSystemCapabilityTypePhoneCall usingBlock:^(SDLSystemCapabilityManager * _Nonnull systemCapabilityManager) {
+                    blockObserverTriggeredCount++;
+                }];
+
+                SDLGetSystemCapabilityResponse *testResponse = [[SDLGetSystemCapabilityResponse alloc] init];
+                testResponse.systemCapability = [[SDLSystemCapability alloc] initWithPhoneCapability:[[SDLPhoneCapability alloc] initWithDialNumber:YES]];
+                SDLRPCResponseNotification *notification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveGetSystemCapabilitiesResponse object:nil rpcResponse:testResponse];
+
+                [[NSNotificationCenter defaultCenter] postNotification:notification];
+            });
+
+            it(@"should notify subscribers of the new data", ^{
+                expect(phoneObserver.selectorCalledCount).toEventually(equal(1));
+                expect(blockObserverTriggeredCount).toEventually(equal(1));
+                expect(navigationObserver.selectorCalledCount).toEventually(equal(0));
+            });
+
+            describe(@"unsubscribing", ^{
+                beforeEach(^{
+                    [testSystemCapabilityManager unsubscribeFromCapabilityType:SDLSystemCapabilityTypePhoneCall withObserver:phoneObserver];
+                    [testSystemCapabilityManager unsubscribeFromCapabilityType:SDLSystemCapabilityTypePhoneCall withObserver:blockObserver];
+
+                    SDLGetSystemCapabilityResponse *testResponse = [[SDLGetSystemCapabilityResponse alloc] init];
+                    testResponse.systemCapability = [[SDLSystemCapability alloc] initWithPhoneCapability:[[SDLPhoneCapability alloc] initWithDialNumber:YES]];
+                    SDLRPCResponseNotification *notification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveGetSystemCapabilitiesResponse object:nil rpcResponse:testResponse];
+
+                    [[NSNotificationCenter defaultCenter] postNotification:notification];
+                });
+
+                it(@"should not notify the subscriber of the new data", ^{
+                    expect(phoneObserver.selectorCalledCount).toEventually(equal(1)); // No change from above
+                    expect(blockObserverTriggeredCount).toEventually(equal(1));
+                    expect(navigationObserver.selectorCalledCount).toEventually(equal(0));
+                });
+            });
+        });
+
+        context(@"from an OnSystemCapabilities notification", ^{
+            __block id blockObserver = nil;
+
+            beforeEach(^{
+                blockObserver = [testSystemCapabilityManager subscribeToCapabilityType:SDLSystemCapabilityTypePhoneCall usingBlock:^(SDLSystemCapabilityManager * _Nonnull systemCapabilityManager) {
+                    blockObserverTriggeredCount++;
+                }];
+
+                SDLOnSystemCapabilityUpdated *testNotification = [[SDLOnSystemCapabilityUpdated alloc] initWithSystemCapability:[[SDLSystemCapability alloc] initWithPhoneCapability:[[SDLPhoneCapability alloc] initWithDialNumber:YES]]];
+                SDLRPCNotificationNotification *notification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidReceiveSystemCapabilityUpdatedNotification object:nil rpcNotification:testNotification];
+
+                [[NSNotificationCenter defaultCenter] postNotification:notification];
+            });
+
+            it(@"should notify subscribers of the new data", ^{
+                expect(phoneObserver.selectorCalledCount).toEventually(equal(1));
+                expect(blockObserverTriggeredCount).toEventually(equal(1));
+                expect(navigationObserver.selectorCalledCount).toEventually(equal(0));
+            });
+
+            describe(@"unsubscribing", ^{
+                beforeEach(^{
+                    [testSystemCapabilityManager unsubscribeFromCapabilityType:SDLSystemCapabilityTypePhoneCall withObserver:phoneObserver];
+                    [testSystemCapabilityManager unsubscribeFromCapabilityType:SDLSystemCapabilityTypePhoneCall withObserver:blockObserver];
+
+                    SDLGetSystemCapabilityResponse *testResponse = [[SDLGetSystemCapabilityResponse alloc] init];
+                    testResponse.systemCapability = [[SDLSystemCapability alloc] initWithPhoneCapability:[[SDLPhoneCapability alloc] initWithDialNumber:YES]];
+                    SDLRPCResponseNotification *notification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveGetSystemCapabilitiesResponse object:nil rpcResponse:testResponse];
+
+                    [[NSNotificationCenter defaultCenter] postNotification:notification];
+                });
+
+                it(@"should not notify the subscriber of the new data", ^{
+                    expect(phoneObserver.selectorCalledCount).toEventually(equal(1)); // No change from above
+                    expect(blockObserverTriggeredCount).toEventually(equal(1));
+                    expect(navigationObserver.selectorCalledCount).toEventually(equal(0));
+                });
+            });
         });
     });
 


### PR DESCRIPTION
Fixes #1222, #1278 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Unit tests have been updated

### Summary
This PR adds a few new methods to subscribe to individual `SystemCapabilityType`s. You can subscribe either using a selector or a block, and the unsubscribe. This basically matches with Java's `addOnSystemCapabilityListener()` and `removeOnSystemCapabilityListener()` methods.

### Changelog
##### Enhancements
* Added methods to subscribe to a `SystemCapabilityType` through the `SDLSystemCapabilityManager`.

##### Bug Fixes
* The `SDLSystemCapabilityManager` will update its properties based on "outside" `GetSystemCapabilityResponse`s.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
