### PR TITLE
Prevent Buffer Overruns

### DIFF
--- a/SmartDeviceLink/SDLControlFramePayloadAudioStartServiceAck.m
+++ b/SmartDeviceLink/SDLControlFramePayloadAudioStartServiceAck.m
@@ -66,7 +66,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)sdl_parse:(NSData *)data {
     BsonObject payloadObject;
-    bson_object_from_bytes_len(&payloadObject, (BytePtr)data.bytes, data.length);
+    size_t retval = bson_object_from_bytes_len(&payloadObject, (BytePtr)data.bytes, data.length);
+    if (retval <= 0) {
+        return;
+    }
 
     self.mtu = bson_object_get_int64(&payloadObject, SDLControlFrameMTUKey);
 

--- a/SmartDeviceLink/SDLControlFramePayloadAudioStartServiceAck.m
+++ b/SmartDeviceLink/SDLControlFramePayloadAudioStartServiceAck.m
@@ -65,7 +65,8 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)sdl_parse:(NSData *)data {
-    BsonObject payloadObject = bson_object_from_bytes((BytePtr)data.bytes);
+    BsonObject payloadObject;
+    bson_object_from_bytes_len(&payloadObject, (BytePtr)data.bytes, data.length);
 
     self.mtu = bson_object_get_int64(&payloadObject, SDLControlFrameMTUKey);
 

--- a/SmartDeviceLink/SDLControlFramePayloadEndService.m
+++ b/SmartDeviceLink/SDLControlFramePayloadEndService.m
@@ -66,7 +66,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)sdl_parse:(NSData *)data {
     BsonObject payloadObject;
-    bson_object_from_bytes_len(&payloadObject, (BytePtr)data.bytes, data.length);
+    size_t retval = bson_object_from_bytes_len(&payloadObject, (BytePtr)data.bytes, data.length);
+    if (retval <= 0) {
+        return;
+    }
 
     self.hashId = bson_object_get_int32(&payloadObject, SDLControlFrameHashIdKey);
 

--- a/SmartDeviceLink/SDLControlFramePayloadEndService.m
+++ b/SmartDeviceLink/SDLControlFramePayloadEndService.m
@@ -65,7 +65,8 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)sdl_parse:(NSData *)data {
-    BsonObject payloadObject = bson_object_from_bytes((BytePtr)data.bytes);
+    BsonObject payloadObject;
+    bson_object_from_bytes_len(&payloadObject, (BytePtr)data.bytes, data.length);
 
     self.hashId = bson_object_get_int32(&payloadObject, SDLControlFrameHashIdKey);
 

--- a/SmartDeviceLink/SDLControlFramePayloadNak.m
+++ b/SmartDeviceLink/SDLControlFramePayloadNak.m
@@ -70,7 +70,9 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)sdl_parse:(NSData *)data {
-    BsonObject payloadObject = bson_object_from_bytes((BytePtr)data.bytes);
+    BsonObject payloadObject;
+    bson_object_from_bytes_len(&payloadObject, (BytePtr)data.bytes, data.length);
+    
     BsonArray *arrayObject = bson_object_get_array(&payloadObject, SDLControlFrameRejectedParams);
     if (arrayObject == NULL) {
         return;

--- a/SmartDeviceLink/SDLControlFramePayloadNak.m
+++ b/SmartDeviceLink/SDLControlFramePayloadNak.m
@@ -71,7 +71,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)sdl_parse:(NSData *)data {
     BsonObject payloadObject;
-    bson_object_from_bytes_len(&payloadObject, (BytePtr)data.bytes, data.length);
+    size_t retval = bson_object_from_bytes_len(&payloadObject, (BytePtr)data.bytes, data.length);
+    if (retval <= 0) {
+        return;
+    }
     
     BsonArray *arrayObject = bson_object_get_array(&payloadObject, SDLControlFrameRejectedParams);
     if (arrayObject == NULL) {

--- a/SmartDeviceLink/SDLControlFramePayloadRPCStartService.m
+++ b/SmartDeviceLink/SDLControlFramePayloadRPCStartService.m
@@ -64,7 +64,8 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)sdl_parse:(NSData *)data {
-    BsonObject payloadObject = bson_object_from_bytes((BytePtr)data.bytes);
+    BsonObject payloadObject;
+    bson_object_from_bytes_len(&payloadObject, (BytePtr)data.bytes, data.length);
 
     char *utf8String = bson_object_get_string(&payloadObject, SDLControlFrameProtocolVersionKey);
     if (utf8String != NULL) {

--- a/SmartDeviceLink/SDLControlFramePayloadRPCStartService.m
+++ b/SmartDeviceLink/SDLControlFramePayloadRPCStartService.m
@@ -65,7 +65,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)sdl_parse:(NSData *)data {
     BsonObject payloadObject;
-    bson_object_from_bytes_len(&payloadObject, (BytePtr)data.bytes, data.length);
+    size_t retval = bson_object_from_bytes_len(&payloadObject, (BytePtr)data.bytes, data.length);
+    if (retval <= 0) {
+        return;
+    }
 
     char *utf8String = bson_object_get_string(&payloadObject, SDLControlFrameProtocolVersionKey);
     if (utf8String != NULL) {

--- a/SmartDeviceLink/SDLControlFramePayloadRPCStartServiceAck.m
+++ b/SmartDeviceLink/SDLControlFramePayloadRPCStartServiceAck.m
@@ -114,7 +114,8 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)sdl_parse:(NSData *)data {
-    BsonObject payloadObject = bson_object_from_bytes((BytePtr)data.bytes);
+    BsonObject payloadObject;
+    bson_object_from_bytes_len(&payloadObject, (BytePtr)data.bytes, data.length);
 
     self.hashId = bson_object_get_int32(&payloadObject, SDLControlFrameHashIdKey);
     self.mtu = bson_object_get_int64(&payloadObject, SDLControlFrameMTUKey);

--- a/SmartDeviceLink/SDLControlFramePayloadRPCStartServiceAck.m
+++ b/SmartDeviceLink/SDLControlFramePayloadRPCStartServiceAck.m
@@ -115,7 +115,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)sdl_parse:(NSData *)data {
     BsonObject payloadObject;
-    bson_object_from_bytes_len(&payloadObject, (BytePtr)data.bytes, data.length);
+    size_t retval = bson_object_from_bytes_len(&payloadObject, (BytePtr)data.bytes, data.length);
+    if (retval <= 0) {
+        return;
+    }
 
     self.hashId = bson_object_get_int32(&payloadObject, SDLControlFrameHashIdKey);
     self.mtu = bson_object_get_int64(&payloadObject, SDLControlFrameMTUKey);

--- a/SmartDeviceLink/SDLControlFramePayloadRegisterSecondaryTransportNak.m
+++ b/SmartDeviceLink/SDLControlFramePayloadRegisterSecondaryTransportNak.m
@@ -64,7 +64,8 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)sdl_parse:(NSData *)data {
-    BsonObject payloadObject = bson_object_from_bytes((BytePtr)data.bytes);
+    BsonObject payloadObject;
+    bson_object_from_bytes_len(&payloadObject, (BytePtr)data.bytes, data.length);
 
     char *reasonString = bson_object_get_string(&payloadObject, SDLControlFrameReasonKey);
     if (reasonString != NULL) {

--- a/SmartDeviceLink/SDLControlFramePayloadRegisterSecondaryTransportNak.m
+++ b/SmartDeviceLink/SDLControlFramePayloadRegisterSecondaryTransportNak.m
@@ -65,7 +65,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)sdl_parse:(NSData *)data {
     BsonObject payloadObject;
-    bson_object_from_bytes_len(&payloadObject, (BytePtr)data.bytes, data.length);
+    size_t retval = bson_object_from_bytes_len(&payloadObject, (BytePtr)data.bytes, data.length);
+    if (retval <= 0) {
+        return;
+    }
 
     char *reasonString = bson_object_get_string(&payloadObject, SDLControlFrameReasonKey);
     if (reasonString != NULL) {

--- a/SmartDeviceLink/SDLControlFramePayloadTransportEventUpdate.m
+++ b/SmartDeviceLink/SDLControlFramePayloadTransportEventUpdate.m
@@ -80,7 +80,8 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)sdl_parse:(NSData *)data {
-    BsonObject payloadObject = bson_object_from_bytes((BytePtr)data.bytes);
+    BsonObject payloadObject;
+    bson_object_from_bytes_len(&payloadObject, (BytePtr)data.bytes, data.length);
 
     char *utf8String = bson_object_get_string(&payloadObject, SDLControlFrameTCPIPAddressKey);
     if (utf8String != NULL) {

--- a/SmartDeviceLink/SDLControlFramePayloadTransportEventUpdate.m
+++ b/SmartDeviceLink/SDLControlFramePayloadTransportEventUpdate.m
@@ -81,7 +81,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)sdl_parse:(NSData *)data {
     BsonObject payloadObject;
-    bson_object_from_bytes_len(&payloadObject, (BytePtr)data.bytes, data.length);
+    size_t retval = bson_object_from_bytes_len(&payloadObject, (BytePtr)data.bytes, data.length);
+    if (retval <= 0) {
+        return;
+    }
 
     char *utf8String = bson_object_get_string(&payloadObject, SDLControlFrameTCPIPAddressKey);
     if (utf8String != NULL) {

--- a/SmartDeviceLink/SDLControlFramePayloadVideoStartService.m
+++ b/SmartDeviceLink/SDLControlFramePayloadVideoStartService.m
@@ -88,7 +88,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)sdl_parse:(NSData *)data {
     BsonObject payloadObject;
-    bson_object_from_bytes_len(&payloadObject, (BytePtr)data.bytes, data.length);
+    size_t retval = bson_object_from_bytes_len(&payloadObject, (BytePtr)data.bytes, data.length);
+    if (retval <= 0) {
+        return;
+    }
 
     self.height = bson_object_get_int32(&payloadObject, SDLControlFrameHeightKey);
     self.width = bson_object_get_int32(&payloadObject, SDLControlFrameWidthKey);

--- a/SmartDeviceLink/SDLControlFramePayloadVideoStartService.m
+++ b/SmartDeviceLink/SDLControlFramePayloadVideoStartService.m
@@ -87,7 +87,8 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)sdl_parse:(NSData *)data {
-    BsonObject payloadObject = bson_object_from_bytes((BytePtr)data.bytes);
+    BsonObject payloadObject;
+    bson_object_from_bytes_len(&payloadObject, (BytePtr)data.bytes, data.length);
 
     self.height = bson_object_get_int32(&payloadObject, SDLControlFrameHeightKey);
     self.width = bson_object_get_int32(&payloadObject, SDLControlFrameWidthKey);

--- a/SmartDeviceLink/SDLControlFramePayloadVideoStartServiceAck.m
+++ b/SmartDeviceLink/SDLControlFramePayloadVideoStartServiceAck.m
@@ -93,7 +93,8 @@
 }
 
 - (void)sdl_parse:(NSData *)data {
-    BsonObject payloadObject = bson_object_from_bytes((BytePtr)data.bytes);
+    BsonObject payloadObject;
+    bson_object_from_bytes_len(&payloadObject, (BytePtr)data.bytes, data.length);
 
     self.mtu = bson_object_get_int64(&payloadObject, SDLControlFrameMTUKey);
     self.height = bson_object_get_int32(&payloadObject, SDLControlFrameHeightKey);

--- a/SmartDeviceLink/SDLControlFramePayloadVideoStartServiceAck.m
+++ b/SmartDeviceLink/SDLControlFramePayloadVideoStartServiceAck.m
@@ -94,7 +94,10 @@
 
 - (void)sdl_parse:(NSData *)data {
     BsonObject payloadObject;
-    bson_object_from_bytes_len(&payloadObject, (BytePtr)data.bytes, data.length);
+    size_t retval = bson_object_from_bytes_len(&payloadObject, (BytePtr)data.bytes, data.length);
+    if (retval <= 0) {
+        return;
+    }
 
     self.mtu = bson_object_get_int64(&payloadObject, SDLControlFrameMTUKey);
     self.height = bson_object_get_int32(&payloadObject, SDLControlFrameHeightKey);


### PR DESCRIPTION
Fixes #1285 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Unit tests were run

### Summary
This PR uses the new BSON library v1.2 methods to prevent possible buffer overruns

### Changelog
##### Bug Fixes
* Prevent possible BSON related buffer overruns

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
