### PR TITLE
Support Pushing a PCM Audio Data Buffer on SDLAudioStreamManager

### DIFF
--- a/SmartDeviceLink/SDLAudioFile.h
+++ b/SmartDeviceLink/SDLAudioFile.h
@@ -12,20 +12,48 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SDLAudioFile : NSObject
 
-@property (copy, nonatomic, readonly) NSURL *inputFileURL;
+/**
+ If initialized with a file URL, the file URL it came from
+ */
+@property (nullable, copy, nonatomic, readonly) NSURL *inputFileURL;
 
-@property (copy, nonatomic, readonly) NSURL *outputFileURL;
+/**
+ If initialized with a file URL, where the transcoder should produce the transcoded PCM audio file
+ */
+@property (nullable, copy, nonatomic, readonly) NSURL *outputFileURL;
 
 /**
  In seconds. UINT32_MAX if unknown.
  */
 @property (assign, nonatomic) UInt32 estimatedDuration;
 
+/**
+ The PCM audio data to be transferred and played
+ */
 @property (copy, nonatomic, readonly) NSData *data;
 
+/**
+ The size of the PCM audio data in bytes
+ */
 @property (assign, nonatomic, readonly) unsigned long long fileSize;
 
+/**
+ Initialize an audio file to be queued and played
+
+ @param inputURL The file that exists on the device to be transcoded and queued
+ @param outputURL The target URL that the transcoded file will be output to
+ @param duration The duration of the file
+ @return The audio file object
+ */
 - (instancetype)initWithInputFileURL:(NSURL *)inputURL outputFileURL:(NSURL *)outputURL estimatedDuration:(UInt32)duration;
+
+/**
+ Initialize a buffer of PCM audio data to be queued and played
+
+ @param data The PCM audio data buffer
+ @return The audio file object
+ */
+- (instancetype)initWithData:(NSData *)data;
 
 @end
 

--- a/SmartDeviceLink/SDLAudioFile.m
+++ b/SmartDeviceLink/SDLAudioFile.m
@@ -32,6 +32,15 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (instancetype)initWithData:(NSData *)data {
+    self = [super init];
+    if (!self) { return nil; }
+
+    _data = data;
+
+    return self;
+}
+
 - (NSData *)data {
     if (_data.length == 0) {
         return [NSData dataWithContentsOfURL:_outputFileURL];

--- a/SmartDeviceLink/SDLAudioStreamManager.h
+++ b/SmartDeviceLink/SDLAudioStreamManager.h
@@ -67,6 +67,13 @@ typedef NS_ENUM(NSInteger, SDLAudioStreamManagerError) {
 - (void)pushWithFileURL:(NSURL *)fileURL;
 
 /**
+ Push a new audio buffer onto the queue. Call `playNextWhenReady` to start playing the pushed audio buffer.
+
+ @param data The audio buffer to be pushed onto the queue
+ */
+- (void)pushWithData:(NSData *)data;
+
+/**
  Play the next item in the queue. If an item is currently playing, it will continue playing and this item will begin playing after it is completed.
 
  When complete, this will callback on the delegate.

--- a/SmartDeviceLink/SDLAudioStreamManager.h
+++ b/SmartDeviceLink/SDLAudioStreamManager.h
@@ -69,6 +69,15 @@ typedef NS_ENUM(NSInteger, SDLAudioStreamManagerError) {
 /**
  Push a new audio buffer onto the queue. Call `playNextWhenReady` to start playing the pushed audio buffer.
 
+ This data must be of the required PCM format. See SDLSystemCapabilityManager.pcmStreamCapability and SDLAudioPassThruCapability.h.
+
+ This is *an example* of a PCM format used by some head units:
+ - audioType: PCM
+ - samplingRate: 16kHZ
+ - bitsPerSample: 16 bits
+
+ There is generally only one channel to the data.
+
  @param data The audio buffer to be pushed onto the queue
  */
 - (void)pushWithData:(NSData *)data;

--- a/SmartDeviceLink/SDLAudioStreamManagerDelegate.h
+++ b/SmartDeviceLink/SDLAudioStreamManagerDelegate.h
@@ -29,11 +29,29 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Called when a file from the SDLAudioStreamManager could not play
 
- @param audioManager  A reference to the audio stream manager
+ @param audioManager A reference to the audio stream manager
  @param fileURL The URL that failed
  @param error The error that occurred
  */
 - (void)audioStreamManager:(SDLAudioStreamManager *)audioManager errorDidOccurForFile:(NSURL *)fileURL error:(NSError *)error;
+
+@optional
+
+/**
+ Called when a data buffer from the SDLAudioStreamManager finishes playing
+
+ @param audioManager A reference to the audio stream manager
+ @param successfully Whether or not the data buffer played successfully
+ */
+- (void)audioStreamManager:(SDLAudioStreamManager *)audioManager dataBufferDidFinishPlayingSuccessfully:(BOOL)successfully;
+
+/**
+ Called when a data buffer from the SDLAudioStreamManager could not play
+
+ @param audioManager A reference to the audio stream manager
+ @param error The error that occurred
+ */
+- (void)audioStreamManager:(SDLAudioStreamManager *)audioManager errorDidOccurForDataBuffer:(NSError *)error;
 
 @end
 

--- a/SmartDeviceLink/SDLStreamingMediaManager.h
+++ b/SmartDeviceLink/SDLStreamingMediaManager.h
@@ -170,7 +170,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)sendVideoData:(CVImageBufferRef)imageBuffer presentationTimestamp:(CMTime)presentationTimestamp;
 
 /**
- *  This method receives PCM audio data and will attempt to send that data across to the head unit for immediate playback
+ *  This method receives PCM audio data and will attempt to send that data across to the head unit for immediate playback.
+ *
+ *  NOTE: See the `.audioManager` (SDLAudioStreamManager) `pushWithData:` method for a more modern API.
  *
  *  @param audioData The data in PCM audio format, to be played
  *

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLAudioStreamManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLAudioStreamManagerSpec.m
@@ -10,6 +10,7 @@ describe(@"the audio stream manager", ^{
     __block SDLAudioStreamManager *testManager = nil;
     __block SDLStreamingAudioManagerMock *mockAudioManager = nil;
     __block NSURL *testAudioFileURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"testAudio" withExtension:@"mp3"];
+    __block NSData *testAudioFileData = [NSData dataWithContentsOfURL:testAudioFileURL options:0 error:nil];
 
     beforeEach(^{
         mockAudioManager = [[SDLStreamingAudioManagerMock alloc] init];
@@ -27,22 +28,45 @@ describe(@"the audio stream manager", ^{
     });
 
     describe(@"when audio streaming is not connected", ^{
-        beforeEach(^{
-            mockAudioManager.audioConnected = NO;
-            [testManager pushWithFileURL:testAudioFileURL];
-
-            [NSThread sleepForTimeInterval:0.5];
-        });
-
-        describe(@"after attempting to play the file", ^{
+        context(@"with a file URL", ^{
             beforeEach(^{
-                [mockAudioManager clearData];
-                [testManager playNextWhenReady];
+                mockAudioManager.audioConnected = NO;
+                [testManager pushWithFileURL:testAudioFileURL];
+
+                [NSThread sleepForTimeInterval:0.5];
             });
 
-            it(@"should fail to send data", ^{
-                expect(mockAudioManager.dataSinceClear.length).to(equal(0));
-                expect(mockAudioManager.fileError.code).to(equal(SDLAudioStreamManagerErrorNotConnected));
+            describe(@"after attempting to play the file", ^{
+                beforeEach(^{
+                    [mockAudioManager clearData];
+                    [testManager playNextWhenReady];
+                });
+
+                it(@"should fail to send data", ^{
+                    expect(mockAudioManager.dataSinceClear.length).to(equal(0));
+                    expect(mockAudioManager.error.code).toEventually(equal(SDLAudioStreamManagerErrorNotConnected));
+                });
+            });
+        });
+
+        context(@"with a data buffer", ^{
+            beforeEach(^{
+                mockAudioManager.audioConnected = NO;
+                [testManager pushWithData:testAudioFileData];
+
+                [NSThread sleepForTimeInterval:0.5];
+            });
+
+            describe(@"after attempting to play the file", ^{
+                beforeEach(^{
+                    [mockAudioManager clearData];
+                    [testManager playNextWhenReady];
+                });
+
+                it(@"should fail to send data", ^{
+                    expect(mockAudioManager.dataSinceClear.length).to(equal(0));
+                    expect(mockAudioManager.error.code).toEventually(equal(SDLAudioStreamManagerErrorNotConnected));
+                });
             });
         });
     });
@@ -65,12 +89,12 @@ describe(@"the audio stream manager", ^{
                 [testManager playNextWhenReady];
             });
 
-            it(@"should be sending data", ^{
+            fit(@"should be sending data", ^{
                 expect(testManager.isPlaying).toEventually(beTrue());
                 expect(mockAudioManager.dataSinceClear.length).toEventually(equal(34380));
 
                 // Fails when it shouldn't, `weakself` goes to nil in `sdl_playNextWhenReady`
-//                expect(mockAudioManager.fileFinishedPlaying).toEventually(beTrue());
+                expect(mockAudioManager.finishedPlaying).toEventually(beTrue());
             });
         });
 
@@ -80,7 +104,45 @@ describe(@"the audio stream manager", ^{
             });
 
             it(@"should have an empty queue", ^{
-                expect(testManager.queue).to(beEmpty());
+                expect(testManager.queue).toEventually(beEmpty());
+            });
+        });
+    });
+
+    describe(@"after adding an audio buffer to the queue", ^{
+        beforeEach(^{
+            mockAudioManager.audioConnected = YES;
+            [testManager pushWithData:testAudioFileData];
+
+            [NSThread sleepForTimeInterval:0.5];
+        });
+
+        it(@"should have a file in the queue", ^{
+            expect(testManager.queue).toNot(beEmpty());
+        });
+
+        describe(@"after attempting to play the audio buffer", ^{
+            beforeEach(^{
+                [mockAudioManager clearData];
+                [testManager playNextWhenReady];
+            });
+
+            it(@"should be sending data", ^{
+                expect(testManager.isPlaying).toEventually(beTrue());
+                expect(mockAudioManager.dataSinceClear.length).toEventually(equal(14838));
+
+                // Fails when it shouldn't, `weakself` goes to nil in `sdl_playNextWhenReady`
+                expect(mockAudioManager.finishedPlaying).toEventually(beTrue());
+            });
+        });
+
+        describe(@"after stopping the manager", ^{
+            beforeEach(^{
+                [testManager stop];
+            });
+
+            it(@"should have an empty queue", ^{
+                expect(testManager.queue).toEventually(beEmpty());
             });
         });
     });

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLAudioStreamManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLAudioStreamManagerSpec.m
@@ -87,9 +87,11 @@ describe(@"the audio stream manager", ^{
             beforeEach(^{
                 [mockAudioManager clearData];
                 [testManager playNextWhenReady];
+
+                [NSThread sleepForTimeInterval:1.0];
             });
 
-            fit(@"should be sending data", ^{
+            it(@"should be sending data", ^{
                 expect(testManager.isPlaying).toEventually(beTrue());
                 expect(mockAudioManager.dataSinceClear.length).toEventually(equal(34380));
 

--- a/SmartDeviceLinkTests/SDLStreamingAudioManagerMock.h
+++ b/SmartDeviceLinkTests/SDLStreamingAudioManagerMock.h
@@ -21,13 +21,14 @@
 #pragma mark SDLStreamingAudioManagerType
 @property (assign, nonatomic, readonly, getter=isAudioConnected) BOOL audioConnected;
 - (BOOL)sendAudioData:(NSData *)audioData;
-
 - (void)setAudioConnected:(BOOL)audioConnected;
 
 #pragma mark SDLAudioStreamManagerDelegate
 - (void)audioStreamManager:(SDLAudioStreamManager *)audioManager fileDidFinishPlaying:(SDLAudioFile *)file successfully:(BOOL)successfully;
+- (void)audioStreamManager:(SDLAudioStreamManager *)audioManager dataBufferDidFinishPlayingSuccessfully:(BOOL)successfully;
 - (void)audioStreamManager:(SDLAudioStreamManager *)audioManager errorDidOccurForFile:(SDLAudioFile *)file error:(NSError *)error;
-@property (assign, nonatomic, readonly) BOOL fileFinishedPlaying;
-@property (strong, nonatomic, readonly) NSError *fileError;
+- (void)audioStreamManager:(SDLAudioStreamManager *)audioManager errorDidOccurForDataBuffer:(NSError *)error;
+@property (assign, nonatomic, readonly) BOOL finishedPlaying;
+@property (strong, nonatomic, readonly) NSError *error;
 
 @end

--- a/SmartDeviceLinkTests/SDLStreamingAudioManagerMock.m
+++ b/SmartDeviceLinkTests/SDLStreamingAudioManagerMock.m
@@ -14,8 +14,8 @@
 
 @property (strong, nonatomic) NSMutableData *mutableDataSinceClear;
 
-@property (assign, nonatomic, readwrite) BOOL fileFinishedPlaying;
-@property (strong, nonatomic, readwrite) NSError *fileError;
+@property (assign, nonatomic, readwrite) BOOL finishedPlaying;
+@property (strong, nonatomic, readwrite) NSError *error;
 
 @end
 
@@ -35,8 +35,8 @@
     _lastSentData = nil;
     _mutableDataSinceClear = nil;
     
-    _fileFinishedPlaying = NO;
-    _fileError = nil;
+    _finishedPlaying = NO;
+    _error = nil;
 }
 
 #pragma mark SDLStreamingAudioManagerType
@@ -62,11 +62,19 @@
 
 #pragma mark SDLAudioStreamManagerDelegate
 - (void)audioStreamManager:(SDLAudioStreamManager *)audioManager fileDidFinishPlaying:(SDLAudioFile *)file successfully:(BOOL)successfully {
-    _fileFinishedPlaying = successfully;
+    _finishedPlaying = successfully;
+}
+
+- (void)audioStreamManager:(SDLAudioStreamManager *)audioManager dataBufferDidFinishPlayingSuccessfully:(BOOL)successfully {
+    _finishedPlaying = successfully;
 }
 
 - (void)audioStreamManager:(SDLAudioStreamManager *)audioManager errorDidOccurForFile:(SDLAudioFile *)file error:(NSError *)error {
-    _fileError = error;
+    _error = error;
+}
+
+- (void)audioStreamManager:(SDLAudioStreamManager *)audioManager errorDidOccurForDataBuffer:(NSError *)error {
+    _error = error;
 }
 
 @end


### PR DESCRIPTION
Fixes #1275 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Unit tests will be updated

### Summary
This PR adds support for RAW PCM audio buffers within the `SDLAudioStreamManager`.

### Changelog
##### Enhancements
* Support raw audio stream buffers within the `SDLAudioStreamManager`.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
