### PR TITLE
Fix position not being set on SDLChoiceSet VRHelpList

### DIFF
--- a/SmartDeviceLink/SDLChoiceSet.m
+++ b/SmartDeviceLink/SDLChoiceSet.m
@@ -123,6 +123,14 @@ static SDLChoiceSetLayout _defaultLayout = SDLChoiceSetLayoutList;
     _defaultLayout = defaultLayout;
 }
 
+- (void)setHelpList:(nullable NSArray<SDLVRHelpItem *> *)helpList {
+    _helpList = helpList;
+
+    for (NSUInteger i = 0; i < _helpList.count; i++) {
+        _helpList[i].position = @(i + 1);
+    }
+}
+
 #pragma mark - Etc.
 
 - (NSString *)description {

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLChoiceSetSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLChoiceSetSpec.m
@@ -69,6 +69,7 @@ describe(@"an SDLChoiceSet", ^{
             expect(testChoiceSet.timeoutPrompt).to(equal([SDLTTSChunk textChunksFromString:testTimeoutPrompt]));
             expect(testChoiceSet.helpPrompt).to(equal([SDLTTSChunk textChunksFromString:testHelpPrompt]));
             expect(testChoiceSet.helpList).to(equal(@[testHelpItem]));
+            expect(testChoiceSet.helpList.firstObject.position).to(equal(1));
             expect(testChoiceSet.delegate).to(equal(testDelegate));
             expect(testChoiceSet.choices).to(equal(@[testCell]));
         });
@@ -148,6 +149,18 @@ describe(@"an SDLChoiceSet", ^{
                     expect(testChoiceSet).to(beNil());
                 });
             });
+        });
+    });
+
+    describe(@"setting data", ^{
+        beforeEach(^{
+            testChoiceSet = [[SDLChoiceSet alloc] init];
+        });
+
+        it(@"should properly set help list position", ^{
+            testChoiceSet.helpList = @[testHelpItem];
+
+            expect(testHelpItem.position).to(equal(1));
         });
     });
 });


### PR DESCRIPTION
Fixes #1291 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Unit tests updated

### Summary
The position of `VRHelpItem`s on `SDLChoiceSet` was being set if they were set in the initializer, but not if they were being set outside of the initializer.

### Changelog
##### Bug Fixes
* The position of `VRHelpItem`s on `SDLChoiceSet` was being set if they were set in the initializer, but not if they were being set outside of the initializer.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)