### PR TITLE
Fix ChoiceSetManager Bugs

### DIFF
--- a/SmartDeviceLink/SDLChoiceSetManager.m
+++ b/SmartDeviceLink/SDLChoiceSetManager.m
@@ -183,7 +183,11 @@ UInt16 const ChoiceCellIdMin = 1;
 #pragma mark Upload / Delete
 
 - (void)preloadChoices:(NSArray<SDLChoiceCell *> *)choices withCompletionHandler:(nullable SDLPreloadChoiceCompletionHandler)handler {
-    if (![self.currentState isEqualToString:SDLChoiceManagerStateReady]) { return; }
+    if (![self.currentState isEqualToString:SDLChoiceManagerStateReady]) {
+        NSError *error = [NSError sdl_choiceSetManager_incorrectState:self.currentState];
+        handler(error);
+        return;
+    }
 
     NSMutableSet<SDLChoiceCell *> *choicesToUpload = [[self sdl_choicesToBeUploadedWithArray:choices] mutableCopy];
     [choicesToUpload minusSet:self.preloadedMutableChoices];

--- a/SmartDeviceLink/SDLError.h
+++ b/SmartDeviceLink/SDLError.h
@@ -68,6 +68,7 @@ extern SDLErrorDomain *const SDLErrorDomainRPCStore;
 + (NSError *)sdl_choiceSetManager_choiceDeletionFailed:(NSDictionary *)userInfo;
 + (NSError *)sdl_choiceSetManager_choiceUploadFailed:(NSDictionary *)userInfo;
 + (NSError *)sdl_choiceSetManager_failedToCreateMenuItems;
++ (NSError *)sdl_choiceSetManager_incorrectState:(NSString *)state;
 
 #pragma mark Transport
 

--- a/SmartDeviceLink/SDLError.m
+++ b/SmartDeviceLink/SDLError.m
@@ -8,6 +8,8 @@
 
 #import "SDLError.h"
 
+#import "SDLChoiceSetManager.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark Error Domains
@@ -235,6 +237,16 @@ SDLErrorDomain *const SDLErrorDomainRPCStore = @"com.sdl.rpcStore.error";
                                                        NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"If you are setting the menuName, it is possible that the head unit is sending incorrect displayCapabilities.", nil)
                                                        };
     return [NSError errorWithDomain:SDLErrorDomainChoiceSetManager code:SDLChoiceSetManagerErrorFailedToCreateMenuItems userInfo:userInfo];
+}
+
++ (NSError *)sdl_choiceSetManager_incorrectState:(SDLChoiceManagerState *)state {
+    NSString *errorString = [NSString stringWithFormat:@"Choice Set Manager error invalid state: %@", state];
+    NSDictionary<NSString *, NSString *> *userInfo = @{
+                                                       NSLocalizedDescriptionKey: errorString,
+                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"The choice set manager could be in an invalid state because the head unit doesn't support choice sets or the manager failed to set up correctly.", nil),
+                                                       NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"If you are setting the menuName, it is possible that the head unit is sending incorrect displayCapabilities.", nil)
+                                                       };
+    return [NSError errorWithDomain:SDLErrorDomainChoiceSetManager code:SDLChoiceSetManagerErrorInvalidState userInfo:userInfo];
 }
 
 #pragma mark Transport

--- a/SmartDeviceLink/SDLErrorConstants.h
+++ b/SmartDeviceLink/SDLErrorConstants.h
@@ -123,7 +123,8 @@ typedef NS_ENUM(NSInteger, SDLChoiceSetManagerError) {
     SDLChoiceSetManagerErrorPendingPresentationDeleted = -1,
     SDLChoiceSetManagerErrorDeletionFailed = -2,
     SDLChoiceSetManagerErrorUploadFailed = -3,
-    SDLChoiceSetManagerErrorFailedToCreateMenuItems = -4
+    SDLChoiceSetManagerErrorFailedToCreateMenuItems = -4,
+    SDLChoiceSetManagerErrorInvalidState = -5
 };
 
 /**

--- a/SmartDeviceLink/SDLPreloadChoicesOperation.m
+++ b/SmartDeviceLink/SDLPreloadChoicesOperation.m
@@ -157,8 +157,15 @@ NS_ASSUME_NONNULL_BEGIN
     } else {
         vrCommands = cell.voiceCommands;
     }
-    
-    NSString *menuName = [self.displayCapabilities hasTextFieldOfName:SDLTextFieldNameMenuName] ? cell.text : nil;
+
+    NSString *menuName = nil;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    if ([self.displayCapabilities.displayType isEqualToEnum:SDLDisplayTypeGen38Inch] || [self.displayCapabilities hasTextFieldOfName:SDLTextFieldNameMenuName]) {
+        menuName = cell.text;
+    }
+#pragma clang diagnostic pop
+
     if(!menuName) {
         SDLLogE(@"Could not convert SDLChoiceCell to SDLCreateInteractionChoiceSet. It will not be shown. Cell: %@", cell);
         return nil;


### PR DESCRIPTION
Fixes #1290 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Unit tests were run and smoke tests performed

### Summary
This PR forces the ChoiceSetManager to work on Ford Sync 3 units even when they pass back bad `DisplayCapabilities` and calls the `preloadChoices` `completionHandler` if it fails.

### Changelog
##### Bug Fixes
* Forces the ChoiceSetManager to work on Ford Sync 3 units even when they pass back bad `DisplayCapabilities` and calls the `preloadChoices` `completionHandler` if it fails.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)