### PR TITLE
Fixed the soft button operation not finishing if no image or text buttons sent

### DIFF
--- a/SmartDeviceLinkTests/SDLSoftButtonReplaceOperationSpec.m
+++ b/SmartDeviceLinkTests/SDLSoftButtonReplaceOperationSpec.m
@@ -52,6 +52,13 @@ describe(@"a soft button replace operation", ^{
     __block SDLSoftButtonState *object3State1 = nil;
     __block SDLSoftButtonObject *button3 = nil;
 
+    __block NSString *object4Name = @"O4 Name";
+    __block NSString *object4State1Name = @"O4S1 Name";
+    __block NSString *object4State1IconName = SDLStaticIconNameAlbum;
+    __block SDLArtwork *object4State1Art = nil;
+    __block SDLSoftButtonState *object4State1 = nil;
+    __block SDLSoftButtonObject *button4 = nil;
+
     __block NSString *testMainField1 = @"Test main field 1";
 
     beforeEach(^{
@@ -72,6 +79,10 @@ describe(@"a soft button replace operation", ^{
         object3State1Art = [[SDLArtwork alloc] initWithStaticIcon:object3State1IconName];
         object3State1 = [[SDLSoftButtonState alloc] initWithStateName:object3State1Name text:object3State1Text artwork:object3State1Art];
         button3 = [[SDLSoftButtonObject alloc] initWithName:object3Name state:object3State1 handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {}];
+
+        object4State1Art = [[SDLArtwork alloc] initWithStaticIcon:object4State1IconName];
+        object4State1 = [[SDLSoftButtonState alloc] initWithStateName:object4State1Name text:nil artwork:object4State1Art];;
+        button4 = [[SDLSoftButtonObject alloc] initWithName:object4Name state:object4State1 handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {}];;
 
         OCMStub([testFileManager uploadArtworks:[OCMArg any] progressHandler:[OCMArg invokeBlock] completionHandler:[OCMArg invokeBlock]]);
     });
@@ -136,6 +147,35 @@ describe(@"a soft button replace operation", ^{
                     expect(sentRequests.firstObject.softButtons.lastObject.text).to(equal(object2State1Text));
                     expect(sentRequests.firstObject.softButtons.lastObject.image).to(beNil());
                     expect(sentRequests.firstObject.softButtons.lastObject.type).to(equal(SDLSoftButtonTypeText));
+                });
+            });
+
+            context(@"but we don't support artworks and some buttons are image-only", ^{
+                __block NSArray<SDLSoftButtonObject *> *testImageOnlySoftButtonObjects = nil;
+
+                beforeEach(^{
+                    testImageOnlySoftButtonObjects = @[button3, button4];
+                });
+
+                beforeEach(^{
+                    SDLSoftButtonCapabilities *capabilities = [[SDLSoftButtonCapabilities alloc] init];
+                    capabilities.imageSupported = @NO;
+
+                    testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities softButtonObjects:testImageOnlySoftButtonObjects mainField1:testMainField1];
+                    [testOp start];
+                });
+
+                it(@"should not send artworks", ^{
+                    OCMReject([testFileManager uploadArtworks:[OCMArg any] completionHandler:[OCMArg any]]);
+                });
+
+                it(@"should not send any buttons", ^{
+                    NSArray<SDLShow *> *sentRequests = testConnectionManager.receivedRequests;
+                    expect(sentRequests).to(haveCount(0));
+                });
+
+                it(@"should have set the operation to finished", ^ {
+                    expect(testOp.isFinished).to(beTrue());
                 });
             });
 


### PR DESCRIPTION
Fixes #1294 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Test cases added

### Summary
The `SDLSoftButtonReplaceOperation` is never finished if the head unit does not support soft button images and some of the soft buttons do not have text (i.e. they are image only). So if other operations are added to the `transactionQueue` in the `SDLSoftButtonManager`, they never execute.

### Changelog
##### Bug Fixes
* Fixed the soft button operation not finishing if no image or text buttons sent by the operation.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)