### PR TITLE
Fix `runScore` being a property and several method / variable names

### DIFF
--- a/SmartDeviceLink/SDLMenuManager.m
+++ b/SmartDeviceLink/SDLMenuManager.m
@@ -58,7 +58,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (assign, nonatomic) UInt32 lastMenuId;
 @property (copy, nonatomic) NSArray<SDLMenuCell *> *oldMenuCells;
-@property (copy, nonatomic, nullable) SDLDynamicMenuUpdateRunScore *runScore;
+
 @end
 
 UInt32 const ParentIdNotFound = UINT32_MAX;
@@ -105,7 +105,6 @@ UInt32 const MenuCellIdMin = 1;
     _hasQueuedUpdate = NO;
     _waitingOnHMIUpdate = NO;
     _waitingUpdateMenuCells = @[];
-    _runScore = nil;
 }
 
 #pragma mark - Setters
@@ -166,11 +165,11 @@ UInt32 const MenuCellIdMin = 1;
         NSArray<NSNumber *> *deleteMenuStatus = tempScore.oldStatus;
         NSArray<NSNumber *> *addMenuStatus = tempScore.updatedStatus;
 
-        NSArray<SDLMenuCell *> *cellsToDelete = [self sdl_filterDeleteMenuItemsWithOldMenuItems:deleteMenuStatus basedOnStatusList:oldKeptCells[startIndex].subCells];
-        NSArray<SDLMenuCell *> *cellsToAdd = [self sdl_filterAddMenuItemsWithNewMenuItems:addMenuStatus basedOnStatusList:newKeptCells[startIndex].subCells];
+        NSArray<SDLMenuCell *> *cellsToDelete = [self sdl_filterDeleteMenuItemsWithOldMenuItems:oldKeptCells[startIndex].subCells basedOnStatusList:deleteMenuStatus];
+        NSArray<SDLMenuCell *> *cellsToAdd = [self sdl_filterAddMenuItemsWithNewMenuItems:newKeptCells[startIndex].subCells basedOnStatusList:addMenuStatus];
 
-        NSArray<SDLMenuCell *> *oldKeeps = [self sdl_filterKeepMenuItemsWithOldMenuItems: deleteMenuStatus basedOnStatusList:oldKeptCells[startIndex].subCells];
-        NSArray<SDLMenuCell *> *newKeeps = [self sdl_filterKeepMenuItemsWithNewMenuItems: addMenuStatus basedOnStatusList:newKeptCells[startIndex].subCells];
+        NSArray<SDLMenuCell *> *oldKeeps = [self sdl_filterKeepMenuItemsWithOldMenuItems:oldKeptCells[startIndex].subCells basedOnStatusList:deleteMenuStatus];
+        NSArray<SDLMenuCell *> *newKeeps = [self sdl_filterKeepMenuItemsWithNewMenuItems:newKeptCells[startIndex].subCells basedOnStatusList:addMenuStatus];
 
         [self sdl_updateIdsOnMenuCells:cellsToAdd parentId:newKeptCells[startIndex].cellId];
         [self transferCellIDFromOldCells:oldKeeps toKeptCells:newKeeps];
@@ -188,46 +187,46 @@ UInt32 const MenuCellIdMin = 1;
     }
 }
 
-- (NSArray<SDLMenuCell *> *)sdl_filterDeleteMenuItemsWithOldMenuItems:(NSArray<NSNumber *> *)oldMenuItems basedOnStatusList:(NSArray<SDLMenuCell *> *)oldList {
+- (NSArray<SDLMenuCell *> *)sdl_filterDeleteMenuItemsWithOldMenuItems:(NSArray<SDLMenuCell *> *)oldMenuCells basedOnStatusList:(NSArray<NSNumber *> *)oldStatusList {
     NSMutableArray<SDLMenuCell *> *deleteCells = [[NSMutableArray alloc] init];
     // The index of the status should corrleate 1-1 with the number of items in the menu
     // [2,0,2,0] => [A,B,C,D] = [B,D]
-    for (NSUInteger index = 0; index < oldMenuItems.count; index++) {
-        if (oldMenuItems[index].integerValue == MenuCellStateDelete) {
-            [deleteCells addObject:oldList[index]];
+    for (NSUInteger index = 0; index < oldStatusList.count; index++) {
+        if (oldStatusList[index].integerValue == MenuCellStateDelete) {
+            [deleteCells addObject:oldMenuCells[index]];
         }
     }
     return [deleteCells copy];
 }
 
-- (NSArray<SDLMenuCell *> *)sdl_filterAddMenuItemsWithNewMenuItems:(NSArray<NSNumber *> *)newMenuItems basedOnStatusList:(NSArray<SDLMenuCell *> *)statusList {
+- (NSArray<SDLMenuCell *> *)sdl_filterAddMenuItemsWithNewMenuItems:(NSArray<SDLMenuCell *> *)newMenuCells basedOnStatusList:(NSArray<NSNumber *> *)newStatusList {
     NSMutableArray<SDLMenuCell *> *addCells = [[NSMutableArray alloc] init];
     // The index of the status should corrleate 1-1 with the number of items in the menu
     // [2,1,2,1] => [A,B,C,D] = [B,D]
-    for (NSUInteger index = 0; index < newMenuItems.count; index++) {
-        if (newMenuItems[index].integerValue == MenuCellStateAdd) {
-            [addCells addObject:statusList[index]];
+    for (NSUInteger index = 0; index < newStatusList.count; index++) {
+        if (newStatusList[index].integerValue == MenuCellStateAdd) {
+            [addCells addObject:newMenuCells[index]];
         }
     }
     return [addCells copy];
 }
 
-- (NSArray<SDLMenuCell *> *)sdl_filterKeepMenuItemsWithOldMenuItems:(NSArray<NSNumber *> *)oldMenuItems basedOnStatusList:(NSArray<SDLMenuCell *> *)statusList  {
+- (NSArray<SDLMenuCell *> *)sdl_filterKeepMenuItemsWithOldMenuItems:(NSArray<SDLMenuCell *> *)oldMenuCells basedOnStatusList:(NSArray<NSNumber *> *)keepStatusList {
     NSMutableArray<SDLMenuCell *> *keepMenuCells = [[NSMutableArray alloc] init];
 
-    for (NSUInteger index = 0; index < oldMenuItems.count; index++) {
-        if (oldMenuItems[index].integerValue == MenuCellStateKeep) {
-            [keepMenuCells addObject:statusList[index]];
+    for (NSUInteger index = 0; index < keepStatusList.count; index++) {
+        if (keepStatusList[index].integerValue == MenuCellStateKeep) {
+            [keepMenuCells addObject:oldMenuCells[index]];
         }
     }
     return [keepMenuCells copy];
 }
 
-- (NSArray<SDLMenuCell *> *)sdl_filterKeepMenuItemsWithNewMenuItems:(NSArray<NSNumber *> *)newMenuItems basedOnStatusList:(NSArray<SDLMenuCell *> *)statusList  {
+- (NSArray<SDLMenuCell *> *)sdl_filterKeepMenuItemsWithNewMenuItems:(NSArray<SDLMenuCell *> *)newMenuCells basedOnStatusList:(NSArray<NSNumber *> *)keepStatusList {
     NSMutableArray<SDLMenuCell *> *keepMenuCells = [[NSMutableArray alloc] init];
-    for (NSUInteger index = 0; index < newMenuItems.count; index++) {
-        if (newMenuItems[index].integerValue == MenuCellStateKeep) {
-            [keepMenuCells addObject:statusList[index]];
+    for (NSUInteger index = 0; index < keepStatusList.count; index++) {
+        if (keepStatusList[index].integerValue == MenuCellStateKeep) {
+            [keepMenuCells addObject:newMenuCells[index]];
         }
     }
     return [keepMenuCells copy];
@@ -243,16 +242,16 @@ UInt32 const MenuCellIdMin = 1;
 #pragma mark - Updating System
 
 - (void)sdl_startDynamicMenuUpdate {
-    _runScore = [SDLDynamicMenuUpdateAlgorithm compareOldMenuCells:self.oldMenuCells updatedMenuCells:self.menuCells];
+    SDLDynamicMenuUpdateRunScore *runScore = [SDLDynamicMenuUpdateAlgorithm compareOldMenuCells:self.oldMenuCells updatedMenuCells:self.menuCells];
 
-    NSArray<NSNumber *> *deleteMenuStatus = self.runScore.oldStatus;
-    NSArray<NSNumber *> *addMenuStatus = self.runScore.updatedStatus;
+    NSArray<NSNumber *> *deleteMenuStatus = runScore.oldStatus;
+    NSArray<NSNumber *> *addMenuStatus = runScore.updatedStatus;
 
-    NSArray<SDLMenuCell *> *cellsToDelete = [self sdl_filterDeleteMenuItemsWithOldMenuItems:deleteMenuStatus basedOnStatusList:self.oldMenuCells];
-    NSArray<SDLMenuCell *> *cellsToAdd = [self sdl_filterAddMenuItemsWithNewMenuItems:addMenuStatus basedOnStatusList:self.menuCells];
+    NSArray<SDLMenuCell *> *cellsToDelete = [self sdl_filterDeleteMenuItemsWithOldMenuItems:self.oldMenuCells basedOnStatusList:deleteMenuStatus];
+    NSArray<SDLMenuCell *> *cellsToAdd = [self sdl_filterAddMenuItemsWithNewMenuItems:self.menuCells basedOnStatusList:addMenuStatus];
     // These arrays should ONLY contain KEEPS. These will be used for SubMenu compares
-    NSArray<SDLMenuCell *> *oldKeeps = [self sdl_filterKeepMenuItemsWithOldMenuItems:deleteMenuStatus basedOnStatusList:self.oldMenuCells];
-    NSArray<SDLMenuCell *> *newKeeps = [self sdl_filterKeepMenuItemsWithNewMenuItems:addMenuStatus basedOnStatusList:self.menuCells];
+    NSArray<SDLMenuCell *> *oldKeeps = [self sdl_filterKeepMenuItemsWithOldMenuItems:self.oldMenuCells basedOnStatusList:deleteMenuStatus];
+    NSArray<SDLMenuCell *> *newKeeps = [self sdl_filterKeepMenuItemsWithNewMenuItems:self.menuCells basedOnStatusList:addMenuStatus];
 
     // Cells that will be added need new ids
     [self sdl_updateIdsOnMenuCells:cellsToAdd parentId:ParentIdNotFound];

--- a/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
+++ b/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
@@ -398,7 +398,7 @@ describe(@"System capability manager", ^{
             __block id blockObserver = nil;
 
             beforeEach(^{
-                blockObserver = [testSystemCapabilityManager subscribeToCapabilityType:SDLSystemCapabilityTypePhoneCall usingBlock:^(SDLSystemCapability * _Nonnull systemCapability) {
+                blockObserver = [testSystemCapabilityManager subscribeToCapabilityType:SDLSystemCapabilityTypePhoneCall withBlock:^(SDLSystemCapability * _Nonnull systemCapability) {
                     blockObserverTriggeredCount++;
                 }];
 
@@ -439,7 +439,7 @@ describe(@"System capability manager", ^{
             __block id blockObserver = nil;
 
             beforeEach(^{
-                blockObserver = [testSystemCapabilityManager subscribeToCapabilityType:SDLSystemCapabilityTypePhoneCall usingBlock:^(SDLSystemCapability * _Nonnull systemCapability) {
+                blockObserver = [testSystemCapabilityManager subscribeToCapabilityType:SDLSystemCapabilityTypePhoneCall withBlock:^(SDLSystemCapability * _Nonnull systemCapability) {
                     blockObserverTriggeredCount++;
                 }];
 


### PR DESCRIPTION
Fixes #1306 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Smoke tests performed

### Summary
This PR fixes some method names and makes a global private property a local variable instead.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
