### PR TITLE
Fix crash in preload if there's no handler and the preload fails

### DIFF
--- a/SmartDeviceLink/SDLChoiceSetManager.m
+++ b/SmartDeviceLink/SDLChoiceSetManager.m
@@ -183,9 +183,11 @@ UInt16 const ChoiceCellIdMin = 1;
 #pragma mark Upload / Delete
 
 - (void)preloadChoices:(NSArray<SDLChoiceCell *> *)choices withCompletionHandler:(nullable SDLPreloadChoiceCompletionHandler)handler {
-    if (![self.currentState isEqualToString:SDLChoiceManagerStateReady]) {
-        NSError *error = [NSError sdl_choiceSetManager_incorrectState:self.currentState];
-        handler(error);
+    if ([self.currentState isEqualToString:SDLChoiceManagerStateShutdown]) {
+        if (handler != nil) {
+            NSError *error = [NSError sdl_choiceSetManager_incorrectState:self.currentState];
+            handler(error);
+        }
         return;
     }
 


### PR DESCRIPTION
Fixes #1308 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Smoke tests were performed

### Summary
* Only fail to queue a choice preload in the shutdown state
* If the handler doesn't exist, don't crash

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)