### PR TITLE
Fix/make reference to primaryProtocol to strong

### DIFF
--- a/SmartDeviceLink/SDLSecondaryTransportManager.m
+++ b/SmartDeviceLink/SDLSecondaryTransportManager.m
@@ -67,7 +67,7 @@ static const int TCPPortUnspecified = -1;
 @property (copy, nonatomic) dispatch_queue_t stateMachineQueue;
 
 // Instance of the protocol that runs on primary transport.
-@property (weak, nonatomic) SDLProtocol *primaryProtocol;
+@property (strong, nonatomic) SDLProtocol *primaryProtocol;
 // A class to catch Start Service ACK and Transport Config Update frames.
 @property (strong, nonatomic) SDLSecondaryTransportPrimaryProtocolHandler *primaryProtocolHandler;
 


### PR DESCRIPTION
Fixes #1310 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
We verified with our devboard and OEM HU

### Summary
Make reference to primaryProtocol in SDLSecondaryTransportManager to strong. This ensures to update video and audio service states correctly at transport disconnect.

### Changelog

##### Bug Fixes
* Fix SDLStreamingMediaManager to be stopped when transport is disconnected

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
