### PR TITLE
do not unregister EA accessory notification on transport dealloc

### DIFF
--- a/SmartDeviceLink/SDLIAPTransport.m
+++ b/SmartDeviceLink/SDLIAPTransport.m
@@ -124,7 +124,6 @@ int const CreateSessionRetries = 3;
  */
 - (void)sdl_stopEventListening {
     SDLLogV(@"SDLIAPTransport stopped listening for events");
-    [[EAAccessoryManager sharedAccessoryManager] unregisterForLocalNotifications];
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 


### PR DESCRIPTION
Fixes #1311 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
We verified this fix with our devboard and OEM HU.

### Summary
Calling EAAccessoryManager#unregisterForLocalNotifications makes all SDLIAPTransport instances not be able to receive EA events. 


### Changelog
##### Bug Fixes
* Fix the issue that SDLIAPTransport does not receive EA events after transport reconnect.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
