### PR TITLE
Fixed session creation failing due to no background task

### DIFF
--- a/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
+++ b/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
@@ -1238,6 +1238,8 @@
 		756C62772289F11F008B57A2 /* SDLDynamicMenuUpdateRunScore.m in Sources */ = {isa = PBXBuildFile; fileRef = 756C62752289F11F008B57A2 /* SDLDynamicMenuUpdateRunScore.m */; };
 		880245A420F79C3400ED195B /* SDLFileManagerConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 880245A220F79C3400ED195B /* SDLFileManagerConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		880245A520F79C3400ED195B /* SDLFileManagerConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 880245A320F79C3400ED195B /* SDLFileManagerConfiguration.m */; };
+		8803DCEF22C2B84B00FBB7CE /* SDLBackgroundTaskManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 8803DCED22C2B84B00FBB7CE /* SDLBackgroundTaskManager.h */; };
+		8803DCF022C2B84B00FBB7CE /* SDLBackgroundTaskManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 8803DCEE22C2B84B00FBB7CE /* SDLBackgroundTaskManager.m */; };
 		880D267A220DDD1000B3F496 /* SDLWeatherServiceDataSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 880D2679220DDD1000B3F496 /* SDLWeatherServiceDataSpec.m */; };
 		880D267D220DE5DF00B3F496 /* SDLWeatherServiceManifest.h in Headers */ = {isa = PBXBuildFile; fileRef = 880D267B220DE5DF00B3F496 /* SDLWeatherServiceManifest.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		880D267E220DE5DF00B3F496 /* SDLWeatherServiceManifest.m in Sources */ = {isa = PBXBuildFile; fileRef = 880D267C220DE5DF00B3F496 /* SDLWeatherServiceManifest.m */; };
@@ -2892,6 +2894,8 @@
 		756C62752289F11F008B57A2 /* SDLDynamicMenuUpdateRunScore.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLDynamicMenuUpdateRunScore.m; sourceTree = "<group>"; };
 		880245A220F79C3400ED195B /* SDLFileManagerConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDLFileManagerConfiguration.h; sourceTree = "<group>"; };
 		880245A320F79C3400ED195B /* SDLFileManagerConfiguration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLFileManagerConfiguration.m; sourceTree = "<group>"; };
+		8803DCED22C2B84B00FBB7CE /* SDLBackgroundTaskManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDLBackgroundTaskManager.h; sourceTree = "<group>"; };
+		8803DCEE22C2B84B00FBB7CE /* SDLBackgroundTaskManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLBackgroundTaskManager.m; sourceTree = "<group>"; };
 		880D2679220DDD1000B3F496 /* SDLWeatherServiceDataSpec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLWeatherServiceDataSpec.m; sourceTree = "<group>"; };
 		880D267B220DE5DF00B3F496 /* SDLWeatherServiceManifest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDLWeatherServiceManifest.h; sourceTree = "<group>"; };
 		880D267C220DE5DF00B3F496 /* SDLWeatherServiceManifest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLWeatherServiceManifest.m; sourceTree = "<group>"; };
@@ -4791,6 +4795,8 @@
 		5D5934F61A85189500687FB9 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				8803DCED22C2B84B00FBB7CE /* SDLBackgroundTaskManager.h */,
+				8803DCEE22C2B84B00FBB7CE /* SDLBackgroundTaskManager.m */,
 				97E26DEA1E807AD70074A3C7 /* SDLMutableDataQueue.h */,
 				97E26DEB1E807AD70074A3C7 /* SDLMutableDataQueue.m */,
 				E9C32B831AB20B2900F283AF /* @categories */,
@@ -6426,6 +6432,7 @@
 				5D61FC511A84238C00846EE7 /* SDLButtonCapabilities.h in Headers */,
 				5D61FDE91A84238C00846EE7 /* SDLUnsubscribeButtonResponse.h in Headers */,
 				5D61FCD51A84238C00846EE7 /* SDLImageType.h in Headers */,
+				8803DCEF22C2B84B00FBB7CE /* SDLBackgroundTaskManager.h in Headers */,
 				5D61FC2F1A84238C00846EE7 /* SDLAddCommandResponse.h in Headers */,
 				5D0C2A0020D9479B008B56CD /* SDLStreamingVideoLifecycleManager.h in Headers */,
 				5D61FD631A84238C00846EE7 /* SDLResetGlobalProperties.h in Headers */,
@@ -7204,6 +7211,7 @@
 				5D61FC5E1A84238C00846EE7 /* SDLChangeRegistrationResponse.m in Sources */,
 				5D8204231BCEA89A00D0A41B /* SDLFileManager.m in Sources */,
 				1EB59CC0202DA26000343A61 /* SDLSeatControlData.m in Sources */,
+				8803DCF022C2B84B00FBB7CE /* SDLBackgroundTaskManager.m in Sources */,
 				5D61FC7D1A84238C00846EE7 /* SDLDeleteInteractionChoiceSetResponse.m in Sources */,
 				DAC572661D10C5640004288B /* CGPoint_Util.m in Sources */,
 				5D00AC681F140F0A004000D9 /* SDLSystemCapabilityType.m in Sources */,

--- a/SmartDeviceLink/SDLBackgroundTaskManager.h
+++ b/SmartDeviceLink/SDLBackgroundTaskManager.h
@@ -11,12 +11,15 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ * Class for managing a background task. 
+ */
 @interface SDLBackgroundTaskManager : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
 
 /**
- *  Convenience init for starting a background task with a specific name
+ *  Convenience init for starting a background task with a specific name.
  *
  *  @param backgroundTaskName  The name for the background task
  *  @return                    A SDLBackgroundTaskManager object
@@ -31,8 +34,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Cleans up a background task when it is stopped. This should be called when:
  *
- *  1. The app has established a session
- *  2. The system has called the `expirationHandler` for the background task. The system may kill the app if the background task is not ended.
+ *  1. The app has established a session.
+ *  2. The system has called the `expirationHandler` for the background task. The system may kill the app if the background task is not ended when `expirationHandler` is called.
  */
 - (void)endBackgroundTask;
 

--- a/SmartDeviceLink/SDLBackgroundTaskManager.h
+++ b/SmartDeviceLink/SDLBackgroundTaskManager.h
@@ -13,8 +13,27 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SDLBackgroundTaskManager : NSObject
 
+- (instancetype)init NS_UNAVAILABLE;
+
+/**
+ *  Convenience init for starting a background task with a specific name
+ *
+ *  @param backgroundTaskName  The name for the background task
+ *  @return                    A SDLBackgroundTaskManager object
+ */
 - (instancetype)initWithBackgroundTaskName:(NSString *)backgroundTaskName;
+
+/**
+ *  Starts a background task that allows the app to establish a session while app is backgrounded. If the app is not currently backgrounded, the background task will remain dormant until the app moves to the background.
+ */
 - (void)startBackgroundTask;
+
+/**
+ *  Cleans up a background task when it is stopped. This should be called when:
+ *
+ *  1. The app has established a session
+ *  2. The system has called the `expirationHandler` for the background task. The system may kill the app if the background task is not ended.
+ */
 - (void)endBackgroundTask;
 
 @end

--- a/SmartDeviceLink/SDLBackgroundTaskManager.h
+++ b/SmartDeviceLink/SDLBackgroundTaskManager.h
@@ -1,0 +1,22 @@
+//
+//  SDLBackgroundTaskManager.h
+//  SmartDeviceLink
+//
+//  Created by Nicole on 6/25/19.
+//  Copyright © 2019 smartdevicelink. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SDLBackgroundTaskManager : NSObject
+
+- (instancetype)initWithBackgroundTaskName:(NSString *)backgroundTaskName;
+- (void)startBackgroundTask;
+- (void)endBackgroundTask;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLBackgroundTaskManager.m
+++ b/SmartDeviceLink/SDLBackgroundTaskManager.m
@@ -59,6 +59,10 @@ NS_ASSUME_NONNULL_BEGIN
     self.currentBackgroundTaskId = UIBackgroundTaskInvalid;
 }
 
+- (void)dealloc {
+    [self endBackgroundTask];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLBackgroundTaskManager.m
+++ b/SmartDeviceLink/SDLBackgroundTaskManager.m
@@ -14,8 +14,9 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface SDLBackgroundTaskManager ()
-@property (nonatomic, assign) NSString *backgroundTaskName;
-@property (nonatomic, assign) UIBackgroundTaskIdentifier backgroundTaskId;
+@property (copy, nonatomic) NSString *backgroundTaskName;
+@property (assign, nonatomic) UIBackgroundTaskIdentifier currentBackgroundTaskId;
+
 @end
 
 @implementation SDLBackgroundTaskManager
@@ -36,18 +37,18 @@ NS_ASSUME_NONNULL_BEGIN
  *  Starts a background task that allows the app to establish a session while app is backgrounded. If the app is not currently backgrounded, the background task will remain dormant until the app moves to the background.
  */
 - (void)startBackgroundTask {
-    if (self.backgroundTaskId != UIBackgroundTaskInvalid) {
+    if (self.currentBackgroundTaskId != UIBackgroundTaskInvalid) {
         SDLLogV(@"The %@ background task is already running.", self.backgroundTaskName);
         return;
     }
 
     __weak typeof(self) weakself = self;
-    self.backgroundTaskId = [[UIApplication sharedApplication] beginBackgroundTaskWithName:self.backgroundTaskName expirationHandler:^{
+    self.currentBackgroundTaskId = [[UIApplication sharedApplication] beginBackgroundTaskWithName:self.backgroundTaskName expirationHandler:^{
         SDLLogD(@"The %@ background task expired", self.backgroundTaskName);
         [weakself endBackgroundTask];
     }];
 
-    SDLLogD(@"The %@ background task started with id: %lu", self.backgroundTaskName, (unsigned long)self.backgroundTaskId);
+    SDLLogD(@"The %@ background task started with id: %lu", self.backgroundTaskName, (unsigned long)self.currentBackgroundTaskId);
 }
 
 /**
@@ -58,14 +59,14 @@ NS_ASSUME_NONNULL_BEGIN
  *
  */
 - (void)endBackgroundTask {
-    if (self.backgroundTaskId == UIBackgroundTaskInvalid) {
+    if (self.currentBackgroundTaskId == UIBackgroundTaskInvalid) {
         SDLLogV(@"Background task already ended. Returning...");
         return;
     }
 
-    SDLLogD(@"Ending background task with id: %lu",  (unsigned long)self.backgroundTaskId);
-    [[UIApplication sharedApplication] endBackgroundTask:self.backgroundTaskId];
-    self.backgroundTaskId = UIBackgroundTaskInvalid;
+    SDLLogD(@"Ending background task with id: %lu",  (unsigned long)self.currentBackgroundTaskId);
+    [[UIApplication sharedApplication] endBackgroundTask:self.currentBackgroundTaskId];
+    self.currentBackgroundTaskId = UIBackgroundTaskInvalid;
 }
 
 @end

--- a/SmartDeviceLink/SDLBackgroundTaskManager.m
+++ b/SmartDeviceLink/SDLBackgroundTaskManager.m
@@ -33,9 +33,6 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-/**
- *  Starts a background task that allows the app to establish a session while app is backgrounded. If the app is not currently backgrounded, the background task will remain dormant until the app moves to the background.
- */
 - (void)startBackgroundTask {
     if (self.currentBackgroundTaskId != UIBackgroundTaskInvalid) {
         SDLLogV(@"The %@ background task is already running.", self.backgroundTaskName);
@@ -51,13 +48,6 @@ NS_ASSUME_NONNULL_BEGIN
     SDLLogD(@"The %@ background task started with id: %lu", self.backgroundTaskName, (unsigned long)self.currentBackgroundTaskId);
 }
 
-/**
- *  Cleans up a background task when it is stopped. This should be called when:
- *
- *  1. The app has established a session
- *  2. The system has called the `expirationHandler` for the background task. The system may kill the app if the background task is not ended.
- *
- */
 - (void)endBackgroundTask {
     if (self.currentBackgroundTaskId == UIBackgroundTaskInvalid) {
         SDLLogV(@"Background task already ended. Returning...");

--- a/SmartDeviceLink/SDLBackgroundTaskManager.m
+++ b/SmartDeviceLink/SDLBackgroundTaskManager.m
@@ -1,0 +1,73 @@
+//
+//  SDLBackgroundTaskManager.m
+//  SmartDeviceLink
+//
+//  Created by Nicole on 6/25/19.
+//  Copyright © 2019 smartdevicelink. All rights reserved.
+//
+
+#import "SDLBackgroundTaskManager.h"
+
+#import "SDLLogMacros.h"
+
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SDLBackgroundTaskManager ()
+@property (nonatomic, assign) NSString *backgroundTaskName;
+@property (nonatomic, assign) UIBackgroundTaskIdentifier backgroundTaskId;
+@end
+
+@implementation SDLBackgroundTaskManager
+
+- (instancetype)initWithBackgroundTaskName:(NSString *)backgroundTaskName {
+    SDLLogV(@"SDLBackgroundTaskManager init with name %@", backgroundTaskName);
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+
+    _backgroundTaskName = backgroundTaskName;
+
+    return self;
+}
+
+/**
+ *  Starts a background task that allows the app to establish a session while app is backgrounded. If the app is not currently backgrounded, the background task will remain dormant until the app moves to the background.
+ */
+- (void)startBackgroundTask {
+    if (self.backgroundTaskId != UIBackgroundTaskInvalid) {
+        SDLLogV(@"The %@ background task is already running.", self.backgroundTaskName);
+        return;
+    }
+
+    __weak typeof(self) weakself = self;
+    self.backgroundTaskId = [[UIApplication sharedApplication] beginBackgroundTaskWithName:self.backgroundTaskName expirationHandler:^{
+        SDLLogD(@"The %@ background task expired", self.backgroundTaskName);
+        [weakself endBackgroundTask];
+    }];
+
+    SDLLogD(@"The %@ background task started with id: %lu", self.backgroundTaskName, (unsigned long)self.backgroundTaskId);
+}
+
+/**
+ *  Cleans up a background task when it is stopped. This should be called when:
+ *
+ *  1. The app has established a session
+ *  2. The system has called the `expirationHandler` for the background task. The system may kill the app if the background task is not ended.
+ *
+ */
+- (void)endBackgroundTask {
+    if (self.backgroundTaskId == UIBackgroundTaskInvalid) {
+        SDLLogV(@"Background task already ended. Returning...");
+        return;
+    }
+
+    SDLLogD(@"Ending background task with id: %lu",  (unsigned long)self.backgroundTaskId);
+    [[UIApplication sharedApplication] endBackgroundTask:self.backgroundTaskId];
+    self.backgroundTaskId = UIBackgroundTaskInvalid;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLIAPTransport.m
+++ b/SmartDeviceLink/SDLIAPTransport.m
@@ -55,6 +55,11 @@ int const CreateSessionRetries = 3;
     // Get notifications if an accessory connects in future
     [self sdl_startEventListening];
 
+    if (UIApplication.sharedApplication.applicationState != UIApplicationStateActive) {
+        SDLLogV(@"Application not in foreground on transport init. Starting a background task");
+        [self sdl_backgroundTaskStart];
+    }
+
     // Wait for setup to complete before scanning for accessories
 
     return self;
@@ -63,7 +68,7 @@ int const CreateSessionRetries = 3;
 #pragma mark - Background Task
 
 /**
- *  Starts a background task that allows the app to search for accessories and while the app is in the background.
+ *  Starts a background task that allows the app to search for accessories while the app is in the background.
  */
 - (void)sdl_backgroundTaskStart {
     if (self.backgroundTaskId != UIBackgroundTaskInvalid) {
@@ -77,7 +82,7 @@ int const CreateSessionRetries = 3;
         [weakself sdl_backgroundTaskEnd];
     }];
 
-    SDLLogD(@"Started a background task with id: %lu", (unsigned long)self.backgroundTaskId);
+    SDLLogD(@"Background task started with id: %lu", (unsigned long)self.backgroundTaskId);
 }
 
 /**

--- a/SmartDeviceLink/SDLIAPTransport.m
+++ b/SmartDeviceLink/SDLIAPTransport.m
@@ -15,7 +15,6 @@
 #import "SDLIAPDataSession.h"
 #import "SDLIAPDataSessionDelegate.h"
 #import "SDLLogMacros.h"
-#import "SDLTimer.h"
 #import <CommonCrypto/CommonDigest.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -81,7 +80,7 @@ int const CreateSessionRetries = 3;
  */
 - (void)sdl_stopEventListening {
     SDLLogV(@"SDLIAPTransport stopped listening for events");
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    [[EAAccessoryManager sharedAccessoryManager] unregisterForLocalNotifications];
 }
 
 #pragma mark EAAccessory Notifications
@@ -133,7 +132,7 @@ int const CreateSessionRetries = 3;
  */
 - (void)sdl_accessoryDisconnected:(NSNotification *)notification {
     EAAccessory *accessory = [notification.userInfo objectForKey:EAAccessoryKey];
-    SDLLogD(@"Accessory with serial number %@ and connectionID %lu disconnecting.", accessory.serialNumber, (unsigned long)accessory.connectionID);
+    SDLLogD(@"Accessory with serial number: %@, and connectionID: %lu disconnecting.", accessory.serialNumber, (unsigned long)accessory.connectionID);
 
     if (self.accessoryConnectDuringActiveSession == YES) {
         SDLLogD(@"Switching transports from Bluetooth to USB. Will reconnect over Bluetooth after disconnecting the USB session.");
@@ -249,7 +248,7 @@ int const CreateSessionRetries = 3;
  *  @param accessory The accessory to try to establish a session with, or nil to scan all connected accessories.
  */
 - (void)sdl_establishSessionWithAccessory:(nullable EAAccessory *)accessory {
-    SDLLogD(@"Attempting to connect accessory: %@", accessory.name);
+    SDLLogD(@"Attempting to connect accessory named: %@, with connectionID: %lu", accessory.name, (unsigned long)accessory.connectionID);
     if (self.retryCounter < CreateSessionRetries) {
         self.retryCounter++;
 

--- a/SmartDeviceLink/SDLIAPTransport.m
+++ b/SmartDeviceLink/SDLIAPTransport.m
@@ -71,9 +71,10 @@ int const CreateSessionRetries = 3;
         return;
     }
 
+    __weak typeof(self) weakself = self;
     self.backgroundTaskId = [[UIApplication sharedApplication] beginBackgroundTaskWithName:BackgroundTaskName expirationHandler:^{
         SDLLogD(@"Background task expired");
-        [self sdl_backgroundTaskEnd];
+        [weakself sdl_backgroundTaskEnd];
     }];
 
     SDLLogD(@"Started a background task with id: %lu", (unsigned long)self.backgroundTaskId);
@@ -124,7 +125,6 @@ int const CreateSessionRetries = 3;
  */
 - (void)sdl_stopEventListening {
     SDLLogV(@"SDLIAPTransport stopped listening for events");
-    [[EAAccessoryManager sharedAccessoryManager] unregisterForLocalNotifications];
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 

--- a/SmartDeviceLink/SDLIAPTransport.m
+++ b/SmartDeviceLink/SDLIAPTransport.m
@@ -598,7 +598,6 @@ int const CreateSessionRetries = 3;
 - (void)dealloc {
     SDLLogV(@"SDLIAPTransport dealloc");
     [self disconnect];
-    [self sdl_backgroundTaskEnd];
     self.controlSession = nil;
     self.dataSession = nil;
     self.delegate = nil;

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -879,6 +879,12 @@ NSString *const BackgroundTaskIAPTransportName = @"com.sdl.transport.iap.backgro
     self.backgroundTaskId = UIBackgroundTaskInvalid;
 }
 
+#pragma mark - Lifecycle Destruction
+
+- (void)dealloc {
+    [self sdl_backgroundTaskEnd];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -12,6 +12,7 @@
 
 #import "NSMapTable+Subscripting.h"
 #import "SDLAsynchronousRPCRequestOperation.h"
+#import "SDLBackgroundTaskManager.h"
 #import "SDLChangeRegistration.h"
 #import "SDLChoiceSetManager.h"
 #import "SDLConfiguration.h"
@@ -57,7 +58,6 @@
 #import "SDLUnregisterAppInterface.h"
 #import "SDLVersion.h"
 
-
 NS_ASSUME_NONNULL_BEGIN
 
 SDLLifecycleState *const SDLLifecycleStateStopped = @"Stopped";
@@ -72,7 +72,7 @@ SDLLifecycleState *const SDLLifecycleStateSettingUpHMI = @"SettingUpHMI";
 SDLLifecycleState *const SDLLifecycleStateUnregistering = @"Unregistering";
 SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
 
-NSString *const BackgroundTaskIAPTransportName = @"com.sdl.transport.iap.backgroundTask";
+NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask";
 
 #pragma mark - SDLManager Private Interface
 
@@ -90,7 +90,7 @@ NSString *const BackgroundTaskIAPTransportName = @"com.sdl.transport.iap.backgro
 @property (copy, nonatomic) SDLManagerReadyBlock readyHandler;
 @property (copy, nonatomic) dispatch_queue_t lifecycleQueue;
 @property (assign, nonatomic) int32_t lastCorrelationId;
-@property (nonatomic, assign) UIBackgroundTaskIdentifier backgroundTaskId;
+@property (copy, nonatomic) SDLBackgroundTaskManager *backgroundTaskManager;
 
 @end
 
@@ -152,6 +152,8 @@ NSString *const BackgroundTaskIAPTransportName = @"com.sdl.transport.iap.backgro
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(hmiStatusDidChange:) name:SDLDidChangeHMIStatusNotification object:_notificationDispatcher];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(remoteHardwareDidUnregister:) name:SDLDidReceiveAppUnregisteredNotification object:_notificationDispatcher];
 
+    _backgroundTaskManager = [[SDLBackgroundTaskManager alloc] initWithBackgroundTaskName: BackgroundTaskTransportName];
+
     return self;
 }
 
@@ -211,9 +213,12 @@ NSString *const BackgroundTaskIAPTransportName = @"com.sdl.transport.iap.backgro
 }
 
 - (void)didEnterStateStarted {
-// Start up the internal proxy object
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    // start a background task so a session can be established even when the app is backgrounded.
+    [self.backgroundTaskManager startBackgroundTask];
+
+    // Start up the internal proxy object
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     if (self.configuration.lifecycleConfig.tcpDebugMode) {
         // secondary transport manager is not used
         self.secondaryTransportManager = nil;
@@ -222,16 +227,13 @@ NSString *const BackgroundTaskIAPTransportName = @"com.sdl.transport.iap.backgro
                                             tcpPort:@(self.configuration.lifecycleConfig.tcpDebugPort).stringValue
                           secondaryTransportManager:self.secondaryTransportManager];
     } else {
-        // start a background task so a session can be established even when the app is backgrounded.
-        [self sdl_backgroundTaskStart];
-
         // we reuse our queue to run secondary transport manager's state machine
         self.secondaryTransportManager = [[SDLSecondaryTransportManager alloc] initWithStreamingProtocolDelegate:self
                                                                                                      serialQueue:self.lifecycleQueue];
         self.proxy = [SDLProxy iapProxyWithListener:self.notificationDispatcher
                           secondaryTransportManager:self.secondaryTransportManager];
     }
-#pragma clang diagnostic pop
+#   pragma clang diagnostic pop
 }
 
 - (void)didEnterStateStopped {
@@ -281,7 +283,7 @@ NSString *const BackgroundTaskIAPTransportName = @"com.sdl.transport.iap.backgro
             [strongSelf sdl_transitionToState:SDLLifecycleStateStarted];
         } else {
             // End any background tasks because a session will not be established
-            [self sdl_backgroundTaskEnd];
+            [self.backgroundTaskManager endBackgroundTask];
         }
     });
 }
@@ -707,7 +709,7 @@ NSString *const BackgroundTaskIAPTransportName = @"com.sdl.transport.iap.backgro
     SDLLogD(@"Transport connected");
 
     // End any background tasks since the transport connected successfully
-    [self sdl_backgroundTaskEnd];
+    [self.backgroundTaskManager endBackgroundTask];
 
     dispatch_async(self.lifecycleQueue, ^{
         [self sdl_transitionToState:SDLLifecycleStateConnected];
@@ -841,48 +843,10 @@ NSString *const BackgroundTaskIAPTransportName = @"com.sdl.transport.iap.backgro
     }
 }
 
-#pragma mark - Background Task
-
-/**
- *  Starts a background task that allows the app to establish a session while app is backgrounded. If the app is not currently backgrounded, the background task will remain dormant until the app moves to the background.
- */
-- (void)sdl_backgroundTaskStart {
-    if (self.backgroundTaskId != UIBackgroundTaskInvalid) {
-        SDLLogV(@"The %@ background task is already running.", BackgroundTaskIAPTransportName);
-        return;
-    }
-
-    __weak typeof(self) weakself = self;
-    self.backgroundTaskId = [[UIApplication sharedApplication] beginBackgroundTaskWithName:BackgroundTaskIAPTransportName expirationHandler:^{
-        SDLLogD(@"The %@ background task expired", BackgroundTaskIAPTransportName);
-        [weakself sdl_backgroundTaskEnd];
-    }];
-
-    SDLLogD(@"The %@ background task started with id: %lu", BackgroundTaskIAPTransportName, (unsigned long)self.backgroundTaskId);
-}
-
-/**
- *  Cleans up a background task when it is stopped. This should be called when:
- *
- *  1. The app has established a session
- *  2. The system has called the `expirationHandler` for the background task. The system may kill the app if the background task is not ended.
- *
- */
-- (void)sdl_backgroundTaskEnd {
-    if (self.backgroundTaskId == UIBackgroundTaskInvalid) {
-        SDLLogV(@"Background task already ended. Returning...");
-        return;
-    }
-
-    SDLLogD(@"Ending background task with id: %lu",  (unsigned long)self.backgroundTaskId);
-    [[UIApplication sharedApplication] endBackgroundTask:self.backgroundTaskId];
-    self.backgroundTaskId = UIBackgroundTaskInvalid;
-}
-
 #pragma mark - Lifecycle Destruction
 
 - (void)dealloc {
-    [self sdl_backgroundTaskEnd];
+    [self.backgroundTaskManager endBackgroundTask];
 }
 
 @end

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -213,7 +213,7 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
 }
 
 - (void)didEnterStateStarted {
-    // start a background task so a session can be established even when the app is backgrounded.
+    // Start a background task so a session can be established even when the app is backgrounded.
     [self.backgroundTaskManager startBackgroundTask];
 
     // Start up the internal proxy object
@@ -233,7 +233,7 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
         self.proxy = [SDLProxy iapProxyWithListener:self.notificationDispatcher
                           secondaryTransportManager:self.secondaryTransportManager];
     }
-#   pragma clang diagnostic pop
+    #pragma clang diagnostic pop
 }
 
 - (void)didEnterStateStopped {
@@ -841,12 +841,6 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
     if (newProtocol != nil) {
         [self.streamManager startVideoWithProtocol:newProtocol];
     }
-}
-
-#pragma mark - Lifecycle Destruction
-
-- (void)dealloc {
-    [self.backgroundTaskManager endBackgroundTask];
 }
 
 @end

--- a/SmartDeviceLink/SDLManager.m
+++ b/SmartDeviceLink/SDLManager.m
@@ -164,6 +164,12 @@ NS_ASSUME_NONNULL_BEGIN
     [[NSNotificationCenter defaultCenter] removeObserver:observer name:rpcName object:nil];
 }
 
+#pragma mark - Lifecycle Destruction
+
+- (void)dealloc {
+    _lifecycleManager = nil;
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLManager.m
+++ b/SmartDeviceLink/SDLManager.m
@@ -164,12 +164,6 @@ NS_ASSUME_NONNULL_BEGIN
     [[NSNotificationCenter defaultCenter] removeObserver:observer name:rpcName object:nil];
 }
 
-#pragma mark - Lifecycle Destruction
-
-- (void)dealloc {
-    _lifecycleManager = nil;
-}
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLProxy.m
+++ b/SmartDeviceLink/SDLProxy.m
@@ -2,7 +2,6 @@
 
 #import "SDLProxy.h"
 
-#import <ExternalAccessory/ExternalAccessory.h>
 #import <UIKit/UIKit.h>
 #import <objc/runtime.h>
 

--- a/SmartDeviceLink/SDLProxy.m
+++ b/SmartDeviceLink/SDLProxy.m
@@ -97,7 +97,6 @@ static float DefaultConnectionTimeout = 45.0;
         [self.transport connect];
 
         SDLLogV(@"Proxy transport initialization");
-        [[EAAccessoryManager sharedAccessoryManager] registerForLocalNotifications];
         
         NSURLSessionConfiguration* configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
         configuration.timeoutIntervalForRequest = DefaultConnectionTimeout;
@@ -136,8 +135,7 @@ static float DefaultConnectionTimeout = 45.0;
     }
     
     [[NSNotificationCenter defaultCenter] removeObserver:self];
-    [[EAAccessoryManager sharedAccessoryManager] unregisterForLocalNotifications];
-    
+
     [_urlSession invalidateAndCancel];
     SDLLogV(@"Proxy dealloc");
 }


### PR DESCRIPTION
Fixes #1316

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
* Smoke tests done with 13 apps

### Summary
1. If the app is not in the foreground when the `SDLIAPTransport` is created, a background task is now started.
2. The background task is no longer destroyed when the transport is deallocated. If the app on the device is not open, this stopped reconnection attempts since code execution stops when the background task is destroyed. 
3. Removed unnecessary listening for `EAAccessory` connections in the `SDLProxy` class.

### Changelog
##### Bug Fixes
* Fixed new transport sessions not being created if a background task is not ongoing.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)