### PR TITLE
add nil check of eaSession at SDLIAPDataSession#startSession

### DIFF
--- a/SmartDeviceLink/SDLIAPDataSession.m
+++ b/SmartDeviceLink/SDLIAPDataSession.m
@@ -63,9 +63,11 @@ NS_ASSUME_NONNULL_BEGIN
             [self.delegate dataSessionShouldRetry];
         }
 
-        self.ioStreamThread = [[NSThread alloc] initWithTarget:self selector:@selector(sdl_accessoryEventLoop) object:nil];
-        [self.ioStreamThread setName:IOStreamThreadName];
-        [self.ioStreamThread start];
+        if (self.eaSession != nil) {
+            self.ioStreamThread = [[NSThread alloc] initWithTarget:self selector:@selector(sdl_accessoryEventLoop) object:nil];
+            [self.ioStreamThread setName:IOStreamThreadName];
+            [self.ioStreamThread start];
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #1321 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
We have tested with our devboard.

### Summary
Add nil check to avoid a crash by assertion.

### Changelog
##### Bug Fixes
* Fix crash when EA session creation failed

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
