### PR TITLE
Updated RegisterAppInterface class header file documentation

### DIFF
--- a/SmartDeviceLink/SDLRegisterAppInterface.h
+++ b/SmartDeviceLink/SDLRegisterAppInterface.h
@@ -137,7 +137,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Provides an abbreviated version of the app name (if needed), that will be displayed on head units that support very few characters. If not provided, the appName is used instead (and will be truncated if too long). It's recommended that this string be no longer than 5 characters.
  *
- * Legacy head units limit the number of characters an app name
+ * Legacy head units may limit the number of characters in an app name.
  *
  * String, Optional, Max length 100 chars
  *

--- a/SmartDeviceLink/SDLRegisterAppInterface.h
+++ b/SmartDeviceLink/SDLRegisterAppInterface.h
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithLifecycleConfiguration:(SDLLifecycleConfiguration *)lifecycleConfiguration;
 
 /**
- * Convenience init for registering the application with an app name, app id and desired language.
+ * Convenience init for registering the application with an app name, app id, and desired language.
  *
  * @param appName                   The mobile application's name
  * @param appId                     An appId used to validate app with policy table entries

--- a/SmartDeviceLink/SDLRegisterAppInterface.h
+++ b/SmartDeviceLink/SDLRegisterAppInterface.h
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithLifecycleConfiguration:(SDLLifecycleConfiguration *)lifecycleConfiguration;
 
 /**
- * Convenience init for registering the application.
+ * Convenience init for registering the application with an app name, app id and desired language.
  *
  * @param appName                   The mobile application's name
  * @param appId                     An appId used to validate app with policy table entries
@@ -49,7 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithAppName:(NSString *)appName appId:(NSString *)appId languageDesired:(SDLLanguage)languageDesired;
 
 /**
- * Convenience init for registering the application.
+ * Convenience init for registering the application with an app name, app id, desired language, whether or not the app is a media app, app types, and the short app name.
  *
  * @param appName                   The mobile application's name
  * @param appId                     An appId used to validate app with policy table entries
@@ -62,7 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithAppName:(NSString *)appName appId:(NSString *)appId languageDesired:(SDLLanguage)languageDesired isMediaApp:(BOOL)isMediaApp appTypes:(NSArray<SDLAppHMIType> *)appTypes shortAppName:(nullable NSString *)shortAppName __deprecated_msg(("Use initWithAppName:appId:fullAppId:languageDesired:isMediaApp:appTypes:shortAppName:ttsName:vrSynonyms:hmiDisplayLanguageDesired:resumeHash:dayColorScheme:nightColorScheme: instead"));
 
 /**
- * Convenience init for registering the application.
+ * Convenience init for registering the application with an app name, app id, desired language, whether or not the app is a media app, app types, the short app name, tts name, voice recognition synonyms, the hmi display language desired, and the resume hash.
  *
  * @param appName                   The mobile application's name
  * @param appId                     An appId used to validate app with policy table entries
@@ -99,45 +99,49 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithAppName:(NSString *)appName appId:(NSString *)appId fullAppId:(nullable NSString *)fullAppId languageDesired:(SDLLanguage)languageDesired isMediaApp:(BOOL)isMediaApp appTypes:(NSArray<SDLAppHMIType> *)appTypes shortAppName:(nullable NSString *)shortAppName ttsName:(nullable NSArray<SDLTTSChunk *> *)ttsName vrSynonyms:(nullable NSArray<NSString *> *)vrSynonyms hmiDisplayLanguageDesired:(SDLLanguage)hmiDisplayLanguageDesired resumeHash:(nullable NSString *)resumeHash dayColorScheme:(nullable SDLTemplateColorScheme *)dayColorScheme nightColorScheme:(nullable SDLTemplateColorScheme *)nightColorScheme;
 
 /**
- * The version of the SDL interface
+ * Specifies the version number of the SmartDeviceLink protocol that is supported by the mobile application.
  *
- * Required
+ * SDLSyncMsgVersion, Required
+ *
+ * @since SDL 1.0
  */
 @property (strong, nonatomic) SDLSyncMsgVersion *syncMsgVersion;
 
 /**
- * The mobile application's name. This name is displayed in the SDL Mobile Applications menu. It also serves as the unique identifier of the application for SmartDeviceLink.
+ * The mobile application's name. This name is displayed in the SDL Mobile Applications menu. It also serves as the unique identifier of the application for SmartDeviceLink. Applications with the same name will be rejected.
  *
  * 1. Needs to be unique over all applications. Applications with the same name will be rejected.
  * 2. May not be empty.
  * 3. May not start with a new line character.
  * 4. May not interfere with any name or synonym of previously registered applications and any predefined blacklist of words (global commands).
  *
- * Required, Max length 100 chars
+ * String, Required, Max length 100 chars
+ *
+ * @since SDL 1.0
  */
 @property (strong, nonatomic) NSString *appName;
 
 /**
- * TTS string for VR recognition of the mobile application name.
+ * Text-to-speech string for voice recognition of the mobile application name. Meant to overcome any failing on speech engine in properly pronouncing / understanding app name.
  *
- * @discussion Meant to overcome any failing on speech engine in properly pronouncing / understanding app name.
  * 1. Needs to be unique over all applications.
  * 2. May not be empty.
  * 3. May not start with a new line character.
  *
- * Optional, Array of SDLTTSChunk, Array size 1 - 100
+ * Array of SDLTTSChunk, Optional, Array size 1 - 100
  *
  * @since SDL 2.0
- * @see SDLTTSChunk
  */
 @property (nullable, strong, nonatomic) NSArray<SDLTTSChunk *> *ttsName;
 
 /**
- * A String representing an abbreviated version of the mobile application's name (if necessary) that will be displayed on the media screen.
+ * Provides an abbreviated version of the app name (if needed), that will be displayed on the NGN (Next Gen Nav) media screen. If not provided, the appName is used instead (and will be truncated if too long)
  *
- * @discussion If not provided, the appName is used instead (and will be truncated if too long)
+ * Legacy head units limit the number of characters an app name
  *
- * Optional, Max length 100 chars
+ * String, Optional, Max length 100 chars
+ *
+ * @since SDL 1.0
  */
 @property (nullable, strong, nonatomic) NSString *ngnMediaScreenAppName;
 
@@ -146,71 +150,72 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion May not interfere with any app name of previously registered applications and any predefined blacklist of words (global commands).
  *
- * Optional, Array of Strings, Array length 1 - 100, Max String length 40
+ * Array of Strings, Optional, Array length 1 - 100, Max String length 40
+ *
+ * @since SDL 1.0
  */
 @property (nullable, strong, nonatomic) NSArray<NSString *> *vrSynonyms;
 
 /**
- * Indicates if the application is a media or a non-media application.
+ * Indicates if the application is a media or a non-media application. Only media applications will be able to stream audio to head units that is audible outside of the BT media source.
  *
- * @discussion Only media applications will be able to stream audio to head units that is audible outside of the BT media source.
+ * Boolean, Required
  *
- * Required, Boolean
+ * @since SDL 1.0
  */
 @property (strong, nonatomic) NSNumber<SDLBool> *isMediaApplication;
 
 /**
- * A Language enumeration indicating what language the application intends to use for user interaction (TTS and VR).
+ * Current app's expected VR+TTS language. If there is a mismatch with the head unit, the app will be able to change this registration with changeRegistration prior to app being brought into focus.
  *
- * @discussion If there is a mismatch with the head unit, the app will be able to change this registration with changeRegistration prior to app being brought into focus.
+ * SDLLanguage, Required
  *
- * Required
+ * @since SDL 1.0
  */
 @property (strong, nonatomic) SDLLanguage languageDesired;
 
 /**
- * An enumeration indicating what language the application intends to use for user interaction (Display).
+ * Current app's expected display language. If there is a mismatch with the head unit, the app will be able to change this registration with changeRegistration prior to app being brought into focus.
  *
- * @discussion If there is a mismatch with the head unit, the app will be able to change this registration with changeRegistration prior to app being brought into focus.
- *
- * Required
+ * SDLLanguage, Required
  *
  * @since SDL 2.0
  */
 @property (strong, nonatomic) SDLLanguage hmiDisplayLanguageDesired;
 
 /**
- * A list of all applicable app types stating which classifications to be given to the app.
+ * List of all applicable app HMI types stating which HMI classifications to be given to the app.
  *
- * Optional, Array of SDLAppHMIType, Array size 1 - 100
+ * Array of SDLAppHMIType, Optional, Array size 1 - 100
  *
  * @since SDL 2.0
- * @see SDLAppHMIType
  */
 @property (nullable, strong, nonatomic) NSArray<SDLAppHMIType> *appHMIType;
 
 /**
- * ID used to uniquely identify current state of all app data that can persist through connection cycles (e.g. ignition cycles).
- *
- * @discussion This registered data (commands, submenus, choice sets, etc.) can be reestablished without needing to explicitly reregister each piece. If omitted, then the previous state of an app's commands, etc. will not be restored. 
+ * ID used to uniquely identify current state of all app data that can persist through connection cycles (e.g. ignition cycles). This registered data (commands, submenus, choice sets, etc.) can be reestablished without needing to explicitly reregister each piece. If omitted, then the previous state of an app's commands, etc. will not be restored.
  *
  * When sending hashID, all RegisterAppInterface parameters should still be provided (e.g. ttsName, etc.).
  *
- * Optional, max length 100 chars
+ * String, Optional, max length 100 chars
+ *
+ * @since SDL 3.0
  */
 @property (nullable, strong, nonatomic) NSString *hashID;
 
 /**
- * Information about the connecting device
+ * Information about the connecting device.
  *
- * Optional
+ * SDLDeviceInfo, Optional
+ *
+ * @since SDL 3.0
  */
 @property (nullable, strong, nonatomic) SDLDeviceInfo *deviceInfo;
 
 /**
- * ID used to validate app with policy table entries
+ * ID used to validate app with policy table entries.
  *
- * Required, max length 100
+ * String, Required, max length 100
  *
  * @see `fullAppID`
  *
@@ -221,30 +226,38 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * A full UUID appID used to validate app with policy table entries.
  *
- *  Optional
+ * @discussion  The `fullAppId` is used to authenticate apps that connect with head units that implement SDL Core v.5.0 and newer. If connecting with older head units, the `fullAppId` can be truncated to create the required `appId` needed to register the app. The `appId` is the first 10 non-dash ("-") characters of the `fullAppID` (e.g. if you have a `fullAppId` of 123e4567-e89b-12d3-a456-426655440000, the `appId` will be 123e4567e8).
  *
- *  @discussion  The `fullAppId` is used to authenticate apps that connect with head units that implement SDL Core v.5.0 and newer. If connecting with older head units, the `fullAppId` can be truncated to create the required `appId` needed to register the app. The `appId` is the first 10 non-dash ("-") characters of the `fullAppID` (e.g. if you have a `fullAppId` of 123e4567-e89b-12d3-a456-426655440000, the `appId` will be 123e4567e8).
+ * String, Optional
+ *
+ * @since SDL 5.0
  */
 @property (nullable, strong, nonatomic) NSString *fullAppID;
 
 /**
- * Information about the application running
+ * Contains detailed information about the registered application.
  *
- * Optional
+ * SDLAppInfo, Optional
+ *
+ * @since SDL 2.0
  */
 @property (nullable, strong, nonatomic) SDLAppInfo *appInfo;
 
 /**
  * The color scheme to be used on a head unit using a "light" or "day" color scheme. The OEM may only support this theme if their head unit only has a light color scheme.
  *
- * Optional
+ * SDLTemplateColorScheme, Optional
+ *
+ * @since SDL 5.0
  */
 @property (strong, nonatomic, nullable) SDLTemplateColorScheme *dayColorScheme;
 
 /**
  * The color scheme to be used on a head unit using a "dark" or "night" color scheme. The OEM may only support this theme if their head unit only has a dark color scheme.
  *
- * Optional
+ * SDLTemplateColorScheme, Optional
+ *
+ * @since SDL 5.0
  */
 @property (strong, nonatomic, nullable) SDLTemplateColorScheme *nightColorScheme;
 

--- a/SmartDeviceLink/SDLRegisterAppInterface.h
+++ b/SmartDeviceLink/SDLRegisterAppInterface.h
@@ -193,7 +193,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, strong, nonatomic) NSArray<SDLAppHMIType> *appHMIType;
 
 /**
- * ID used to uniquely identify current state of all app data that can persist through connection cycles (e.g. ignition cycles). This registered data (commands, submenus, choice sets, etc.) can be reestablished without needing to explicitly reregister each piece. If omitted, then the previous state of an app's commands, etc. will not be restored.
+ * ID used to uniquely identify a previous state of all app data that can persist through connection cycles (e.g. ignition cycles). This registered data (commands, submenus, choice sets, etc.) can be reestablished without needing to explicitly re-send each piece. If omitted, then the previous state of an app's commands, etc. will not be restored.
  *
  * When sending hashID, all RegisterAppInterface parameters should still be provided (e.g. ttsName, etc.).
  *

--- a/SmartDeviceLink/SDLRegisterAppInterface.h
+++ b/SmartDeviceLink/SDLRegisterAppInterface.h
@@ -13,6 +13,9 @@
 @class SDLTemplateColorScheme;
 @class SDLTTSChunk;
 
+
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * Registers the application's interface with SDL. The `RegisterAppInterface` RPC declares the properties of the app, including the messaging interface version, the app name, etc. The mobile application must establish its interface registration with SDL before any other interaction with SDL can take place. The registration lasts until it is terminated either by the application calling the `SDLUnregisterAppInterface` method, or by SDL sending an `SDLOnAppInterfaceUnregistered` notification, or by loss of the underlying transport connection, or closing of the underlying message transmission protocol RPC session.
  *
@@ -26,9 +29,6 @@
  *
  * @see SDLUnregisterAppInterface, SDLOnAppInterfaceUnregistered
  */
-
-NS_ASSUME_NONNULL_BEGIN
-
 @interface SDLRegisterAppInterface : SDLRPCRequest
 
 /**

--- a/SmartDeviceLink/SDLRegisterAppInterface.h
+++ b/SmartDeviceLink/SDLRegisterAppInterface.h
@@ -157,7 +157,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, strong, nonatomic) NSArray<NSString *> *vrSynonyms;
 
 /**
- * Indicates if the application is a media or a non-media application. Only media applications will be able to stream audio to head units that is audible outside of the BT media source.
+ * Indicates if the application is a media or a non-media application. Media applications will appear in the head unit's media source list and can use the `MEDIA` template.
  *
  * Boolean, Required
  *

--- a/SmartDeviceLink/SDLRegisterAppInterface.h
+++ b/SmartDeviceLink/SDLRegisterAppInterface.h
@@ -135,7 +135,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, strong, nonatomic) NSArray<SDLTTSChunk *> *ttsName;
 
 /**
- * Provides an abbreviated version of the app name (if needed), that will be displayed on the NGN (Next Gen Nav) media screen. If not provided, the appName is used instead (and will be truncated if too long)
+ * Provides an abbreviated version of the app name (if needed), that will be displayed on head units that support very few characters. If not provided, the appName is used instead (and will be truncated if too long). It's recommended that this string be no longer than 5 characters.
  *
  * Legacy head units limit the number of characters an app name
  *

--- a/SmartDeviceLink/SDLRegisterAppInterface.h
+++ b/SmartDeviceLink/SDLRegisterAppInterface.h
@@ -166,7 +166,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic) NSNumber<SDLBool> *isMediaApplication;
 
 /**
- * Current app's expected VR+TTS language. If there is a mismatch with the head unit, the app will be able to change this registration with changeRegistration prior to app being brought into focus.
+ * App's starting VR+TTS language. If there is a mismatch with the head unit, the app will be able to change its language with ChangeRegistration prior to app being brought into focus.
  *
  * SDLLanguage, Required
  *

--- a/SmartDeviceLink/SDLRegisterAppInterface.h
+++ b/SmartDeviceLink/SDLRegisterAppInterface.h
@@ -175,7 +175,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic) SDLLanguage languageDesired;
 
 /**
- * Current app's expected display language. If there is a mismatch with the head unit, the app will be able to change this registration with changeRegistration prior to app being brought into focus.
+ * Current app's expected display language. If there is a mismatch with the head unit, the app will be able to change its language with ChangeRegistration prior to app being brought into focus.
  *
  * SDLLanguage, Required
  *

--- a/SmartDeviceLink/SDLRegisterAppInterfaceResponse.h
+++ b/SmartDeviceLink/SDLRegisterAppInterfaceResponse.h
@@ -174,7 +174,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, strong, nonatomic) SDLHMICapabilities *hmiCapabilities;
 
 /**
- * The SmartDeviceLink version
+ * The version of SDL Core running on the connected head unit
  *
  * String, Optional, Max length: 100
  *

--- a/SmartDeviceLink/SDLRegisterAppInterfaceResponse.h
+++ b/SmartDeviceLink/SDLRegisterAppInterfaceResponse.h
@@ -20,14 +20,13 @@
 @class SDLVehicleType;
 
 
-/**
- Response to SDLRegisterAppInterface
-
- Since SmartDeviceLink 1.0
- */
-
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ * Response to SDLRegisterAppInterface
+ *
+ * @since SDL 1.0
+ */
 @interface SDLRegisterAppInterfaceResponse : SDLRPCResponse
 
 /**
@@ -157,35 +156,47 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, strong, nonatomic) SDLVehicleType *vehicleType;
 
 /**
- Specifies the white-list of supported diagnostic modes (0x00-0xFF) capable for DiagnosticMessage requests. If a mode outside this list is requested, it will be rejected.
-
- Optional, Array of length 1 - 100, Integer 0 - 255
+ * Specifies the white-list of supported diagnostic modes (0x00-0xFF) capable for DiagnosticMessage requests. If a mode outside this list is requested, it will be rejected.
+ *
+ * Array of Integers, Optional, Array of length 1 - 100, Value range: 0 - 255
+ *
+ * @since SDL 3.0
  */
 @property (nullable, strong, nonatomic) NSArray<NSNumber<SDLInt> *> *supportedDiagModes;
 
 /**
- Specifies the availability of various SDL features.
-
- Optional
+ * Specifies the HMI capabilities.
+ *
+ * SDLHMICapabilities, Optional
+ *
+ * @since SDL 3.0
  */
 @property (nullable, strong, nonatomic) SDLHMICapabilities *hmiCapabilities;
 
 /**
- The SmartDeviceLink Core version
-
- Optional, String max length 100
+ * The SmartDeviceLink version
+ *
+ * String, Optional, Max length: 100
+ *
+ * @since SDL 3.0
  */
 @property (nullable, strong, nonatomic) NSString *sdlVersion;
 
 /**
- The software version of the system that implements SmartDeviceLink Core
-
- Optional, String max length 100
+ * The software version of the system that implements the SmartDeviceLink core.
+ *
+ * String, Optional, Max length: 100
+ *
+ * @since SDL 3.0
  */
 @property (nullable, strong, nonatomic) NSString *systemSoftwareVersion;
 
 /**
- Whether or not the app's icon already existed on the system and was resumed. That means that the icon does not need to be sent by the app.
+ * Existence of apps icon at system. If true, apps icon was resumed at system. If false, apps icon is not resumed at system.
+ *
+ * Bool, Optional
+ *
+ * @since SDL 5.0
  */
 @property (nullable, strong, nonatomic) NSNumber<SDLBool> *iconResumed;
 

--- a/SmartDeviceLink/SDLRegisterAppInterfaceResponse.h
+++ b/SmartDeviceLink/SDLRegisterAppInterfaceResponse.h
@@ -102,7 +102,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, strong, nonatomic) NSArray<SDLHMIZoneCapabilities> *hmiZoneCapabilities;
 
 /**
- * Contains information about the TTS capabilities.
+ * Contains information about the text-to-speech capabilities.
  *
  * Array of SDLSpeechCapabilities, Optional, Array of length 1 - 100
  *

--- a/SmartDeviceLink/SDLRegisterAppInterfaceResponse.h
+++ b/SmartDeviceLink/SDLRegisterAppInterfaceResponse.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SDLRegisterAppInterfaceResponse : SDLRPCResponse
 
 /**
- * Specifies the version number of the SmartDeviceLink protocol that is supported by the mobile application.
+ * Specifies the negotiated version number of the SmartDeviceLink protocol that is to be supported by the mobile application.
  *
  * SDLSyncMsgVersion, Optional
  *

--- a/SmartDeviceLink/SDLRegisterAppInterfaceResponse.h
+++ b/SmartDeviceLink/SDLRegisterAppInterfaceResponse.h
@@ -31,98 +31,128 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SDLRegisterAppInterfaceResponse : SDLRPCResponse
 
 /**
- The RPC spec version supported by the connected IVI system.
-
- Optional
+ * Specifies the version number of the SmartDeviceLink protocol that is supported by the mobile application.
+ *
+ * SDLSyncMsgVersion, Optional
+ *
+ * @since SDL 1.0
  */
 @property (nullable, strong, nonatomic) SDLSyncMsgVersion *syncMsgVersion;
 
 /**
- The currently active VR+TTS language on the module. See "Language" for options.
-
- Optional
+ * The currently active VR+TTS language on the module. See "Language" for options.
+ *
+ * SDLLanguage, Optional
+ *
+ * @since SDL 1.0
  */
 @property (nullable, strong, nonatomic) SDLLanguage language;
 
 /**
- The currently active display language on the module. See "Language" for options.
-
- Since SmartDeviceLink 2.0
-
- Optional
+ * The currently active display language on the module. See "Language" for options.
+ *
+ * SDLLanguage, Optional
+ *
+ * @since SDL 2.0
  */
 @property (nullable, strong, nonatomic) SDLLanguage hmiDisplayLanguage;
 
 /**
- Contains information about the display for the SDL system to which the application is currently connected.
-
- Optional
+ * Contains information about the display capabilities.
+ *
+ * SDLDisplayCapabilities, Optional
+ *
+ * @since SDL 1.0
  */
 @property (nullable, strong, nonatomic) SDLDisplayCapabilities *displayCapabilities;
 
 /**
- Provides information about the capabilities of a SDL HMI button.
-
- Optional, Array of length 1 - 100, of SDLButtonCapabilities
+ * Contains information about a button's capabilities.
+ *
+ * Array of SDLButtonCapabilities, Optional, Array of length 1 - 100
+ *
+ * @since SDL 1.0
  */
 @property (nullable, strong, nonatomic) NSArray<SDLButtonCapabilities *> *buttonCapabilities;
 
 /**
- Contains information about a SoftButton's capabilities.
-
- Optional, Array of length 1 - 100, of SDLSoftButtonCapabilities
+ * Contains information about a SoftButton's capabilities.
+ *
+ * Array of SDLSoftButtonCapabilities, Optional, Array of length 1 - 100
+ *
+ * @since SDL 2.0
  */
 @property (nullable, strong, nonatomic) NSArray<SDLSoftButtonCapabilities *> *softButtonCapabilities;
 
 /**
- If returned, the platform supports custom on-screen Presets
- 
- Optional
+ * If returned, the platform supports custom on-screen Presets
+ *
+ * SDLPresetBankCapabilities, Optional
+ *
+ * @since SDL 2.0
  */
 @property (nullable, strong, nonatomic) SDLPresetBankCapabilities *presetBankCapabilities;
 
 /**
- Specifies HMI Zones in the vehicle.
-
- Optional, Array of length 1 - 100, of SDLHMIZoneCapabilities
+ * Contains information about the HMI zone capabilities.
+ *
+ * Array of SDLHMIZoneCapabilities, Optional, Array of length 1 - 100
+ *
+ * @since SDL 1.0
  */
 @property (nullable, strong, nonatomic) NSArray<SDLHMIZoneCapabilities> *hmiZoneCapabilities;
 
 /**
- Contains information about TTS capabilities on the SDL platform.
-
- Optional, Array of length 1 - 100, of SDLSpeechCapabilities
+ * Contains information about the TTS capabilities.
+ *
+ * Array of SDLSpeechCapabilities, Optional, Array of length 1 - 100
+ *
+ * @since SDL 1.0
  */
 @property (nullable, strong, nonatomic) NSArray<SDLSpeechCapabilities> *speechCapabilities;
 
 /**
- Contains information about the speech capabilities on the SDL platform
+ * Contains a list of prerecorded speech items present on the platform.
  *
- * Optional, Array of length 1 - 100, of SDLPrerecordedSpeech
+ * Array of SDLPrerecordedSpeech, Optional, Array of length 1 - 100
+ *
+ * @since SDL 3.0
  */
 @property (nullable, strong, nonatomic) NSArray<SDLPrerecordedSpeech> *prerecordedSpeech;
 
 /**
- The VR capabilities of the connected SDL platform.
-
- Optional, Array of length 1 - 100, of SDLVRCapabilities
+ * Contains information about the VR capabilities.
+ *
+ * Array of SDLVRCapabilities, Optional, Array of length 1 - 100
+ *
+ * @since SDL 1.0
  */
 @property (nullable, strong, nonatomic) NSArray<SDLVRCapabilities> *vrCapabilities;
 
 /**
- Describes different audio type configurations for SDLPerformAudioPassThru, e.g. {8kHz,8-bit,PCM}
-
- Optional, Array of length 1 - 100, of SDLAudioPassThruCapabilities
+ * Describes different audio type configurations for PerformAudioPassThru, e.g. {8kHz,8-bit,PCM}. The audio is recorded in monaural.
+ *
+ * Array of SDLAudioPassThruCapabilities, Optional, Array of length 1 - 100
+ *
+ * @since SDL 2.0
  */
 @property (nullable, strong, nonatomic) NSArray<SDLAudioPassThruCapabilities *> *audioPassThruCapabilities;
 
 /**
- Describes different audio type configurations for the audio PCM stream service, e.g. {8kHz,8-bit,PCM}
+ * Describes different audio type configurations for the audio PCM stream service, e.g. {8kHz,8-bit,PCM}
+ *
+ * SDLAudioPassThruCapabilities, Optional
+ *
+ * @since SDL 4.1
  */
 @property (nullable, strong, nonatomic) SDLAudioPassThruCapabilities *pcmStreamCapabilities;
 
 /**
- Specifies the connected vehicle's type
+ * Specifies the connected vehicle's type.
+ *
+ * SDLVehicleType, Optional
+ *
+ * @since SDL 2.0
  */
 @property (nullable, strong, nonatomic) SDLVehicleType *vehicleType;
 

--- a/SmartDeviceLink/SDLRegisterAppInterfaceResponse.h
+++ b/SmartDeviceLink/SDLRegisterAppInterfaceResponse.h
@@ -66,7 +66,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, strong, nonatomic) SDLDisplayCapabilities *displayCapabilities;
 
 /**
- * Contains information about a button's capabilities.
+ * Contains information about the head unit button capabilities.
  *
  * Array of SDLButtonCapabilities, Optional, Array of length 1 - 100
  *

--- a/SmartDeviceLink/SDLRegisterAppInterfaceResponse.h
+++ b/SmartDeviceLink/SDLRegisterAppInterfaceResponse.h
@@ -57,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, strong, nonatomic) SDLLanguage hmiDisplayLanguage;
 
 /**
- * Contains information about the display capabilities.
+ * Contains information about the display's capabilities.
  *
  * SDLDisplayCapabilities, Optional
  *

--- a/SmartDeviceLink/SDLRegisterAppInterfaceResponse.h
+++ b/SmartDeviceLink/SDLRegisterAppInterfaceResponse.h
@@ -75,7 +75,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, strong, nonatomic) NSArray<SDLButtonCapabilities *> *buttonCapabilities;
 
 /**
- * Contains information about a SoftButton's capabilities.
+ * Contains information about the head unit soft button capabilities.
  *
  * Array of SDLSoftButtonCapabilities, Optional, Array of length 1 - 100
  *


### PR DESCRIPTION
Fixes #1318

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
No testing needed. Documentation updates only.

### Summary
* The documentation in the `SDLRegisterAppInterface` header file now matches the RPC Spec (https://github.com/smartdevicelink/rpc_spec#registerappinterface).
* The documentation in the `SDLRegisterAppInterfaceResponse` header file now matches the RPC Spec (https://github.com/smartdevicelink/rpc_spec#registerappinterface-1).

### Changelog
##### Enhancements
* Updated the `SDLRegisterAppInterface` and `SDLRegisterAppInterfaceResponse`header file documentation.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)