### PR TITLE
Background task for establishing transport session now stopped when lifecycle manager transitions to ready state

### DIFF
--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -282,7 +282,7 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
         if (shouldRestart) {
             [strongSelf sdl_transitionToState:SDLLifecycleStateStarted];
         } else {
-            // End any background tasks because a session will not be established
+            // End the background task because a session will not be established
             [self.backgroundTaskManager endBackgroundTask];
         }
     });
@@ -498,6 +498,9 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
         	[self.delegate audioStreamingState:SDLAudioStreamingStateNotAudible didChangeToState:self.audioStreamingState];
     	}
     });
+
+    // Stop the background task now that setup has completed
+    [self.backgroundTaskManager endBackgroundTask];
 }
 
 - (void)didEnterStateUnregistering {
@@ -707,9 +710,6 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
 
 - (void)transportDidConnect {
     SDLLogD(@"Transport connected");
-
-    // End any background tasks since the transport connected successfully
-    [self.backgroundTaskManager endBackgroundTask];
 
     dispatch_async(self.lifecycleQueue, ^{
         [self sdl_transitionToState:SDLLifecycleStateConnected];


### PR DESCRIPTION
Fixes #1327 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Smoke tests performed. 
* Connected 10 apps (all backgrounded) to a head unit via iAP and waited 10 minutes  before launching and interacting with the app. 
* Waited 10 minutes before pulling and reconnecting the phone using a USB cord.

### Summary
* Instead of stopping any ongoing background task when the transport is established, the background task is now stopped after all setup for the library managers has completed and the lifecycle manager has entered the ready state. This ensures that the `RegisterAppInterface` request is sent to Core (theoretically once the session has been established successfully, the SDL app should have unlimited background time, however there have been issues with the app being suspended before the RAI request is sent to Core).

### Changelog
##### Breaking Changes
* none

##### Enhancements
* n/a

##### Bug Fixes
* Fixed destroyed background task preventing the RAI request being sent to Core

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)