### PR TITLE
Hotfix Release 6.3.1

### DIFF
--- a/SmartDeviceLink/SDLIAPTransport.m
+++ b/SmartDeviceLink/SDLIAPTransport.m
@@ -80,7 +80,7 @@ int const CreateSessionRetries = 3;
  */
 - (void)sdl_stopEventListening {
     SDLLogV(@"SDLIAPTransport stopped listening for events");
-    [[EAAccessoryManager sharedAccessoryManager] unregisterForLocalNotifications];
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 #pragma mark EAAccessory Notifications


### PR DESCRIPTION
### Risk
This PR makes **no** API changes.

### Testing Plan
Smoke Tests

### Summary
This hotfix release fixes IAP transport issues.

### Changelog
##### Bug Fixes
* Fix unregistering for EATransport notifications can interfere with other apps' EATransport notifications (#1329).
* Fix issues related to the background task running when the device is in the process of making an IAP connection but is in the background (#1326, #1327)

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
