### PR TITLE
Implement SDL-0186 Template Titles

### DIFF
--- a/Example Apps/Example ObjC/ProxyManager.m
+++ b/Example Apps/Example ObjC/ProxyManager.m
@@ -188,6 +188,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     [screenManager beginUpdates];
     screenManager.textAlignment = SDLTextAlignmentLeft;
+    screenManager.title = isTextEnabled ? @"Home" : nil;
     screenManager.textField1 = isTextEnabled ? SmartDeviceLinkText : nil;
     screenManager.textField2 = isTextEnabled ? [NSString stringWithFormat:@"Obj-C %@", ExampleAppText] : nil;
     screenManager.textField3 = isTextEnabled ? self.vehicleDataManager.vehicleOdometerData : nil;

--- a/Example Apps/Example Swift/ProxyManager.swift
+++ b/Example Apps/Example Swift/ProxyManager.swift
@@ -266,6 +266,7 @@ private extension ProxyManager {
 
         screenManager.beginUpdates()
         screenManager.textAlignment = .left
+        screenManager.title = isTextVisible ? "Home" : nil
         screenManager.textField1 = isTextVisible ? SmartDeviceLinkText : nil
         screenManager.textField2 = isTextVisible ? "Swift \(ExampleAppText)" : nil
         screenManager.textField3 = isTextVisible ? vehicleDataManager.vehicleOdometerData : nil

--- a/SmartDeviceLink/SDLRPCParameterNames.h
+++ b/SmartDeviceLink/SDLRPCParameterNames.h
@@ -591,6 +591,7 @@ extern SDLRPCParameterName const SDLRPCParameterNameTemperatureLow;
 extern SDLRPCParameterName const SDLRPCParameterNameTemperatureUnit;
 extern SDLRPCParameterName const SDLRPCParameterNameTemperatureUnitAvailable;
 extern SDLRPCParameterName const SDLRPCParameterNameTemplatesAvailable;
+extern SDLRPCParameterName const SDLRPCParameterNameTemplateTitle;
 extern SDLRPCParameterName const SDLRPCParameterNameTertiaryText;
 extern SDLRPCParameterName const SDLRPCParameterNameText;
 extern SDLRPCParameterName const SDLRPCParameterNameTextFields;

--- a/SmartDeviceLink/SDLRPCParameterNames.m
+++ b/SmartDeviceLink/SDLRPCParameterNames.m
@@ -586,6 +586,7 @@ SDLRPCParameterName const SDLRPCParameterNameTemperatureLow = @"temperatureLow";
 SDLRPCParameterName const SDLRPCParameterNameTemperatureUnit = @"temperatureUnit";
 SDLRPCParameterName const SDLRPCParameterNameTemperatureUnitAvailable = @"temperatureUnitAvailable";
 SDLRPCParameterName const SDLRPCParameterNameTemplatesAvailable = @"templatesAvailable";
+SDLRPCParameterName const SDLRPCParameterNameTemplateTitle = @"templateTitle";
 SDLRPCParameterName const SDLRPCParameterNameTertiaryText = @"tertiaryText";
 SDLRPCParameterName const SDLRPCParameterNameText = @"text";
 SDLRPCParameterName const SDLRPCParameterNameTextFields = @"textFields";

--- a/SmartDeviceLink/SDLScreenManager.h
+++ b/SmartDeviceLink/SDLScreenManager.h
@@ -106,6 +106,11 @@ typedef void(^SDLPreloadChoiceCompletionHandler)(NSError *__nullable error);
  */
 @property (copy, nonatomic, nullable) SDLMetadataType textField4Type;
 
+/**
+ The title of the current template layout.
+ */
+@property (copy, nonatomic, nullable) NSString *title;
+
 #pragma mark Soft Buttons
 
 /**

--- a/SmartDeviceLink/SDLScreenManager.m
+++ b/SmartDeviceLink/SDLScreenManager.m
@@ -126,6 +126,10 @@ NS_ASSUME_NONNULL_BEGIN
     self.textAndGraphicManager.textField4Type = textField4Type;
 }
 
+- (void)setTitle:(nullable NSString *)title {
+    self.textAndGraphicManager.title = title;
+}
+
 - (void)setSoftButtonObjects:(NSArray<SDLSoftButtonObject *> *)softButtonObjects {
     self.softButtonManager.softButtonObjects = softButtonObjects;
 }

--- a/SmartDeviceLink/SDLShow.h
+++ b/SmartDeviceLink/SDLShow.h
@@ -246,6 +246,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (strong, nonatomic, nullable) SDLMetadataTags *metadataTags;
 
+/**
+ The title of the current template.
+
+ How this will be displayed is dependent on the OEM design and implementation of the template.
+ */
+@property (strong, nonatomic, nullable) NSString *templateTitle;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLShow.h
+++ b/SmartDeviceLink/SDLShow.h
@@ -250,6 +250,8 @@ NS_ASSUME_NONNULL_BEGIN
  The title of the current template.
 
  How this will be displayed is dependent on the OEM design and implementation of the template.
+
+ Optional, since SmartDeviceLink 6.0
  */
 @property (strong, nonatomic, nullable) NSString *templateTitle;
 

--- a/SmartDeviceLink/SDLShow.m
+++ b/SmartDeviceLink/SDLShow.m
@@ -204,6 +204,14 @@ NS_ASSUME_NONNULL_BEGIN
     return [self.parameters sdl_objectForName:SDLRPCParameterNameMetadataTags ofClass:SDLMetadataTags.class error:nil];
 }
 
+- (void)setTemplateTitle:(nullable NSString *)templateTitle {
+    [self.parameters sdl_setObject:templateTitle forName:SDLRPCParameterNameTemplateTitle];
+}
+
+- (nullable NSString *)templateTitle {
+    return [self.parameters sdl_objectForName:SDLRPCParameterNameTemplateTitle ofClass:NSString.class error:nil];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLTextAndGraphicManager.h
+++ b/SmartDeviceLink/SDLTextAndGraphicManager.h
@@ -36,6 +36,7 @@ typedef void(^SDLTextAndGraphicUpdateCompletionHandler)(NSError *__nullable erro
 @property (copy, nonatomic, nullable) NSString *textField3;
 @property (copy, nonatomic, nullable) NSString *textField4;
 @property (copy, nonatomic, nullable) NSString *mediaTrackTextField;
+@property (copy, nonatomic, nullable) NSString *title;
 @property (strong, nonatomic, nullable) SDLArtwork *primaryGraphic;
 @property (strong, nonatomic, nullable) SDLArtwork *secondaryGraphic;
 

--- a/SmartDeviceLink/SDLTextAndGraphicManager.m
+++ b/SmartDeviceLink/SDLTextAndGraphicManager.m
@@ -282,6 +282,12 @@ NS_ASSUME_NONNULL_BEGIN
     } else {
         show.mediaTrack = @"";
     }
+
+    if (self.title != nil) {
+        show.templateTitle = self.title;
+    } else {
+        show.templateTitle = @"";
+    }
     
     NSArray *nonNilFields = [self sdl_findNonNilTextFields];
     if (nonNilFields.count == 0) { return show; }
@@ -435,6 +441,7 @@ NS_ASSUME_NONNULL_BEGIN
     show.mainField3 = @"";
     show.mainField4 = @"";
     show.mediaTrack = @"";
+    show.templateTitle = @"";
 
     return show;
 }
@@ -448,6 +455,7 @@ NS_ASSUME_NONNULL_BEGIN
     newShow.mainField3 = show.mainField3;
     newShow.mainField4 = show.mainField4;
     newShow.mediaTrack = show.mediaTrack;
+    newShow.templateTitle = show.templateTitle;
     newShow.metadataTags = show.metadataTags;
 
     return newShow;
@@ -481,6 +489,7 @@ NS_ASSUME_NONNULL_BEGIN
     self.currentScreenData.mainField3 = show.mainField3 ?: self.currentScreenData.mainField3;
     self.currentScreenData.mainField4 = show.mainField4 ?: self.currentScreenData.mainField4;
     self.currentScreenData.mediaTrack = show.mediaTrack ?: self.currentScreenData.mediaTrack;
+    self.currentScreenData.templateTitle = show.templateTitle ?: self.currentScreenData.templateTitle;
     self.currentScreenData.metadataTags = show.metadataTags ?: self.currentScreenData.metadataTags;
     self.currentScreenData.alignment = show.alignment ?: self.currentScreenData.alignment;
     self.currentScreenData.graphic = show.graphic ?: self.currentScreenData.graphic;
@@ -590,6 +599,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)setMediaTrackTextField:(nullable NSString *)mediaTrackTextField {
     _mediaTrackTextField = mediaTrackTextField;
+    _isDirty = YES;
+    if (!self.isBatchingUpdates) {
+        [self updateWithCompletionHandler:nil];
+    }
+}
+
+- (void)setTitle:(nullable NSString *)title {
+    _title = title;
     _isDirty = YES;
     if (!self.isBatchingUpdates) {
         [self updateWithCompletionHandler:nil];

--- a/SmartDeviceLink/SDLTextFieldName.h
+++ b/SmartDeviceLink/SDLTextFieldName.h
@@ -38,6 +38,13 @@ extern SDLTextFieldName const SDLTextFieldNameMainField3;
 extern SDLTextFieldName const SDLTextFieldNameMainField4;
 
 /**
+ The title line of the persistent display. Applies to SDLShow.
+
+ @since SDL 6.0
+ */
+extern SDLTextFieldName const SDLTextFieldNameTemplateTitle;
+
+/**
  * The status bar on the NGN display. Applies to SDLShow.
  */
 extern SDLTextFieldName const SDLTextFieldNameStatusBar;

--- a/SmartDeviceLink/SDLTextFieldName.m
+++ b/SmartDeviceLink/SDLTextFieldName.m
@@ -8,6 +8,7 @@ SDLTextFieldName const SDLTextFieldNameMainField1 = @"mainField1";
 SDLTextFieldName const SDLTextFieldNameMainField2 = @"mainField2";
 SDLTextFieldName const SDLTextFieldNameMainField3 = @"mainField3";
 SDLTextFieldName const SDLTextFieldNameMainField4 = @"mainField4";
+SDLTextFieldName const SDLTextFieldNameTemplateTitle = @"templateTitle";
 SDLTextFieldName const SDLTextFieldNameStatusBar = @"statusBar";
 SDLTextFieldName const SDLTextFieldNameMediaClock = @"mediaClock";
 SDLTextFieldName const SDLTextFieldNameMediaTrack = @"mediaTrack";

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicManagerSpec.m
@@ -63,6 +63,7 @@ describe(@"text and graphic manager", ^{
         expect(testManager.textField3).to(beNil());
         expect(testManager.textField4).to(beNil());
         expect(testManager.mediaTrackTextField).to(beNil());
+        expect(testManager.title).to(beNil());
         expect(testManager.primaryGraphic).to(beNil());
         expect(testManager.secondaryGraphic).to(beNil());
         expect(testManager.alignment).to(equal(SDLTextAlignmentCenter));
@@ -155,6 +156,14 @@ describe(@"text and graphic manager", ^{
                 testManager.mediaTrackTextField = testString;
 
                 expect(testManager.mediaTrackTextField).to(equal(testString));
+                expect(testManager.inProgressUpdate).to(beNil());
+                expect(testManager.isDirty).to(beTrue());
+            });
+
+            it(@"should set template title", ^{
+                testManager.title = testString;
+
+                expect(testManager.title).to(equal(testString));
                 expect(testManager.inProgressUpdate).to(beNil());
                 expect(testManager.isDirty).to(beTrue());
             });
@@ -261,6 +270,14 @@ describe(@"text and graphic manager", ^{
                 expect(testManager.isDirty).to(beFalse());
             });
 
+            it(@"should set template title text field", ^{
+                testManager.title = testString;
+
+                expect(testManager.title).to(equal(testString));
+                expect(testManager.inProgressUpdate).toNot(beNil());
+                expect(testManager.isDirty).to(beFalse());
+            });
+
             it(@"should set primary graphic", ^{
                 testManager.primaryGraphic = testArtwork;
 
@@ -325,6 +342,7 @@ describe(@"text and graphic manager", ^{
         NSString *textLine3 = @"line3";
         NSString *textLine4 = @"line4";
         NSString *textMediaTrack = @"line5";
+        NSString *textTitle = @"title";
 
         SDLMetadataType line1Type = SDLMetadataTypeMediaTitle;
         SDLMetadataType line2Type = SDLMetadataTypeMediaAlbum;
@@ -340,6 +358,7 @@ describe(@"text and graphic manager", ^{
             testManager.textField3 = nil;
             testManager.textField4 = nil;
             testManager.mediaTrackTextField = nil;
+            testManager.title = nil;
             testManager.textField1Type = nil;
             testManager.textField2Type = nil;
             testManager.textField3Type = nil;
@@ -361,6 +380,17 @@ describe(@"text and graphic manager", ^{
                 [testManager updateWithCompletionHandler:nil];
 
                 expect(testManager.inProgressUpdate.mediaTrack).to(equal(textMediaTrack));
+                expect(testManager.inProgressUpdate.mainField1).to(beEmpty());
+                expect(testManager.inProgressUpdate.metadataTags.mainField1).to(beNil());
+            });
+
+            it(@"should set title properly", ^{
+                testManager.title = textTitle;
+
+                testManager.batchUpdates = NO;
+                [testManager updateWithCompletionHandler:nil];
+
+                expect(testManager.inProgressUpdate.templateTitle).to(equal(textTitle));
                 expect(testManager.inProgressUpdate.mainField1).to(beEmpty());
                 expect(testManager.inProgressUpdate.metadataTags.mainField1).to(beNil());
             });
@@ -451,6 +481,17 @@ describe(@"text and graphic manager", ^{
                 [testManager updateWithCompletionHandler:nil];
 
                 expect(testManager.inProgressUpdate.mediaTrack).to(equal(textMediaTrack));
+                expect(testManager.inProgressUpdate.mainField1).to(beEmpty());
+                expect(testManager.inProgressUpdate.metadataTags.mainField1).to(beNil());
+            });
+
+            it(@"should set title properly", ^{
+                testManager.title = textTitle;
+
+                testManager.batchUpdates = NO;
+                [testManager updateWithCompletionHandler:nil];
+
+                expect(testManager.inProgressUpdate.templateTitle).to(equal(textTitle));
                 expect(testManager.inProgressUpdate.mainField1).to(beEmpty());
                 expect(testManager.inProgressUpdate.metadataTags.mainField1).to(beNil());
             });
@@ -554,6 +595,17 @@ describe(@"text and graphic manager", ^{
                 expect(testManager.inProgressUpdate.metadataTags.mainField1).to(beNil());
             });
 
+            it(@"should set title properly", ^{
+                testManager.title = textTitle;
+
+                testManager.batchUpdates = NO;
+                [testManager updateWithCompletionHandler:nil];
+
+                expect(testManager.inProgressUpdate.templateTitle).to(equal(textTitle));
+                expect(testManager.inProgressUpdate.mainField1).to(beEmpty());
+                expect(testManager.inProgressUpdate.metadataTags.mainField1).to(beNil());
+            });
+
             it(@"should format a one line text and metadata update properly", ^{
                 testManager.textField1 = textLine1;
                 testManager.textField1Type = line1Type;
@@ -653,6 +705,17 @@ describe(@"text and graphic manager", ^{
                 [testManager updateWithCompletionHandler:nil];
 
                 expect(testManager.inProgressUpdate.mediaTrack).to(equal(textMediaTrack));
+                expect(testManager.inProgressUpdate.mainField1).to(beEmpty());
+                expect(testManager.inProgressUpdate.metadataTags.mainField1).to(beNil());
+            });
+
+            it(@"should set title properly", ^{
+                testManager.title = textTitle;
+
+                testManager.batchUpdates = NO;
+                [testManager updateWithCompletionHandler:nil];
+
+                expect(testManager.inProgressUpdate.templateTitle).to(equal(textTitle));
                 expect(testManager.inProgressUpdate.mainField1).to(beEmpty());
                 expect(testManager.inProgressUpdate.metadataTags.mainField1).to(beNil());
             });

--- a/SmartDeviceLinkTests/RPCSpecs/EnumSpecs/SDLTextFieldNameSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/EnumSpecs/SDLTextFieldNameSpec.m
@@ -18,6 +18,7 @@ describe(@"Individual Enum Value Tests", ^ {
         expect(SDLTextFieldNameMainField2).to(equal(@"mainField2"));
         expect(SDLTextFieldNameMainField3).to(equal(@"mainField3"));
         expect(SDLTextFieldNameMainField4).to(equal(@"mainField4"));
+        expect(SDLTextFieldNameTemplateTitle).to(equal(@"templateTitle"));
         expect(SDLTextFieldNameStatusBar).to(equal(@"statusBar"));
         expect(SDLTextFieldNameMediaClock).to(equal(@"mediaClock"));
         expect(SDLTextFieldNameMediaTrack).to(equal(@"mediaTrack"));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLShowSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLShowSpec.m
@@ -38,6 +38,7 @@ describe(@"Getter/Setter Tests", ^ {
         testRequest.statusBar = @"status";
         testRequest.mediaClock = @"TheTime";
         testRequest.mediaTrack = @"In The Clear";
+        testRequest.templateTitle = @"Hello World";
         testRequest.graphic = image1;
         testRequest.secondaryGraphic = image2;
         testRequest.softButtons = [@[button] mutableCopy];
@@ -52,6 +53,7 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testRequest.statusBar).to(equal(@"status"));
         expect(testRequest.mediaClock).to(equal(@"TheTime"));
         expect(testRequest.mediaTrack).to(equal(@"In The Clear"));
+        expect(testRequest.templateTitle).to(equal(@"Hello World"));
         expect(testRequest.graphic).to(equal(image1));
         expect(testRequest.secondaryGraphic).to(equal(image2));
         expect(testRequest.softButtons).to(equal([@[button] mutableCopy]));
@@ -71,6 +73,7 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testRequest.statusBar).to(beNil());
         expect(testRequest.mediaClock).to(beNil());
         expect(testRequest.mediaTrack).to(beNil());
+        expect(testRequest.templateTitle).to(beNil());
         expect(testRequest.graphic).to(beNil());
         expect(testRequest.secondaryGraphic).to(beNil());
         expect(testRequest.softButtons).to(beNil());
@@ -86,6 +89,7 @@ describe(@"Getter/Setter Tests", ^ {
         __block NSString *testStatusBarString = @"Test Status";
         __block NSString *testMediaClockString = @"Test Clock";
         __block NSString *testMediaTrackString = @"Test Track";
+        __block NSString *testTemplateTitleString = @"Hello World";
         __block SDLImage *testGraphic = nil;
         __block NSArray<NSString *> *testCustomPresets = nil;
         __block SDLSoftButton *testButton = nil;
@@ -115,6 +119,7 @@ describe(@"Getter/Setter Tests", ^ {
             expect(testShow.statusBar).to(beNil());
             expect(testShow.mediaClock).to(beNil());
             expect(testShow.mediaTrack).to(beNil());
+            expect(testShow.templateTitle).to(beNil());
             expect(testShow.graphic).to(beNil());
             expect(testShow.secondaryGraphic).to(beNil());
             expect(testShow.softButtons).to(beNil());
@@ -130,6 +135,7 @@ describe(@"Getter/Setter Tests", ^ {
             expect(testShow.statusBar).to(beNil());
             expect(testShow.mediaClock).to(beNil());
             expect(testShow.mediaTrack).to(beNil());
+            expect(testShow.templateTitle).to(beNil());
             expect(testShow.graphic).to(beNil());
             expect(testShow.secondaryGraphic).to(beNil());
             expect(testShow.softButtons).to(beNil());
@@ -147,6 +153,7 @@ describe(@"Getter/Setter Tests", ^ {
             expect(testShow.statusBar).to(beNil());
             expect(testShow.mediaClock).to(beNil());
             expect(testShow.mediaTrack).to(beNil());
+            expect(testShow.templateTitle).to(beNil());
             expect(testShow.graphic).to(beNil());
             expect(testShow.secondaryGraphic).to(beNil());
             expect(testShow.softButtons).to(beNil());
@@ -165,6 +172,7 @@ describe(@"Getter/Setter Tests", ^ {
             expect(testShow.statusBar).to(beNil());
             expect(testShow.mediaClock).to(beNil());
             expect(testShow.mediaTrack).to(beNil());
+            expect(testShow.templateTitle).to(beNil());
             expect(testShow.graphic).to(beNil());
             expect(testShow.secondaryGraphic).to(beNil());
             expect(testShow.softButtons).to(beNil());
@@ -182,6 +190,7 @@ describe(@"Getter/Setter Tests", ^ {
             expect(testShow.statusBar).to(beNil());
             expect(testShow.mediaClock).to(beNil());
             expect(testShow.mediaTrack).to(beNil());
+            expect(testShow.templateTitle).to(beNil());
             expect(testShow.graphic).to(beNil());
             expect(testShow.secondaryGraphic).to(beNil());
             expect(testShow.softButtons).to(beNil());
@@ -200,6 +209,7 @@ describe(@"Getter/Setter Tests", ^ {
             expect(testShow.statusBar).to(beNil());
             expect(testShow.mediaClock).to(beNil());
             expect(testShow.mediaTrack).to(beNil());
+            expect(testShow.templateTitle).to(beNil());
             expect(testShow.graphic).to(beNil());
             expect(testShow.secondaryGraphic).to(beNil());
             expect(testShow.softButtons).to(beNil());
@@ -217,6 +227,7 @@ describe(@"Getter/Setter Tests", ^ {
             expect(testShow.statusBar).to(beNil());
             expect(testShow.mediaClock).to(beNil());
             expect(testShow.mediaTrack).to(beNil());
+            expect(testShow.templateTitle).to(beNil());
             expect(testShow.graphic).to(beNil());
             expect(testShow.secondaryGraphic).to(beNil());
             expect(testShow.softButtons).to(beNil());
@@ -235,6 +246,7 @@ describe(@"Getter/Setter Tests", ^ {
             expect(testShow.statusBar).to(beNil());
             expect(testShow.mediaClock).to(beNil());
             expect(testShow.mediaTrack).to(beNil());
+            expect(testShow.templateTitle).to(beNil());
             expect(testShow.graphic).to(beNil());
             expect(testShow.secondaryGraphic).to(beNil());
             expect(testShow.softButtons).to(beNil());
@@ -252,6 +264,7 @@ describe(@"Getter/Setter Tests", ^ {
             expect(testShow.statusBar).to(equal(testStatusBarString));
             expect(testShow.mediaClock).to(equal(testMediaClockString));
             expect(testShow.mediaTrack).to(equal(testMediaTrackString));
+            expect(testShow.templateTitle).to(beNil());
             expect(testShow.graphic).to(beNil());
             expect(testShow.secondaryGraphic).to(beNil());
             expect(testShow.softButtons).to(beNil());
@@ -270,6 +283,7 @@ describe(@"Getter/Setter Tests", ^ {
             expect(testShow.statusBar).to(beNil());
             expect(testShow.mediaClock).to(beNil());
             expect(testShow.mediaTrack).to(beNil());
+            expect(testShow.templateTitle).to(beNil());
             expect(testShow.graphic).to(beNil());
             expect(testShow.secondaryGraphic).to(beNil());
             expect(testShow.softButtons).to(beNil());
@@ -287,6 +301,7 @@ describe(@"Getter/Setter Tests", ^ {
             expect(testShow.statusBar).to(equal(testStatusBarString));
             expect(testShow.mediaClock).to(equal(testMediaClockString));
             expect(testShow.mediaTrack).to(equal(testMediaTrackString));
+            expect(testShow.templateTitle).to(beNil());
             expect(testShow.graphic).to(equal(testGraphic));
             expect(testShow.secondaryGraphic).to(beNil());
             expect(testShow.softButtons).to(contain(testButton));
@@ -305,6 +320,7 @@ describe(@"Getter/Setter Tests", ^ {
             expect(testShow.statusBar).to(beNil());
             expect(testShow.mediaClock).to(beNil());
             expect(testShow.mediaTrack).to(beNil());
+            expect(testShow.templateTitle).to(beNil());
             expect(testShow.graphic).to(beNil());
             expect(testShow.secondaryGraphic).to(beNil());
             expect(testShow.softButtons).to(beNil());
@@ -323,6 +339,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                        SDLRPCParameterNameStatusBar:@"status",
                                                        SDLRPCParameterNameMediaClock:@"TheTime",
                                                        SDLRPCParameterNameMediaTrack:@"In The Clear",
+                                                       SDLRPCParameterNameTemplateTitle: @"Hello World",
                                                        SDLRPCParameterNameGraphic:image1,
                                                        SDLRPCParameterNameSecondaryGraphic:image2,
                                                        SDLRPCParameterNameSoftButtons:[@[button] mutableCopy],
@@ -342,6 +359,7 @@ describe(@"Getter/Setter Tests", ^ {
             expect(testRequest.statusBar).to(equal(@"status"));
             expect(testRequest.mediaClock).to(equal(@"TheTime"));
             expect(testRequest.mediaTrack).to(equal(@"In The Clear"));
+            expect(testRequest.templateTitle).to(equal(@"Hello World"));
             expect(testRequest.graphic).to(equal(image1));
             expect(testRequest.secondaryGraphic).to(equal(image2));
             expect(testRequest.softButtons).to(equal([@[button] mutableCopy]));


### PR DESCRIPTION
Fixes #1031 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Unit tests updated and smoke tests performed

### Summary
Adds the ability to set a title text field in Show that declares the title of the screen the user is on.

### Changelog
##### Enhancements
* Implement SDL-0186 to set a title for the current screen the user is on.

### Tasks Remaining:
- [x] Smoke test against Core PR.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
