### PR TITLE
Update MaxProxyRPCVersion to 6.0.0

### DIFF
--- a/SmartDeviceLink/SDLGlobals.m
+++ b/SmartDeviceLink/SDLGlobals.m
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 // VERSION DEPENDENT CODE
 NSString *const SDLMaxProxyProtocolVersion = @"5.2.0";
-NSString *const SDLMaxProxyRPCVersion =  @"5.1.0";
+NSString *const SDLMaxProxyRPCVersion =  @"6.0.0";
 
 NSUInteger const SDLDefaultMTUSize = UINT32_MAX;
 NSUInteger const SDLV1MTUSize = 1024;

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLRegisterAppInterfaceSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLRegisterAppInterfaceSpec.m
@@ -43,7 +43,7 @@ describe(@"RegisterAppInterface Tests", ^{
     __block SDLAppInfo *appInfo = nil;
     __block SDLTemplateColorScheme *colorScheme = nil;
 
-    __block SDLSyncMsgVersion *currentSyncMsgVersion = [[SDLSyncMsgVersion alloc] initWithMajorVersion:5 minorVersion:1 patchVersion:0];
+    __block SDLSyncMsgVersion *currentSyncMsgVersion = [[SDLSyncMsgVersion alloc] initWithMajorVersion:6 minorVersion:0 patchVersion:0];
 
     beforeEach(^{
         testRegisterAppInterface = nil;


### PR DESCRIPTION
Fixes #1344 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
n/a

### Summary
This PR updates our max proxy RPC version to 6.0.0 to support the Fall 2019 release of SDL Core.

### Changelog
##### Enhancements
* Update the library to support RPC spec v6.0.0

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
