### PR TITLE
Fix the Permission Manager sending too many observer updates

### DIFF
--- a/SmartDeviceLink/SDLPermissionManager.m
+++ b/SmartDeviceLink/SDLPermissionManager.m
@@ -185,7 +185,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSArray<SDLPermissionFilter *> *currentFilters = [self.filters copy];
 
     // We can eliminate calling those filters who had no permission changes, so we'll filter down and see which had permissions that changed
-    NSArray<SDLPermissionFilter *> *modifiedFilters = [self.class sdl_filterPermissionChangesForFilters:currentFilters updatedPermissions:newPermissionItems];
+    NSArray<SDLPermissionFilter *> *modifiedFilters = [self.class sdl_filterPermissionChangesForFilters:currentFilters currentPermissions:self.permissions updatedPermissions:newPermissionItems];
 
     // We need the old group status and new group status for all allowed filters so we know if they should be called
     NSDictionary<SDLPermissionObserverIdentifier, NSNumber<SDLInt> *> *allAllowedFiltersWithOldStatus = [self sdl_currentStatusForFilters:modifiedFilters];
@@ -312,19 +312,20 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 /**
- *  Takes a set of filters and a set of updated permission items. Loops through each permission for each filter and determines if the filter contains a permission that was updated. Returns the set of filters  that contain an updated permission.
- *
- *  @param filters         The set of filters to check
- *  @param permissionItems The set of updated permissions to test each filter against
- *
- *  @return An array of filters that contained one of the passed permissions
+ Takes a set of filters and a set of updated permission items. Loops through each permission for each filter and determines if the filter contains a permission that was updated. Returns the set of filters that contain an updated permission.
+
+ @param filters The set of filters to check
+ @param currentPermissions The current set of permissions to check the updated permissions and make sure they were modified
+ @param updatedPermissions The set of updated permissions to test each filter against
+ @return An array of filters that contained one of the passed permissions
  */
-+ (NSArray<SDLPermissionFilter *> *)sdl_filterPermissionChangesForFilters:(NSArray<SDLPermissionFilter *> *)filters updatedPermissions:(NSArray<SDLPermissionItem *> *)permissionItems {
++ (NSArray<SDLPermissionFilter *> *)sdl_filterPermissionChangesForFilters:(NSArray<SDLPermissionFilter *> *)filters currentPermissions:(NSMutableDictionary<SDLPermissionRPCName, SDLPermissionItem *> *)currentPermissions updatedPermissions:(NSArray<SDLPermissionItem *> *)updatedPermissions {
     NSMutableArray<SDLPermissionFilter *> *modifiedFilters = [NSMutableArray arrayWithCapacity:filters.count];
 
     // Loop through each updated permission item for each filter, if the filter had something modified, store it and go to the next filter
     for (SDLPermissionFilter *filter in filters) {
-        for (SDLPermissionItem *item in permissionItems) {
+        NSArray<SDLPermissionItem *> *modifiedPermissionItems = [self sdl_modifiedUpdatedPermissions:updatedPermissions comparedToCurrentPermissions:currentPermissions];
+        for (SDLPermissionItem *item in modifiedPermissionItems) {
             if ([filter.rpcNames containsObject:item.rpcName]) {
                 [modifiedFilters addObject:filter];
                 break;
@@ -333,6 +334,19 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     return [modifiedFilters copy];
+}
+
++ (NSArray<SDLPermissionItem *> *)sdl_modifiedUpdatedPermissions:(NSArray<SDLPermissionItem *> *)permissionItems comparedToCurrentPermissions:(NSMutableDictionary<SDLPermissionRPCName, SDLPermissionItem *> *)currentPermissions {
+    NSMutableArray<SDLPermissionItem *> *modifiedPermissions = [NSMutableArray arrayWithCapacity:permissionItems.count];
+
+    for (SDLPermissionItem *item in permissionItems) {
+        SDLPermissionItem *currentItem = currentPermissions[item.rpcName];
+        if (![item isEqual:currentItem]) {
+            [modifiedPermissions addObject:item];
+        }
+    }
+
+    return [modifiedPermissions copy];
 }
 
 @end

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLPermissionsManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLPermissionsManagerSpec.m
@@ -449,6 +449,37 @@ describe(@"SDLPermissionsManager", ^{
                     NSNumber<SDLBool> *allDisallowed = changeDicts[1][testRPCNameAllDisallowed];
                     expect(allDisallowed).to(equal(@NO));
                 });
+
+                describe(@"when the permission has not changed", ^{
+                    __block SDLOnPermissionsChange *testPermissionChangeUpdateNoChange = nil;
+                    __block SDLPermissionItem *testPermissionUpdatedNoChange = nil;
+
+                    beforeEach(^{
+                        numberOfTimesObserverCalled = 0;
+
+                        // Create a permission update disallowing our current HMI level for the observed permission
+                        SDLParameterPermissions *testParameterPermissions = [[SDLParameterPermissions alloc] init];
+                        SDLHMIPermissions *testHMIPermissionsUpdated = [[SDLHMIPermissions alloc] init];
+                        testHMIPermissionsUpdated.allowed = @[SDLHMILevelBackground, SDLHMILevelFull];
+                        testHMIPermissionsUpdated.userDisallowed = @[SDLHMILevelLimited, SDLHMILevelNone];
+
+                        testPermissionUpdatedNoChange = [[SDLPermissionItem alloc] init];
+                        testPermissionUpdatedNoChange.rpcName = testRPCNameAllAllowed;
+                        testPermissionUpdatedNoChange.hmiPermissions = testHMIPermissionsUpdated;
+                        testPermissionUpdatedNoChange.parameterPermissions = testParameterPermissions;
+
+                        testPermissionChangeUpdateNoChange = [[SDLOnPermissionsChange alloc] init];
+                        testPermissionChangeUpdateNoChange.permissionItem = [NSArray arrayWithObject:testPermissionUpdated];
+
+                        // Send the permission update
+                        SDLRPCNotificationNotification *updatedNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidChangePermissionsNotification object:nil rpcNotification:testPermissionChangeUpdate];
+                        [[NSNotificationCenter defaultCenter] postNotification:updatedNotification];
+                    });
+
+                    it(@"should not call the filter observer again", ^{
+                        expect(numberOfTimesObserverCalled).to(equal(0));
+                    });
+                });
             });
             
             context(@"to match an all allowed observer", ^{


### PR DESCRIPTION
Fixes #965 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Unit tests have been updated

### Summary
`OnPermissionChange` is sent with _all_ RPCs, not just the changed RPCs. Therefore the `SDLPermissionManager` sends observer updates with too many changes on the filters. Now, we will check the observer update against our currently known permissions to see if they actually did change.

### Changelog
##### Bug Fixes
* Fixed `SDLPermissionManager` notifying observers of permission changes when things didn't actually change.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
