### PR TITLE
Add config option to disable lock screen dismiss gesture

### DIFF
--- a/SmartDeviceLink/SDLLockScreenConfiguration.h
+++ b/SmartDeviceLink/SDLLockScreenConfiguration.h
@@ -14,9 +14,9 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SDLLockScreenConfiguration : NSObject <NSCopying>
 
 /**
- *  Whether or not the lock screen should be shown in the "lock screen optional" state. Defaults to false.
+ *  Whether or not the lock screen should be shown in the "lock screen optional" state. Defaults to NO.
  *
- *  @discussion In order for the "lock screen optional" state to occur, the following must be true:
+ *  In order for the "lock screen optional" state to occur, the following must be true:
  *  1. The app should have received at least 1 driver distraction notification (i.e. a `OnDriverDistraction` notification) from SDL Core. Older versions of Core did not send a notification immediately on connection.
  *  2. The driver is not distracted (i.e. the last `OnDriverDistraction` notification received was for a driver distraction state off).
  *  3. The `hmiLevel` can not be `NONE`.
@@ -25,7 +25,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic) BOOL showInOptionalState;
 
 /**
- *  If YES, the lock screen should be managed by SDL and automatically engage when necessary. If NO, then the lock screen will never be engaged.
+ If YES, then the lock screen can be dismissed with a downward swipe on compatible head units. Requires a connection of SDL 6.0+ and the head unit to enable the feature. Defaults to YES.
+ */
+@property (assign, nonatomic) BOOL enableDismissGesture;
+
+/**
+ *  If YES, the lock screen should be managed by SDL and automatically engage when necessary. If NO, then the lock screen will never be engaged. Defaults to YES.
  */
 @property (assign, nonatomic, readonly) BOOL enableAutomaticLockScreen;
 

--- a/SmartDeviceLink/SDLLockScreenConfiguration.m
+++ b/SmartDeviceLink/SDLLockScreenConfiguration.m
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Lifecycle
 
-- (instancetype)initWithAutoLockScreen:(BOOL)enableAutomatic enableInOptional:(BOOL)enableOptional backgroundColor:(UIColor *)backgroundColor appIcon:(nullable UIImage *)appIcon viewController:(nullable UIViewController *)customViewController {
+- (instancetype)initWithAutoLockScreen:(BOOL)enableAutomatic enableInOptional:(BOOL)enableOptional enableDismissGesture:(BOOL)enableDismissGesture backgroundColor:(UIColor *)backgroundColor appIcon:(nullable UIImage *)appIcon viewController:(nullable UIViewController *)customViewController {
     self = [super init];
     if (!self) {
         return nil;
@@ -28,6 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     _enableAutomaticLockScreen = enableAutomatic;
     _showInOptionalState = enableOptional;
+    _enableDismissGesture = enableDismissGesture;
     _backgroundColor = backgroundColor;
     _appIcon = appIcon;
     _customViewController = customViewController;
@@ -36,11 +37,11 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 + (instancetype)disabledConfiguration {
-    return [[self alloc] initWithAutoLockScreen:NO enableInOptional:NO backgroundColor:[self sdl_defaultBackgroundColor] appIcon:nil viewController:nil];
+    return [[self alloc] initWithAutoLockScreen:NO enableInOptional:NO enableDismissGesture:NO backgroundColor:[self sdl_defaultBackgroundColor] appIcon:nil viewController:nil];
 }
 
 + (instancetype)enabledConfiguration {
-    return [[self alloc] initWithAutoLockScreen:YES enableInOptional:NO backgroundColor:[self sdl_defaultBackgroundColor] appIcon:nil viewController:nil];
+    return [[self alloc] initWithAutoLockScreen:YES enableInOptional:NO enableDismissGesture:YES backgroundColor:[self sdl_defaultBackgroundColor] appIcon:nil viewController:nil];
 }
 
 + (instancetype)enabledConfigurationWithAppIcon:(UIImage *)lockScreenAppIcon backgroundColor:(nullable UIColor *)lockScreenBackgroundColor {
@@ -48,11 +49,11 @@ NS_ASSUME_NONNULL_BEGIN
         lockScreenBackgroundColor = [self.class sdl_defaultBackgroundColor];
     }
 
-    return [[self alloc] initWithAutoLockScreen:YES enableInOptional:NO backgroundColor:lockScreenBackgroundColor appIcon:lockScreenAppIcon viewController:nil];
+    return [[self alloc] initWithAutoLockScreen:YES enableInOptional:NO enableDismissGesture:YES backgroundColor:lockScreenBackgroundColor appIcon:lockScreenAppIcon viewController:nil];
 }
 
 + (instancetype)enabledConfigurationWithViewController:(UIViewController *)viewController {
-    return [[self alloc] initWithAutoLockScreen:YES enableInOptional:NO backgroundColor:[self.class sdl_defaultBackgroundColor] appIcon:nil viewController:viewController];
+    return [[self alloc] initWithAutoLockScreen:YES enableInOptional:NO enableDismissGesture:YES backgroundColor:[self.class sdl_defaultBackgroundColor] appIcon:nil viewController:viewController];
 }
 
 
@@ -66,11 +67,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - NSCopying
 
 - (id)copyWithZone:(nullable NSZone *)zone {
-    SDLLockScreenConfiguration *new = [[SDLLockScreenConfiguration allocWithZone:zone] initWithAutoLockScreen : _enableAutomaticLockScreen
-                                           enableInOptional : _showInOptionalState
-                                               backgroundColor : _backgroundColor
-                                                   appIcon : _appIcon
-                                                       viewController : _customViewController];
+    SDLLockScreenConfiguration *new = [[SDLLockScreenConfiguration allocWithZone:zone] initWithAutoLockScreen:_enableAutomaticLockScreen enableInOptional:_showInOptionalState enableDismissGesture:_enableDismissGesture backgroundColor:_backgroundColor appIcon:_appIcon viewController:_customViewController];
 
     return new;
 }

--- a/SmartDeviceLink/SDLLockScreenManager.m
+++ b/SmartDeviceLink/SDLLockScreenManager.m
@@ -172,7 +172,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)sdl_updateLockScreenDismissable {
     if (self.lastDriverDistractionNotification == nil ||
         self.lastDriverDistractionNotification.lockScreenDismissalEnabled == nil ||
-        !self.lastDriverDistractionNotification.lockScreenDismissalEnabled.boolValue) {
+        !self.lastDriverDistractionNotification.lockScreenDismissalEnabled.boolValue ||
+        !self.config.enableDismissGesture) {
         self.lockScreenDismissable = NO;
     } else {
         self.lockScreenDismissable = YES;

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLLockScreenConfigurationSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLLockScreenConfigurationSpec.m
@@ -14,8 +14,9 @@ describe(@"a lock screen configuration", ^{
         });
         
         it(@"should properly set properties", ^{
-            expect(@(testConfig.enableAutomaticLockScreen)).to(beFalsy());
-            expect(@(testConfig.showInOptionalState)).to(beFalsy());
+            expect(testConfig.enableAutomaticLockScreen).to(beFalse());
+            expect(testConfig.showInOptionalState).to(beFalse());
+            expect(testConfig.enableDismissGesture).to(beFalse());
             expect(testConfig.backgroundColor).to(equal([UIColor colorWithRed:(57.0/255.0) green:(78.0/255.0) blue:(96.0/255.0) alpha:1.0]));
             expect(testConfig.appIcon).to(beNil());
             expect(testConfig.customViewController).to(beNil());
@@ -28,8 +29,9 @@ describe(@"a lock screen configuration", ^{
         });
         
         it(@"should properly set properties", ^{
-            expect(@(testConfig.enableAutomaticLockScreen)).to(beTruthy());
-            expect(@(testConfig.showInOptionalState)).to(beFalsy());
+            expect(testConfig.enableAutomaticLockScreen).to(beTrue());
+            expect(testConfig.showInOptionalState).to(beFalse());
+            expect(testConfig.enableDismissGesture).to(beTrue());
             expect(testConfig.backgroundColor).to(equal([UIColor colorWithRed:(57.0/255.0) green:(78.0/255.0) blue:(96.0/255.0) alpha:1.0]));
             expect(testConfig.appIcon).to(beNil());
             expect(testConfig.customViewController).to(beNil());
@@ -48,8 +50,9 @@ describe(@"a lock screen configuration", ^{
         });
         
         it(@"should properly set properties", ^{
-            expect(@(testConfig.enableAutomaticLockScreen)).to(beTruthy());
-            expect(@(testConfig.showInOptionalState)).to(beFalsy());
+            expect(testConfig.enableAutomaticLockScreen).to(beTrue());
+            expect(testConfig.showInOptionalState).to(beFalse());
+            expect(testConfig.enableDismissGesture).to(beTrue());
             expect(testConfig.backgroundColor).to(equal([UIColor blueColor]));
             expect(testConfig.appIcon).to(equal(testImage));
             expect(testConfig.customViewController).to(beNil());
@@ -66,8 +69,9 @@ describe(@"a lock screen configuration", ^{
         });
         
         it(@"should properly set properties", ^{
-            expect(@(testConfig.enableAutomaticLockScreen)).to(beTruthy());
-            expect(@(testConfig.showInOptionalState)).to(beFalsy());
+            expect(testConfig.enableAutomaticLockScreen).to(beTrue());
+            expect(testConfig.showInOptionalState).to(beFalse());
+            expect(testConfig.enableDismissGesture).to(beTrue());
             expect(testConfig.backgroundColor).to(equal([UIColor colorWithRed:(57.0/255.0) green:(78.0/255.0) blue:(96.0/255.0) alpha:1.0]));
             expect(testConfig.appIcon).to(beNil());
             expect(testConfig.customViewController).to(equal(testVC));


### PR DESCRIPTION
Fixes #1365

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Unit tests have been added.

### Summary
Add a config option to disable the dismissal gesture on the lock screen when passenger mode is disabled.

### Changelog
##### Enhancements
* Add a config option to disable the dismissal gesture on the lock screen when passenger mode is disabled.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
