### PR TITLE
Fix ChoiceSetManager not calling back correctly if a WARNING occurs

### DIFF
--- a/SmartDeviceLink/SDLPresentChoiceSetOperation.m
+++ b/SmartDeviceLink/SDLPresentChoiceSetOperation.m
@@ -129,7 +129,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)sdl_presentChoiceSet {
     __weak typeof(self) weakself = self;
     [self.connectionManager sendConnectionRequest:self.performInteraction withResponseHandler:^(__kindof SDLRPCRequest * _Nullable request, __kindof SDLRPCResponse * _Nullable response, NSError * _Nullable error) {
-        if (!response.success.boolValue && error != nil) {
+        if (!response.success.boolValue || error != nil) {
             SDLLogE(@"Presenting choice set failed with response: %@, error: %@", response, error);
             weakself.internalError = error;
 

--- a/SmartDeviceLink/SDLPresentChoiceSetOperation.m
+++ b/SmartDeviceLink/SDLPresentChoiceSetOperation.m
@@ -129,7 +129,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)sdl_presentChoiceSet {
     __weak typeof(self) weakself = self;
     [self.connectionManager sendConnectionRequest:self.performInteraction withResponseHandler:^(__kindof SDLRPCRequest * _Nullable request, __kindof SDLRPCResponse * _Nullable response, NSError * _Nullable error) {
-        if (error != nil) {
+        if (!response.success.boolValue && error != nil) {
             SDLLogE(@"Presenting choice set failed with response: %@, error: %@", response, error);
             weakself.internalError = error;
 


### PR DESCRIPTION
Fixes #1363 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Tests performed against sdl_hmi

### Summary
This PR adds an additional check to `SDLPresentChoiceSetOperation` to only return an error if the RPC response `success` is `NO`.

### Changelog
##### Bug Fixes
* Presenting a choice set no longer fails in certain cases when it's successful.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
