### PR TITLE
change log level to error from assert at detecting wrong object in store

### DIFF
--- a/SmartDeviceLink/NSMutableDictionary+Store.m
+++ b/SmartDeviceLink/NSMutableDictionary+Store.m
@@ -55,7 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
         // The object in the store is not correct, we'll assert in debug and return an error and nil
         NSError *wrongObjectError = [NSError sdl_rpcStore_invalidObjectErrorWithObject:obj expectedType:classType];
 
-        SDLLogAssert(@"Retrieving object from store error: %@", wrongObjectError.localizedFailureReason);
+        SDLLogE(@"Retrieving object from store error: %@", wrongObjectError.localizedFailureReason);
 
         if (error) {
             *error = wrongObjectError;


### PR DESCRIPTION
Fixes #1372 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
We tested with our internal devboard and HU

### Summary
Fix not to raise an exception when detecting wrong object type in a store

### Changelog
##### Bug Fixes
* Fix not to raise an exception when detecting wrong object type in a store

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
