### PR TITLE
Add a single state soft button object without having to create a stat…

### DIFF
--- a/SmartDeviceLink/SDLSoftButtonObject.h
+++ b/SmartDeviceLink/SDLSoftButtonObject.h
@@ -10,6 +10,7 @@
 
 #import "SDLNotificationConstants.h"
 
+@class SDLArtwork;
 @class SDLSoftButton;
 @class SDLSoftButtonObject;
 @class SDLSoftButtonState;

--- a/SmartDeviceLink/SDLSoftButtonObject.h
+++ b/SmartDeviceLink/SDLSoftButtonObject.h
@@ -58,10 +58,22 @@ NS_ASSUME_NONNULL_BEGIN
  Create a single-state soft button. For example, a button that brings up a Perform Interaction menu.
 
  @param name The name of the button
- @param eventHandler The handler to be called when the button is in the current state and is pressed
  @param state The single state of the button
+ @param eventHandler The handler to be called when the button is pressed
+ @return The button object
  */
 - (instancetype)initWithName:(NSString *)name state:(SDLSoftButtonState *)state handler:(nullable SDLRPCButtonNotificationHandler)eventHandler;
+
+/**
+ Create a single-state soft button. For example, a button that brings up a Perform Interaction menu.
+
+ @param name The name of the button
+ @param text The text to be displayed on the button
+ @param artwork The artwork to be displayed on the button
+ @param eventHandler The handler to be called when the button is pressed
+ @return The button object
+ */
+- (instancetype)initWithName:(NSString *)name text:(nullable NSString *)text artwork:(nullable SDLArtwork *)artwork handler:(nullable SDLRPCButtonNotificationHandler)eventHandler;
 
 /**
  Transition the soft button to another state in the `states` property. The wrapper considers all transitions valid (assuming a state with that name exists).

--- a/SmartDeviceLink/SDLSoftButtonObject.m
+++ b/SmartDeviceLink/SDLSoftButtonObject.m
@@ -53,6 +53,11 @@ NS_ASSUME_NONNULL_BEGIN
     return [self initWithName:name states:@[state] initialStateName:state.name handler:eventHandler];
 }
 
+- (instancetype)initWithName:(NSString *)name text:(nullable NSString *)text artwork:(nullable SDLArtwork *)artwork handler:(nullable SDLRPCButtonNotificationHandler)eventHandler {
+    SDLSoftButtonState *implicitState = [[SDLSoftButtonState alloc] initWithStateName:name text:text artwork:artwork];
+    return [self initWithName:name state:implicitState handler:eventHandler];
+}
+
 - (BOOL)transitionToStateNamed:(NSString *)stateName {
     if ([self stateWithName:stateName] == nil) {
         SDLLogE(@"Attempted to transition to state: %@ on soft button: %@ but no state with that name was found", stateName, self.name);

--- a/SmartDeviceLink/SDLSoftButtonObject.m
+++ b/SmartDeviceLink/SDLSoftButtonObject.m
@@ -64,6 +64,11 @@ NS_ASSUME_NONNULL_BEGIN
         return NO;
     }
 
+    if (self.states.count == 1) {
+        SDLLogW(@"There's only one state, so no transitioning is possible!");
+        return NO;
+    }
+
     SDLLogD(@"Transitioning button %@ to state %@", self.name, stateName);
     self.currentStateName = stateName;
     [self.manager sdl_transitionSoftButton:self];

--- a/SmartDeviceLinkTests/SDLSoftButtonObjectSpec.m
+++ b/SmartDeviceLinkTests/SDLSoftButtonObjectSpec.m
@@ -2,6 +2,7 @@
 #import <Nimble/Nimble.h>
 #import <OCMock/OCMock.h>
 
+#import "SDLArtwork.h"
 #import "SDLSoftButton.h"
 #import "SDLSoftButtonObject.h"
 #import "SDLSoftButtonState.h"
@@ -38,6 +39,36 @@ describe(@"a soft button object", ^{
 
         it(@"should return a state when asked and not when incorrect", ^{
             SDLSoftButtonState *returnedState = [testObject stateWithName:testSingleStateName];
+            expect(returnedState).toNot(beNil());
+
+            returnedState = [testObject stateWithName:@"Some other state"];
+            expect(returnedState).to(beNil());
+        });
+    });
+
+    context(@"with a single state implicitly created", ^{
+        NSString *testText = @"Hello";
+        SDLArtwork *testArt = [[SDLArtwork alloc] initWithStaticIcon:SDLStaticIconNameKey];
+
+        beforeEach(^{
+            testObject = [[SDLSoftButtonObject alloc] initWithName:testObjectName text:testText artwork:testArt handler:nil];
+        });
+
+        it(@"should create correctly", ^{
+            expect(testObject.name).to(equal(testObjectName));
+            expect(testObject.currentState.name).to(equal(testObjectName));
+            expect(testObject.currentState.text).to(equal(testText));
+            expect(testObject.currentState.artwork).to(equal(testArt));
+            expect(testObject.states).to(haveCount(1));
+        });
+
+        it(@"should not allow transitioning to another state", ^{
+            BOOL performedTransition = [testObject transitionToStateNamed:@"Some other state"];
+            expect(performedTransition).to(beFalse());
+        });
+
+        it(@"should return a state when asked and not when incorrect", ^{
+            SDLSoftButtonState *returnedState = [testObject stateWithName:testObjectName];
             expect(returnedState).toNot(beNil());
 
             returnedState = [testObject stateWithName:@"Some other state"];


### PR DESCRIPTION
Fixes #1375 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Unit tests added

### Summary
This PR adds the ability to create a soft button object in one line by implicitly creating the soft button state.

### Changelog
##### Enhancements
* Add an API to create a soft button state implicitly while creating the soft button object.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
