### PR TITLE
Configuration Option for Secondary Transports

### DIFF
--- a/SmartDeviceLink/SDLLifecycleConfiguration.h
+++ b/SmartDeviceLink/SDLLifecycleConfiguration.h
@@ -19,6 +19,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NS_OPTIONS(NSUInteger, SDLSecondaryTransports) {
+    SDLSecondaryTransportsNone = 0,
+    SDLSecondaryTransportsTCP = 1 << 0
+};
+
 /**
  *  Configuration options for SDLManager
  */
@@ -177,6 +182,15 @@ NS_ASSUME_NONNULL_BEGIN
  The minimum RPC version that will be permitted to connect. This defaults to 1.0.0. If the RPC version of the head unit connected is below this version, an UnregisterAppInterface will be sent.
  */
 @property (strong, nonatomic) SDLVersion *minimumRPCVersion;
+
+/**
+ Which transports are permitted to be used as secondary transports. A secondary transport is a transport that is connected as an alternate, higher bandwidth transport for situations when a low-bandwidth primary transport (such as Bluetooth) will restrict certain features (such as video streaming navigation).
+
+ The only currently available secondary transport is TCP over WiFi. This is set to permit TCP by default, but it can be disabled by using SDLSecondaryTransportsNone instead.
+
+ This will only affect apps that have high-bandwidth requirements; currently that is only video streaming navigation apps.
+ */
+@property (assign, nonatomic) SDLSecondaryTransports allowedSecondaryTransports;
 
 @end
 

--- a/SmartDeviceLink/SDLLifecycleConfiguration.m
+++ b/SmartDeviceLink/SDLLifecycleConfiguration.m
@@ -69,6 +69,7 @@ static NSUInteger const AppIdCharacterCount = 10;
     _voiceRecognitionCommandNames = nil;
     _minimumProtocolVersion = [SDLVersion versionWithString:@"1.0.0"];
     _minimumRPCVersion = [SDLVersion versionWithString:@"1.0.0"];
+    _allowedSecondaryTransports = SDLSecondaryTransportsTCP;
 
     _fullAppId = fullAppId;
     _appId = fullAppId != nil ? [self.class sdlex_shortAppIdFromFullAppId:fullAppId] : appId;
@@ -156,6 +157,7 @@ static NSUInteger const AppIdCharacterCount = 10;
     newConfig->_voiceRecognitionCommandNames = _voiceRecognitionCommandNames;
     newConfig->_dayColorScheme = _dayColorScheme;
     newConfig->_nightColorScheme = _nightColorScheme;
+    newConfig->_allowedSecondaryTransports = _allowedSecondaryTransports;
 
     return newConfig;
 }

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -224,19 +224,18 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
     // Start up the internal proxy object
     #pragma clang diagnostic push
     #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    self.secondaryTransportManager = nil;
     if (self.configuration.lifecycleConfig.tcpDebugMode) {
-        // secondary transport manager is not used
-        self.secondaryTransportManager = nil;
         self.proxy = [SDLProxy tcpProxyWithListener:self.notificationDispatcher
                                        tcpIPAddress:self.configuration.lifecycleConfig.tcpDebugIPAddress
                                             tcpPort:@(self.configuration.lifecycleConfig.tcpDebugPort).stringValue
                           secondaryTransportManager:self.secondaryTransportManager];
+    } else if (self.configuration.lifecycleConfig.allowedSecondaryTransports == SDLSecondaryTransportsNone) {
+        self.proxy = [SDLProxy iapProxyWithListener:self.notificationDispatcher secondaryTransportManager:nil];
     } else {
-        // we reuse our queue to run secondary transport manager's state machine
-        self.secondaryTransportManager = [[SDLSecondaryTransportManager alloc] initWithStreamingProtocolDelegate:self
-                                                                                                     serialQueue:self.lifecycleQueue];
-        self.proxy = [SDLProxy iapProxyWithListener:self.notificationDispatcher
-                          secondaryTransportManager:self.secondaryTransportManager];
+        // We reuse our queue to run secondary transport manager's state machine
+        self.secondaryTransportManager = [[SDLSecondaryTransportManager alloc] initWithStreamingProtocolDelegate:self serialQueue:self.lifecycleQueue];
+        self.proxy = [SDLProxy iapProxyWithListener:self.notificationDispatcher secondaryTransportManager:self.secondaryTransportManager];
     }
     #pragma clang diagnostic pop
 }

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleManagerSpec.m
@@ -668,6 +668,28 @@ describe(@"a lifecycle manager", ^{
     });
 });
 
+describe(@"configuring the lifecycle manager", ^{
+    __block SDLLifecycleConfiguration *lifecycleConfig = nil;
+    __block SDLLifecycleManager *testManager = nil;
+
+    beforeEach(^{
+        lifecycleConfig = [SDLLifecycleConfiguration defaultConfigurationWithAppName:@"Test app" fullAppId:@"Test ID"];
+    });
+
+    context(@"if no secondary transport is allowed", ^{
+        beforeEach(^{
+            lifecycleConfig.allowedSecondaryTransports = SDLSecondaryTransportsNone;
+
+            SDLConfiguration *config = [[SDLConfiguration alloc] initWithLifecycle:lifecycleConfig lockScreen:nil logging:nil fileManager:nil];
+            testManager = [[SDLLifecycleManager alloc] initWithConfiguration:config delegate:nil];
+        });
+
+        it(@"should not create a secondary transport manager", ^{
+            expect(testManager.secondaryTransportManager).to(beNil());
+        });
+    });
+});
+
 QuickSpecEnd
 
 #pragma clang diagnostic pop


### PR DESCRIPTION
Fixes #1380

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Unit tests have been added

### Summary
Aligned with the Java suite library to provide developers with options on how to use secondary transports.

### Changelog
##### Enhancements
* Add a lifecycle configuration option to disable/enable secondary transports.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
