### PR TITLE
SystemCapabilityManager fails to support SeatLocation capability

### DIFF
--- a/SmartDeviceLink/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.m
@@ -262,7 +262,7 @@ typedef NSString * SDLServiceID;
  *  @return An array of all possible system capability types
  */
 + (NSArray<SDLSystemCapabilityType> *)sdl_systemCapabilityTypes {
-    return @[SDLSystemCapabilityTypeAppServices, SDLSystemCapabilityTypeNavigation, SDLSystemCapabilityTypePhoneCall, SDLSystemCapabilityTypeVideoStreaming, SDLSystemCapabilityTypeRemoteControl];
+    return @[SDLSystemCapabilityTypeAppServices, SDLSystemCapabilityTypeNavigation, SDLSystemCapabilityTypePhoneCall, SDLSystemCapabilityTypeVideoStreaming, SDLSystemCapabilityTypeRemoteControl, SDLSystemCapabilityTypeSeatLocation];
 }
 
 /**

--- a/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
+++ b/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
@@ -67,6 +67,8 @@ describe(@"System capability manager", ^{
         expect(testSystemCapabilityManager.videoStreamingCapability).to(beNil());
         expect(testSystemCapabilityManager.remoteControlCapability).to(beNil());
         expect(testSystemCapabilityManager.appServicesCapabilities).to(beNil());
+        expect(testSystemCapabilityManager.seatLocationCapability).to(beNil());
+
     });
 
     context(@"When notified of a register app interface response", ^{
@@ -549,7 +551,7 @@ describe(@"System capability manager", ^{
         });
 
         it(@"should send GetSystemCapability subscriptions for all known capabilities", ^{
-            expect(testConnectionManager.receivedRequests).to(haveCount(5));
+            expect(testConnectionManager.receivedRequests).to(haveCount(6));
             expect(testConnectionManager.receivedRequests.lastObject).to(beAnInstanceOf([SDLGetSystemCapability class]));
         });
     });
@@ -576,6 +578,7 @@ describe(@"System capability manager", ^{
             expect(testSystemCapabilityManager.videoStreamingCapability).to(beNil());
             expect(testSystemCapabilityManager.remoteControlCapability).to(beNil());
             expect(testSystemCapabilityManager.appServicesCapabilities).to(beNil());
+            expect(testSystemCapabilityManager.seatLocationCapability).to(beNil());
         });
     });
 });


### PR DESCRIPTION
Fixes #1396 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Added  `SDLSystemCapabilityTypeSeatLocation` to `+ (NSArray<SDLSystemCapabilityType> *)sdl_systemCapabilityTypes`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
