### PR TITLE
Add remoteControl to HMICapabilities

### DIFF
--- a/SmartDeviceLink/SDLHMICapabilities.h
+++ b/SmartDeviceLink/SDLHMICapabilities.h
@@ -6,12 +6,19 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ Contains information about the HMI capabilities.
+
+ Since SDL 3.0
+**/
 @interface SDLHMICapabilities : SDLRPCStruct
 
 /**
  Availability of built in Nav. True: Available, False: Not Available
  
  Boolean value. Optional.
+
+ Since SDL 3.0
  */
 @property (nullable, copy, nonatomic) NSNumber<SDLBool> *navigation;
 
@@ -19,6 +26,8 @@ NS_ASSUME_NONNULL_BEGIN
  Availability of built in phone. True: Available, False: Not Available
  
  Boolean value. Optional.
+
+ Since SDL 3.0
  */
 @property (nullable, copy, nonatomic) NSNumber<SDLBool> *phoneCall;
 
@@ -26,6 +35,8 @@ NS_ASSUME_NONNULL_BEGIN
  Availability of built in video streaming. True: Available, False: Not Available
 
  Boolean value. Optional.
+
+ Since SDL 4.5
  */
 @property (nullable, copy, nonatomic) NSNumber<SDLBool> *videoStreaming;
 
@@ -33,6 +44,8 @@ NS_ASSUME_NONNULL_BEGIN
  Availability of built in remote control. True: Available, False: Not Available
 
  Boolean value. Optional.
+
+ Since SDL 4.5
 **/
 @property (nullable, copy, nonatomic) NSNumber<SDLBool> *remoteControl;
 

--- a/SmartDeviceLink/SDLHMICapabilities.h
+++ b/SmartDeviceLink/SDLHMICapabilities.h
@@ -29,6 +29,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nullable, copy, nonatomic) NSNumber<SDLBool> *videoStreaming;
 
+/**
+ Availability of built in remote control. True: Available, False: Not Available
+
+ Boolean value. Optional.
+**/
+@property (nullable, copy, nonatomic) NSNumber<SDLBool> *remoteControl;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLHMICapabilities.m
+++ b/SmartDeviceLink/SDLHMICapabilities.m
@@ -35,6 +35,14 @@ NS_ASSUME_NONNULL_BEGIN
     return [self.store sdl_objectForName:SDLRPCParameterNameVideoStreaming ofClass:NSNumber.class error:nil];
 }
 
+- (void)setRemoteControl:(nullable NSNumber<SDLBool> *)remoteControl {
+    [self.store sdl_setObject:remoteControl forName:SDLRPCParameterNameRemoteControl];
+}
+
+- (nullable NSNumber<SDLBool> *)remoteControl {
+    return [self.store sdl_objectForName:SDLRPCParameterNameRemoteControl ofClass:NSNumber.class error:nil];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLRPCParameterNames.h
+++ b/SmartDeviceLink/SDLRPCParameterNames.h
@@ -506,6 +506,7 @@ extern SDLRPCParameterName const SDLRPCParameterNameRect;
 extern SDLRPCParameterName const SDLRPCParameterNameRed;
 extern SDLRPCParameterName const SDLRPCParameterNameRegion;
 extern SDLRPCParameterName const SDLRPCParameterNameRegions;
+extern SDLRPCParameterName const SDLRPCParameterNameRemoteControl;
 extern SDLRPCParameterName const SDLRPCParameterNameRemoteControlCapability;
 extern SDLRPCParameterName const SDLRPCParameterNameRequest;
 extern SDLRPCParameterName const SDLRPCParameterNameRequestServiceActive;

--- a/SmartDeviceLink/SDLRPCParameterNames.m
+++ b/SmartDeviceLink/SDLRPCParameterNames.m
@@ -500,6 +500,7 @@ SDLRPCParameterName const SDLRPCParameterNameRed = @"red";
 SDLRPCParameterName const SDLRPCParameterNameRect = @"rect";
 SDLRPCParameterName const SDLRPCParameterNameRegion = @"REG";
 SDLRPCParameterName const SDLRPCParameterNameRegions = @"regions";
+SDLRPCParameterName const SDLRPCParameterNameRemoteControl = @"remoteControl";
 SDLRPCParameterName const SDLRPCParameterNameRemoteControlCapability = @"remoteControlCapability";
 SDLRPCParameterName const SDLRPCParameterNameRequest = @"request";
 SDLRPCParameterName const SDLRPCParameterNameRequestServiceActive = @"requestServiceActive";

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLHMICapabilitiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLHMICapabilitiesSpec.m
@@ -17,6 +17,7 @@ describe(@"SDLHMICapabilities struct", ^{
     __block NSNumber *somePhoneCallState = @NO;
     __block NSNumber *someNavigationState = @YES;
     __block NSNumber *someVideoStreamState = @NO;
+    __block NSNumber *someRemoteControlState = @YES;
     
     context(@"When initialized with properties", ^{
         beforeEach(^{
@@ -24,6 +25,7 @@ describe(@"SDLHMICapabilities struct", ^{
             testStruct.phoneCall = somePhoneCallState;
             testStruct.navigation = someNavigationState;
             testStruct.videoStreaming = someVideoStreamState;
+            testStruct.remoteControl = someRemoteControlState;
         });
         
         it(@"should properly set phone call", ^{
@@ -37,6 +39,10 @@ describe(@"SDLHMICapabilities struct", ^{
         it(@"should properly set video streaming", ^{
             expect(testStruct.videoStreaming).to(equal(someVideoStreamState));
         });
+
+        it(@"should properly set remote control", ^{
+            expect(testStruct.remoteControl).to(equal(someRemoteControlState));
+        });
     });
     
     context(@"When initialized with a dictionary", ^{
@@ -44,7 +50,8 @@ describe(@"SDLHMICapabilities struct", ^{
             NSDictionary<NSString *, NSNumber *> *structInitDict = @{
                                              SDLRPCParameterNameNavigation: someNavigationState,
                                              SDLRPCParameterNamePhoneCall: somePhoneCallState,
-                                             SDLRPCParameterNameVideoStreaming: someVideoStreamState
+                                             SDLRPCParameterNameVideoStreaming: someVideoStreamState,
+                                             SDLRPCParameterNameRemoteControl: someRemoteControlState
                                              };
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -63,6 +70,10 @@ describe(@"SDLHMICapabilities struct", ^{
         it(@"should properly set video streaming", ^{
             expect(testStruct.videoStreaming).to(equal(someVideoStreamState));
         });
+
+        it(@"should properly set remote control", ^{
+            expect(testStruct.remoteControl).to(equal(someRemoteControlState));
+        });
     });
     
     context(@"When not initialized", ^{
@@ -80,6 +91,10 @@ describe(@"SDLHMICapabilities struct", ^{
 
         it(@"video streaming should be nil", ^{
             expect(testStruct.videoStreaming).to(beNil());
+        });
+
+        it(@"remote control should be nil", ^{
+            expect(testStruct.remoteControl).to(beNil());
         });
     });
 });


### PR DESCRIPTION
Fixes #1395 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
See if remoteControl object is obtainable.

```
NSLog(@"Remote Control status: %@ ", self.sdlManager.systemCapabilityManager.hmiCapabilities.remoteControl);
```

### Summary
Added Remote Control object to hmiCapabilities struct

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
