### PR TITLE
Update SDLAsynchronousOperation subclasses to abort on start if they're cancelled

### DIFF
--- a/SmartDeviceLink/SDLAsynchronousRPCOperation.m
+++ b/SmartDeviceLink/SDLAsynchronousRPCOperation.m
@@ -21,17 +21,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@implementation SDLAsynchronousRPCOperation {
-    BOOL executing;
-    BOOL finished;
-}
+@implementation SDLAsynchronousRPCOperation
 
 - (instancetype)init {
     self = [super init];
     if (!self) { return nil; }
-
-    executing = NO;
-    finished = NO;
 
     _operationId = [NSUUID UUID];
 
@@ -49,6 +43,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)start {
     [super start];
+    if (self.isCancelled) { return; }
+
     [self sdl_sendRPC:self.rpc];
 }
 

--- a/SmartDeviceLink/SDLAsynchronousRPCRequestOperation.m
+++ b/SmartDeviceLink/SDLAsynchronousRPCRequestOperation.m
@@ -72,6 +72,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)start {
     [super start];
+    if (self.isCancelled) { return; }
 
     [self sdl_sendRequests];
 }

--- a/SmartDeviceLink/SDLCheckChoiceVROptionalOperation.m
+++ b/SmartDeviceLink/SDLCheckChoiceVROptionalOperation.m
@@ -38,6 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)start {
     [super start];
+    if (self.isCancelled) { return; }
 
     [self sdl_sendTestChoices];
 }

--- a/SmartDeviceLink/SDLDeleteChoicesOperation.m
+++ b/SmartDeviceLink/SDLDeleteChoicesOperation.m
@@ -45,6 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)start {
     [super start];
+    if (self.isCancelled) { return; }
 
     [self sdl_sendDeletions];
 }

--- a/SmartDeviceLink/SDLDeleteFileOperation.m
+++ b/SmartDeviceLink/SDLDeleteFileOperation.m
@@ -40,6 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)start {
     [super start];
+    if (self.isCancelled) { return; }
 
     [self sdl_deleteFile];
 }

--- a/SmartDeviceLink/SDLListFilesOperation.m
+++ b/SmartDeviceLink/SDLListFilesOperation.m
@@ -41,6 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)start {
     [super start];
+    if (self.isCancelled) { return; }
 
     [self sdl_listFiles];
 }

--- a/SmartDeviceLink/SDLPreloadChoicesOperation.m
+++ b/SmartDeviceLink/SDLPreloadChoicesOperation.m
@@ -61,6 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)start {
     [super start];
+    if (self.isCancelled) { return; }
 
     [self sdl_preloadCellArtworksWithCompletionHandler:^(NSError * _Nullable error) {
         self.internalError = error;

--- a/SmartDeviceLink/SDLPresentChoiceSetOperation.m
+++ b/SmartDeviceLink/SDLPresentChoiceSetOperation.m
@@ -92,6 +92,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)start {
     [super start];
+    if (self.isCancelled) { return; }
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_keyboardInputNotification:) name:SDLDidReceiveKeyboardInputNotification object:nil];
 
@@ -99,11 +100,6 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)sdl_start {
-    if (self.isCancelled) {
-        [self finishOperation];
-        return;
-    }
-
     // Check if we're using a keyboard (searchable) choice set and setup keyboard properties if we need to
     if (self.keyboardDelegate != nil && [self.keyboardDelegate respondsToSelector:@selector(customKeyboardConfiguration)]) {
         SDLKeyboardProperties *customProperties = self.keyboardDelegate.customKeyboardConfiguration;

--- a/SmartDeviceLink/SDLPresentKeyboardOperation.m
+++ b/SmartDeviceLink/SDLPresentKeyboardOperation.m
@@ -59,6 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)start {
     [super start];
+    if (self.isCancelled) { return; }
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_keyboardInputNotification:) name:SDLDidReceiveKeyboardInputNotification object:nil];
 

--- a/SmartDeviceLink/SDLSequentialRPCRequestOperation.m
+++ b/SmartDeviceLink/SDLSequentialRPCRequestOperation.m
@@ -54,6 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)start {
     [super start];
+    if (self.isCancelled) { return; }
 
     [self sdl_sendNextRequest];
 }

--- a/SmartDeviceLink/SDLSoftButtonReplaceOperation.m
+++ b/SmartDeviceLink/SDLSoftButtonReplaceOperation.m
@@ -49,6 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)start {
     [super start];
+    if (self.isCancelled) { return; }
 
     // Check the state of our images
     if (![self sdl_supportsSoftButtonImages]) {

--- a/SmartDeviceLink/SDLSoftButtonTransitionOperation.m
+++ b/SmartDeviceLink/SDLSoftButtonTransitionOperation.m
@@ -44,6 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)start {
     [super start];
+    if (self.isCancelled) { return; }
 
     [self sdl_sendNewSoftButtons];
 }

--- a/SmartDeviceLink/SDLUploadFileOperation.m
+++ b/SmartDeviceLink/SDLUploadFileOperation.m
@@ -53,6 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)start {
     [super start];
+    if (self.isCancelled) { return; }
 
     [self sdl_sendFile:self.fileWrapper.file mtuSize:[[SDLGlobals sharedGlobals] mtuSizeForServiceType:SDLServiceTypeRPC] withCompletion:self.fileWrapper.completionHandler];
 }

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLPresentKeyboardOperationSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLPresentKeyboardOperationSpec.m
@@ -437,7 +437,7 @@ describe(@"present keyboard operation", ^{
 
                 it(@"should not attempt to send a cancel interaction", ^{
                     SDLCancelInteraction *lastRequest = testConnectionManager.receivedRequests.lastObject;
-                    expect(lastRequest).toNot(beAnInstanceOf([SDLCancelInteraction class]));
+                    expect(lastRequest).to(beNil());
                 });
 
                 it(@"should finish", ^{


### PR DESCRIPTION
Fixes #1379 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Unit tests performed 

### Summary
This PR updates `SDLAsynchronousOperation` subclasses to exit as early as possible if they're cancelled instead of starting then cancelling.

### Changelog
##### Bug Fixes
* Operations will now exit out earlier when cancelled before running.

### Tasks Remaining:
- [x] Run tests against Manticore

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
