### PR TITLE
Fix Bitrate Update for Video Streaming

### DIFF
--- a/SmartDeviceLink/SDLStreamingMediaConfiguration.h
+++ b/SmartDeviceLink/SDLStreamingMediaConfiguration.h
@@ -45,16 +45,8 @@ typedef NS_ENUM(NSUInteger, SDLCarWindowRenderingType) {
  *  Properties to use for applications that utilize the video encoder for streaming. See VTCompressionProperties.h for more details. For example, you can set kVTCompressionPropertyKey_ExpectedFrameRate to set your framerate. Setting the framerate this way will also set the framerate if you use CarWindow automatic streaming.
  *
  *  Other properties you may want to try adjusting include kVTCompressionPropertyKey_AverageBitRate and kVTCompressionPropertyKey_DataRateLimits.
-
- @note Setting values can be override by StreamingMediaManager when `allowOverrideEncoderSettings` property is YES.
-
  */
 @property (copy, nonatomic, nullable) NSDictionary<NSString *, id> *customVideoEncoderSettings;
-
-/**
- When YES, the StreamingMediaManager will override encoder settings by the capability values returned from HMI. If you wish not to allow overriding encoder settings, set it to NO. Defaults to YES.
- */
-@property (assign, nonatomic) BOOL allowOverrideEncoderSettings;
 
 /**
  Usable to change run time video stream setup behavior. Only use this and modify the results if you *really* know what you're doing. The head unit defaults are generally good.

--- a/SmartDeviceLink/SDLStreamingMediaConfiguration.h
+++ b/SmartDeviceLink/SDLStreamingMediaConfiguration.h
@@ -46,7 +46,7 @@ typedef NS_ENUM(NSUInteger, SDLCarWindowRenderingType) {
  *
  *  Other properties you may want to try adjusting include kVTCompressionPropertyKey_AverageBitRate and kVTCompressionPropertyKey_DataRateLimits.
 
- @note Setting values can be overridden by StreamingMediaManager when `allowOverrideEncoderSettings` property is YES.
+ @note Setting values can be override by StreamingMediaManager when `allowOverrideEncoderSettings` property is YES.
 
  */
 @property (copy, nonatomic, nullable) NSDictionary<NSString *, id> *customVideoEncoderSettings;

--- a/SmartDeviceLink/SDLStreamingMediaConfiguration.m
+++ b/SmartDeviceLink/SDLStreamingMediaConfiguration.m
@@ -37,7 +37,6 @@ NS_ASSUME_NONNULL_BEGIN
     _carWindowRenderingType = SDLCarWindowRenderingTypeLayer;
     _enableForcedFramerateSync = YES;
     _allowMultipleViewControllerOrientations = NO;
-    _allowOverrideEncoderSettings = YES;
 
     return self;
 }

--- a/SmartDeviceLink/SDLStreamingMediaConfiguration.m
+++ b/SmartDeviceLink/SDLStreamingMediaConfiguration.m
@@ -69,7 +69,6 @@ NS_ASSUME_NONNULL_BEGIN
     newConfig.carWindowRenderingType = self.carWindowRenderingType;
     newConfig.enableForcedFramerateSync = self.enableForcedFramerateSync;
     newConfig.allowMultipleViewControllerOrientations = self.allowMultipleViewControllerOrientations;
-    newConfig.allowOverrideEncoderSettings = self.allowOverrideEncoderSettings;
     
     return newConfig;
 }

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.h
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.h
@@ -136,12 +136,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic) BOOL showVideoBackgroundDisplay;
 
 
-/**
-  When YES, the StreamingMediaManager will override encoder settings by the capability values returned from HMI. Defaults to YES.
- */
-@property (assign, nonatomic) BOOL allowOverrideEncoderSettings;
-
-
 - (instancetype)init NS_UNAVAILABLE;
 
 /**

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -346,7 +346,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
             weakSelf.preferredResolutions = @[capability.preferredResolution];
 
             if (capability.maxBitrate != nil) {
-                NSNumber *bitrate = [[NSNumber alloc] initWithUnsignedLongLong:(capability.maxBitrate.unsignedLongLongValue * 1000)];
+                NSNumber *bitrate = [[NSNumber alloc] initWithInt:[capability.maxBitrate intValue] * 1000]; // HMI returns bitrate in kbps.
                 NSMutableDictionary *settings = [[NSMutableDictionary alloc] init];
                 [settings addEntriesFromDictionary: self.videoEncoderSettings];
                 [settings setObject:bitrate forKey:(__bridge NSString *)kVTCompressionPropertyKey_AverageBitRate];

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -124,7 +124,6 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
     _screenSize = SDLDefaultScreenSize;
     _backgroundingPixelBuffer = NULL;
     _showVideoBackgroundDisplay = YES;
-    _allowOverrideEncoderSettings = configuration.streamingMediaConfig.allowOverrideEncoderSettings;
     _preferredFormatIndex = 0;
     _preferredResolutionIndex = 0;
 
@@ -346,7 +345,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
             weakSelf.preferredFormats = capability.supportedFormats;
             weakSelf.preferredResolutions = @[capability.preferredResolution];
 
-            if (weakSelf.allowOverrideEncoderSettings && capability.maxBitrate != nil) {
+            if (capability.maxBitrate != nil) {
                 NSNumber *bitrate = [[NSNumber alloc] initWithUnsignedLongLong:(capability.maxBitrate.unsignedLongLongValue * 1000)];
                 NSMutableDictionary *settings = [[NSMutableDictionary alloc] init];
                 [settings addEntriesFromDictionary: self.videoEncoderSettings];

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -345,14 +345,6 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
             weakSelf.preferredFormats = capability.supportedFormats;
             weakSelf.preferredResolutions = @[capability.preferredResolution];
 
-            if (capability.maxBitrate != nil) {
-                NSNumber *bitrate = [[NSNumber alloc] initWithInt:[capability.maxBitrate intValue] * 1000]; // HMI returns bitrate in kbps.
-                NSMutableDictionary *settings = [[NSMutableDictionary alloc] init];
-                [settings addEntriesFromDictionary: self.videoEncoderSettings];
-                [settings setObject:bitrate forKey:(__bridge NSString *)kVTCompressionPropertyKey_AverageBitRate];
-                weakSelf.videoEncoderSettings = settings;
-            }
-
             if (weakSelf.dataSource != nil) {
                 SDLLogV(@"Calling data source for modified preferred formats");
                 weakSelf.preferredFormats = [weakSelf.dataSource preferredVideoFormatOrderFromHeadUnitPreferredOrder:weakSelf.preferredFormats];

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingVideoLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingVideoLifecycleManagerSpec.m
@@ -91,7 +91,6 @@ describe(@"the streaming video manager", ^{
         expect(@(streamingLifecycleManager.pixelBufferPool == NULL)).to(equal(@YES));
         expect(@(streamingLifecycleManager.requestedEncryptionType)).to(equal(@(SDLStreamingEncryptionFlagNone)));
         expect(@(streamingLifecycleManager.showVideoBackgroundDisplay)).to(equal(@YES));
-        expect(@(streamingLifecycleManager.allowOverrideEncoderSettings)).to(equal(@YES));
         expect(streamingLifecycleManager.currentAppState).to(equal(SDLAppStateActive));
         expect(streamingLifecycleManager.currentVideoStreamState).to(equal(SDLVideoStreamManagerStateStopped));
         expect(streamingLifecycleManager.videoFormat).to(beNil());


### PR DESCRIPTION
Fixes #1392 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
I tested with our internal devboard.

### Summary
reflect bitrate value returned from HMI in video encoder settings, except the case that app specified custom bitrate in encoder settings.

### Changelog

##### Enhancements
* reflect bitrate value returned from HMI in video encoder settings, except the case that app specified custom bitrate in encoder settings.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
