### PR TITLE
Add HMICapabilities.appServices parameter

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "Quick/Nimble" "v8.0.1"
-github "Quick/Quick" "v2.0.0"
+github "Quick/Nimble" "v8.0.4"
+github "Quick/Quick" "v2.2.0"
 github "erikdoe/ocmock" "v3.4.3"
-github "uber/ios-snapshot-test-case" "6.0.3"
+github "uber/ios-snapshot-test-case" "6.1.0"

--- a/SmartDeviceLink/SDLHMICapabilities.h
+++ b/SmartDeviceLink/SDLHMICapabilities.h
@@ -49,6 +49,17 @@ NS_ASSUME_NONNULL_BEGIN
 **/
 @property (nullable, copy, nonatomic) NSNumber<SDLBool> *remoteControl;
 
+/**
+ Availability of app services. True: Available, False: Not Available
+
+ App services is supported since SDL 5.1. If your connection is 5.1+, you can assume that app services is available even though between v5.1 and v6.0 this parameter is `nil`.
+
+ Boolean value. Optional.
+
+ Since SDL 6.0
+**/
+@property (nullable, copy, nonatomic) NSNumber<SDLBool> *appServices;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLHMICapabilities.m
+++ b/SmartDeviceLink/SDLHMICapabilities.m
@@ -43,6 +43,14 @@ NS_ASSUME_NONNULL_BEGIN
     return [self.store sdl_objectForName:SDLRPCParameterNameRemoteControl ofClass:NSNumber.class error:nil];
 }
 
+- (void)setAppServices:(nullable NSNumber<SDLBool> *)appServices {
+    [self.store sdl_setObject:appServices forName:SDLRPCParameterNameAppServices];
+}
+
+- (nullable NSNumber<SDLBool> *)appServices {
+    return [self.store sdl_objectForName:SDLRPCParameterNameAppServices ofClass:NSNumber.class error:nil];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLHMICapabilitiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLHMICapabilitiesSpec.m
@@ -18,6 +18,8 @@ describe(@"SDLHMICapabilities struct", ^{
     __block NSNumber *someNavigationState = @YES;
     __block NSNumber *someVideoStreamState = @NO;
     __block NSNumber *someRemoteControlState = @YES;
+    __block NSNumber *someAppServicesState = @YES;
+         
     
     context(@"When initialized with properties", ^{
         beforeEach(^{
@@ -26,22 +28,15 @@ describe(@"SDLHMICapabilities struct", ^{
             testStruct.navigation = someNavigationState;
             testStruct.videoStreaming = someVideoStreamState;
             testStruct.remoteControl = someRemoteControlState;
+            testStruct.appServices = someAppServicesState;
         });
         
-        it(@"should properly set phone call", ^{
+        it(@"should properly set properties", ^{
             expect(testStruct.phoneCall).to(equal(somePhoneCallState));
-        });
-        
-        it(@"should properly set navigation", ^{
             expect(testStruct.navigation).to(equal(someNavigationState));
-        });
-
-        it(@"should properly set video streaming", ^{
             expect(testStruct.videoStreaming).to(equal(someVideoStreamState));
-        });
-
-        it(@"should properly set remote control", ^{
             expect(testStruct.remoteControl).to(equal(someRemoteControlState));
+            expect(testStruct.appServices).to(equal(someAppServicesState));
         });
     });
     
@@ -51,7 +46,8 @@ describe(@"SDLHMICapabilities struct", ^{
                                              SDLRPCParameterNameNavigation: someNavigationState,
                                              SDLRPCParameterNamePhoneCall: somePhoneCallState,
                                              SDLRPCParameterNameVideoStreaming: someVideoStreamState,
-                                             SDLRPCParameterNameRemoteControl: someRemoteControlState
+                                             SDLRPCParameterNameRemoteControl: someRemoteControlState,
+                                             SDLRPCParameterNameAppServices: someAppServicesState
                                              };
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -59,20 +55,12 @@ describe(@"SDLHMICapabilities struct", ^{
 #pragma clang diagnostic pop
         });
         
-        it(@"should properly set phone call", ^{
+        it(@"should properly set properties", ^{
             expect(testStruct.phoneCall).to(equal(somePhoneCallState));
-        });
-        
-        it(@"should properly set navigation", ^{
             expect(testStruct.navigation).to(equal(someNavigationState));
-        });
-
-        it(@"should properly set video streaming", ^{
             expect(testStruct.videoStreaming).to(equal(someVideoStreamState));
-        });
-
-        it(@"should properly set remote control", ^{
             expect(testStruct.remoteControl).to(equal(someRemoteControlState));
+            expect(testStruct.appServices).to(equal(someAppServicesState));
         });
     });
     
@@ -81,20 +69,12 @@ describe(@"SDLHMICapabilities struct", ^{
             testStruct = nil;
         });
         
-        it(@"phoneCall should be nil", ^{
+        it(@"properties should be nil", ^{
             expect(testStruct.phoneCall).to(beNil());
-        });
-        
-        it(@"navigation should be nil", ^{
             expect(testStruct.navigation).to(beNil());
-        });
-
-        it(@"video streaming should be nil", ^{
             expect(testStruct.videoStreaming).to(beNil());
-        });
-
-        it(@"remote control should be nil", ^{
             expect(testStruct.remoteControl).to(beNil());
+            expect(testStruct.appServices).to(beNil());
         });
     });
 });


### PR DESCRIPTION
Fixes #1389 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Unit tests and smoke tests

### Summary
Added an `HMICapabilities` parameter for checking if `appServices` is available.

### Changelog
##### Enhancements
* Add `HMICapabilities.appServices`

##### Bug Fixes
* Update tests to work on Xcode 11

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
