### PR TITLE
Update some RPC response params to be optional

### DIFF
--- a/SmartDeviceLink/SDLDiagnosticMessageResponse.h
+++ b/SmartDeviceLink/SDLDiagnosticMessageResponse.h
@@ -16,9 +16,9 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Array of bytes comprising CAN message result.
 
- Required
+ Optional
  */
-@property (strong, nonatomic) NSArray<NSNumber<SDLInt> *> *messageDataResult;
+@property (nullable, strong, nonatomic) NSArray<NSNumber<SDLInt> *> *messageDataResult;
 
 @end
 

--- a/SmartDeviceLink/SDLDiagnosticMessageResponse.m
+++ b/SmartDeviceLink/SDLDiagnosticMessageResponse.m
@@ -20,11 +20,11 @@ NS_ASSUME_NONNULL_BEGIN
 }
 #pragma clang diagnostic pop
 
-- (void)setMessageDataResult:(NSArray<NSNumber<SDLInt> *> *)messageDataResult {
+- (void)setMessageDataResult:(nullable NSArray<NSNumber<SDLInt> *> *)messageDataResult {
     [self.parameters sdl_setObject:messageDataResult forName:SDLRPCParameterNameMessageDataResult];
 }
 
-- (NSArray<NSNumber<SDLInt> *> *)messageDataResult {
+- (nullable NSArray<NSNumber<SDLInt> *> *)messageDataResult {
     NSError *error = nil;
     return [self.parameters sdl_objectsForName:SDLRPCParameterNameMessageDataResult ofClass:NSNumber.class error:&error];
 }

--- a/SmartDeviceLink/SDLGetDTCsResponse.h
+++ b/SmartDeviceLink/SDLGetDTCsResponse.h
@@ -16,8 +16,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  2 byte ECU Header for DTC response (as defined in VHR_Layout_Specification_DTCs.pdf)
+
+ Optional
  */
-@property (strong, nonatomic) NSNumber<SDLInt> *ecuHeader;
+@property (nullable, strong, nonatomic) NSNumber<SDLInt> *ecuHeader;
 
 /**
  Array of all reported DTCs on module (ecuHeader contains information if list is truncated). Each DTC is represented by 4 bytes (3 bytes of data and 1 byte status as defined in VHR_Layout_Specification_DTCs.pdf).

--- a/SmartDeviceLink/SDLGetDTCsResponse.m
+++ b/SmartDeviceLink/SDLGetDTCsResponse.m
@@ -21,11 +21,11 @@ NS_ASSUME_NONNULL_BEGIN
 }
 #pragma clang diagnostic pop
 
-- (void)setEcuHeader:(NSNumber<SDLInt> *)ecuHeader {
+- (void)setEcuHeader:(nullable NSNumber<SDLInt> *)ecuHeader {
     [self.parameters sdl_setObject:ecuHeader forName:SDLRPCParameterNameECUHeader];
 }
 
-- (NSNumber<SDLInt> *)ecuHeader {
+- (nullable NSNumber<SDLInt> *)ecuHeader {
     NSError *error = nil;
     return [self.parameters sdl_objectForName:SDLRPCParameterNameECUHeader ofClass:NSNumber.class error:&error];
 }

--- a/SmartDeviceLink/SDLGetInteriorVehicleDataResponse.h
+++ b/SmartDeviceLink/SDLGetInteriorVehicleDataResponse.h
@@ -14,8 +14,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  The requested data
+
+ Optional
  */
-@property (strong, nonatomic) SDLModuleData *moduleData;
+@property (nullable, strong, nonatomic) SDLModuleData *moduleData;
 
 /**
  It is a conditional-mandatory parameter: must be returned in case "subscribe" parameter was present in the related request.

--- a/SmartDeviceLink/SDLGetInteriorVehicleDataResponse.m
+++ b/SmartDeviceLink/SDLGetInteriorVehicleDataResponse.m
@@ -22,11 +22,11 @@ NS_ASSUME_NONNULL_BEGIN
 }
 #pragma clang diagnostic pop
 
-- (void)setModuleData:(SDLModuleData *)moduleData {
+- (void)setModuleData:(nullable SDLModuleData *)moduleData {
     [self.parameters sdl_setObject:moduleData forName:SDLRPCParameterNameModuleData];
 }
 
-- (SDLModuleData *)moduleData {
+- (nullable SDLModuleData *)moduleData {
     NSError *error = nil;
     return [self.parameters sdl_objectForName:SDLRPCParameterNameModuleData ofClass:SDLModuleData.class error:&error];
 }

--- a/SmartDeviceLink/SDLGetSystemCapabilityResponse.h
+++ b/SmartDeviceLink/SDLGetSystemCapabilityResponse.h
@@ -22,8 +22,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  The requested system capability, of the type that was sent in the request
+
+ Optional
  */
-@property (strong, nonatomic) SDLSystemCapability *systemCapability;
+@property (nullable, strong, nonatomic) SDLSystemCapability *systemCapability;
 
 @end
 

--- a/SmartDeviceLink/SDLGetSystemCapabilityResponse.m
+++ b/SmartDeviceLink/SDLGetSystemCapabilityResponse.m
@@ -30,11 +30,11 @@ NS_ASSUME_NONNULL_BEGIN
 }
 #pragma clang diagnostic pop
 
-- (void)setSystemCapability:(SDLSystemCapability *)systemCapability {
+- (void)setSystemCapability:(nullable SDLSystemCapability *)systemCapability {
     [self.parameters sdl_setObject:systemCapability forName:SDLRPCParameterNameSystemCapability];
 }
 
-- (SDLSystemCapability *)systemCapability {
+- (nullable SDLSystemCapability *)systemCapability {
     NSError *error = nil;
     return [self.parameters sdl_objectForName:SDLRPCParameterNameSystemCapability ofClass:SDLSystemCapability.class error:&error];
 }

--- a/SmartDeviceLink/SDLSetInteriorVehicleDataResponse.h
+++ b/SmartDeviceLink/SDLSetInteriorVehicleDataResponse.h
@@ -14,8 +14,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  The new module data for the requested module
+
+ Optional
  */
-@property (strong, nonatomic) SDLModuleData *moduleData;
+@property (nullable, strong, nonatomic) SDLModuleData *moduleData;
 
 @end
 

--- a/SmartDeviceLink/SDLSetInteriorVehicleDataResponse.m
+++ b/SmartDeviceLink/SDLSetInteriorVehicleDataResponse.m
@@ -21,11 +21,11 @@ NS_ASSUME_NONNULL_BEGIN
 }
 #pragma clang diagnostic pop
 
-- (void)setModuleData:(SDLModuleData *)moduleData {
+- (void)setModuleData:(nullable SDLModuleData *)moduleData {
     [self.parameters sdl_setObject:moduleData forName:SDLRPCParameterNameModuleData];
 }
 
-- (SDLModuleData *)moduleData {
+- (nullable SDLModuleData *)moduleData {
     NSError *error = nil;
     return [self.parameters sdl_objectForName:SDLRPCParameterNameModuleData ofClass:SDLModuleData.class error:&error];
 }


### PR DESCRIPTION
Fixes #1417 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Make RPC request and check the response

### Summary
Made the folllwing params optional

ecuHeader in RPC GetDTCs
messageDataResult in RPC DiagnosticMessage
moduleData in RPC GetInteriorVehicleData
moduleData in RPC SetInteriorVehicleData
systemCapability in RPC GetSystemCapability

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
