### PR TITLE
Add a check before popping the mutable data queue buffer

### DIFF
--- a/SmartDeviceLink/SDLMutableDataQueue.m
+++ b/SmartDeviceLink/SDLMutableDataQueue.m
@@ -42,9 +42,9 @@ NS_ASSUME_NONNULL_BEGIN
     NSMutableData *dataAtFront = nil;
 
     @synchronized(self) {
-        if (self.elements.count) {
+        if (self.elements.count > 0) {
             // The front of the queue is always at index 0
-            dataAtFront = self.elements[0];
+            dataAtFront = self.elements.firstObject;
             self.frontDequeued = YES;
         }
     }
@@ -54,6 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)popBuffer {
     @synchronized(self) {
+        if (self.elements.count <= 0) { return; }
         [self.elements removeObjectAtIndex:0];
     }
 }


### PR DESCRIPTION
Fixes #1433 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Unit tests were run

### Summary
Added a check to the `SDLMutableDataQueue` buffer to prevent crashes when attempting to pop the buffer.

### Changelog
##### Bug Fixes
* Fixed a possible crash when popping some data off the buffer internally.

### Tasks Remaining:
- [ ] [Task 1]
- [ ] [Task 2]

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
