### PR TITLE
Update vehicle data RPCs' generic data getters to return nullable

### DIFF
--- a/SmartDeviceLink/SDLGetVehicleData.h
+++ b/SmartDeviceLink/SDLGetVehicleData.h
@@ -280,7 +280,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   Added in SmartDeviceLink 6.0
  */
-- (void)setOEMCustomVehicleData:(NSString *)vehicleDataName withVehicleDataState:(BOOL)vehicleDataState;
+- (void)setOEMCustomVehicleData:(NSString *)vehicleDataName withVehicleDataState:(BOOL)vehicleDataState NS_SWIFT_NAME(setOEMCustomVehicleData(name:state:));
 
 /**
  Gets the OEM custom vehicle data value for any given OEM custom vehicle data name.

--- a/SmartDeviceLink/SDLGetVehicleData.h
+++ b/SmartDeviceLink/SDLGetVehicleData.h
@@ -290,7 +290,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   Added in SmartDeviceLink 6.0
  */
-- (NSNumber<SDLBool> *)getOEMCustomVehicleData:(NSString *)vehicleDataName;
+- (nullable NSNumber<SDLBool> *)getOEMCustomVehicleData:(NSString *)vehicleDataName;
 
 @end
 

--- a/SmartDeviceLink/SDLGetVehicleData.m
+++ b/SmartDeviceLink/SDLGetVehicleData.m
@@ -313,7 +313,7 @@ NS_ASSUME_NONNULL_BEGIN
     [self.parameters sdl_setObject:@(vehicleDataState) forName:vehicleDataName];
 }
 
-- (NSNumber<SDLBool> *)getOEMCustomVehicleData:(NSString *)vehicleDataName {
+- (nullable NSNumber<SDLBool> *)getOEMCustomVehicleData:(NSString *)vehicleDataName {
     return [self.parameters sdl_objectForName:vehicleDataName ofClass:NSNumber.class error:nil];
 }
 

--- a/SmartDeviceLink/SDLGetVehicleDataResponse.h
+++ b/SmartDeviceLink/SDLGetVehicleDataResponse.h
@@ -194,7 +194,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   Added in SmartDeviceLink 6.0
  */
-- (void)setOEMCustomVehicleData:(NSString *)vehicleDataName withVehicleDataState:(NSObject *)vehicleDataState;
+- (void)setOEMCustomVehicleData:(NSString *)vehicleDataName withVehicleDataState:(NSObject *)vehicleDataState NS_SWIFT_NAME(setOEMCustomVehicleData(name:state:));
 
 /**
  Gets the OEM custom vehicle data item for any given OEM custom vehicle data name.

--- a/SmartDeviceLink/SDLGetVehicleDataResponse.h
+++ b/SmartDeviceLink/SDLGetVehicleDataResponse.h
@@ -204,7 +204,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   Added in SmartDeviceLink 6.0
  */
-- (NSObject *)getOEMCustomVehicleData:(NSString *)vehicleDataName;
+- (nullable NSObject *)getOEMCustomVehicleData:(NSString *)vehicleDataName;
 
 @end
 

--- a/SmartDeviceLink/SDLGetVehicleDataResponse.m
+++ b/SmartDeviceLink/SDLGetVehicleDataResponse.m
@@ -277,7 +277,7 @@ NS_ASSUME_NONNULL_BEGIN
     [self.parameters sdl_setObject:vehicleDataState forName:vehicleDataName];
 }
 
-- (NSObject *)getOEMCustomVehicleData:(NSString *)vehicleDataName {
+- (nullable NSObject *)getOEMCustomVehicleData:(NSString *)vehicleDataName {
     return [self.parameters sdl_objectForName:vehicleDataName ofClass:NSObject.class error:nil];
 }
 

--- a/SmartDeviceLink/SDLOnVehicleData.h
+++ b/SmartDeviceLink/SDLOnVehicleData.h
@@ -194,7 +194,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   Added in SmartDeviceLink 6.0
  */
-- (void)setOEMCustomVehicleData:(NSString *)vehicleDataName withVehicleDataState:(NSObject *)vehicleDataState;
+- (void)setOEMCustomVehicleData:(NSString *)vehicleDataName withVehicleDataState:(NSObject *)vehicleDataState NS_SWIFT_NAME(setOEMCustomVehicleData(name:state:));
 
 /**
  Gets the OEM custom vehicle data item for any given OEM custom vehicle data name.

--- a/SmartDeviceLink/SDLOnVehicleData.h
+++ b/SmartDeviceLink/SDLOnVehicleData.h
@@ -204,7 +204,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   Added in SmartDeviceLink 6.0
  */
-- (NSObject *)getOEMCustomVehicleData:(NSString *)vehicleDataName;
+- (nullable NSObject *)getOEMCustomVehicleData:(NSString *)vehicleDataName;
 
 @end
 

--- a/SmartDeviceLink/SDLOnVehicleData.m
+++ b/SmartDeviceLink/SDLOnVehicleData.m
@@ -276,7 +276,7 @@ NS_ASSUME_NONNULL_BEGIN
     [self.parameters sdl_setObject:vehicleDataState forName:vehicleDataName];
 }
 
-- (NSObject *)getOEMCustomVehicleData:(NSString *)vehicleDataName {
+- (nullable NSObject *)getOEMCustomVehicleData:(NSString *)vehicleDataName {
     return [self.parameters sdl_objectForName:vehicleDataName ofClass:NSObject.class error:nil];
 }
 

--- a/SmartDeviceLink/SDLSubscribeVehicleData.h
+++ b/SmartDeviceLink/SDLSubscribeVehicleData.h
@@ -274,7 +274,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   Added in SmartDeviceLink 6.0
  */
-- (void)setOEMCustomVehicleData:(NSString *)vehicleDataName withVehicleDataState:(BOOL)vehicleDataState;
+- (void)setOEMCustomVehicleData:(NSString *)vehicleDataName withVehicleDataState:(BOOL)vehicleDataState NS_SWIFT_NAME(setOEMCustomVehicleData(name:state:));
 
 /**
  Gets the OEM custom vehicle data value for any given OEM custom vehicle data name.

--- a/SmartDeviceLink/SDLSubscribeVehicleData.h
+++ b/SmartDeviceLink/SDLSubscribeVehicleData.h
@@ -284,7 +284,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   Added in SmartDeviceLink 6.0
  */
-- (NSNumber<SDLBool> *)getOEMCustomVehicleData:(NSString *)vehicleDataName;
+- (nullable NSNumber<SDLBool> *)getOEMCustomVehicleData:(NSString *)vehicleDataName;
 
 
 

--- a/SmartDeviceLink/SDLSubscribeVehicleData.m
+++ b/SmartDeviceLink/SDLSubscribeVehicleData.m
@@ -304,7 +304,7 @@ NS_ASSUME_NONNULL_BEGIN
     [self.parameters sdl_setObject:@(vehicleDataState) forName:vehicleDataName];
 }
 
-- (NSNumber<SDLBool> *)getOEMCustomVehicleData:(NSString *)vehicleDataName {
+- (nullable NSNumber<SDLBool> *)getOEMCustomVehicleData:(NSString *)vehicleDataName {
     return [self.parameters sdl_objectForName:vehicleDataName ofClass:NSNumber.class error:nil];
 }
 

--- a/SmartDeviceLink/SDLSubscribeVehicleDataResponse.h
+++ b/SmartDeviceLink/SDLSubscribeVehicleDataResponse.h
@@ -227,7 +227,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   Added SmartDeviceLink 6.0
  */
-- (void)setOEMCustomVehicleData:(NSString *)vehicleDataName withVehicleDataState:(SDLVehicleDataResult *)vehicleDataState;
+- (void)setOEMCustomVehicleData:(NSString *)vehicleDataName withVehicleDataState:(SDLVehicleDataResult *)vehicleDataState NS_SWIFT_NAME(setOEMCustomVehicleData(name:state:));
 
 /**
  Gets the OEM custom vehicle data state for any given OEM custom vehicle data name.

--- a/SmartDeviceLink/SDLSubscribeVehicleDataResponse.h
+++ b/SmartDeviceLink/SDLSubscribeVehicleDataResponse.h
@@ -237,7 +237,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   Added SmartDeviceLink 6.0
  */
-- (SDLVehicleDataResult *)getOEMCustomVehicleData:(NSString *)vehicleDataName;
+- (nullable SDLVehicleDataResult *)getOEMCustomVehicleData:(NSString *)vehicleDataName;
 
 @end
 

--- a/SmartDeviceLink/SDLSubscribeVehicleDataResponse.m
+++ b/SmartDeviceLink/SDLSubscribeVehicleDataResponse.m
@@ -258,7 +258,7 @@ NS_ASSUME_NONNULL_BEGIN
     [self.parameters sdl_setObject:vehicleDataState forName:vehicleDataName];
 }
 
-- (SDLVehicleDataResult *)getOEMCustomVehicleData:(NSString *)vehicleDataName {
+- (nullable SDLVehicleDataResult *)getOEMCustomVehicleData:(NSString *)vehicleDataName {
     return [self.parameters sdl_objectForName:vehicleDataName ofClass:SDLVehicleDataResult.class error:nil];
 }
 

--- a/SmartDeviceLink/SDLUnsubscribeVehicleData.h
+++ b/SmartDeviceLink/SDLUnsubscribeVehicleData.h
@@ -286,7 +286,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   Added SmartDeviceLink 6.0
  */
-- (NSNumber<SDLBool> *)getOEMCustomVehicleData:(NSString *)vehicleDataName;
+- (nullable NSNumber<SDLBool> *)getOEMCustomVehicleData:(NSString *)vehicleDataName;
 
 @end
 

--- a/SmartDeviceLink/SDLUnsubscribeVehicleData.h
+++ b/SmartDeviceLink/SDLUnsubscribeVehicleData.h
@@ -276,7 +276,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   Added SmartDeviceLink 6.0
  */
-- (void)setOEMCustomVehicleData:(NSString *)vehicleDataName withVehicleDataState:(BOOL)vehicleDataState;
+- (void)setOEMCustomVehicleData:(NSString *)vehicleDataName withVehicleDataState:(BOOL)vehicleDataState NS_SWIFT_NAME(setOEMCustomVehicleData(name:state:));
 
 /**
  Gets the OEM custom vehicle data state for any given OEM custom vehicle data name.

--- a/SmartDeviceLink/SDLUnsubscribeVehicleData.m
+++ b/SmartDeviceLink/SDLUnsubscribeVehicleData.m
@@ -304,7 +304,7 @@ NS_ASSUME_NONNULL_BEGIN
     [self.parameters sdl_setObject:@(vehicleDataState) forName:vehicleDataName];
 }
 
-- (NSNumber<SDLBool> *)getOEMCustomVehicleData:(NSString *)vehicleDataName {
+- (nullable NSNumber<SDLBool> *)getOEMCustomVehicleData:(NSString *)vehicleDataName {
     return [self.parameters sdl_objectForName:vehicleDataName ofClass:NSNumber.class error:nil];
 }
 

--- a/SmartDeviceLink/SDLUnsubscribeVehicleDataResponse.h
+++ b/SmartDeviceLink/SDLUnsubscribeVehicleDataResponse.h
@@ -236,7 +236,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  Added SmartDeviceLink 6.0
  */
-- (SDLVehicleDataResult *)getOEMCustomVehicleData:(NSString *)vehicleDataName;
+- (nullable SDLVehicleDataResult *)getOEMCustomVehicleData:(NSString *)vehicleDataName;
 
 @end
 

--- a/SmartDeviceLink/SDLUnsubscribeVehicleDataResponse.h
+++ b/SmartDeviceLink/SDLUnsubscribeVehicleDataResponse.h
@@ -226,7 +226,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  Added SmartDeviceLink 6.0
  */
-- (void)setOEMCustomVehicleData:(NSString *)vehicleDataName withVehicleDataState:(SDLVehicleDataResult *)vehicleDataState;
+- (void)setOEMCustomVehicleData:(NSString *)vehicleDataName withVehicleDataState:(SDLVehicleDataResult *)vehicleDataState NS_SWIFT_NAME(setOEMCustomVehicleData(name:state:));
 
 /**
  Gets the OEM custom vehicle data state for any given OEM custom vehicle data name.

--- a/SmartDeviceLink/SDLUnsubscribeVehicleDataResponse.m
+++ b/SmartDeviceLink/SDLUnsubscribeVehicleDataResponse.m
@@ -258,7 +258,7 @@ NS_ASSUME_NONNULL_BEGIN
     [self.parameters sdl_setObject:vehicleDataState forName:vehicleDataName];
 }
 
-- (SDLVehicleDataResult *)getOEMCustomVehicleData:(NSString *)vehicleDataName {
+- (nullable SDLVehicleDataResult *)getOEMCustomVehicleData:(NSString *)vehicleDataName {
     return [self.parameters sdl_objectForName:vehicleDataName ofClass:SDLVehicleDataResult.class error:nil];
 }
 

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLMenuManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLMenuManagerSpec.m
@@ -153,7 +153,7 @@ describe(@"menu manager", ^{
                 testManager.currentSystemContext = SDLSystemContextMenu;
             });
 
-            fit(@"should update the menu configuration", ^{
+            it(@"should update the menu configuration", ^{
                 testManager.menuConfiguration = testMenuConfiguration;
                 expect(mockConnectionManager.receivedRequests).toNot(beEmpty());
                 expect(testManager.menuConfiguration).to(equal(testMenuConfiguration));


### PR DESCRIPTION
Fixes #1442 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes (API changes are internal to this release).

### Testing Plan
Unit tests performed

### Summary
This PR updates Generic Network Signal Data getters to return `nullable`. Also updates the swift names of the setters.

### Changelog
##### Bug Fixes
* Getting generic vehicle data that has not been set will no longer return `nil` unexpectedly.
* Update the swift names of the generic vehicle data setters.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
