### PR TITLE
Fix some RemoteControlCapabilities parameters having the wrong type

### DIFF
--- a/SmartDeviceLink/SDLRemoteControlCapabilities.m
+++ b/SmartDeviceLink/SDLRemoteControlCapabilities.m
@@ -80,19 +80,41 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setHmiSettingsControlCapabilities:(nullable NSArray<SDLHMISettingsControlCapabilities *> *)hmiSettingsControlCapabilities {
-    [self.store sdl_setObject:hmiSettingsControlCapabilities forName:SDLRPCParameterNameHmiSettingsControlCapabilities];
+    // TODO: This parameter should not be an array according to the spec, in a future major version change, this parameter's type should be altered
+    if (hmiSettingsControlCapabilities.count == 0) {
+        [self.store sdl_setObject:nil forName:SDLRPCParameterNameHmiSettingsControlCapabilities];
+        return;
+    }
+
+    SDLHMISettingsControlCapabilities *capability = hmiSettingsControlCapabilities.firstObject;
+
+    [self.store sdl_setObject:capability forName:SDLRPCParameterNameHmiSettingsControlCapabilities];
 }
 
 - (nullable NSArray<SDLHMISettingsControlCapabilities *> *)hmiSettingsControlCapabilities {
-    return [self.store sdl_objectsForName:SDLRPCParameterNameHmiSettingsControlCapabilities ofClass:SDLHMISettingsControlCapabilities.class error:nil];
+    SDLHMISettingsControlCapabilities *capability = [self.store sdl_objectForName:SDLRPCParameterNameHmiSettingsControlCapabilities ofClass:SDLHMISettingsControlCapabilities.class error:nil];
+    if (capability == nil) { return nil; }
+
+    return @[capability];
 }
 
 - (void)setLightControlCapabilities:(nullable NSArray<SDLLightControlCapabilities *> *)lightControlCapabilities {
-    [self.store sdl_setObject:lightControlCapabilities forName:SDLRPCParameterNameLightControlCapabilities];
+    // TODO: This parameter should not be an array according to the spec, in a future major version change, this parameter's type should be altered
+    if (lightControlCapabilities.count == 0) {
+        [self.store sdl_setObject:nil forName:SDLRPCParameterNameLightControlCapabilities];
+        return;
+    }
+
+    SDLLightControlCapabilities *capability = lightControlCapabilities.firstObject;
+
+    [self.store sdl_setObject:capability forName:SDLRPCParameterNameLightControlCapabilities];
 }
 
 - (nullable NSArray<SDLLightControlCapabilities *> *)lightControlCapabilities {
-    return [self.store sdl_objectsForName:SDLRPCParameterNameLightControlCapabilities ofClass:SDLLightControlCapabilities.class error:nil];
+    SDLLightControlCapabilities *capability = [self.store sdl_objectForName:SDLRPCParameterNameLightControlCapabilities ofClass:SDLLightControlCapabilities.class error:nil];
+    if (capability == nil) { return nil; }
+
+    return @[capability];
 }
 
 @end


### PR DESCRIPTION
Fixes #1441 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Unit tests performed

### Summary
This PR alters the internals of getting and setting two `RemoteControlCapabilities` parameters so that what is typed in the sdl_ios library will work with the RPC spec even though they diverge.

### Changelog
##### Bug Fixes
* Fix `SDLRemoteControlCapabilities.lightControlCapabilities` and `SDLRemoteControlCapabilities.hmiSettingsControlCapabilities` to not crash when getting the parameter from Core, and to properly send the value to Core.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
