### PR TITLE
Don't create the encryption lifecycle manager if it won't be used

### DIFF
--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -154,7 +154,7 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
         SDLLogV(@"Skipping StreamingMediaManager setup due to app type");
     }
     
-    if (configuration.encryptionConfig != nil) {
+    if (configuration.encryptionConfig.securityManagers != nil) {
         _encryptionLifecycleManager = [[SDLEncryptionLifecycleManager alloc] initWithConnectionManager:self configuration:_configuration.encryptionConfig];
     }
 

--- a/SmartDeviceLink/SDLTextAndGraphicManager.m
+++ b/SmartDeviceLink/SDLTextAndGraphicManager.m
@@ -700,7 +700,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)sdl_displayCapabilityDidUpdate:(SDLSystemCapability *)systemCapability {
     // we won't use the object in the parameter but the convenience method of the system capability manager
-    NSLog(@"PING");
     self.windowCapability = self.systemCapabilityManager.defaultMainWindowCapability;
     
     // Auto-send an updated show


### PR DESCRIPTION
Fixes #1446 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Unit tests were run and smoke tests were performed

### Summary
This PR fixes creating the `encryptionLifecycleManager` _only_ when security managers will be used.

Bugfixes are internal to this release.

### Changelog
##### Bug Fixes
* Fixes creating the `encryptionLifecycleManager` _only_ when security managers will be used.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
