### PR TITLE
The displays property is now reset when system capability manager is stopped

### DIFF
--- a/SmartDeviceLink/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.m
@@ -117,6 +117,7 @@ typedef NSString * SDLServiceID;
 - (void)stop {
     SDLLogD(@"System Capability manager stopped");
     _displayCapabilities = nil;
+    _displays = nil;
     _hmiCapabilities = nil;
     _softButtonCapabilities = nil;
     _buttonCapabilities = nil;

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLMenuManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLMenuManagerSpec.m
@@ -153,7 +153,7 @@ describe(@"menu manager", ^{
                 testManager.currentSystemContext = SDLSystemContextMenu;
             });
 
-            fit(@"should update the menu configuration", ^{
+            it(@"should update the menu configuration", ^{
                 testManager.menuConfiguration = testMenuConfiguration;
                 expect(mockConnectionManager.receivedRequests).toNot(beEmpty());
                 expect(testManager.menuConfiguration).to(equal(testMenuConfiguration));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLRemoteControlCapabilitiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLRemoteControlCapabilitiesSpec.m
@@ -24,12 +24,8 @@ __block SDLClimateControlCapabilities* someClimateControlCapabilities = [[SDLCli
 __block SDLRadioControlCapabilities* someRadioControlCapabilities = [[SDLRadioControlCapabilities alloc] init];
 __block SDLButtonCapabilities* someButtonControlCapabilities = [[SDLButtonCapabilities alloc] init];
 __block SDLSeatControlCapabilities* someSeatControlCapabilities = [[SDLSeatControlCapabilities alloc] init];
-
-
 __block SDLAudioControlCapabilities* someAudioControlCapabilities = [[SDLAudioControlCapabilities alloc] init];
-
 __block SDLLightControlCapabilities* someLightControlCapabilities = [[SDLLightControlCapabilities alloc] init];
-
 __block SDLHMISettingsControlCapabilities* someHMISettingsControlCapabilities = [[SDLHMISettingsControlCapabilities alloc] init];
 
 
@@ -48,15 +44,14 @@ describe(@"Initialization tests", ^{
     });
     
     it(@"should properly initialize initWithDictionary", ^{
-        
-        NSMutableDictionary* dict = [@{SDLRPCParameterNameClimateControlCapabilities : [@[someClimateControlCapabilities] copy],
-                                       SDLRPCParameterNameRadioControlCapabilities :[@[someRadioControlCapabilities] copy],
-                                       SDLRPCParameterNameButtonCapabilities :[@[someButtonControlCapabilities] copy],
-                                       SDLRPCParameterNameSeatControlCapabilities:[@[someSeatControlCapabilities]copy],
-                                       SDLRPCParameterNameAudioControlCapabilities :[@[someAudioControlCapabilities] copy],
-                                       SDLRPCParameterNameLightControlCapabilities :[@[someLightControlCapabilities] copy],
-                                       SDLRPCParameterNameHmiSettingsControlCapabilities : [@[someHMISettingsControlCapabilities] copy]
-                                       } mutableCopy];
+        NSDictionary *dict = @{SDLRPCParameterNameClimateControlCapabilities:@[someClimateControlCapabilities],
+                                       SDLRPCParameterNameRadioControlCapabilities:@[someRadioControlCapabilities],
+                                       SDLRPCParameterNameButtonCapabilities:@[someButtonControlCapabilities],
+                                       SDLRPCParameterNameSeatControlCapabilities:@[someSeatControlCapabilities],
+                                       SDLRPCParameterNameAudioControlCapabilities:@[someAudioControlCapabilities],
+                                       SDLRPCParameterNameLightControlCapabilities:someLightControlCapabilities,
+                                       SDLRPCParameterNameHmiSettingsControlCapabilities: someHMISettingsControlCapabilities
+                                       };
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLRemoteControlCapabilities* testStruct = [[SDLRemoteControlCapabilities alloc] initWithDictionary:dict];

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLRemoteControlCapabilitiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLRemoteControlCapabilitiesSpec.m
@@ -50,7 +50,7 @@ describe(@"Initialization tests", ^{
                                        SDLRPCParameterNameSeatControlCapabilities:@[someSeatControlCapabilities],
                                        SDLRPCParameterNameAudioControlCapabilities:@[someAudioControlCapabilities],
                                        SDLRPCParameterNameLightControlCapabilities:someLightControlCapabilities,
-                                       SDLRPCParameterNameHmiSettingsControlCapabilities: someHMISettingsControlCapabilities
+                                       SDLRPCParameterNameHmiSettingsControlCapabilities:someHMISettingsControlCapabilities
                                        };
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"


### PR DESCRIPTION
Fixes #1445 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Smoke tested

### Summary
The `displays` property is now reset to `nil` when system capability manager is stopped.

### Changelog
##### Bug Fixes
* The `displays` property is now reset to `nil` when system capability manager is stopped due to the app disconnecting from the head unit.
* Fixed failing test case in SDLRemoteControlCapabilitiesSpec.m 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
