### PR TITLE
Only sessions with same connectionID as the disconnected accessory should be closed

### DIFF
--- a/SmartDeviceLink/SDLIAPTransport.m
+++ b/SmartDeviceLink/SDLIAPTransport.m
@@ -140,10 +140,18 @@ int const CreateSessionRetries = 3;
         SDLLogV(@"Accessory (%@, %@), disconnected, but no session is in progress.", accessory.name, accessory.serialNumber);
         [self sdl_closeSessions];
     } else if (self.dataSession.isSessionInProgress) {
+        if (self.dataSession.connectionID != accessory.connectionID) {
+            SDLLogD(@"Accessory's connectionID, %lu, does not match the connectionID of the current data session, %lu. Another phone disconnected from the head unit. The session will not be closed.", accessory.connectionID, self.dataSession.connectionID);
+            return;
+        }
         // The data session has been established. Tell the delegate that the transport has disconnected. The lifecycle manager will destroy and create a new transport object.
         SDLLogV(@"Accessory (%@, %@) disconnected during a data session", accessory.name, accessory.serialNumber);
         [self sdl_destroyTransport];
     } else if (self.controlSession.isSessionInProgress) {
+        if (self.controlSession.connectionID != accessory.connectionID) {
+            SDLLogD(@"Accessory's connectionID, %lu, does not match the connectionID of the current control session, %lu. Another phone disconnected from the head unit. The session will not be closed.", accessory.connectionID, self.controlSession.connectionID);
+            return;
+        }
         // The data session has yet to be established so the transport has not yet connected. DO NOT unregister for notifications from the accessory.
         SDLLogV(@"Accessory (%@, %@) disconnected during a control session", accessory.name, accessory.serialNumber);
         [self sdl_closeSessions];


### PR DESCRIPTION
Fixes #1431 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Smoke tests

### Summary
Only sessions with same connectionID as the disconnected accessory are now closed. Otherwise if two phones are connected to the same head unit then the sessions will be closed for all apps on **both** phones when one phone disconnects.

### Changelog
##### Bug Fixes
* Only sessions with same connectionID as the disconnected accessory are now closed.

### Tasks Remaining:
- [x] Test with two phones using USB
- [x] Test with two phones using BT
- [x] Test with one phone using USB and one using BT
- [x] Test with one phone using with an app using a control session and one phone with an app using a data session.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
