### PR TITLE
Keep File Manager from Error State on disallowed

### DIFF
--- a/SmartDeviceLink/SDLFileManager.m
+++ b/SmartDeviceLink/SDLFileManager.m
@@ -179,9 +179,9 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
             BLOCK_RETURN;
         }
 
-        // If there was an error, we'll pass the error to the startup handler and cancel out other then in case of DISALLOWED
+        // If there was an error, we'll pass the error to the startup handler and cancel out
         if (error != nil) {
-            // In the case we are DISALLOWED we still want to transition to a ready state
+            // HAX: In the case we are DISALLOWED we still want to transition to a ready state. Some head units return DISALLOWED for this RPC but otherwise work.
             if([error.userInfo[@"resultCode"] isEqualToEnum:SDLResultDisallowed]) {
                 SDLLogW(@"ListFiles is disallowed. Certain file manager APIs may not work properly.");
                 [weakSelf.stateMachine transitionToState:SDLFileManagerStateReady];

--- a/SmartDeviceLink/SDLFileManager.m
+++ b/SmartDeviceLink/SDLFileManager.m
@@ -208,7 +208,6 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
 
 - (void)sdl_listRemoteFilesWithCompletionHandler:(SDLFileManagerListFilesCompletionHandler)handler {
     __weak typeof(self) weakSelf = self;
-
     SDLListFilesOperation *listOperation = [[SDLListFilesOperation alloc] initWithConnectionManager:self.connectionManager completionHandler:^(BOOL success, NSUInteger bytesAvailable, NSArray<NSString *> *_Nonnull fileNames, NSError *_Nullable error) {
         if (error != nil || !success) {
             handler(success, bytesAvailable, fileNames, error);

--- a/SmartDeviceLink/SDLFileManager.m
+++ b/SmartDeviceLink/SDLFileManager.m
@@ -183,6 +183,7 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
         if (error != nil) {
             // In the case we are DISALLOWED we still want to transition to a ready state
             if([error.userInfo[@"resultCode"] isEqualToEnum:SDLResultDisallowed]) {
+                SDLLogW(@"ListFiles is disallowed. Certain file RPC may not work properly.");
                 [weakSelf.stateMachine transitionToState:SDLFileManagerStateReady];
                 BLOCK_RETURN;
             }

--- a/SmartDeviceLink/SDLFileManager.m
+++ b/SmartDeviceLink/SDLFileManager.m
@@ -210,10 +210,6 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
 
     SDLListFilesOperation *listOperation = [[SDLListFilesOperation alloc] initWithConnectionManager:self.connectionManager completionHandler:^(BOOL success, NSUInteger bytesAvailable, NSArray<NSString *> *_Nonnull fileNames, NSError *_Nullable error) {
         if (error != nil || !success) {
-            if([error.userInfo[@"resultCode"] isEqualToEnum:SDLResultDisallowed]) {
-                [weakSelf.mutableRemoteFileNames addObjectsFromArray:fileNames];
-                weakSelf.bytesAvailable = bytesAvailable;
-            }
             handler(success, bytesAvailable, fileNames, error);
             BLOCK_RETURN;
         }

--- a/SmartDeviceLink/SDLFileManager.m
+++ b/SmartDeviceLink/SDLFileManager.m
@@ -183,7 +183,7 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
         if (error != nil) {
             // In the case we are DISALLOWED we still want to transition to a ready state
             if([error.userInfo[@"resultCode"] isEqualToEnum:SDLResultDisallowed]) {
-                SDLLogW(@"ListFiles is disallowed. Certain file RPC may not work properly.");
+                SDLLogW(@"ListFiles is disallowed. Certain file manager APIs may not work properly.");
                 [weakSelf.stateMachine transitionToState:SDLFileManagerStateReady];
                 BLOCK_RETURN;
             }

--- a/SmartDeviceLink/SDLFileManager.m
+++ b/SmartDeviceLink/SDLFileManager.m
@@ -182,7 +182,7 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
         // If there was an error, we'll pass the error to the startup handler and cancel out other then in case of DISALLOWED
         if (error != nil) {
             // In the case we are DISALLOWED we still want to transition to a ready state
-            if([error.localizedDescription isEqualToString:@"DISALLOWED"]) {
+            if([error.userInfo[@"resultCode"] isEqualToEnum:SDLResultDisallowed]) {
                 [weakSelf.stateMachine transitionToState:SDLFileManagerStateReady];
                 BLOCK_RETURN;
             }
@@ -207,9 +207,10 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
 
 - (void)sdl_listRemoteFilesWithCompletionHandler:(SDLFileManagerListFilesCompletionHandler)handler {
     __weak typeof(self) weakSelf = self;
+
     SDLListFilesOperation *listOperation = [[SDLListFilesOperation alloc] initWithConnectionManager:self.connectionManager completionHandler:^(BOOL success, NSUInteger bytesAvailable, NSArray<NSString *> *_Nonnull fileNames, NSError *_Nullable error) {
         if (error != nil || !success) {
-            if([error.localizedDescription isEqualToString:@"DISALLOWED"]) {
+            if([error.userInfo[@"resultCode"] isEqualToEnum:SDLResultDisallowed]) {
                 [weakSelf.mutableRemoteFileNames addObjectsFromArray:fileNames];
                 weakSelf.bytesAvailable = bytesAvailable;
             }

--- a/SmartDeviceLink/SDLListFilesOperation.m
+++ b/SmartDeviceLink/SDLListFilesOperation.m
@@ -64,8 +64,7 @@ NS_ASSUME_NONNULL_BEGIN
                 results[@"resultCode"] = SDLResultDisallowed;
                 NSError *resultError = [NSError errorWithDomain:error.domain code:error.code userInfo:results];
                 weakSelf.completionHandler(success, bytesAvailable, fileNames, resultError);
-            }
-            else {
+            } else {
                 weakSelf.completionHandler(success, bytesAvailable, fileNames, error);
             }
         }

--- a/SmartDeviceLink/SDLListFilesOperation.m
+++ b/SmartDeviceLink/SDLListFilesOperation.m
@@ -59,9 +59,9 @@ NS_ASSUME_NONNULL_BEGIN
         NSUInteger bytesAvailable = listFilesResponse.spaceAvailable != nil ? listFilesResponse.spaceAvailable.unsignedIntegerValue : 2000000000;
 
         if (weakSelf.completionHandler != nil) {
-            if([response.resultCode isEqualToEnum:SDLResultDisallowed]) {
+            if(error != nil) {
                 NSMutableDictionary *results = [error.userInfo mutableCopy];
-                results[@"resultCode"] = SDLResultDisallowed;
+                results[@"resultCode"] = response.resultCode;
                 NSError *resultError = [NSError errorWithDomain:error.domain code:error.code userInfo:results];
                 weakSelf.completionHandler(success, bytesAvailable, fileNames, resultError);
             } else {

--- a/SmartDeviceLink/SDLListFilesOperation.m
+++ b/SmartDeviceLink/SDLListFilesOperation.m
@@ -59,7 +59,15 @@ NS_ASSUME_NONNULL_BEGIN
         NSUInteger bytesAvailable = listFilesResponse.spaceAvailable != nil ? listFilesResponse.spaceAvailable.unsignedIntegerValue : 2000000000;
 
         if (weakSelf.completionHandler != nil) {
-            weakSelf.completionHandler(success, bytesAvailable, fileNames, error);
+            if([response.resultCode isEqualToEnum:SDLResultDisallowed]) {
+                NSMutableDictionary *results = [error.userInfo mutableCopy];
+                results[@"resultCode"] = SDLResultDisallowed;
+                NSError *resultError = [NSError errorWithDomain:error.domain code:error.code userInfo:results];
+                weakSelf.completionHandler(success, bytesAvailable, fileNames, resultError);
+            }
+            else {
+                weakSelf.completionHandler(success, bytesAvailable, fileNames, error);
+            }
         }
 
         [weakSelf finishOperation];

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLFileManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLFileManagerSpec.m
@@ -157,6 +157,22 @@ describe(@"uploading / deleting single files with the file manager", ^{
             });
         });
 
+        describe(@"after receiving a ListFiles error with a resulCode", ^{
+            beforeEach(^{
+                SDLListFilesOperation *operation = testFileManager.pendingTransactions.firstObject;
+                NSMutableDictionary *userInfo = [[NSError sdl_fileManager_unableToStartError].userInfo mutableCopy];
+                userInfo[@"resultCode"] = SDLResultDisallowed;
+                NSError *errorWithResultCode = [NSError errorWithDomain:[NSError sdl_fileManager_unableToStartError].domain code:[NSError sdl_fileManager_unableToStartError].code userInfo:userInfo];
+                operation.completionHandler(NO, initialSpaceAvailable, testInitialFileNames, errorWithResultCode);
+            });
+
+            it(@"should handle the error properly", ^{
+                expect(testFileManager.currentState).to(match(SDLFileManagerStateReady));
+                expect(testFileManager.remoteFileNames).to(beEmpty());
+                expect(@(testFileManager.bytesAvailable)).to(equal(initialSpaceAvailable));
+            });
+        });
+
         describe(@"after receiving a ListFiles response", ^{
             beforeEach(^{
                 SDLListFilesOperation *operation = testFileManager.pendingTransactions.firstObject;

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLFileManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLFileManagerSpec.m
@@ -157,7 +157,7 @@ describe(@"uploading / deleting single files with the file manager", ^{
             });
         });
 
-        describe(@"after receiving a ListFiles error with a resulCode", ^{
+        describe(@"after receiving a ListFiles error with a resultCode DISALLOWED", ^{
             beforeEach(^{
                 SDLListFilesOperation *operation = testFileManager.pendingTransactions.firstObject;
                 NSMutableDictionary *userInfo = [[NSError sdl_fileManager_unableToStartError].userInfo mutableCopy];

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLListFilesOperationSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLListFilesOperationSpec.m
@@ -93,14 +93,6 @@ describe(@"List Files Operation", ^{
                 badResponse.spaceAvailable = responseSpaceAvailable;
                 badResponse.filenames = responseFileNames;
             });
-            
-            it(@"should have called completion handler with error", ^{
-                [testConnectionManager respondToLastRequestWithResponse:badResponse error:[NSError sdl_lifecycle_unknownRemoteErrorWithDescription:responseErrorDescription andReason:responseErrorReason]];
-
-                expect(errorResult.localizedDescription).to(match(responseErrorDescription));
-                expect(errorResult.localizedFailureReason).to(match(responseErrorReason));
-                expect(@(successResult)).to(equal(@NO));
-            });
 
             it(@"should have called completion handler with error including a resultCode ", ^{
                 badResponse.resultCode = SDLResultDisallowed;

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLListFilesOperationSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLListFilesOperationSpec.m
@@ -92,13 +92,12 @@ describe(@"List Files Operation", ^{
                 badResponse.success = @NO;
                 badResponse.spaceAvailable = responseSpaceAvailable;
                 badResponse.filenames = responseFileNames;
-            });
-
-            it(@"should have called completion handler with error including a resultCode", ^{
                 badResponse.resultCode = SDLResultDisallowed;
 
                 [testConnectionManager respondToLastRequestWithResponse:badResponse error:[NSError sdl_lifecycle_unknownRemoteErrorWithDescription:responseErrorDescription andReason:responseErrorReason]];
+            });
 
+            it(@"should have called completion handler with error including a resultCode", ^{
                 expect(errorResult.localizedDescription).to(match(responseErrorDescription));
                 expect(errorResult.localizedFailureReason).to(match(responseErrorReason));
                 expect(errorResult.userInfo[@"resultCode"]).to(equal(@"DISALLOWED"));

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLListFilesOperationSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLListFilesOperationSpec.m
@@ -94,7 +94,7 @@ describe(@"List Files Operation", ^{
                 badResponse.filenames = responseFileNames;
             });
 
-            it(@"should have called completion handler with error including a resultCode ", ^{
+            it(@"should have called completion handler with error including a resultCode", ^{
                 badResponse.resultCode = SDLResultDisallowed;
 
                 [testConnectionManager respondToLastRequestWithResponse:badResponse error:[NSError sdl_lifecycle_unknownRemoteErrorWithDescription:responseErrorDescription andReason:responseErrorReason]];


### PR DESCRIPTION
Fixes #1454 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Test against example app using Xcode 11. Make sure to remove `ListFiles`RPC from cores policy table in order to recreate a `disallowed`

### Summary
This PR adds a check to see if the error was `disallowed`. If it is `disallowed` we no longer want to Error but rather continue with the setup process. 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
