### PR TITLE
Change example app resultCode check to the success bool instead

### DIFF
--- a/Example Apps/Example ObjC/MenuManager.m
+++ b/Example Apps/Example ObjC/MenuManager.m
@@ -99,7 +99,7 @@ NS_ASSUME_NONNULL_BEGIN
     SDLMenuCell *cell = [[SDLMenuCell alloc] initWithTitle:@"Non - Media (Default)" icon:nil voiceCommands:nil handler:^(SDLTriggerSource  _Nonnull triggerSource) {
         SDLSetDisplayLayout* display = [[SDLSetDisplayLayout alloc] initWithPredefinedLayout:SDLPredefinedLayoutNonMedia];
         [manager sendRequest:display withResponseHandler:^(SDLRPCRequest *request, SDLRPCResponse *response, NSError *error) {
-            if (![response.resultCode isEqualToEnum:SDLResultSuccess]) {
+            if (!response.success) {
                 [manager sendRequest:[AlertManager alertWithMessageAndCloseButton:errorMessage textField2:nil iconName:nil]];
             }
         }];
@@ -110,7 +110,7 @@ NS_ASSUME_NONNULL_BEGIN
     SDLMenuCell *cell2 = [[SDLMenuCell alloc] initWithTitle:@"Graphic With Text" icon:nil voiceCommands:nil handler:^(SDLTriggerSource  _Nonnull triggerSource) {
         SDLSetDisplayLayout* display = [[SDLSetDisplayLayout alloc] initWithPredefinedLayout:SDLPredefinedLayoutGraphicWithText];
         [manager sendRequest:display withResponseHandler:^(SDLRPCRequest *request, SDLRPCResponse *response, NSError *error) {
-            if (![response.resultCode isEqualToEnum:SDLResultSuccess]) {
+            if (!response.success) {
                 [manager sendRequest:[AlertManager alertWithMessageAndCloseButton:errorMessage textField2:nil iconName:nil]];
             }
         }];

--- a/Example Apps/Example Swift/MenuManager.swift
+++ b/Example Apps/Example Swift/MenuManager.swift
@@ -132,7 +132,7 @@ private extension MenuManager {
         submenuItems.append(SDLMenuCell(title: submenuTitleNonMedia, icon: nil, voiceCommands: nil, handler: { (triggerSource) in
             let display = SDLSetDisplayLayout(predefinedLayout: .nonMedia)
             manager.send(request: display) { (request, response, error) in
-                guard !response?.success == .some(true) else {
+                guard response?.success.boolValue == .some(true) else {
                     manager.send(AlertManager.alertWithMessageAndCloseButton(errorMessage))
                     return
                 }
@@ -144,7 +144,7 @@ private extension MenuManager {
         submenuItems.append(SDLMenuCell(title: submenuTitleGraphicText, icon: nil, voiceCommands: nil, handler: { (triggerSource) in
             let display = SDLSetDisplayLayout(predefinedLayout: .graphicWithText)
             manager.send(request: display) { (request, response, error) in
-                guard !response?.success == .some(true) else {
+                guard response?.success.boolValue == .some(true) else {
                     manager.send(AlertManager.alertWithMessageAndCloseButton(errorMessage))
                     return
                 }

--- a/Example Apps/Example Swift/MenuManager.swift
+++ b/Example Apps/Example Swift/MenuManager.swift
@@ -132,7 +132,7 @@ private extension MenuManager {
         submenuItems.append(SDLMenuCell(title: submenuTitleNonMedia, icon: nil, voiceCommands: nil, handler: { (triggerSource) in
             let display = SDLSetDisplayLayout(predefinedLayout: .nonMedia)
             manager.send(request: display) { (request, response, error) in
-                guard response?.resultCode == .success else {
+                guard !response?.success == .some(true) else {
                     manager.send(AlertManager.alertWithMessageAndCloseButton(errorMessage))
                     return
                 }
@@ -144,7 +144,7 @@ private extension MenuManager {
         submenuItems.append(SDLMenuCell(title: submenuTitleGraphicText, icon: nil, voiceCommands: nil, handler: { (triggerSource) in
             let display = SDLSetDisplayLayout(predefinedLayout: .graphicWithText)
             manager.send(request: display) { (request, response, error) in
-                guard response?.resultCode == .success else {
+                guard !response?.success == .some(true) else {
                     manager.send(AlertManager.alertWithMessageAndCloseButton(errorMessage))
                     return
                 }


### PR DESCRIPTION
Fixes #1456 

This PR is **not ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
To be tested against Core 6.0

### Summary
This PR updates the example apps to not show a warning alert when the `SetDisplayLayout` returns a `WARNINGS` result code on Core 6.0+ due to the deprecation of `SetDisplayLayout`.

### Changelog
##### Bug Fixes
* Fixed example app showing an error alert when changing templates on Core 6.0+.

### Tasks Remaining:
- [x] Test against Core 6.0

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
