### PR TITLE
Fixed failing iAP transport test cases

### DIFF
--- a/SmartDeviceLinkTests/TransportSpecs/iAP/SDLIAPTransportSpec.m
+++ b/SmartDeviceLinkTests/TransportSpecs/iAP/SDLIAPTransportSpec.m
@@ -144,6 +144,7 @@ describe(@"SDLIAPTransport", ^{
             beforeEach(^{
                 mockDataSession = OCMClassMock([SDLIAPDataSession class]);
                 OCMStub([mockDataSession isSessionInProgress]).andReturn(YES);
+                OCMStub([mockDataSession connectionID]).andReturn(mockAccessory.connectionID);
                 transport.dataSession = mockDataSession;
                 transport.controlSession = nil;
 
@@ -171,6 +172,7 @@ describe(@"SDLIAPTransport", ^{
             beforeEach(^{
                 mockControlSession = OCMClassMock([SDLIAPControlSession class]);
                 OCMStub([mockControlSession isSessionInProgress]).andReturn(YES);
+                OCMStub([mockControlSession connectionID]).andReturn(mockAccessory.connectionID);
                 transport.controlSession = mockControlSession;
                 transport.dataSession = nil;
 


### PR DESCRIPTION
Fixes #1457 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
This PR fixes the test cases

### Summary
Fixed failing test cases due to the mock session returning a `nil` `connectionID`.

### Changelog
##### Bug Fixes
* Fixed failing test cases

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
