### PR TITLE
Revert removing the data session delay

### DIFF
--- a/SmartDeviceLink/SDLIAPDataSession.m
+++ b/SmartDeviceLink/SDLIAPDataSession.m
@@ -110,9 +110,6 @@ NS_ASSUME_NONNULL_BEGIN
     [self sdl_isIOThreadCanceled:self.canceledSemaphore completionHandler:^(BOOL success) {
         if (success == NO) {
             SDLLogE(@"Destroying thread (IOStreamThread) for data session when I/O streams have not yet closed.");
-
-            // FIX: Try to close the session if the canceledSemaphore is never triggered by the `sdl_accessoryEventLoop`
-            [self sdl_closeSession];
         }
         self.ioStreamThread = nil;
         [super cleanupClosedSession];

--- a/SmartDeviceLink/SDLIAPTransport.m
+++ b/SmartDeviceLink/SDLIAPTransport.m
@@ -98,8 +98,11 @@ int const CreateSessionRetries = 3;
         return;
     }
 
+    double retryDelay = self.sdl_retryDelay;
+    SDLLogD(@"Accessory Connected (%@), Opening in %0.03fs", notification.userInfo[EAAccessoryKey], retryDelay);
+
     self.retryCounter = 0;
-    [self sdl_connect:newAccessory];
+    [self performSelector:@selector(sdl_connect:) withObject:nil afterDelay:retryDelay];
 }
 
 /**
@@ -501,21 +504,14 @@ int const CreateSessionRetries = 3;
 
     if ([protocolString isEqualToString:MultiSessionProtocolString] && SDL_SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"9")) {
         self.dataSession = [[SDLIAPDataSession alloc] initWithAccessory:accessory delegate:self forProtocol:protocolString];
-
-        SDLLogD(@"Accessory Connected (%@), Opening immediately", accessory);
         [self.dataSession startSession];
         return YES;
     } else if ([protocolString isEqualToString:ControlProtocolString]) {
         self.controlSession = [[SDLIAPControlSession alloc] initWithAccessory:accessory delegate:self];
-
-        double retryDelay = [self sdl_retryDelay];
-        SDLLogD(@"Accessory Connected (%@), Opening in %0.03fs", accessory, retryDelay);
-        [self.controlSession performSelector:@selector(startSession) withObject:nil afterDelay:retryDelay];
+        [self.controlSession startSession];
         return YES;
     } else if ([protocolString isEqualToString:LegacyProtocolString]) {
         self.dataSession = [[SDLIAPDataSession alloc] initWithAccessory:accessory delegate:self forProtocol:protocolString];
-
-        SDLLogD(@"Accessory Connected (%@), Opening immediately", accessory);
         [self.dataSession startSession];
         return YES;
     }


### PR DESCRIPTION
Fixes #1462 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Smoke tests will be performed with available iAP modules.

### Summary
This PR reverts #1385 to allow for further testing. [See this comment by the Ford team for more detail](https://github.com/smartdevicelink/sdl_ios/pull/1343#issuecomment-546969237).

### Changelog
##### Bug Fixes
* Revert #1385 to delay data session connections.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
