### PR TITLE
Fix iOS 13 lock screen presentation crash

### DIFF
--- a/SmartDeviceLink/SDLScreenshotViewController.m
+++ b/SmartDeviceLink/SDLScreenshotViewController.m
@@ -47,9 +47,9 @@
 
 // HAX: https://github.com/smartdevicelink/sdl_ios/issues/1250
 - (BOOL)shouldAutorotate {
-    UIViewController *viewController = [self sdl_topMostControllerForWindow:[UIApplication sharedApplication].windows[0]];
+    UIViewController *viewController = [self sdl_topMostControllerForWindow:[UIApplication sharedApplication].windows.firstObject];
 
-    if (viewController == self) {
+    if (viewController == nil || viewController == self) {
         return YES;
     } else if (viewController != nil) {
         return viewController.shouldAutorotate;

--- a/SmartDeviceLink/SDLScreenshotViewController.m
+++ b/SmartDeviceLink/SDLScreenshotViewController.m
@@ -34,9 +34,9 @@
 
 // HAX: https://github.com/smartdevicelink/sdl_ios/issues/1250
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations {
-    UIViewController *viewController = [self sdl_topMostControllerForWindow:[UIApplication sharedApplication].windows[0]];
+    UIViewController *viewController = [self sdl_topMostControllerForWindow:[UIApplication sharedApplication].windows.firstObject];
 
-    if (viewController == self) {
+    if (viewController == nil || viewController == self) {
         return UIInterfaceOrientationMaskAll;
     } else if (viewController != nil) {
         return viewController.supportedInterfaceOrientations;


### PR DESCRIPTION
Fixes #1430 

This PR is ready for review.

### Risk
This PR makes no API changes.

### Summary
Use firstObject instead of indexing directly for safety.

* [Bug Fix Info]
Gracefully handle indexing

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)