### PR TITLE
Fix SystemCapabilityManager subscribe not returning the correct type

### DIFF
--- a/SmartDeviceLink/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.m
@@ -579,7 +579,7 @@ typedef NSString * SDLServiceID;
 
 - (BOOL)subscribeToCapabilityType:(SDLSystemCapabilityType)type withObserver:(id<NSObject>)observer selector:(SEL)selector {
     // DISPLAYS always works due to old-style SetDisplayLayoutRepsonse updates, but otherwise, subscriptions won't work
-    if (!self.supportsSubscriptions && ![type isEqualToEnum:SDLSystemCapabilityTypeDisplays]) { return nil; }
+    if (!self.supportsSubscriptions && ![type isEqualToEnum:SDLSystemCapabilityTypeDisplays]) { return NO; }
 
     NSUInteger numberOfParametersInSelector = [NSStringFromSelector(selector) componentsSeparatedByString:@":"].count - 1;
     if (numberOfParametersInSelector > 1) { return NO; }
@@ -587,7 +587,7 @@ typedef NSString * SDLServiceID;
     SDLSystemCapabilityObserver *observerObject = [[SDLSystemCapabilityObserver alloc] initWithObserver:observer selector:selector];
     [self.capabilityObservers[type] addObject:observerObject];
 
-    return observerObject.observer;
+    return YES;
 }
 
 - (void)unsubscribeFromCapabilityType:(SDLSystemCapabilityType)type withObserver:(id)observer {


### PR DESCRIPTION
Fixes #1465 

This PR is **ready** for review.

NOTE: This is against master for a hotfix release.

### Risk
This PR makes **no** API changes.

### Testing Plan
Unit tests run. This is a very small change and I don't believe full smoke testing is necessary.

### Summary
This fixes an issue with `SDLSystemCapabilityManager.subscribeToCapabilityType:withObserver:selector:` returning the wrong type even though the correct type is declared.

### Changelog
##### Bug Fixes
* Fix `SDLSystemCapabilityManager.subscribeToCapabilityType:withObserver:selector:` returning the wrong type even though the correct type is declared.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
