### PR TITLE
Recreate the lock screen view controller 

### DIFF
--- a/SmartDeviceLink/SDLLockScreenPresenter.m
+++ b/SmartDeviceLink/SDLLockScreenPresenter.m
@@ -34,8 +34,6 @@ NS_ASSUME_NONNULL_BEGIN
     CGRect screenFrame = [[UIScreen mainScreen] bounds];
     _lockWindow = [[UIWindow alloc] initWithFrame:screenFrame];
     _lockWindow.backgroundColor = [UIColor clearColor];
-    _screenshotViewController = [[SDLScreenshotViewController alloc] init];
-    _lockWindow.rootViewController = _screenshotViewController;
 
     return self;
 }

--- a/SmartDeviceLink/SDLLockScreenPresenter.m
+++ b/SmartDeviceLink/SDLLockScreenPresenter.m
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SDLLockScreenPresenter ()
 
-@property (strong, nonatomic) SDLScreenshotViewController *screenshotViewController;
+@property (strong, nonatomic, nullable) SDLScreenshotViewController *screenshotViewController;
 @property (strong, nonatomic) UIWindow *lockWindow;
 
 @end
@@ -44,7 +44,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)present {
     SDLLogD(@"Trying to present lock screen");
+
+    __weak typeof(self) weakself = self;
     dispatch_async(dispatch_get_main_queue(), ^{
+        weakself.screenshotViewController = [[SDLScreenshotViewController alloc] init];
+        weakself.lockWindow.rootViewController = weakself.screenshotViewController;
+
         if (@available(iOS 13.0, *)) {
             [self sdl_presentIOS13];
         } else {
@@ -155,12 +160,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)dismiss {
     SDLLogD(@"Trying to dismiss lock screen");
+
+    __weak typeof(self) weakself = self;
     dispatch_async(dispatch_get_main_queue(), ^{
         if (@available(iOS 13.0, *)) {
             [self sdl_dismissIOS13];
         } else {
             [self sdl_dismissIOS12];
         }
+
+        weakself.lockWindow.rootViewController = nil;
+        weakself.screenshotViewController = nil;
     });
 }
 


### PR DESCRIPTION
Fixes #1480 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
No unit tests were added.

#### Core Tests
* Displaying and hiding the lock screen verified 10x in a row.
* Additional verification will be requested from the issue reporter.

Core version / branch / commit hash / module tested against: Sync Gen 3.4 19317_DEVTEST
HMI name / version / branch / commit hash / module tested against: n/a

### Summary
This PR changes the `SDLScreenshotViewController` from being created once when the `SDLLockScreenPresenter` is initialized to creating it every time the lock screen is going to be created and destroying it when the lock screen dismisses.

### Changelog
##### Bug Fixes
* Fix the lock window not taking the app's window's characteristics if the app's window changes.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
