### PR TITLE
Fixed soft button operation never finishing if template does not support soft buttons

### DIFF
--- a/SmartDeviceLink/SDLSoftButtonReplaceOperation.m
+++ b/SmartDeviceLink/SDLSoftButtonReplaceOperation.m
@@ -60,8 +60,8 @@ NS_ASSUME_NONNULL_BEGIN
         [self sdl_sendCurrentStateTextOnlySoftButtonsWithCompletionHandler:^(BOOL success) {
             if (!success) {
                 SDLLogE(@"Head unit does not support images and some of the soft buttons do not have text, so none of the buttons will be sent.");
-                [weakself finishOperation];
             }
+            [weakself finishOperation];
         }];
     } else if ([self sdl_currentStateHasImages] && ![self sdl_allCurrentStateImagesAreUploaded]) {
         // If there are images that aren't uploaded

--- a/SmartDeviceLinkTests/SDLSoftButtonReplaceOperationSpec.m
+++ b/SmartDeviceLinkTests/SDLSoftButtonReplaceOperationSpec.m
@@ -60,6 +60,9 @@ describe(@"a soft button replace operation", ^{
 
     __block NSString *testMainField1 = @"Test main field 1";
 
+    __block SDLRPCResponse *successResponse = nil;
+    __block SDLRPCResponse *failedResponse = nil;
+
     beforeEach(^{
         resultError = nil;
         hasCalledOperationCompletionHandler = NO;
@@ -84,6 +87,14 @@ describe(@"a soft button replace operation", ^{
         button4 = [[SDLSoftButtonObject alloc] initWithName:object4Name state:object4State1 handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {}];;
 
         OCMStub([testFileManager uploadArtworks:[OCMArg any] progressHandler:[OCMArg invokeBlock] completionHandler:[OCMArg invokeBlock]]);
+
+        successResponse = [[SDLRPCResponse alloc] init];
+        successResponse.success = @YES;
+        successResponse.resultCode = SDLResultSuccess;
+
+        failedResponse = [[SDLRPCResponse alloc] init];
+        failedResponse.success = @NO;
+        failedResponse.resultCode = SDLResultRejected;
     });
 
     it(@"should have a priority of 'normal'", ^{
@@ -114,6 +125,22 @@ describe(@"a soft button replace operation", ^{
                 expect(sentRequests.firstObject.softButtons.firstObject.image).to(beNil());
                 expect(sentRequests.firstObject.softButtons.firstObject.type).to(equal(SDLSoftButtonTypeText));
             });
+
+            context(@"When a response is received to the text upload", ^{
+                it(@"should finish the operation on a successful response", ^{
+                    [testConnectionManager respondToLastRequestWithResponse:successResponse];
+
+                    expect(testOp.isFinished).to(beTrue());
+                    expect(testOp.isExecuting).to(beFalse());
+                });
+
+                it(@"should finish the operation on a failed response", ^{
+                    [testConnectionManager respondToLastRequestWithResponse:failedResponse];
+
+                    expect(testOp.isFinished).to(beTrue());
+                    expect(testOp.isExecuting).to(beFalse());
+                });
+            });
         });
 
         context(@"with artworks", ^{
@@ -123,7 +150,7 @@ describe(@"a soft button replace operation", ^{
                 testSoftButtonObjects = @[button1, button2];
             });
 
-            fcontext(@"but the HMI does not support artworks", ^{
+            context(@"but the HMI does not support artworks", ^{
                 beforeEach(^{
                     SDLSoftButtonCapabilities *capabilities = [[SDLSoftButtonCapabilities alloc] init];
                     capabilities.imageSupported = @NO;
@@ -152,9 +179,6 @@ describe(@"a soft button replace operation", ^{
 
                 context(@"When a response is received to the text upload", ^{
                     it(@"should finish the operation on a successful response", ^{
-                        SDLRPCResponse *successResponse = [[SDLRPCResponse alloc] init];
-                        successResponse.success = @YES;
-                        successResponse.resultCode = SDLResultSuccess;
                         [testConnectionManager respondToLastRequestWithResponse:successResponse];
 
                         expect(testOp.isFinished).to(beTrue());
@@ -162,9 +186,6 @@ describe(@"a soft button replace operation", ^{
                     });
 
                     it(@"should finish the operation on a failed response", ^{
-                        SDLRPCResponse *failedResponse = [[SDLRPCResponse alloc] init];
-                        failedResponse.success = @NO;
-                        failedResponse.resultCode = SDLResultRejected;
                         [testConnectionManager respondToLastRequestWithResponse:failedResponse];
 
                         expect(testOp.isFinished).to(beTrue());
@@ -233,6 +254,22 @@ describe(@"a soft button replace operation", ^{
                         expect(sentRequests.firstObject.softButtons.lastObject.image).toNot(beNil());
                         expect(sentRequests.firstObject.softButtons.lastObject.type).to(equal(SDLSoftButtonTypeBoth));
                     });
+
+                    context(@"When a response is received to the text upload", ^{
+                        it(@"should finish the operation on a successful response", ^{
+                            [testConnectionManager respondToLastRequestWithResponse:successResponse];
+
+                            expect(testOp.isFinished).to(beTrue());
+                            expect(testOp.isExecuting).to(beFalse());
+                        });
+
+                        it(@"should finish the operation on a failed response", ^{
+                            [testConnectionManager respondToLastRequestWithResponse:failedResponse];
+
+                            expect(testOp.isFinished).to(beTrue());
+                            expect(testOp.isExecuting).to(beFalse());
+                        });
+                    });
                 });
 
                 context(@"when the artworks need uploading", ^{
@@ -262,6 +299,22 @@ describe(@"a soft button replace operation", ^{
                             expect(sentRequests.firstObject.softButtons.firstObject.text).to(equal(object3State1Text));
                             expect(sentRequests.firstObject.softButtons.firstObject.image).toNot(beNil());
                             expect(sentRequests.firstObject.softButtons.firstObject.type).to(equal(SDLSoftButtonTypeBoth));
+                        });
+
+                        context(@"When a response is received to the text upload", ^{
+                            it(@"should finish the operation on a successful response", ^{
+                                [testConnectionManager respondToLastRequestWithResponse:successResponse];
+
+                                expect(testOp.isFinished).to(beTrue());
+                                expect(testOp.isExecuting).to(beFalse());
+                            });
+
+                            it(@"should finish the operation on a failed response", ^{
+                                [testConnectionManager respondToLastRequestWithResponse:failedResponse];
+
+                                expect(testOp.isFinished).to(beTrue());
+                                expect(testOp.isExecuting).to(beFalse());
+                            });
                         });
                     });
 
@@ -301,6 +354,22 @@ describe(@"a soft button replace operation", ^{
                             expect(sentRequests.lastObject.softButtons.lastObject.text).to(equal(object2State1Text));
                             expect(sentRequests.lastObject.softButtons.lastObject.image).toNot(beNil());
                             expect(sentRequests.lastObject.softButtons.lastObject.type).to(equal(SDLSoftButtonTypeBoth));
+                        });
+
+                        context(@"When a response is received to the text upload", ^{
+                            it(@"should finish the operation on a successful response", ^{
+                                [testConnectionManager respondToLastRequestWithResponse:successResponse];
+
+                                expect(testOp.isFinished).to(beTrue());
+                                expect(testOp.isExecuting).to(beFalse());
+                            });
+
+                            it(@"should finish the operation on a failed response", ^{
+                                [testConnectionManager respondToLastRequestWithResponse:failedResponse];
+
+                                expect(testOp.isFinished).to(beTrue());
+                                expect(testOp.isExecuting).to(beFalse());
+                            });
                         });
                     });
                 });


### PR DESCRIPTION
Fixes #1474 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
* Added unit tests to the `SDLSoftButtonReplaceOperationSpec` to check if the operation finishes as expected.

#### Core Tests
* This can not be easily tested with generic_hmi due to an existing bug: https://github.com/smartdevicelink/generic_hmi/issues/228. Also, since sdl_hmi only supports 1 template, this can not be tested with sdl_hmi. 
 
##### Reproduction Steps
1. Send a `LARGE_GRAPHIC_WITH_SOFTBUTTONS` template and use the screen manager to send 8 soft buttons when the template has been set successfully.
1. Send a `LARGE_GRAPHIC_ONLY` template and use the screen manager to send 8 new soft buttons when the template has been set successfully. To reproduce the bug, set a break point in the `SDLSoftButtonManager`'s `sdl_displayCapabilityDidUpdate:` and manually set the `SDLSoftButtonReplaceOperation`'s `capabilities` to `nil` in the console. 
1. Send a `LARGE_GRAPHIC_WITH_SOFTBUTTONS` template and use the screen manager to send 8 new soft buttons when the template has been set successfully. The new buttons will not be sent.

Core version / branch / commit hash / module tested against: sdl_core, commit 4d283e625dfa09d166d572fa7bf6e98e91f05050 (tag: 6.0.0_RC2, origin/release/6.0.0, release/6.0.0)

HMI name / version / branch / commit hash / module tested against: generic_hmi, commit 8fd46298ec636896add85afbea78c550d79fd2b0 (HEAD -> develop, tag: 0.7.0-RC, origin/release/0.7.0)

### Summary
Fixed an issue with the soft button `transactionQueue` freezing when a newly set template does not support soft buttons. This was due to the operation not being finished after sending the text only soft buttons successfully. 

### Changelog
##### Bug Fixes
* Fixed the soft button replace operation never finishing if newly set template does not support soft buttons. 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
