### PR TITLE
Add APIs to SDLTemplateConfiguration for Objective-C++ compatibility

### DIFF
--- a/SmartDeviceLink/SDLTemplateConfiguration.h
+++ b/SmartDeviceLink/SDLTemplateConfiguration.h
@@ -22,6 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (instancetype)initWithPredefinedLayout:(SDLPredefinedLayout)predefinedLayout;
 
+// HAX: We are doing this because `template` is a C++ keyword and won't compile.
 #ifndef __cplusplus
 /**
  Init with the required values.

--- a/SmartDeviceLink/SDLTemplateConfiguration.h
+++ b/SmartDeviceLink/SDLTemplateConfiguration.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Used to set an alternate template layout to a window.
- 
+
  @since SDL 6.0
  */
 @interface SDLTemplateConfiguration : SDLRPCStruct
@@ -22,9 +22,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (instancetype)initWithPredefinedLayout:(SDLPredefinedLayout)predefinedLayout;
 
+#ifndef __cplusplus
 /**
  Init with the required values.
- 
+
  @param template Predefined or dynamically created window template. Currently only predefined window template layouts are defined.
  */
 - (instancetype)initWithTemplate:(NSString *)template;
@@ -32,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Convinience constructor with all the parameters.
- 
+
  @param template Predefined or dynamically created window template. Currently only predefined window template layouts are defined.
  @param dayColorScheme The color scheme to use when the head unit is in a light / day situation. If nil, the existing color scheme will be used.
  @param nightColorScheme The color scheme to use when the head unit is in a dark / night situation.
@@ -43,6 +44,31 @@ NS_ASSUME_NONNULL_BEGIN
  Predefined or dynamically created window template. Currently only predefined window template layouts are defined.
  */
 @property (strong, nonatomic) NSString *template;
+#endif
+
+#ifdef __cplusplus
+/**
+ Init with the required values.
+
+ @param templateName Predefined or dynamically created window template. Currently only predefined window template layouts are defined.
+ */
+- (instancetype)initWithTemplate:(NSString *)templateName;
+
+
+/**
+ Convinience constructor with all the parameters.
+
+ @param templateName Predefined or dynamically created window template. Currently only predefined window template layouts are defined.
+ @param dayColorScheme The color scheme to use when the head unit is in a light / day situation. If nil, the existing color scheme will be used.
+ @param nightColorScheme The color scheme to use when the head unit is in a dark / night situation.
+ */
+- (instancetype)initWithTemplate:(NSString *)templateName dayColorScheme:(nullable SDLTemplateColorScheme *)dayColorScheme nightColorScheme:(nullable SDLTemplateColorScheme *)nightColorScheme;
+
+/**
+ Predefined or dynamically created window template. Currently only predefined window template layouts are defined.
+ */
+@property (strong, nonatomic) NSString *templateName;
+#endif
 
 /**
  The color scheme to use when the head unit is in a light / day situation.

--- a/SmartDeviceLink/SDLTemplateConfiguration.m
+++ b/SmartDeviceLink/SDLTemplateConfiguration.m
@@ -1,60 +1,85 @@
 //
-//  SDLTemplateConfiguration.m
+//  SDLTemplateConfiguration.h
 //  SmartDeviceLink
 
-#import "SDLTemplateConfiguration.h"
+#import "SDLTemplateColorScheme.h"
+#import "SDLPredefinedLayout.h"
 
-#import "NSMutableDictionary+Store.h"
-#import "SDLRPCParameterNames.h"
+NS_ASSUME_NONNULL_BEGIN
 
-@implementation SDLTemplateConfiguration
+/**
+ Used to set an alternate template layout to a window.
+
+ @since SDL 6.0
+ */
+@interface SDLTemplateConfiguration : SDLRPCStruct
 
 
-- (instancetype)initWithPredefinedLayout:(SDLPredefinedLayout)predefinedLayout {
-    return [self initWithTemplate:predefinedLayout];
-}
+/**
+ Constructor with the required values.
 
-- (instancetype)initWithTemplate:(NSString *)template {
-    self = [super init];
-    if (!self) {
-        return nil;
-    }
-    self.template = template;
-    return self;
-}
+ @param predefinedLayout A template layout an app uses to display information. The broad details of the layout are defined, but the details depend on the IVI system. Used in SetDisplayLayout.
+ */
+- (instancetype)initWithPredefinedLayout:(SDLPredefinedLayout)predefinedLayout;
 
-- (instancetype)initWithTemplate:(NSString *)template dayColorScheme:(nullable SDLTemplateColorScheme *)dayColorScheme nightColorScheme:(nullable SDLTemplateColorScheme *)nightColorScheme {
-    self = [self initWithTemplate:template];
-    if (!self) {
-        return nil;
-    }
-    self.dayColorScheme = dayColorScheme;
-    self.nightColorScheme = nightColorScheme;
-    return self;
-}
+#ifndef __cplusplus
+/**
+ Init with the required values.
 
-- (void)setTemplate:(NSString *)template {
-    [self.store sdl_setObject:template forName:SDLRPCParameterNameTemplate];
-}
+ @param template Predefined or dynamically created window template. Currently only predefined window template layouts are defined.
+ */
+- (instancetype)initWithTemplate:(NSString *)template;
 
-- (NSString *)template {
-    return [self.store sdl_objectForName:SDLRPCParameterNameTemplate ofClass:NSString.class error:nil];
-}
 
-- (void)setDayColorScheme:(nullable SDLTemplateColorScheme *)dayColorScheme {
-    [self.store sdl_setObject:dayColorScheme forName:SDLRPCParameterNameDayColorScheme];
-}
+/**
+ Convinience constructor with all the parameters.
 
-- (nullable SDLTemplateColorScheme *)dayColorScheme {
-    return [self.store sdl_objectForName:SDLRPCParameterNameDayColorScheme ofClass:SDLTemplateColorScheme.class error:nil];
-}
+ @param template Predefined or dynamically created window template. Currently only predefined window template layouts are defined.
+ @param dayColorScheme The color scheme to use when the head unit is in a light / day situation. If nil, the existing color scheme will be used.
+ @param nightColorScheme The color scheme to use when the head unit is in a dark / night situation.
+ */
+- (instancetype)initWithTemplate:(NSString *)template dayColorScheme:(nullable SDLTemplateColorScheme *)dayColorScheme nightColorScheme:(nullable SDLTemplateColorScheme *)nightColorScheme;
 
-- (void)setNightColorScheme:(nullable SDLTemplateColorScheme *)nightColorScheme {
-    [self.store sdl_setObject:nightColorScheme forName:SDLRPCParameterNameNightColorScheme];
-}
+/**
+ Predefined or dynamically created window template. Currently only predefined window template layouts are defined.
+ */
+@property (strong, nonatomic) NSString *template;
+#endif
 
-- (nullable SDLTemplateColorScheme *)nightColorScheme {
-    return [self.store sdl_objectForName:SDLRPCParameterNameNightColorScheme ofClass:SDLTemplateColorScheme.class error:nil];
-}
+#ifdef __cplusplus
+/**
+ Init with the required values.
+
+ @param templateName Predefined or dynamically created window template. Currently only predefined window template layouts are defined.
+ */
+- (instancetype)initWithTemplate:(NSString *)templateName;
+
+
+/**
+ Convinience constructor with all the parameters.
+
+ @param templateName Predefined or dynamically created window template. Currently only predefined window template layouts are defined.
+ @param dayColorScheme The color scheme to use when the head unit is in a light / day situation. If nil, the existing color scheme will be used.
+ @param nightColorScheme The color scheme to use when the head unit is in a dark / night situation.
+ */
+- (instancetype)initWithTemplate:(NSString *)templateName dayColorScheme:(nullable SDLTemplateColorScheme *)dayColorScheme nightColorScheme:(nullable SDLTemplateColorScheme *)nightColorScheme;
+
+/**
+ Predefined or dynamically created window template. Currently only predefined window template layouts are defined.
+ */
+@property (strong, nonatomic) NSString *templateName;
+#endif
+
+/**
+ The color scheme to use when the head unit is in a light / day situation.
+ */
+@property (strong, nonatomic, nullable) SDLTemplateColorScheme *dayColorScheme;
+
+/**
+ The color scheme to use when the head unit is in a dark / night situation.
+ */
+@property (strong, nonatomic, nullable) SDLTemplateColorScheme *nightColorScheme;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLTemplateConfiguration.m
+++ b/SmartDeviceLink/SDLTemplateConfiguration.m
@@ -1,85 +1,91 @@
 //
-//  SDLTemplateConfiguration.h
+//  SDLTemplateConfiguration.m
 //  SmartDeviceLink
 
-#import "SDLTemplateColorScheme.h"
-#import "SDLPredefinedLayout.h"
+#import "SDLTemplateConfiguration.h"
 
-NS_ASSUME_NONNULL_BEGIN
+#import "NSMutableDictionary+Store.h"
+#import "SDLRPCParameterNames.h"
 
-/**
- Used to set an alternate template layout to a window.
-
- @since SDL 6.0
- */
-@interface SDLTemplateConfiguration : SDLRPCStruct
+@implementation SDLTemplateConfiguration
 
 
-/**
- Constructor with the required values.
-
- @param predefinedLayout A template layout an app uses to display information. The broad details of the layout are defined, but the details depend on the IVI system. Used in SetDisplayLayout.
- */
-- (instancetype)initWithPredefinedLayout:(SDLPredefinedLayout)predefinedLayout;
+- (instancetype)initWithPredefinedLayout:(SDLPredefinedLayout)predefinedLayout {
+    return [self initWithTemplate:predefinedLayout];
+}
 
 #ifndef __cplusplus
-/**
- Init with the required values.
+- (instancetype)initWithTemplate:(NSString *)template {
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+    self.template = template;
+    return self;
+}
 
- @param template Predefined or dynamically created window template. Currently only predefined window template layouts are defined.
- */
-- (instancetype)initWithTemplate:(NSString *)template;
+- (instancetype)initWithTemplate:(NSString *)template dayColorScheme:(nullable SDLTemplateColorScheme *)dayColorScheme nightColorScheme:(nullable SDLTemplateColorScheme *)nightColorScheme {
+    self = [self initWithTemplate:template];
+    if (!self) {
+        return nil;
+    }
+    self.dayColorScheme = dayColorScheme;
+    self.nightColorScheme = nightColorScheme;
+    return self;
+}
 
+- (void)setTemplate:(NSString *)template {
+    [self.store sdl_setObject:template forName:SDLRPCParameterNameTemplate];
+}
 
-/**
- Convinience constructor with all the parameters.
-
- @param template Predefined or dynamically created window template. Currently only predefined window template layouts are defined.
- @param dayColorScheme The color scheme to use when the head unit is in a light / day situation. If nil, the existing color scheme will be used.
- @param nightColorScheme The color scheme to use when the head unit is in a dark / night situation.
- */
-- (instancetype)initWithTemplate:(NSString *)template dayColorScheme:(nullable SDLTemplateColorScheme *)dayColorScheme nightColorScheme:(nullable SDLTemplateColorScheme *)nightColorScheme;
-
-/**
- Predefined or dynamically created window template. Currently only predefined window template layouts are defined.
- */
-@property (strong, nonatomic) NSString *template;
+- (NSString *)template {
+    return [self.store sdl_objectForName:SDLRPCParameterNameTemplate ofClass:NSString.class error:nil];
+}
 #endif
 
-#ifdef __cplusplus
-/**
- Init with the required values.
+#ifdef _cplusplus
+- (instancetype)initWithTemplate:(NSString *)templateName {
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+    self.templateName = templateName;
+    return self;
+}
 
- @param templateName Predefined or dynamically created window template. Currently only predefined window template layouts are defined.
- */
-- (instancetype)initWithTemplate:(NSString *)templateName;
+- (instancetype)initWithTemplate:(NSString *)templateName dayColorScheme:(nullable SDLTemplateColorScheme *)dayColorScheme nightColorScheme:(nullable SDLTemplateColorScheme *)nightColorScheme; {
+    self = [self initWithTemplate:templateName];
+    if (!self) {
+        return nil;
+    }
+    self.dayColorScheme = dayColorScheme;
+    self.nightColorScheme = nightColorScheme;
+    return self;
+}
 
+- (void)setTemplateName:(NSString *)templateName {
+    [self.store sdl_setObject:template forName:SDLRPCParameterNameTemplate];
+}
 
-/**
- Convinience constructor with all the parameters.
-
- @param templateName Predefined or dynamically created window template. Currently only predefined window template layouts are defined.
- @param dayColorScheme The color scheme to use when the head unit is in a light / day situation. If nil, the existing color scheme will be used.
- @param nightColorScheme The color scheme to use when the head unit is in a dark / night situation.
- */
-- (instancetype)initWithTemplate:(NSString *)templateName dayColorScheme:(nullable SDLTemplateColorScheme *)dayColorScheme nightColorScheme:(nullable SDLTemplateColorScheme *)nightColorScheme;
-
-/**
- Predefined or dynamically created window template. Currently only predefined window template layouts are defined.
- */
-@property (strong, nonatomic) NSString *templateName;
+- (NSString *)templateName {
+    return [self.store sdl_objectForName:SDLRPCParameterNameTemplate ofClass:NSString.class error:nil];
+}
 #endif
 
-/**
- The color scheme to use when the head unit is in a light / day situation.
- */
-@property (strong, nonatomic, nullable) SDLTemplateColorScheme *dayColorScheme;
+- (void)setDayColorScheme:(nullable SDLTemplateColorScheme *)dayColorScheme {
+    [self.store sdl_setObject:dayColorScheme forName:SDLRPCParameterNameDayColorScheme];
+}
 
-/**
- The color scheme to use when the head unit is in a dark / night situation.
- */
-@property (strong, nonatomic, nullable) SDLTemplateColorScheme *nightColorScheme;
+- (nullable SDLTemplateColorScheme *)dayColorScheme {
+    return [self.store sdl_objectForName:SDLRPCParameterNameDayColorScheme ofClass:SDLTemplateColorScheme.class error:nil];
+}
+
+- (void)setNightColorScheme:(nullable SDLTemplateColorScheme *)nightColorScheme {
+    [self.store sdl_setObject:nightColorScheme forName:SDLRPCParameterNameNightColorScheme];
+}
+
+- (nullable SDLTemplateColorScheme *)nightColorScheme {
+    return [self.store sdl_objectForName:SDLRPCParameterNameNightColorScheme ofClass:SDLTemplateColorScheme.class error:nil];
+}
 
 @end
-
-NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Fixes #1478

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
No unit tests were added, this was a compile time issue

#### Core Tests
No Core tests were performed because this was a compile time issue. Tests were performed internal to the project.

Core version / branch / commit hash / module tested against: n/a
HMI name / version / branch / commit hash / module tested against: n/a

### Summary
This PR adds conditional compilation if the app is using Objective-C++ to change `SDLTemplateConfiguration.template` to `.templateName` because `template` is a C++ keyword. This is a minor version change due to APIs being added in Objective-C++ projects.

### Changelog
##### Bug Fixes
* Fix Objective-C++ projects not compiling due to keyword usage.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
