### PR TITLE
Only try to remove from run loop when we aren't closing

### DIFF
--- a/SmartDeviceLink/SDLIAPSession.m
+++ b/SmartDeviceLink/SDLIAPSession.m
@@ -61,10 +61,12 @@ NS_ASSUME_NONNULL_BEGIN
     if (status1 != NSStreamStatusNotOpen &&
         status1 != NSStreamStatusClosed) {
         [stream close];
+    } else if (status1 == NSStreamStatusNotOpen) {
+        // It's implicitly removed from the stream when it's closed, but not if it was never opened.
+        // When the USB cable is disconnected, the app will will call this method after the `NSStreamEventEndEncountered` event. The stream will already be in the closed state but it still needs to be removed from the run loop.
+        [stream removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
     }
 
-    // When the USB cable is disconnected, the app will will call this method after the `NSStreamEventEndEncountered` event. The stream will already be in the closed state but it still needs to be removed from the run loop.
-    [stream removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
     [stream setDelegate:nil];
 
     NSUInteger status2 = stream.streamStatus;


### PR DESCRIPTION
Fixes #1494 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
No unit tests were added because the change made no changes to unit test results and the bug is not testable via unit tests.

#### Core Tests
Connected via IAP to a Ford Sync 3 module.

* Disconnected and reconnected multiple times by pulling and reconnecting USB cord.

Core version / branch / commit hash / module tested against: Ford Sync 3 - 19317_DEVTEST
HMI name / version / branch / commit hash / module tested against: unknown

### Summary
The bug has not been reproducible, therefore this fix is also not reproducible. This PR is for visibility purposes.

### Changelog
##### Bug Fixes
* Theoretical fix to a background, low-memory crash issue.

### Tasks Remaining:
- [ ] Reproduce the issue to test the fix.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
