### PR TITLE
Only create lockscreen UIWindow as needed

### DIFF
--- a/SmartDeviceLink/SDLLockScreenPresenter.h
+++ b/SmartDeviceLink/SDLLockScreenPresenter.h
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  The view controller to be presented.
  */
-@property (strong, nonatomic) UIViewController *lockViewController;
+@property (strong, nonatomic, nullable) UIViewController *lockViewController;
 
 /**
  *  Whether or not `viewController` is currently presented.

--- a/SmartDeviceLink/SDLLockScreenPresenter.m
+++ b/SmartDeviceLink/SDLLockScreenPresenter.m
@@ -156,17 +156,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)dismiss {
     SDLLogD(@"Trying to dismiss lock screen");
-
-    __weak typeof(self) weakself = self;
     dispatch_async(dispatch_get_main_queue(), ^{
         if (@available(iOS 13.0, *)) {
             [self sdl_dismissIOS13];
         } else {
             [self sdl_dismissIOS12];
         }
-
-        weakself.lockWindow.rootViewController = nil;
-        weakself.screenshotViewController = nil;
     });
 }
 

--- a/SmartDeviceLink/SDLLockScreenPresenter.m
+++ b/SmartDeviceLink/SDLLockScreenPresenter.m
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SDLLockScreenPresenter ()
 
 @property (strong, nonatomic, nullable) SDLScreenshotViewController *screenshotViewController;
-@property (strong, nonatomic, nullable) UIWindow *lockWindow;
+@property (strong, nonatomic) UIWindow *lockWindow;
 
 @end
 
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Lifecycle
 
-- (nullable UIWindow *)lockWindow {
+- (UIWindow *)lockWindow {
     if(!_lockWindow) {
         CGRect screenFrame = [[UIScreen mainScreen] bounds];
         _lockWindow = [[UIWindow alloc] initWithFrame:screenFrame];

--- a/SmartDeviceLink/SDLLockScreenPresenter.m
+++ b/SmartDeviceLink/SDLLockScreenPresenter.m
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SDLLockScreenPresenter ()
 
 @property (strong, nonatomic, nullable) SDLScreenshotViewController *screenshotViewController;
-@property (strong, nonatomic) UIWindow *lockWindow;
+@property (strong, nonatomic, nullable) UIWindow *lockWindow;
 
 @end
 
@@ -27,15 +27,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Lifecycle
 
-- (instancetype)init {
-    self = [super init];
-    if (!self) { return nil; }
-
-    CGRect screenFrame = [[UIScreen mainScreen] bounds];
-    _lockWindow = [[UIWindow alloc] initWithFrame:screenFrame];
-    _lockWindow.backgroundColor = [UIColor clearColor];
-
-    return self;
+- (nullable UIWindow *)lockWindow {
+    if(!_lockWindow) {
+        CGRect screenFrame = [[UIScreen mainScreen] bounds];
+        _lockWindow = [[UIWindow alloc] initWithFrame:screenFrame];
+        _lockWindow.backgroundColor = [UIColor clearColor];
+    }
+    return _lockWindow;
 }
 
 #pragma mark - Present Lock Window
@@ -62,7 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
         return;
     }
 
-    NSArray* windows = [[UIApplication sharedApplication] windows];
+    NSArray *windows = [[UIApplication sharedApplication] windows];
     UIWindow *appWindow = nil;
     for (UIWindow *window in windows) {
         if (window != self.lockWindow) {

--- a/SmartDeviceLink/SDLLockScreenPresenter.m
+++ b/SmartDeviceLink/SDLLockScreenPresenter.m
@@ -25,17 +25,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLLockScreenPresenter
 
-#pragma mark - Lifecycle
-
-- (nullable UIWindow *)lockWindow {
-    if(!_lockWindow) {
-        CGRect screenFrame = [[UIScreen mainScreen] bounds];
-        _lockWindow = [[UIWindow alloc] initWithFrame:screenFrame];
-        _lockWindow.backgroundColor = [UIColor clearColor];
-    }
-    return _lockWindow;
-}
-
 #pragma mark - Present Lock Window
 
 - (void)present {
@@ -43,6 +32,12 @@ NS_ASSUME_NONNULL_BEGIN
 
     __weak typeof(self) weakself = self;
     dispatch_async(dispatch_get_main_queue(), ^{
+        if(!weakself.lockWindow) {
+            CGRect screenFrame = [[UIScreen mainScreen] bounds];
+            weakself.lockWindow = [[UIWindow alloc] initWithFrame:screenFrame];
+            weakself.lockWindow.backgroundColor = [UIColor clearColor];
+        }
+
         weakself.screenshotViewController = [[SDLScreenshotViewController alloc] init];
         weakself.lockWindow.rootViewController = weakself.screenshotViewController;
 
@@ -166,7 +161,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)sdl_dismissIOS12 {
-    NSArray* windows = [[UIApplication sharedApplication] windows];
+    NSArray *windows = [[UIApplication sharedApplication] windows];
     UIWindow *appWindow = nil;
     for (UIWindow *window in windows) {
         SDLLogV(@"Checking window: %@", window);


### PR DESCRIPTION
Fixes #1496 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Unit test cases were run.

#### Core Tests
Core version / branch / commit hash / module tested against: SYNC 3, v3.0
HMI name / version / branch / commit hash / module tested against: SYNC 3, v3.0

### Summary
The lock screen window is now created when the lock screen is presented and destroyed when the lock screen is dismissed. This prevents a lock screen `UIWindow` from being added to `[UIApplication sharedApplication].windows` unnecessarily when the SDL app starts as the user may never connect to a head unit.    

### Changelog
##### Bug Fixes
* The lock screen `UIWindow` is now created on presentation and destroyed on dismissal instead of being created immediately and persisting thought the app session. 

### Tasks Remaining:
- [x] iAP transport smoke tests - iOS 13
- [x] iAP transport smoke tests - iOS 12
- [x] Video streaming smoke tests 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
