### PR TITLE
LockScreen bounds should always be full bounds of Main screen

### DIFF
--- a/SmartDeviceLink/SDLLockScreenPresenter.m
+++ b/SmartDeviceLink/SDLLockScreenPresenter.m
@@ -134,12 +134,8 @@ NS_ASSUME_NONNULL_BEGIN
     // We let ourselves know that the lockscreen will present, because we have to pause streaming video for that 0.3 seconds or else it will be very janky.
     [[NSNotificationCenter defaultCenter] postNotificationName:SDLLockScreenManagerWillPresentLockScreenViewController object:nil];
 
-    CGRect firstFrame = appWindow.frame;
-    firstFrame.origin.x = CGRectGetWidth(firstFrame);
-    appWindow.frame = firstFrame;
-
     // We then move the lockWindow to the original appWindow location.
-    self.lockWindow.frame = appWindow.bounds;
+    self.lockWindow.frame = UIScreen.mainScreen.bounds;
     [self.screenshotViewController loadScreenshotOfWindow:appWindow];
     [self.lockWindow makeKeyAndVisible];
 
@@ -232,12 +228,6 @@ NS_ASSUME_NONNULL_BEGIN
     // Dismiss the lockscreen
     SDLLogD(@"Dismiss lock screen window from app window: %@", appWindow);
     [self.lockViewController dismissViewControllerAnimated:YES completion:^{
-        CGRect lockFrame = self.lockWindow.frame;
-        lockFrame.origin.x = CGRectGetWidth(lockFrame);
-        self.lockWindow.frame = lockFrame;
-
-        // Quickly move the map back, and make it the key window.
-        appWindow.frame = self.lockWindow.bounds;
         [appWindow makeKeyAndVisible];
 
         // Tell ourselves we are done.


### PR DESCRIPTION
Fixes #1492 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [n/a] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
There are no unit tests for this class 

#### Core Tests
Tested against TDK

### Summary
Made the lockscreen always be the full size of the phone screen when presented

#### Bug Fixes
Fixes the issue that sets the lockscreen to the size of the `appWindow`, in some cases the appWIndow may not be the full size of the screen. This can cause issues with how the lockscreen looks when presented.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
