### PR TITLE
Fixed the wrong window being shown by lock screen presenter

### DIFF
--- a/SmartDeviceLink/SDLLockScreenManager.m
+++ b/SmartDeviceLink/SDLLockScreenManager.m
@@ -156,26 +156,38 @@ NS_ASSUME_NONNULL_BEGIN
         return;
     }
 
-    // Present the VC depending on the lock screen status
-    if (self.config.displayMode == SDLLockScreenConfigurationDisplayModeAlways) {
-        if (!self.presenter.presented && self.canPresent) {
-            [self.presenter present];
-        }
-    } else if ([self.lastLockNotification.lockScreenStatus isEqualToEnum:SDLLockScreenStatusRequired]) {
-        if (!self.presenter.presented && self.canPresent && !self.lockScreenDismissedByUser) {
-            [self.presenter present];
-        }
-    } else if ([self.lastLockNotification.lockScreenStatus isEqualToEnum:SDLLockScreenStatusOptional]) {
-        if (self.config.displayMode == SDLLockScreenConfigurationDisplayModeOptionalOrRequired && !self.presenter.presented && self.canPresent && !self.lockScreenDismissedByUser) {
-            [self.presenter present];
-        } else if (self.config.displayMode != SDLLockScreenConfigurationDisplayModeOptionalOrRequired && self.presenter.presented) {
-            [self.presenter dismiss];
-        }
-    } else if ([self.lastLockNotification.lockScreenStatus isEqualToEnum:SDLLockScreenStatusOff]) {
-        if (self.presenter.presented) {
-            [self.presenter dismiss];
-        }
-    }
+    __weak typeof(self) weakself = self;
+	dispatch_async(dispatch_get_main_queue(), ^{
+		if (!([UIApplication sharedApplication].applicationState == UIApplicationStateActive)) {
+			// Don't present lock screen when app is backgrounded because the screenshot will be a black screen
+			return;
+		}
+
+		[weakself sdl_checkLockScreenStatus];
+	});
+}
+
+- (void)sdl_checkLockScreenStatus {
+	// Present the VC depending on the lock screen status
+	if (self.config.displayMode == SDLLockScreenConfigurationDisplayModeAlways) {
+		if (!self.presenter.presented && self.canPresent) {
+			[self.presenter present];
+		}
+	} else if ([self.lastLockNotification.lockScreenStatus isEqualToEnum:SDLLockScreenStatusRequired]) {
+		if (!self.presenter.presented && self.canPresent && !self.lockScreenDismissedByUser) {
+			[self.presenter present];
+		}
+	} else if ([self.lastLockNotification.lockScreenStatus isEqualToEnum:SDLLockScreenStatusOptional]) {
+		if (self.config.displayMode == SDLLockScreenConfigurationDisplayModeOptionalOrRequired && !self.presenter.presented && self.canPresent && !self.lockScreenDismissedByUser) {
+			[self.presenter present];
+		} else if (self.config.displayMode != SDLLockScreenConfigurationDisplayModeOptionalOrRequired && self.presenter.presented) {
+			[self.presenter dismiss];
+		}
+	} else if ([self.lastLockNotification.lockScreenStatus isEqualToEnum:SDLLockScreenStatusOff]) {
+		if (self.presenter.presented) {
+			[self.presenter dismiss];
+		}
+	}
 }
 
 - (void)sdl_updateLockScreenDismissable {

--- a/SmartDeviceLink/SDLLockScreenPresenter.m
+++ b/SmartDeviceLink/SDLLockScreenPresenter.m
@@ -136,7 +136,7 @@ NS_ASSUME_NONNULL_BEGIN
     // We let ourselves know that the lockscreen will present, because we have to pause streaming video for that 0.3 seconds or else it will be very janky.
     [[NSNotificationCenter defaultCenter] postNotificationName:SDLLockScreenManagerWillPresentLockScreenViewController object:nil];
 
-	// Save the currently visible root view controller so we can find it when dismissing the lock screen window
+	// Save the currently visible root view controller so we can find it when dismissing the lock screen window. It is not possible to present/dismiss a view in a window that is not visible so we don't have to worry about the `rootViewController` changing.
 	self.coveredRootViewController = appWindow.rootViewController;
 
     CGRect firstFrame = appWindow.frame;

--- a/SmartDeviceLink/SDLLockScreenPresenter.m
+++ b/SmartDeviceLink/SDLLockScreenPresenter.m
@@ -207,7 +207,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         NSArray<UIWindow *> *windows = appWindowScene.windows;
         UIWindow *appWindow = nil;
-        for (UIWindow *window in windows.reverseObjectEnumerator) {
+        for (UIWindow *window in windows) {
             SDLLogV(@"Checking window: %@", window);
             if ([window.rootViewController isKindOfClass:[self.coveredRootViewController class]]) {
                 appWindow = window;

--- a/SmartDeviceLink/SDLLockScreenPresenter.m
+++ b/SmartDeviceLink/SDLLockScreenPresenter.m
@@ -98,10 +98,11 @@ NS_ASSUME_NONNULL_BEGIN
             }
         }
 
+		// Find the currently visible app window
         NSArray<UIWindow *> *windows = appWindowScene.windows;
         UIWindow *appWindow = nil;
         for (UIWindow *window in windows) {
-            if (window != self.lockWindow) {
+            if (window.isKeyWindow) {
                 SDLLogV(@"Found app window");
                 appWindow = window;
                 break;
@@ -202,9 +203,9 @@ NS_ASSUME_NONNULL_BEGIN
 
         NSArray<UIWindow *> *windows = appWindowScene.windows;
         UIWindow *appWindow = nil;
-        for (UIWindow *window in windows) {
+        for (UIWindow *window in windows.reverseObjectEnumerator) {
             SDLLogV(@"Checking window: %@", window);
-            if (window != self.lockWindow) {
+            if (window != self.lockWindow && ![window.rootViewController isKindOfClass:[UIInputViewController class]]) {
                 appWindow = window;
                 break;
             }

--- a/SmartDeviceLink/SDLLockScreenPresenter.m
+++ b/SmartDeviceLink/SDLLockScreenPresenter.m
@@ -19,6 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (strong, nonatomic) SDLScreenshotViewController *screenshotViewController;
 @property (strong, nonatomic) UIWindow *lockWindow;
+@property (strong, nonatomic, nullable) UIViewController *coveredRootViewController;
 
 @end
 
@@ -135,6 +136,9 @@ NS_ASSUME_NONNULL_BEGIN
     // We let ourselves know that the lockscreen will present, because we have to pause streaming video for that 0.3 seconds or else it will be very janky.
     [[NSNotificationCenter defaultCenter] postNotificationName:SDLLockScreenManagerWillPresentLockScreenViewController object:nil];
 
+	// Save the currently visible root view controller so we can find it when dismissing the lock screen window
+	self.coveredRootViewController = appWindow.rootViewController;
+
     CGRect firstFrame = appWindow.frame;
     firstFrame.origin.x = CGRectGetWidth(firstFrame);
     appWindow.frame = firstFrame;
@@ -205,8 +209,9 @@ NS_ASSUME_NONNULL_BEGIN
         UIWindow *appWindow = nil;
         for (UIWindow *window in windows.reverseObjectEnumerator) {
             SDLLogV(@"Checking window: %@", window);
-            if (window != self.lockWindow && ![window.rootViewController isKindOfClass:[UIInputViewController class]]) {
+            if ([window.rootViewController isKindOfClass:[self.coveredRootViewController class]]) {
                 appWindow = window;
+				self.coveredRootViewController = nil;
                 break;
             }
         }

--- a/SmartDeviceLink/SDLLockScreenPresenter.m
+++ b/SmartDeviceLink/SDLLockScreenPresenter.m
@@ -63,7 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSArray* windows = [[UIApplication sharedApplication] windows];
     UIWindow *appWindow = nil;
     for (UIWindow *window in windows) {
-        if (window != self.lockWindow) {
+        if (window.isKeyWindow) {
             appWindow = window;
             break;
         }
@@ -174,7 +174,7 @@ NS_ASSUME_NONNULL_BEGIN
     UIWindow *appWindow = nil;
     for (UIWindow *window in windows) {
         SDLLogV(@"Checking window: %@", window);
-        if (window != self.lockWindow) {
+        if ([window.rootViewController isKindOfClass:[self.coveredRootViewController class]]) {
             appWindow = window;
             break;
         }
@@ -211,7 +211,6 @@ NS_ASSUME_NONNULL_BEGIN
             SDLLogV(@"Checking window: %@", window);
             if ([window.rootViewController isKindOfClass:[self.coveredRootViewController class]]) {
                 appWindow = window;
-				self.coveredRootViewController = nil;
                 break;
             }
         }
@@ -245,6 +244,8 @@ NS_ASSUME_NONNULL_BEGIN
         // Quickly move the map back, and make it the key window.
         appWindow.frame = self.lockWindow.bounds;
         [appWindow makeKeyAndVisible];
+
+		self.coveredRootViewController = nil;
 
         // Tell ourselves we are done.
         [[NSNotificationCenter defaultCenter] postNotificationName:SDLLockScreenManagerDidDismissLockScreenViewController object:nil];


### PR DESCRIPTION
Fixes #1501 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Unit tests were run.

#### Core Tests
Smoke tests perform with SYNC 3.

Core version / branch / commit hash / module tested against: SYNC 3 v3.0
HMI name / version / branch / commit hash / module tested against: SYNC 3 v3.0

### Summary
Fixed the lock screen presenter selecting the wrong `UIWindow` when the app has multiple `UIWindow`s. This bug created the following issues:
1. The wrong view controller snapshot was shown when presenting the lock screen window (snapshot is used for animating the presentation of the lock screen). 
1. The wrong `UIWindow` was made visible when dismissing the lock screen window. 

### Changelog
##### Bug Fixes
* Fixed the lock screen presenter selecting the wrong `UIWindow` when the app has multiple `UIWindow`s.

### Tasks Remaining:
- [x] Smoke tests

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
