### PR TITLE
LockScreen Dismiss animation 

### DIFF
--- a/SmartDeviceLink/SDLLockScreenPresenter.m
+++ b/SmartDeviceLink/SDLLockScreenPresenter.m
@@ -22,6 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+BOOL isDissmissing = NO;
 
 @implementation SDLLockScreenPresenter
 
@@ -155,6 +156,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)dismiss {
     SDLLogD(@"Trying to dismiss lock screen");
+    if(isDissmissing) {
+        return;
+    }
     dispatch_async(dispatch_get_main_queue(), ^{
         if (@available(iOS 13.0, *)) {
             [self sdl_dismissIOS13];
@@ -231,6 +235,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     // Dismiss the lockscreen
     SDLLogD(@"Dismiss lock screen window from app window: %@", appWindow);
+    isDissmissing = YES;
     [self.lockViewController dismissViewControllerAnimated:YES completion:^{
         CGRect lockFrame = self.lockWindow.frame;
         lockFrame.origin.x = CGRectGetWidth(lockFrame);
@@ -242,6 +247,8 @@ NS_ASSUME_NONNULL_BEGIN
 
         // Tell ourselves we are done.
         [[NSNotificationCenter defaultCenter] postNotificationName:SDLLockScreenManagerDidDismissLockScreenViewController object:nil];
+
+        isDissmissing = NO;
     }];
 }
 


### PR DESCRIPTION
Fixes #1504 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [n/a] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests
Tested Lockscreen animation to make sure that dismiss is called once and the screen dismiss animation is shown

Core version / branch / commit hash / module tested against: TDK, SYNC 3, V3.0

### Summary
Made a change that makes sure the dismiss lock screen is only fired once so the animation can occur


##### Bug Fixes
dismissViewControllerAnimated was being called twice causing issues with the lockscreen animation

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
