### PR TITLE
Fixing lock screen dismiss call if not being presented.

### DIFF
--- a/SmartDeviceLink/SDLLockScreenPresenter.m
+++ b/SmartDeviceLink/SDLLockScreenPresenter.m
@@ -163,6 +163,12 @@ NS_ASSUME_NONNULL_BEGIN
         if (completionHandler == nil) { return; }
         return completionHandler();
     }
+    
+    if (self.lockViewController.presentingViewController == nil) {
+        SDLLogW(@"Attempted to dismiss lockscreen, but lockViewController is not presented");
+        if (completionHandler == nil) { return; }
+        return completionHandler();
+    }
 
     // Let ourselves know that the lockscreen will dismiss so we can pause video streaming for a few milliseconds - otherwise the animation to dismiss the lockscreen will be very janky.
     [[NSNotificationCenter defaultCenter] postNotificationName:SDLLockScreenManagerWillDismissLockScreenViewController object:nil];


### PR DESCRIPTION
Fixes #1523 

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

##### Bug Fixes
* Fixes issue where LockScreenWillDismiss notification appears without LockScreenDidDismiss.

### Tasks Remaining:
- [x] [Add early return if lock view controller is not presented]
- [x] [Run existing unit tests successfully]

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
