### PR TITLE
Create XM, AM and FM Convenience inits

### DIFF
--- a/SmartDeviceLink/SDLRadioControlData.h
+++ b/SmartDeviceLink/SDLRadioControlData.h
@@ -41,7 +41,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (instancetype)initWithFrequencyInteger:(nullable NSNumber<SDLInt> *)frequencyInteger frequencyFraction:(nullable NSNumber<SDLInt> *)frequencyFraction band:(nullable SDLRadioBand)band hdChannel:(nullable NSNumber<SDLInt> *)hdChannel radioEnable:(nullable NSNumber<SDLBool> *)radioEnable hdRadioEnable:(nullable NSNumber<SDLBool> *)hdRadioEnable;
 
-
 /// Constructs a newly allocated SDLRadioControlCapabilities object with given parameters.
 ///
 /// @param frequencyInteger Must be between 875 and 1080

--- a/SmartDeviceLink/SDLRadioControlData.h
+++ b/SmartDeviceLink/SDLRadioControlData.h
@@ -41,6 +41,38 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (instancetype)initWithFrequencyInteger:(nullable NSNumber<SDLInt> *)frequencyInteger frequencyFraction:(nullable NSNumber<SDLInt> *)frequencyFraction band:(nullable SDLRadioBand)band hdChannel:(nullable NSNumber<SDLInt> *)hdChannel radioEnable:(nullable NSNumber<SDLBool> *)radioEnable hdRadioEnable:(nullable NSNumber<SDLBool> *)hdRadioEnable;
 
+
+/// Constructs a newly allocated SDLRadioControlCapabilities object with given parameters.
+///
+/// @param frequencyInteger Must be between 875 and 1080
+/// @param frequencyFraction Must be between 0 and 9
+/// @return An instance of the SDLRadioControlData class
+- (instancetype)initFMWithFrequencyInteger:(nullable NSNumber<SDLInt> *)frequencyInteger frequencyFraction:(nullable NSNumber<SDLInt> *)frequencyFraction;
+
+/// Constructs a newly allocated SDLRadioControlCapabilities object with given parameters.
+///
+/// @param hdChannel Must be between 0 and 7
+/// @return An instance of the SDLRadioControlData class
+- (instancetype)initFMWithHdChannel:(nullable NSNumber<SDLInt> *)hdChannel;
+
+/// Constructs a newly allocated SDLRadioControlCapabilities object with given parameters.
+///
+/// @param frequencyInteger Must be between 875 and 1080
+/// @return An instance of the SDLRadioControlData class
+- (instancetype)initAMWithFrequencyInteger:(nullable NSNumber<SDLInt> *)frequencyInteger;
+
+/// Constructs a newly allocated SDLRadioControlCapabilities object with given parameters.
+///
+/// @param hdChannel Must be between 0 and 7
+/// @return An instance of the SDLRadioControlData class
+- (instancetype)initAMWithHdChannel:(nullable NSNumber<SDLInt> *)hdChannel;
+
+/// Constructs a newly allocated SDLRadioControlCapabilities object with given parameters.
+///
+/// @param frequencyInteger Must be between 1 and 1710
+/// @return An instance of the SDLRadioControlData class
+- (instancetype)initXMWithFrequencyInteger:(nullable NSNumber<SDLInt> *)frequencyInteger;
+
 /**
  * The integer part of the frequency ie for 101.7 this value should be 101
  *

--- a/SmartDeviceLink/SDLRadioControlData.h
+++ b/SmartDeviceLink/SDLRadioControlData.h
@@ -45,26 +45,16 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// @param frequencyInteger Must be between 0 and 1710
 /// @param frequencyFraction Must be between 0 and 9
-/// @return An instance of the SDLRadioControlData class
-- (instancetype)initFMWithFrequencyInteger:(nullable NSNumber<SDLInt> *)frequencyInteger frequencyFraction:(nullable NSNumber<SDLInt> *)frequencyFraction;
-
-/// Constructs a newly allocated SDLRadioControlCapabilities object with given parameters.
-///
 /// @param hdChannel Must be between 0 and 7
 /// @return An instance of the SDLRadioControlData class
-- (instancetype)initFMWithHdChannel:(nullable NSNumber<SDLInt> *)hdChannel;
+- (instancetype)initFMWithFrequencyInteger:(nullable NSNumber<SDLInt> *)frequencyInteger frequencyFraction:(nullable NSNumber<SDLInt> *)frequencyFraction hdChannel:(nullable NSNumber<SDLInt> *)hdChannel;
 
 /// Constructs a newly allocated SDLRadioControlCapabilities object with given parameters.
 ///
 /// @param frequencyInteger Must be between 0 and 1710
-/// @return An instance of the SDLRadioControlData class
-- (instancetype)initAMWithFrequencyInteger:(nullable NSNumber<SDLInt> *)frequencyInteger;
-
-/// Constructs a newly allocated SDLRadioControlCapabilities object with given parameters.
-///
 /// @param hdChannel Must be between 0 and 7
 /// @return An instance of the SDLRadioControlData class
-- (instancetype)initAMWithHdChannel:(nullable NSNumber<SDLInt> *)hdChannel;
+- (instancetype)initAMWithFrequencyInteger:(nullable NSNumber<SDLInt> *)frequencyInteger hdChannel:(nullable NSNumber<SDLInt> *)hdChannel;
 
 /// Constructs a newly allocated SDLRadioControlCapabilities object with given parameters.
 ///

--- a/SmartDeviceLink/SDLRadioControlData.h
+++ b/SmartDeviceLink/SDLRadioControlData.h
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Constructs a newly allocated SDLRadioControlCapabilities object with given parameters.
 ///
-/// @param frequencyInteger Must be between 875 and 1080
+/// @param frequencyInteger Must be between 0 and 1710
 /// @param frequencyFraction Must be between 0 and 9
 /// @return An instance of the SDLRadioControlData class
 - (instancetype)initFMWithFrequencyInteger:(nullable NSNumber<SDLInt> *)frequencyInteger frequencyFraction:(nullable NSNumber<SDLInt> *)frequencyFraction;
@@ -56,7 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Constructs a newly allocated SDLRadioControlCapabilities object with given parameters.
 ///
-/// @param frequencyInteger Must be between 875 and 1080
+/// @param frequencyInteger Must be between 0 and 1710
 /// @return An instance of the SDLRadioControlData class
 - (instancetype)initAMWithFrequencyInteger:(nullable NSNumber<SDLInt> *)frequencyInteger;
 

--- a/SmartDeviceLink/SDLRadioControlData.m
+++ b/SmartDeviceLink/SDLRadioControlData.m
@@ -48,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
     if(!self) {
         return nil;
     }
-
+    
     self.band = SDLRadioBandFM;
     self.frequencyInteger = frequencyInteger;
     self.frequencyFraction = frequencyFraction;

--- a/SmartDeviceLink/SDLRadioControlData.m
+++ b/SmartDeviceLink/SDLRadioControlData.m
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (instancetype)initFMWithFrequencyInteger:(nullable NSNumber<SDLInt> *)frequencyInteger frequencyFraction:(nullable NSNumber<SDLInt> *)frequencyFraction {
+- (instancetype)initFMWithFrequencyInteger:(nullable NSNumber<SDLInt> *)frequencyInteger frequencyFraction:(nullable NSNumber<SDLInt> *)frequencyFraction hdChannel:(nullable NSNumber<SDLInt> *)hdChannel {
     self = [self init];
     if(!self) {
         return nil;
@@ -52,18 +52,20 @@ NS_ASSUME_NONNULL_BEGIN
     self.band = SDLRadioBandFM;
     self.frequencyInteger = frequencyInteger;
     self.frequencyFraction = frequencyFraction;
+    self.hdChannel = hdChannel;
 
     return self;
 }
 
-- (instancetype)initAMWithFrequencyInteger:(nullable NSNumber<SDLInt> *)frequencyInteger {
+- (instancetype)initAMWithFrequencyInteger:(nullable NSNumber<SDLInt> *)frequencyInteger hdChannel:(nullable NSNumber<SDLInt> *)hdChannel {
     self = [self init];
     if(!self) {
         return nil;
     }
 
-    self.frequencyInteger = frequencyInteger;
     self.band = SDLRadioBandAM;
+    self.frequencyInteger = frequencyInteger;
+    self.hdChannel = hdChannel;
 
     return self;
 }
@@ -76,30 +78,6 @@ NS_ASSUME_NONNULL_BEGIN
 
     self.frequencyInteger = frequencyInteger;
     self.band = SDLRadioBandXM;
-
-    return self;
-}
-
-- (instancetype)initFMWithHdChannel:(nullable NSNumber<SDLInt> *)hdChannel {
-    self = [self init];
-     if(!self) {
-         return nil;
-     }
-
-    self.hdChannel = hdChannel;
-    self.band = SDLRadioBandFM;
-
-    return self;
-}
-
-- (instancetype)initAMWithHdChannel:(nullable NSNumber<SDLInt> *)hdChannel {
-    self = [self init];
-    if(!self) {
-        return nil;
-    }
-
-    self.hdChannel = hdChannel;
-    self.band = SDLRadioBandAM;
 
     return self;
 }

--- a/SmartDeviceLink/SDLRadioControlData.m
+++ b/SmartDeviceLink/SDLRadioControlData.m
@@ -43,6 +43,67 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (instancetype)initFMWithFrequencyInteger:(nullable NSNumber<SDLInt> *)frequencyInteger frequencyFraction:(nullable NSNumber<SDLInt> *)frequencyFraction {
+    self = [self init];
+    if(!self) {
+        return nil;
+    }
+
+    self.band = SDLRadioBandFM;
+    self.frequencyInteger = frequencyInteger;
+    self.frequencyFraction = frequencyFraction;
+
+    return self;
+}
+
+- (instancetype)initAMWithFrequencyInteger:(nullable NSNumber<SDLInt> *)frequencyInteger {
+    self = [self init];
+    if(!self) {
+        return nil;
+    }
+
+    self.frequencyInteger = frequencyInteger;
+    self.band = SDLRadioBandAM;
+
+    return self;
+}
+
+- (instancetype)initXMWithFrequencyInteger:(nullable NSNumber<SDLInt> *)frequencyInteger {
+    self = [self init];
+    if(!self) {
+        return nil;
+    }
+
+    self.frequencyInteger = frequencyInteger;
+    self.band = SDLRadioBandXM;
+
+    return self;
+}
+
+- (instancetype)initFMWithHdChannel:(nullable NSNumber<SDLInt> *)hdChannel {
+    self = [self init];
+     if(!self) {
+         return nil;
+     }
+
+    self.hdChannel = hdChannel;
+    self.band = SDLRadioBandFM;
+
+    return self;
+}
+
+- (instancetype)initAMWithHdChannel:(nullable NSNumber<SDLInt> *)hdChannel {
+    self = [self init];
+    if(!self) {
+        return nil;
+    }
+
+    self.hdChannel = hdChannel;
+    self.band = SDLRadioBandAM;
+
+    return self;
+}
+
 - (void)setFrequencyInteger:(nullable NSNumber<SDLInt> *)frequencyInteger {
     [self.store sdl_setObject:frequencyInteger forName:SDLRPCParameterNameFrequencyInteger];
 }

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLRadioControlDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLRadioControlDataSpec.m
@@ -155,6 +155,44 @@ describe(@"Initialization tests", ^{
         expect(testStruct.hdRadioEnable).to(equal(@YES));
     });
 
+    it(@"Should get correctly when initialized FM radio control capabilities parameters", ^ {
+        SDLRadioControlData* testStruct = [[SDLRadioControlData alloc] initFMWithFrequencyInteger:@101 frequencyFraction:@7];
+
+        expect(testStruct.frequencyInteger).to(equal(@101));
+        expect(testStruct.frequencyFraction).to(equal(@7));
+        expect(testStruct.band).to(equal(SDLRadioBandFM));
+    });
+
+    it(@"Should get correctly when initialized FM radio control capabilities parameters", ^ {
+        SDLRadioControlData* testStruct = [[SDLRadioControlData alloc] initFMWithHdChannel:@5];
+
+        expect(testStruct.hdChannel).to(equal(@5));
+        expect(testStruct.band).to(equal(SDLRadioBandFM));
+    });
+
+    it(@"Should get correctly when initialized AM radio control capabilities parameters", ^ {
+        SDLRadioControlData* testStruct = [[SDLRadioControlData alloc] initAMWithFrequencyInteger:@101];
+
+        expect(testStruct.frequencyInteger).to(equal(@101));
+        expect(testStruct.band).to(equal(SDLRadioBandAM));
+    });
+
+    it(@"Should get correctly when initialized AM radio control capabilities parameters", ^ {
+        SDLRadioControlData* testStruct = [[SDLRadioControlData alloc] initAMWithHdChannel:@5];
+
+        expect(testStruct.hdChannel).to(equal(@5));
+        expect(testStruct.band).to(equal(SDLRadioBandAM));
+    });
+
+    it(@"Should get correctly when initialized XM radio control capabilities parameters", ^ {
+        SDLRadioControlData* testStruct = [[SDLRadioControlData alloc] initXMWithFrequencyInteger:@101];
+
+        expect(testStruct.frequencyInteger).to(equal(@101));
+        expect(testStruct.band).to(equal(SDLRadioBandXM));
+    });
+
+
+
 });
 
 QuickSpecEnd

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLRadioControlDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLRadioControlDataSpec.m
@@ -156,32 +156,20 @@ describe(@"Initialization tests", ^{
     });
 
     it(@"Should get correctly when initialized FM radio control capabilities parameters", ^ {
-        SDLRadioControlData* testStruct = [[SDLRadioControlData alloc] initFMWithFrequencyInteger:@101 frequencyFraction:@7];
+        SDLRadioControlData* testStruct = [[SDLRadioControlData alloc] initFMWithFrequencyInteger:@101 frequencyFraction:@7 hdChannel:@2];
 
         expect(testStruct.frequencyInteger).to(equal(@101));
         expect(testStruct.frequencyFraction).to(equal(@7));
         expect(testStruct.band).to(equal(SDLRadioBandFM));
-    });
-
-    it(@"Should get correctly when initialized FM radio control capabilities parameters", ^ {
-        SDLRadioControlData* testStruct = [[SDLRadioControlData alloc] initFMWithHdChannel:@5];
-
-        expect(testStruct.hdChannel).to(equal(@5));
-        expect(testStruct.band).to(equal(SDLRadioBandFM));
+        expect(testStruct.hdChannel).to(equal(@2));
     });
 
     it(@"Should get correctly when initialized AM radio control capabilities parameters", ^ {
-        SDLRadioControlData* testStruct = [[SDLRadioControlData alloc] initAMWithFrequencyInteger:@101];
+        SDLRadioControlData* testStruct = [[SDLRadioControlData alloc] initAMWithFrequencyInteger:@101 hdChannel:@2];
 
         expect(testStruct.frequencyInteger).to(equal(@101));
         expect(testStruct.band).to(equal(SDLRadioBandAM));
-    });
-
-    it(@"Should get correctly when initialized AM radio control capabilities parameters", ^ {
-        SDLRadioControlData* testStruct = [[SDLRadioControlData alloc] initAMWithHdChannel:@5];
-
-        expect(testStruct.hdChannel).to(equal(@5));
-        expect(testStruct.band).to(equal(SDLRadioBandAM));
+        expect(testStruct.hdChannel).to(equal(@2));
     });
 
     it(@"Should get correctly when initialized XM radio control capabilities parameters", ^ {


### PR DESCRIPTION
Fixes #1206 

This PR is **not ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Added unit test to create an SDLRadioControlData and make sure the correct variables are set properly

#### Core Tests
Tested that the data is set correctly 

Core version / branch / commit hash / module tested against: Develop
HMI name / version / branch / commit hash / module tested against: Develop

### Summary
Added a few Convenience inits to set data for XM, FM and AM frequency

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
