### PR TITLE
Fix HMI status is cleared

### DIFF
--- a/SmartDeviceLink/SDLStreamingAudioLifecycleManager.h
+++ b/SmartDeviceLink/SDLStreamingAudioLifecycleManager.h
@@ -36,6 +36,13 @@ NS_ASSUME_NONNULL_BEGIN
 @property (copy, nonatomic, nullable) SDLHMILevel hmiLevel;
 
 /**
+ *  oldHmiLevel: save HMI status at stop manager, resume HMI status at start manager.
+ *  resumeHMIStatus: YES: need resume HMI status    NO: no need resume HMI status
+*/
+@property (copy, nonatomic, nullable) SDLHMILevel oldHmiLevel;
+@property (nonatomic) BOOL resumeHMIStatus;
+
+/**
  *  Whether or not the audio session is connected.
  */
 @property (assign, nonatomic, readonly, getter=isAudioConnected) BOOL audioConnected;

--- a/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
@@ -90,7 +90,12 @@ NS_ASSUME_NONNULL_BEGIN
             [self.protocol.protocolDelegateTable addObject:self];
         }
     }
-
+    
+    // resume HMIState when start manager
+    if (_resumeHMIStatus) {
+        self.hmiLevel = self.oldHmiLevel;
+    }
+    
     // attempt to start streaming since we may already have necessary conditions met
     [self sdl_startAudioSession];
 }
@@ -99,6 +104,9 @@ NS_ASSUME_NONNULL_BEGIN
     SDLLogD(@"Stopping manager");
     [self sdl_stopAudioSession];
 
+    // cleared state when stop manager
+    self.oldHmiLevel = self.hmiLevel;
+    self.resumeHMIStatus = YES;
     self.hmiLevel = SDLHMILevelNone;
 
     [self.audioStreamStateMachine transitionToState:SDLAudioStreamManagerStateStopped];
@@ -261,6 +269,8 @@ NS_ASSUME_NONNULL_BEGIN
     }
     
     self.hmiLevel = hmiStatus.hmiLevel;
+    // received notification of HMI status change, no need resume HMIStatus.
+    self.resumeHMIStatus = NO;
 
     // if startWithProtocol has not been called yet, abort here
     if (!self.protocol) { return; }

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.h
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.h
@@ -43,6 +43,15 @@ NS_ASSUME_NONNULL_BEGIN
 @property (copy, nonatomic, nullable) SDLVideoStreamingState videoStreamingState;
 
 /**
+ *  oldHmiLevel: save HMI status at stop manager, resume HMI status at start manager.
+ *  oldVideoStreamingState: save HMI status at stop manager, resume HMI status at start manager.
+ *  resumeHMIStatus: YES: need resume HMI status    NO: no need resume HMI status
+ */
+@property (copy, nonatomic, nullable) SDLHMILevel oldHmiLevel;
+@property (copy, nonatomic, nullable) SDLVideoStreamingState oldVideoStreamingState;
+@property (nonatomic) BOOL resumeHMIStatus;
+
+/**
  *  Touch Manager responsible for providing touch event notifications.
  */
 @property (nonatomic, strong, readonly) SDLTouchManager *touchManager;

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -185,6 +185,12 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
             [self.protocol.protocolDelegateTable addObject:self];
         }
     }
+    
+    // resume HMIState when start manager
+    if (_resumeHMIStatus) {
+        _hmiLevel = _oldHmiLevel;
+        _videoStreamingState = _oldVideoStreamingState;
+    }
 
     // attempt to start streaming since we may already have necessary conditions met
     [self sdl_startVideoSession];
@@ -199,6 +205,10 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
     _preferredFormatIndex = 0;
     _preferredResolutionIndex = 0;
 
+    // cleared state when stop manager
+    _oldHmiLevel = _hmiLevel;
+    _oldVideoStreamingState = _videoStreamingState;
+    _resumeHMIStatus = YES;
     _hmiLevel = SDLHMILevelNone;
     _videoStreamingState = SDLVideoStreamingStateNotStreamable;
     _lastPresentationTimestamp = kCMTimeInvalid;
@@ -611,6 +621,8 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
         return;
     }
     self.hmiLevel = hmiStatus.hmiLevel;
+    // received notification of HMI status change, no need resume HMIStatus.
+    self.resumeHMIStatus = NO;
 
     SDLVideoStreamingState newState = hmiStatus.videoStreamingState ?: SDLVideoStreamingStateStreamable;
     if (![self.videoStreamingState isEqualToEnum:newState]) {


### PR DESCRIPTION
Fixes #1471  and #1479

This PR is **ready** for review.

### Risk 
This PR makes **no** API changes.

### Testing Plan
Covered by Unit tests.

### Summary
**Reason**
#1471	When TestApp is switched to the background, the status is cleared.  						
		・The HMILevel changes to NONE					
		・VideoStream changes to NOTStreamable.					
#1479	After disconnecting TCP, the status is cleared. 						
		・The HMILevel changes to NONE					
		・VideoStream changes to NOTStreamable.					
							
The root cause of #1471 and #1479 is the same. 							
Both of them will invoke the stop function of  SDLStreamingVideoLifecycleManager, and clear the status. When it's time to revert, it can not revert due to the wrong status.							
★audioStream has the same problem.

**Solution**
1. When SDLStreamingVideoLifecycleManager's stop method is called, record current HMILevel and streamable to lastHMILevel and lastStreamable.
2. Add resumeHMIStatus flag, by which status can be reverted.
3. Receive new HMILevel status from HU, reset resumeHMIStatus flag.
4. Before sdl_startVideoSession, if resumeHMIStatus flag is true, recover lastHMILevel and lastStreamable to current HMILevel and streamable.

**Sequence(#1471)**
![image](https://user-images.githubusercontent.com/35795928/73035816-e1a12780-3e8c-11ea-8ee9-2f6c928f167f.png)


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)