### PR TITLE
Update #if DEBUG directive in SDLLogMacros

### DIFF
--- a/SmartDeviceLink/SDLLogMacros.h
+++ b/SmartDeviceLink/SDLLogMacros.h
@@ -37,7 +37,7 @@
 
 #pragma mark Debug Logs
 
-#if DEBUG
+#if DEBUG+0
 
 /**
  Log data bytes coming or going from SDL and the remote system to the console in verbose logging mode


### PR DESCRIPTION
Fixes #1514 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [n/a] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
`SDLLockScreenViewControllerSnapshotTests` tests fail

#### Core Tests
n/a

Core version / branch / commit hash / module tested against: n/a
HMI name / version / branch / commit hash / module tested against: n/a

### Summary
This PR only adds default value to preprocessor directive

### Changelog
##### Breaking Changes
was
`#if DEBUG`
now
`#if DEBUG+0`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)