### PR TITLE
Fixed multiple issues where video stream resuming fails

### DIFF
--- a/SmartDeviceLink/SDLCarWindow.m
+++ b/SmartDeviceLink/SDLCarWindow.m
@@ -94,6 +94,8 @@ NS_ASSUME_NONNULL_BEGIN
     if (pixelBuffer != nil) {
         [self.streamManager sendVideoData:pixelBuffer];
         CVPixelBufferRelease(pixelBuffer);
+    } else {
+        SDLLogE(@"Video frame will not be sent because the pixel buffer is nil");
     }
 }
 

--- a/SmartDeviceLink/SDLCarWindow.m
+++ b/SmartDeviceLink/SDLCarWindow.m
@@ -92,7 +92,11 @@ NS_ASSUME_NONNULL_BEGIN
     CGImageRef imageRef = screenshot.CGImage;
     CVPixelBufferRef pixelBuffer = [self.class sdl_pixelBufferForImageRef:imageRef usingPool:self.streamManager.pixelBufferPool];
     if (pixelBuffer != nil) {
-        [self.streamManager sendVideoData:pixelBuffer];
+        BOOL success = [self.streamManager sendVideoData:pixelBuffer];
+        if (!success) {
+            SDLLogE(@"Video frame will not be sent because the video frame encoding failed");
+            return;
+        }
         CVPixelBufferRelease(pixelBuffer);
     } else {
         SDLLogE(@"Video frame will not be sent because the pixel buffer is nil");
@@ -190,6 +194,11 @@ NS_ASSUME_NONNULL_BEGIN
     if (self.streamManager.videoScaleManager.appViewportFrame.size.width == 0) {
         // The dimensions of the display screen is unknown because the connected head unit did not provide a screen resolution in the `RegisterAppInterfaceResponse` or in the video start service ACK.
         SDLLogW(@"The dimensions of the display's screen are unknown. The CarWindow frame will not be resized.");
+        return;
+    }
+
+    if (CGRectEqualToRect(rootViewController.view.frame, self.streamManager.videoScaleManager.appViewportFrame)) {
+        SDLLogV(@"The CarWindow frame is already the correct size");
         return;
     }
 

--- a/SmartDeviceLink/SDLCarWindow.m
+++ b/SmartDeviceLink/SDLCarWindow.m
@@ -99,7 +99,7 @@ NS_ASSUME_NONNULL_BEGIN
         }
         CVPixelBufferRelease(pixelBuffer);
     } else {
-        SDLLogE(@"Video frame will not be sent because the pixel buffer is nil");
+        SDLLogE(@"Video frame will not be sent because the pixelBuffer is nil");
     }
 }
 
@@ -198,7 +198,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     if (CGRectEqualToRect(rootViewController.view.frame, self.streamManager.videoScaleManager.appViewportFrame)) {
-        SDLLogV(@"The CarWindow frame is already the correct size");
+        SDLLogV(@"The rootViewController frame is already the correct size: %@", NSStringFromCGRect(rootViewController.view.frame));
         return;
     }
 

--- a/SmartDeviceLink/SDLH264VideoEncoder.m
+++ b/SmartDeviceLink/SDLH264VideoEncoder.m
@@ -185,7 +185,7 @@ static NSDictionary<NSString *, id>* _defaultVideoEncoderSettings;
 }
 
 - (CVPixelBufferPoolRef CV_NULLABLE)pixelBufferPool {
-    // HAX: When the app is backgrounded, sometimes the compression session gets invalidated (this can happen the first time the app is backgrounded or the tenth). This causes the pool to fail when the app is foregrounded and video frames are sent again. Attempt to fix this by recreating the compression session.
+    // HAX: When the app is backgrounded, sometimes the compression session gets invalidated (this can happen the first time the app is backgrounded or the tenth). This causes the pool and/or the compression session to fail when the app is foregrounded and video frames are sent again. Attempt to fix this by recreating the compression session.
     if (self.pool == NULL) {
         BOOL success = [self sdl_resetCompressionSession];
         if (success == NO) {

--- a/SmartDeviceLink/SDLH264VideoEncoder.m
+++ b/SmartDeviceLink/SDLH264VideoEncoder.m
@@ -26,7 +26,7 @@ static NSDictionary<NSString *, id>* _defaultVideoEncoderSettings;
 @property (assign, nonatomic) NSUInteger currentFrameNumber;
 @property (assign, nonatomic) double timestampOffset;
 
-@property (assign, nonatomic, nullable) CVPixelBufferPoolRef pool;
+@property (assign, nonatomic, readwrite) CVPixelBufferPoolRef CV_NULLABLE pixelBufferPool;
 @property (assign, nonatomic) CGSize imageDimensions;
 
 @end
@@ -135,7 +135,6 @@ static NSDictionary<NSString *, id>* _defaultVideoEncoderSettings;
 
 - (void)stop {
     _currentFrameNumber = 0;
-    _imageDimensions = CGSizeZero;
     _timestampOffset = 0.0;
 
     if (self.compressionSession != NULL) {
@@ -186,16 +185,16 @@ static NSDictionary<NSString *, id>* _defaultVideoEncoderSettings;
 
 - (CVPixelBufferPoolRef CV_NULLABLE)pixelBufferPool {
     // HAX: When the app is backgrounded, sometimes the compression session gets invalidated (this can happen the first time the app is backgrounded or the tenth). This causes the pool and/or the compression session to fail when the app is foregrounded and video frames are sent again. Attempt to fix this by recreating the compression session.
-    if (self.pool == NULL) {
+    if (!_pixelBufferPool) {
         BOOL success = [self sdl_resetCompressionSession];
         if (success == NO) {
             return NULL;
         }
 
-        self.pool = VTCompressionSessionGetPixelBufferPool(self.compressionSession);
+        _pixelBufferPool = VTCompressionSessionGetPixelBufferPool(self.compressionSession);
     }
 
-    return self.pool;
+    return _pixelBufferPool;
 }
 
 #pragma mark - Private

--- a/SmartDeviceLink/SDLH264VideoEncoder.m
+++ b/SmartDeviceLink/SDLH264VideoEncoder.m
@@ -138,8 +138,6 @@ static NSDictionary<NSString *, id>* _defaultVideoEncoderSettings;
         CFRelease(self.compressionSession);
         self.compressionSession = NULL;
     }
-
-    self.pool = nil;
 }
 
 - (BOOL)encodeFrame:(CVImageBufferRef)imageBuffer {

--- a/SmartDeviceLink/SDLH264VideoEncoder.m
+++ b/SmartDeviceLink/SDLH264VideoEncoder.m
@@ -334,12 +334,7 @@ void sdl_videoEncoderOutputCallback(void * CM_NULLABLE outputCallbackRefCon, voi
 /// Attempts to create a new VTCompressionSession using the image dimensions passed when the video encoder was created and returns whether or not creating the new compression session was created successfully.
 - (BOOL)sdl_resetCompressionSession {
     OSStatus status = VTCompressionSessionCreate(NULL, (int32_t)self.imageDimensions.width, (int32_t)self.imageDimensions.height, kCMVideoCodecType_H264, NULL, self.sdl_pixelBufferOptions, NULL, &sdl_videoEncoderOutputCallback, (__bridge void *)self, &_compressionSession);
-
-    if (status == noErr) {
-        return NO;
-    }
-
-    return YES;
+    return (status == noErr) ? YES : NO;
 }
 
 @end

--- a/SmartDeviceLink/SDLH264VideoEncoder.m
+++ b/SmartDeviceLink/SDLH264VideoEncoder.m
@@ -182,7 +182,7 @@ static NSDictionary<NSString *, id>* _defaultVideoEncoderSettings;
 }
 
 - (CVPixelBufferPoolRef CV_NULLABLE)pixelBufferPool {
-    // HAX: When the app is backgrounded, some of the time the compression session gets invalidated. This causes the pool to fail when the app is foregrounded and video frames are sent again.
+    // HAX: When the app is backgrounded, sometimes the compression session gets invalidated. This causes the pool to fail when the app is foregrounded and video frames are sent again.
     if (self.pool == nil) {
         NSError* error = nil;
         [self sdl_resetCompressionSessionWithError:&error];

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -269,6 +269,7 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
     [self.lockScreenManager stop];
     [self.screenManager stop];
     [self.encryptionLifecycleManager stop];
+    [self.streamManager stop];
     if (self.secondaryTransportManager != nil) {
         [self.secondaryTransportManager stop];
     } else {

--- a/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
@@ -41,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (weak, nonatomic) SDLProtocol *protocol;
 
 @property (copy, nonatomic) NSArray<NSString *> *secureMakes;
-@property (copy, nonatomic) NSString *connectedVehicleMake;
+@property (copy, nonatomic, nullable) NSString *connectedVehicleMake;
 
 @end
 
@@ -58,6 +58,7 @@ NS_ASSUME_NONNULL_BEGIN
     _connectionManager = connectionManager;
     _audioManager = [[SDLAudioStreamManager alloc] initWithManager:self];
     _requestedEncryptionType = streamingConfiguration.maximumDesiredEncryption;
+    _connectedVehicleMake = nil;
 
     NSMutableArray<NSString *> *tempMakeArray = [NSMutableArray array];
 #pragma clang diagnostic push
@@ -95,11 +96,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)stop {
     SDLLogD(@"Stopping audio streaming lifecycle manager");
+    _protocol = nil;
     _hmiLevel = SDLHMILevelNone;
-
-    if (!self.isAudioStopped) {
-        [self.audioStreamStateMachine transitionToState:SDLAudioStreamManagerStateStopped];
-    }
+    _connectedVehicleMake = nil;
+    [self.audioStreamStateMachine transitionToState:SDLAudioStreamManagerStateStopped];
 }
 
 - (BOOL)sendAudioData:(NSData*)audioData {
@@ -307,10 +307,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)isHmiStateAudioStreamCapable {
     return [self.hmiLevel isEqualToEnum:SDLHMILevelLimited] || [self.hmiLevel isEqualToEnum:SDLHMILevelFull];
-}
-
-- (BOOL)isAudioStopped {
-    return [self.audioStreamStateMachine isCurrentState:SDLAudioStreamManagerStateStopped];
 }
 
 @end

--- a/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
@@ -170,7 +170,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 #pragma mark - SDLProtocolListener
-#pragma mark Video / Audio Start Service ACK
+#pragma mark Start Service ACK
 
 - (void)handleProtocolStartServiceACKMessage:(SDLProtocolMessage *)startServiceACK {
     switch (startServiceACK.header.serviceType) {
@@ -195,7 +195,7 @@ NS_ASSUME_NONNULL_BEGIN
     [self.audioStreamStateMachine transitionToState:SDLAudioStreamManagerStateReady];
 }
 
-#pragma mark Video / Audio Start Service NAK
+#pragma mark Start Service NAK
 
 - (void)handleProtocolStartServiceNAKMessage:(SDLProtocolMessage *)startServiceNAK {
     switch (startServiceNAK.header.serviceType) {
@@ -211,7 +211,7 @@ NS_ASSUME_NONNULL_BEGIN
     [self sdl_transitionToStoppedState:SDLServiceTypeAudio];
 }
 
-#pragma mark Video / Audio End Service
+#pragma mark End Service
 
 - (void)handleProtocolEndServiceACKMessage:(SDLProtocolMessage *)endServiceACK {
     SDLLogD(@"%@ service ended", (endServiceACK.header.serviceType == SDLServiceTypeVideo ? @"Video" : @"Audio"));

--- a/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
@@ -56,9 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
     SDLLogV(@"Creating AudioStreamingLifecycleManager");
 
     _connectionManager = connectionManager;
-
     _audioManager = [[SDLAudioStreamManager alloc] initWithManager:self];
-
     _requestedEncryptionType = streamingConfiguration.maximumDesiredEncryption;
 
     NSMutableArray<NSString *> *tempMakeArray = [NSMutableArray array];
@@ -96,12 +94,12 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)stop {
-    SDLLogD(@"Stopping manager");
-    [self sdl_stopAudioSession];
+    SDLLogD(@"Stopping audio streaming lifecycle manager");
+    _hmiLevel = SDLHMILevelNone;
 
-    self.hmiLevel = SDLHMILevelNone;
-
-    [self.audioStreamStateMachine transitionToState:SDLAudioStreamManagerStateStopped];
+    if (!self.isAudioStopped) {
+        [self.audioStreamStateMachine transitionToState:SDLAudioStreamManagerStateStopped];
+    }
 }
 
 - (BOOL)sendAudioData:(NSData*)audioData {
@@ -313,6 +311,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)isHmiStateAudioStreamCapable {
     return [self.hmiLevel isEqualToEnum:SDLHMILevelLimited] || [self.hmiLevel isEqualToEnum:SDLHMILevelFull];
+}
+
+- (BOOL)isAudioStopped {
+    return [self.audioStreamStateMachine isCurrentState:SDLAudioStreamManagerStateStopped];
 }
 
 @end

--- a/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
@@ -171,12 +171,8 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark Start Service ACK
 
 - (void)handleProtocolStartServiceACKMessage:(SDLProtocolMessage *)startServiceACK {
-    switch (startServiceACK.header.serviceType) {
-        case SDLServiceTypeAudio: {
-            [self sdl_handleAudioStartServiceAck:startServiceACK];
-        } break;
-        default: break;
-    }
+    if (startServiceACK.header.serviceType != SDLServiceTypeAudio) { return; }
+    [self sdl_handleAudioStartServiceAck:startServiceACK];
 }
 
 - (void)sdl_handleAudioStartServiceAck:(SDLProtocolMessage *)audioStartServiceAck {
@@ -196,12 +192,8 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark Start Service NAK
 
 - (void)handleProtocolStartServiceNAKMessage:(SDLProtocolMessage *)startServiceNAK {
-    switch (startServiceNAK.header.serviceType) {
-        case SDLServiceTypeAudio: {
-            [self sdl_handleAudioStartServiceNak:startServiceNAK];
-        } break;
-        default: break;
-    }
+    if (startServiceNAK.header.serviceType != SDLServiceTypeAudio) { return; }
+    [self sdl_handleAudioStartServiceNak:startServiceNAK];
 }
 
 - (void)sdl_handleAudioStartServiceNak:(SDLProtocolMessage *)audioStartServiceNak {
@@ -212,12 +204,16 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark End Service
 
 - (void)handleProtocolEndServiceACKMessage:(SDLProtocolMessage *)endServiceACK {
-    SDLLogD(@"%@ service ended", (endServiceACK.header.serviceType == SDLServiceTypeVideo ? @"Video" : @"Audio"));
+    if (endServiceACK.header.serviceType != SDLServiceTypeAudio) { return; }
+    SDLLogD(@"Audio service ended successfully");
+
     [self sdl_transitionToStoppedState:endServiceACK.header.serviceType];
 }
 
 - (void)handleProtocolEndServiceNAKMessage:(SDLProtocolMessage *)endServiceNAK {
-    SDLLogW(@"%@ service ended with end service NAK", (endServiceNAK.header.serviceType == SDLServiceTypeVideo ? @"Video" : @"Audio"));
+    if (endServiceNAK.header.serviceType != SDLServiceTypeAudio) { return; }
+    SDLLogE(@"Audio service did not end successfully");
+
     [self sdl_transitionToStoppedState:endServiceNAK.header.serviceType];
 }
 

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -718,11 +718,6 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
         SDLLogV(@"DisplayLink frame fired, duration: %f, last frame timestamp: %f, target timestamp: (not available)", displayLink.duration, displayLink.timestamp);
     }
 
-//    if (![self.hmiLevel isEqualToEnum:SDLHMILevelFull]) {
-//        SDLLogD(@"hmiLevel is not FULL. Not sending video data: %@", self.hmiLevel);
-//        return;
-//    }
-
     [self.touchManager syncFrame];
     [self.carWindow syncFrame];
 }

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -570,6 +570,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
 
 - (void)handleProtocolEndServiceNAKMessage:(SDLProtocolMessage *)endServiceNAK {
     if (endServiceNAK.header.serviceType != SDLServiceTypeVideo) { return; }
+    SDLLogE(@"Video service did not end successfully");
 
     [self sdl_transitionToStoppedState:endServiceNAK.header.serviceType];
 }

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -476,9 +476,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
 
 - (void)didEnterStateVideoStreamSuspended {
     SDLLogD(@"Video stream suspended");
-
     [self disposeDisplayLink];
-
     [[NSNotificationCenter defaultCenter] postNotificationName:SDLVideoStreamSuspendedNotification object:nil];
 }
 

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -718,10 +718,10 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
         SDLLogV(@"DisplayLink frame fired, duration: %f, last frame timestamp: %f, target timestamp: (not available)", displayLink.duration, displayLink.timestamp);
     }
 
-    if (![self.hmiLevel isEqualToEnum:SDLHMILevelFull]) {
-        SDLLogD(@"hmiLevel is not FULL. Not sending video data: %@", self.hmiLevel);
-        return;
-    }
+//    if (![self.hmiLevel isEqualToEnum:SDLHMILevelFull]) {
+//        SDLLogD(@"hmiLevel is not FULL. Not sending video data: %@", self.hmiLevel);
+//        return;
+//    }
 
     [self.touchManager syncFrame];
     [self.carWindow syncFrame];

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -646,7 +646,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
     if (!self.protocol) { return; }
 
     if (![self.hmiLevel isEqualToEnum:SDLHMILevelNone] && self.isVideoConnected) {
-        [self resetVideo];
+        //do nothing
     } else if (self.isHmiStateVideoStreamCapable) {
         [self sdl_startVideoSession];
     } else {

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -203,10 +203,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
     _lastPresentationTimestamp = kCMTimeInvalid;
 
     [self.videoScaleManager stop];
-
-    if (!self.isVideoStopped) {
-        [self.videoStreamStateMachine transitionToState:SDLVideoStreamManagerStateStopped];
-    }
+    [self.videoStreamStateMachine transitionToState:SDLVideoStreamManagerStateStopped];
 }
 
 - (BOOL)sendVideoData:(CVImageBufferRef)imageBuffer {
@@ -253,10 +250,6 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
 
 - (BOOL)isVideoStreamingPaused {
     return !(self.isVideoConnected && self.isHmiStateVideoStreamCapable && self.isAppStateVideoStreamCapable);
-}
-
-- (BOOL)isVideoStopped {
-    return [self.videoStreamStateMachine isCurrentState:SDLVideoStreamManagerStateStopped];
 }
 
 - (CVPixelBufferPoolRef __nullable)pixelBufferPool {

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -71,7 +71,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
 @property (strong, nonatomic) NSMutableDictionary *videoEncoderSettings;
 @property (copy, nonatomic) NSDictionary<NSString *, id> *customEncoderSettings;
 @property (copy, nonatomic) NSArray<NSString *> *secureMakes;
-@property (copy, nonatomic) NSString *connectedVehicleMake;
+@property (copy, nonatomic, nullable) NSString *connectedVehicleMake;
 
 @property (copy, nonatomic, readonly) NSString *appName;
 @property (assign, nonatomic) CV_NULLABLE CVPixelBufferRef backgroundingPixelBuffer;
@@ -127,6 +127,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
     _touchManager = [[SDLTouchManager alloc] initWithHitTester:(id)_focusableItemManager videoScaleManager:_videoScaleManager];
 
     _requestedEncryptionType = configuration.streamingMediaConfig.maximumDesiredEncryption;
+    _connectedVehicleMake = nil;
     _dataSource = configuration.streamingMediaConfig.dataSource;
     _useDisplayLink = configuration.streamingMediaConfig.enableForcedFramerateSync;
     _backgroundingPixelBuffer = NULL;
@@ -201,6 +202,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
     _hmiLevel = SDLHMILevelNone;
     _videoStreamingState = SDLVideoStreamingStateNotStreamable;
     _lastPresentationTimestamp = kCMTimeInvalid;
+    _connectedVehicleMake = nil;
 
     [self.videoScaleManager stop];
     [self.videoStreamStateMachine transitionToState:SDLVideoStreamManagerStateStopped];

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -483,7 +483,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
 }
 
 #pragma mark - SDLProtocolListener
-#pragma mark Video / Audio Start Service ACK
+#pragma mark Start Service ACK
 
 - (void)handleProtocolStartServiceACKMessage:(SDLProtocolMessage *)startServiceACK {
     switch (startServiceACK.header.serviceType) {
@@ -526,7 +526,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
     [self.videoStreamStateMachine transitionToState:SDLVideoStreamManagerStateReady];
 }
 
-#pragma mark Video / Audio Start Service NAK
+#pragma mark Start Service NAK
 
 - (void)handleProtocolStartServiceNAKMessage:(SDLProtocolMessage *)startServiceNAK {
     switch (startServiceNAK.header.serviceType) {
@@ -562,7 +562,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
     [self sdl_sendVideoStartService];
 }
 
-#pragma mark Video / Audio End Service
+#pragma mark End Service
 
 - (void)handleProtocolEndServiceACKMessage:(SDLProtocolMessage *)endServiceACK {
     SDLLogD(@"%@ service ended", (endServiceACK.header.serviceType == SDLServiceTypeVideo ? @"Video" : @"Audio"));

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingAudioLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingAudioLifecycleManagerSpec.m
@@ -402,6 +402,38 @@ describe(@"the streaming audio manager", ^{
             });
         });
     });
+
+    describe(@"when stopped", ^{
+        context(@"if audio not stopped", ^{
+            beforeEach(^{
+                [streamingLifecycleManager.audioStreamStateMachine setToState:SDLAudioStreamManagerStateReady fromOldState:nil callEnterTransition:NO];
+                [streamingLifecycleManager stop];
+            });
+
+            it(@"should transition to the stopped state", ^{
+                expect(streamingLifecycleManager.currentAudioStreamState).to(equal(SDLAudioStreamManagerStateStopped));
+            });
+
+            it(@"should reset the hmiLevel", ^{
+                expect(streamingLifecycleManager.hmiLevel).to(equal(SDLHMILevelNone));
+            });
+        });
+
+        context(@"if audio is already stopped", ^{
+            beforeEach(^{
+                [streamingLifecycleManager.audioStreamStateMachine setToState:SDLAudioStreamManagerStateStopped fromOldState:nil callEnterTransition:NO];
+                [streamingLifecycleManager stop];
+            });
+
+            it(@"should stay in the stopped state", ^{
+                expect(streamingLifecycleManager.currentAudioStreamState).to(equal(SDLAudioStreamManagerStateStopped));
+            });
+
+            it(@"should reset the hmiLevel", ^{
+                expect(streamingLifecycleManager.hmiLevel).to(equal(SDLHMILevelNone));
+            });
+        });
+    });
 });
 
 QuickSpecEnd

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingAudioLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingAudioLifecycleManagerSpec.m
@@ -20,6 +20,12 @@
 #import "SDLV2ProtocolMessage.h"
 #import "TestConnectionManager.h"
 
+
+@interface SDLStreamingAudioLifecycleManager()
+@property (weak, nonatomic) SDLProtocol *protocol;
+@property (copy, nonatomic, nullable) NSString *connectedVehicleMake;
+@end
+
 QuickSpecBegin(SDLStreamingAudioLifecycleManagerSpec)
 
 describe(@"the streaming audio manager", ^{
@@ -414,8 +420,10 @@ describe(@"the streaming audio manager", ^{
                 expect(streamingLifecycleManager.currentAudioStreamState).to(equal(SDLAudioStreamManagerStateStopped));
             });
 
-            it(@"should reset the hmiLevel", ^{
+            it(@"should reset the saved properties", ^{
+                expect(streamingLifecycleManager.protocol).to(beNil());
                 expect(streamingLifecycleManager.hmiLevel).to(equal(SDLHMILevelNone));
+                expect(streamingLifecycleManager.connectedVehicleMake).to(beNil());
             });
         });
 
@@ -429,8 +437,10 @@ describe(@"the streaming audio manager", ^{
                 expect(streamingLifecycleManager.currentAudioStreamState).to(equal(SDLAudioStreamManagerStateStopped));
             });
 
-            it(@"should reset the hmiLevel", ^{
+            it(@"should reset the saved properties", ^{
+                expect(streamingLifecycleManager.protocol).to(beNil());
                 expect(streamingLifecycleManager.hmiLevel).to(equal(SDLHMILevelNone));
+                expect(streamingLifecycleManager.connectedVehicleMake).to(beNil());
             });
         });
     });

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingVideoLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingVideoLifecycleManagerSpec.m
@@ -42,6 +42,8 @@
 #import "SDLHMICapabilities.h"
 
 @interface SDLStreamingVideoLifecycleManager ()
+@property (weak, nonatomic) SDLProtocol *protocol;
+@property (copy, nonatomic) NSString *connectedVehicleMake;
 @property (copy, nonatomic, readonly) NSString *appName;
 @property (copy, nonatomic, readonly) NSString *videoStreamBackgroundString;
 @end
@@ -709,6 +711,48 @@ describe(@"the streaming video manager", ^{
                 it(@"should have set all the right properties", ^{
                     expect(streamingLifecycleManager.currentVideoStreamState).to(equal(SDLVideoStreamManagerStateStopped));
                 });
+            });
+        });
+    });
+
+    describe(@"when stopped", ^{
+        context(@"if video is not stopped", ^{
+            beforeEach(^{
+                [streamingLifecycleManager.videoStreamStateMachine setToState:SDLVideoStreamManagerStateReady fromOldState:nil callEnterTransition:NO];
+                [streamingLifecycleManager stop];
+            });
+
+            it(@"should transition to the stopped state", ^{
+                expect(streamingLifecycleManager.currentVideoStreamState).to(equal(SDLVideoStreamManagerStateStopped));
+            });
+
+            it(@"should reset the saved properties", ^{
+                expect(streamingLifecycleManager.protocol).to(beNil());
+                expect(streamingLifecycleManager.connectedVehicleMake).to(beNil());
+                expect(streamingLifecycleManager.hmiLevel).to(equal(SDLHMILevelNone));
+                expect(streamingLifecycleManager.videoStreamingState).to(equal(SDLVideoStreamingStateNotStreamable));
+                expect(streamingLifecycleManager.preferredFormatIndex).to(equal(0));
+                expect(streamingLifecycleManager.preferredResolutionIndex).to(equal(0));
+            });
+        });
+
+        context(@"if video is already stopped", ^{
+            beforeEach(^{
+                [streamingLifecycleManager.videoStreamStateMachine setToState:SDLAudioStreamManagerStateStopped fromOldState:nil callEnterTransition:NO];
+                [streamingLifecycleManager stop];
+            });
+
+            it(@"should stay in the stopped state", ^{
+                expect(streamingLifecycleManager.currentVideoStreamState).to(equal(SDLVideoStreamManagerStateStopped));
+            });
+
+            it(@"should reset the saved properties", ^{
+                expect(streamingLifecycleManager.protocol).to(beNil());
+                expect(streamingLifecycleManager.connectedVehicleMake).to(beNil());
+                expect(streamingLifecycleManager.hmiLevel).to(equal(SDLHMILevelNone));
+                expect(streamingLifecycleManager.videoStreamingState).to(equal(SDLVideoStreamingStateNotStreamable));
+                expect(streamingLifecycleManager.preferredFormatIndex).to(equal(0));
+                expect(streamingLifecycleManager.preferredResolutionIndex).to(equal(0));
             });
         });
     });

--- a/SmartDeviceLinkTests/SDLH264VideoEncoderSpec.m
+++ b/SmartDeviceLinkTests/SDLH264VideoEncoderSpec.m
@@ -18,6 +18,12 @@
 #import "SDLRTPH264Packetizer.h"
 #import "SDLVideoStreamingProtocol.h"
 
+@interface SDLH264VideoEncoder ()
+@property (assign, nonatomic) NSUInteger currentFrameNumber;
+@property (assign, nonatomic) double timestampOffset;
+@property (assign, nonatomic, nullable) VTCompressionSessionRef compressionSession;
+@end
+
 QuickSpecBegin(SDLH264VideoEncoderSpec)
 
 describe(@"a video encoder", ^{
@@ -55,9 +61,11 @@ describe(@"a video encoder", ^{
             beforeEach(^{
                 [testVideoEncoder stop];
             });
-            
-            it(@"should have a nil pixel buffer pool", ^{
-                expect(@(testVideoEncoder.pixelBufferPool == NULL)).to(equal(@YES));
+
+            it(@"should reset the saved properties", ^{
+               expect(testVideoEncoder.currentFrameNumber).to(equal(0));
+               expect(testVideoEncoder.timestampOffset).to(equal(0.0));
+               expect((id)testVideoEncoder.compressionSession).to(beNil());
             });
         });
     });


### PR DESCRIPTION
Fixes #1527 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
I added unit test for testing stopping the `SDLStreamingVideoScaleManager`, `SDLStreamingAudioLifecycleManager` and `SDLH264VideoEncoder` when the session between the accessory and device is closed. 

#### Core Tests
Core version / branch / commit hash / module tested against: SYNC 3.4 BUILD 19353_DEVTEST_r133796
HMI name / version / branch / commit hash / module tested against: same as above

### Summary
1. The streaming video lifecycle manager was not reset correctly on disconnect so sometimes an end video service request was sent incorrectly when a new session opened.
1. The pixel buffer pool in the `SDLH264VideoEncoder` class randomly invalidates itself when the device app is backgrounded. Handling was added to reset the pixel buffer pool when necessary, otherwise video frames will not be sent.
1. If the the response to the video start service comes after the app has been put in the background then the app now transitions to the suspended state instead of attempting to send video frames.
1. The streaming audio lifecycle manager now resets correctly on disconnect.

When testing you may run into this issue [1540](https://github.com/smartdevicelink/sdl_ios/issues/1540) where no video is streamed by the `CarWindow` due to the video encoder failing when the app on the device is backgrounded. You will see error logs now when the `pixelBuffer` fails. 

### Changelog
##### Bug Fixes
* Fixed several issues where video stream resuming fails.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
