### PR TITLE
Update SDLTouch to handle NSNull occurence

### DIFF
--- a/SmartDeviceLink/SDLTouch.m
+++ b/SmartDeviceLink/SDLTouch.m
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
         _identifier = touchEvent.touchEventId.integerValue;
         NSArray<NSNumber<SDLInt> *> * timestamp = touchEvent.timeStamp;
         // In the event we receive a null timestamp, we will supply a device timestamp.
-        if (!timestamp || ![timestamp isKindOfClass:[NSArray class]]) {
+        if (!timestamp || ![timestamp isKindOfClass:[NSArray class]] || timestamp.count == 0) {
             _timeStamp = (NSUInteger)([[NSDate date] timeIntervalSince1970] * 1000);
         } else {
             NSNumber *timeStampNumber = (NSNumber *)timestamp[0];

--- a/SmartDeviceLink/SDLTouch.m
+++ b/SmartDeviceLink/SDLTouch.m
@@ -32,13 +32,13 @@ NS_ASSUME_NONNULL_BEGIN
     self = [self init];
     if (self) {
         _identifier = touchEvent.touchEventId.integerValue;
-
-        id firstTimeStamp = touchEvent.timeStamp.firstObject;
+        
+        id timestamp = touchEvent.timeStamp;
         // In the event we receive a null timestamp, we will supply a device timestamp.
-        if ([firstTimeStamp isKindOfClass:[NSNull class]] && [firstTimeStamp isEqual:[NSNull null]]) {
+        if (!timestamp || ![timestamp isKindOfClass:[NSArray class]]) {
             _timeStamp = (NSUInteger)([[NSDate date] timeIntervalSince1970] * 1000);
         } else {
-            NSNumber *timeStampNumber = (NSNumber *)firstTimeStamp;
+            NSNumber *timeStampNumber = (NSNumber *)timestamp[0];
             _timeStamp = timeStampNumber.unsignedIntegerValue;
         }
 

--- a/SmartDeviceLink/SDLTouch.m
+++ b/SmartDeviceLink/SDLTouch.m
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
         _identifier = touchEvent.touchEventId.integerValue;
         NSArray<NSNumber<SDLInt> *> * timestamp = touchEvent.timeStamp;
         // In the event we receive a null timestamp, we will supply a device timestamp.
-        if (!timestamp || ![timestamp isKindOfClass:[NSArray class]] || timestamp.count == 0) {
+        if ((timestamp == nil) || (timestamp.count == 0)) {
             _timeStamp = (NSUInteger)([[NSDate date] timeIntervalSince1970] * 1000);
         } else {
             NSNumber *timeStampNumber = (NSNumber *)timestamp[0];

--- a/SmartDeviceLink/SDLTouch.m
+++ b/SmartDeviceLink/SDLTouch.m
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
     self = [self init];
     if (self) {
         _identifier = touchEvent.touchEventId.integerValue;
-        NSArray<NSNumber<SDLInt> *> * timestamp = touchEvent.timeStamp;
+        NSArray<NSNumber<SDLInt> *> *timestamp = touchEvent.timeStamp;
         // In the event we receive a null timestamp, we will supply a device timestamp.
         if ((timestamp == nil) || (timestamp.count == 0)) {
             _timeStamp = (NSUInteger)([[NSDate date] timeIntervalSince1970] * 1000);

--- a/SmartDeviceLink/SDLTouch.m
+++ b/SmartDeviceLink/SDLTouch.m
@@ -32,8 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
     self = [self init];
     if (self) {
         _identifier = touchEvent.touchEventId.integerValue;
-        
-        id timestamp = touchEvent.timeStamp;
+        NSArray<NSNumber<SDLInt> *> * timestamp = touchEvent.timeStamp;
         // In the event we receive a null timestamp, we will supply a device timestamp.
         if (!timestamp || ![timestamp isKindOfClass:[NSArray class]]) {
             _timeStamp = (NSUInteger)([[NSDate date] timeIntervalSince1970] * 1000);


### PR DESCRIPTION
Fixes #1534 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Running all existing unit tests validating no existing test fails. Adding new tests resulted into assertion crashes therefore checking that this PR doesn't harm any valid touch event json was the testing focus.

#### Core Tests
Tested against
Core version: 4.2 Ford 
HMI name: SYNC 3.0 (MY18) which can cause the issue of sending "null" for timestamps.

Test steps on affected IVI:
1.  Connect nav app to SYNC3
2. Activate nav app
3. Move nav app map somewhere
4. Confirm SYNC3 did send "null" in the touch event
5. check that app logs show "null" being replaced with phone clock
6. Confirm that nav app map moves

Test steps on functional IVI:
1.  Connect nav app to SYNC3
2. Activate nav app
3. Move nav app map somewhere
4. Confirm SYNC3 did send timestamps in the touch event
5. check that app logs show the timestamps 
6. Confirm that nav app map moves

### Summary
The changes are very small. Basically the change is to read the "timeStamp" param from the TouchEvent struct. Now with the new type checking, the param may return `nil` instead of whatever the head unit sent (previously it might have been [NSNull]).

The issue of wrong JSON data is already known. This PR replaces an old and outdated workaround with a new workaround.

##### Bug Fixes
* Fixes the issue that touch input is not computed properly.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
