### PR TITLE
Align System Capability Manager Behavior with Java Suite

### DIFF
--- a/Example Apps/Example ObjC/ProxyManager.m
+++ b/Example Apps/Example ObjC/ProxyManager.m
@@ -161,15 +161,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)sdlex_showInitialData {
     if (![self.sdlManager.hmiLevel isEqualToEnum:SDLHMILevelFull]) { return; }
 
-    SDLSystemCapabilityManager *scm = self.sdlManager.systemCapabilityManager;
-    id observerObj = [scm subscribeToCapabilityType:SDLSystemCapabilityTypeDisplays withUpdateHandler:^(SDLSystemCapability * _Nullable capability, BOOL subscribed, NSError * _Nullable error) {
-        NSLog(@"SCM update: %@, %@, %@", capability, (subscribed ? @"YES" : @"NO"), error);
-    }];
-
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(10.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        [scm unsubscribeFromCapabilityType:SDLSystemCapabilityTypeDisplays withObserver:observerObj];
-    });
-
     SDLSetDisplayLayout *setDisplayLayout = [[SDLSetDisplayLayout alloc] initWithPredefinedLayout:SDLPredefinedLayoutNonMedia];
     [self.sdlManager sendRequest:setDisplayLayout];
 

--- a/Example Apps/Example ObjC/ProxyManager.m
+++ b/Example Apps/Example ObjC/ProxyManager.m
@@ -161,6 +161,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)sdlex_showInitialData {
     if (![self.sdlManager.hmiLevel isEqualToEnum:SDLHMILevelFull]) { return; }
 
+    SDLSystemCapabilityManager *scm = self.sdlManager.systemCapabilityManager;
+    id observerObj = [scm subscribeToCapabilityType:SDLSystemCapabilityTypeDisplays withUpdateHandler:^(SDLSystemCapability * _Nullable capability, BOOL subscribed, NSError * _Nullable error) {
+        NSLog(@"SCM update: %@, %@, %@", capability, (subscribed ? @"YES" : @"NO"), error);
+    }];
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(10.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [scm unsubscribeFromCapabilityType:SDLSystemCapabilityTypeDisplays withObserver:observerObj];
+    });
+
     SDLSetDisplayLayout *setDisplayLayout = [[SDLSetDisplayLayout alloc] initWithPredefinedLayout:SDLPredefinedLayoutNonMedia];
     [self.sdlManager sendRequest:setDisplayLayout];
 

--- a/SmartDeviceLink-iOS.xcodeproj/xcshareddata/xcschemes/SmartDeviceLink-Example-ObjC.xcscheme
+++ b/SmartDeviceLink-iOS.xcodeproj/xcshareddata/xcschemes/SmartDeviceLink-Example-ObjC.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1130"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5D4019AE1A76EC350006B0C2"
+               BuildableName = "SDL Example.app"
+               BlueprintName = "SmartDeviceLink-Example-ObjC"
+               ReferencedContainer = "container:SmartDeviceLink-iOS.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5D4019AE1A76EC350006B0C2"
+            BuildableName = "SDL Example.app"
+            BlueprintName = "SmartDeviceLink-Example-ObjC"
+            ReferencedContainer = "container:SmartDeviceLink-iOS.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5D4019AE1A76EC350006B0C2"
+            BuildableName = "SDL Example.app"
+            BlueprintName = "SmartDeviceLink-Example-ObjC"
+            ReferencedContainer = "container:SmartDeviceLink-iOS.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SmartDeviceLink/SDLError.h
+++ b/SmartDeviceLink/SDLError.h
@@ -80,6 +80,8 @@ extern SDLErrorDomain *const SDLErrorDomainRPCStore;
 #pragma mark System Capability Manager
 
 + (NSError *)sdl_systemCapabilityManager_moduleDoesNotSupportSystemCapabilities;
++ (NSError *)sdl_systemCapabilityManager_cannotUpdateInHMINONE;
++ (NSError *)sdl_systemCapabilityManager_cannotUpdateTypeDISPLAYS;
 
 #pragma mark Transport
 

--- a/SmartDeviceLink/SDLError.h
+++ b/SmartDeviceLink/SDLError.h
@@ -76,6 +76,11 @@ extern SDLErrorDomain *const SDLErrorDomainRPCStore;
 + (NSError *)sdl_choiceSetManager_failedToCreateMenuItems;
 + (NSError *)sdl_choiceSetManager_incorrectState:(NSString *)state;
 
+
+#pragma mark System Capability Manager
+
++ (NSError *)sdl_systemCapabilityManager_moduleDoesNotSupportSystemCapabilities;
+
 #pragma mark Transport
 
 + (NSError *)sdl_transport_unknownError;
@@ -86,10 +91,6 @@ extern SDLErrorDomain *const SDLErrorDomainRPCStore;
 #pragma mark Store
 
 + (NSError *)sdl_rpcStore_invalidObjectErrorWithObject:(id)wrongObject expectedType:(Class)type;
-
-#pragma mark System Capability Manager
-
-+ (NSError *)sdl_systemCapabilityManager_moduleDoesNotSupportCapabilityType;
 
 @end
 

--- a/SmartDeviceLink/SDLError.h
+++ b/SmartDeviceLink/SDLError.h
@@ -23,6 +23,7 @@ extern SDLErrorDomain *const SDLErrorDomainTextAndGraphicManager;
 extern SDLErrorDomain *const SDLErrorDomainSoftButtonManager;
 extern SDLErrorDomain *const SDLErrorDomainMenuManager;
 extern SDLErrorDomain *const SDLErrorDomainChoiceSetManager;
+extern SDLErrorDomain *const SDLErrorDomainSystemCapabilityManager;
 extern SDLErrorDomain *const SDLErrorDomainTransport;
 extern SDLErrorDomain *const SDLErrorDomainRPCStore;
 
@@ -85,6 +86,10 @@ extern SDLErrorDomain *const SDLErrorDomainRPCStore;
 #pragma mark Store
 
 + (NSError *)sdl_rpcStore_invalidObjectErrorWithObject:(id)wrongObject expectedType:(Class)type;
+
+#pragma mark System Capability Manager
+
++ (NSError *)sdl_systemCapabilityManager_moduleDoesNotSupportCapabilityType;
 
 @end
 

--- a/SmartDeviceLink/SDLError.m
+++ b/SmartDeviceLink/SDLError.m
@@ -411,7 +411,7 @@ SDLErrorDomain *const SDLErrorDomainRPCStore = @"com.sdl.rpcStore.error";
 
 + (NSException *)sdl_invalidSelectorExceptionWithSelector:(SEL)selector {
     return [NSException exceptionWithName:@"com.sdl.systemCapabilityManager.selectorException"
-                                   reason:[NSString stringWithFormat:@"Capability observation selector: %@ does not match possible selectors, which must have between 0 and 3 parameters", NSStringFromSelector(selector)]
+                                   reason:[NSString stringWithFormat:@"Capability observation selector: %@ does not match possible selectors, which must have between 0 and 3 parameters, or is not a selector on the observer object. Check that your selector is formatted correctly, and that your observer is not nil. You should unsubscribe an observer before it goes to nil.", NSStringFromSelector(selector)]
                                  userInfo:nil];
 }
 

--- a/SmartDeviceLink/SDLError.m
+++ b/SmartDeviceLink/SDLError.m
@@ -21,6 +21,7 @@ SDLErrorDomain *const SDLErrorDomainTextAndGraphicManager = @"com.sdl.textandgra
 SDLErrorDomain *const SDLErrorDomainSoftButtonManager = @"com.sdl.softbuttonmanager.error";
 SDLErrorDomain *const SDLErrorDomainMenuManager = @"com.sdl.menumanager.error";
 SDLErrorDomain *const SDLErrorDomainChoiceSetManager = @"com.sdl.choicesetmanager.error";
+SDLErrorDomain *const SDLErrorDomainSystemCapabilityManager = @"com.sdl.systemcapabilitymanager.error";
 SDLErrorDomain *const SDLErrorDomainTransport = @"com.sdl.transport.error";
 SDLErrorDomain *const SDLErrorDomainRPCStore = @"com.sdl.rpcStore.error";
 
@@ -286,6 +287,12 @@ SDLErrorDomain *const SDLErrorDomainRPCStore = @"com.sdl.rpcStore.error";
                                                        NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"If you are setting the menuName, it is possible that the head unit is sending incorrect displayCapabilities.", nil)
                                                        };
     return [NSError errorWithDomain:SDLErrorDomainChoiceSetManager code:SDLChoiceSetManagerErrorInvalidState userInfo:userInfo];
+}
+
+#pragma mark System Capability Manager
+
++ (NSError *)sdl_systemCapabilityManager_moduleDoesNotSupportCapabilityType {
+    return [NSError errorWithDomain:SDLErrorDomainSystemCapabilityManager code:SDLSystemCapabilityManagerErrorModuleDoesNotSupportCapabilityType userInfo:nil];
 }
 
 #pragma mark Transport

--- a/SmartDeviceLink/SDLError.m
+++ b/SmartDeviceLink/SDLError.m
@@ -291,8 +291,13 @@ SDLErrorDomain *const SDLErrorDomainRPCStore = @"com.sdl.rpcStore.error";
 
 #pragma mark System Capability Manager
 
-+ (NSError *)sdl_systemCapabilityManager_moduleDoesNotSupportCapabilityType {
-    return [NSError errorWithDomain:SDLErrorDomainSystemCapabilityManager code:SDLSystemCapabilityManagerErrorModuleDoesNotSupportCapabilityType userInfo:nil];
++ (NSError *)sdl_systemCapabilityManager_moduleDoesNotSupportSystemCapabilities {
+    NSDictionary<NSString *, NSString *> *userInfo = @{
+                                                       NSLocalizedDescriptionKey: NSLocalizedString(@"Module does not understand system capabilities", nil),
+                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"The connected module does not support system capabilities", nil),
+                                                       NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"Use isCapabilitySupported to know if the feature is supported on the head unit, but no more infomration about the feature will be available on this module", nil)
+                                                       };
+    return [NSError errorWithDomain:SDLErrorDomainSystemCapabilityManager code:SDLSystemCapabilityManagerErrorModuleDoesNotSupportSystemCapabilities userInfo:userInfo];
 }
 
 #pragma mark Transport

--- a/SmartDeviceLink/SDLError.m
+++ b/SmartDeviceLink/SDLError.m
@@ -381,7 +381,7 @@ SDLErrorDomain *const SDLErrorDomainRPCStore = @"com.sdl.rpcStore.error";
 
 + (NSException *)sdl_invalidSelectorExceptionWithSelector:(SEL)selector {
     return [NSException exceptionWithName:@"com.sdl.systemCapabilityManager.selectorException"
-                                   reason:[NSString stringWithFormat:@"Capability observation selector: %@ does not match possible selectors, which must have either 0 or 1 parameters", NSStringFromSelector(selector)]
+                                   reason:[NSString stringWithFormat:@"Capability observation selector: %@ does not match possible selectors, which must have between 0 and 3 parameters", NSStringFromSelector(selector)]
                                  userInfo:nil];
 }
 

--- a/SmartDeviceLink/SDLError.m
+++ b/SmartDeviceLink/SDLError.m
@@ -300,6 +300,24 @@ SDLErrorDomain *const SDLErrorDomainRPCStore = @"com.sdl.rpcStore.error";
     return [NSError errorWithDomain:SDLErrorDomainSystemCapabilityManager code:SDLSystemCapabilityManagerErrorModuleDoesNotSupportSystemCapabilities userInfo:userInfo];
 }
 
++ (NSError *)sdl_systemCapabilityManager_cannotUpdateInHMINONE {
+    NSDictionary<NSString *, NSString *> *userInfo = @{
+                                                       NSLocalizedDescriptionKey: NSLocalizedString(@"System capabilities cannot be updated in HMI NONE.", nil),
+                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"The system capability manager attempted to subscribe or update a system capability in HMI NONE, which is not allowed.", nil),
+                                                       NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"Wait until you are in HMI BACKGROUND, LIMITED, OR FULL before subscribing or updating a capability.", nil)
+                                                       };
+    return [NSError errorWithDomain:SDLErrorDomainSystemCapabilityManager code:SDLSystemCapabilityManagerErrorHMINone userInfo:userInfo];
+}
+
++ (NSError *)sdl_systemCapabilityManager_cannotUpdateTypeDISPLAYS {
+    NSDictionary<NSString *, NSString *> *userInfo = @{
+                                                       NSLocalizedDescriptionKey: NSLocalizedString(@"System capability type DISPLAYS cannot be updated.", nil),
+                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"The system capability manager attempted to update  system capability type DISPLAYS, which is not allowed.", nil),
+                                                       NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"Subscribe to DISPLAYS to automatically receive updates or retrieve a cached display capability value directly from the SystemCapabilityManager.", nil)
+                                                       };
+    return [NSError errorWithDomain:SDLErrorDomainSystemCapabilityManager code:SDLSystemCapabilityManagerErrorCannotUpdateTypeDisplays userInfo:userInfo];
+}
+
 #pragma mark Transport
 
 + (NSError *)sdl_transport_unknownError {

--- a/SmartDeviceLink/SDLErrorConstants.h
+++ b/SmartDeviceLink/SDLErrorConstants.h
@@ -153,7 +153,7 @@ typedef NS_ENUM(NSInteger, SDLChoiceSetManagerError) {
 };
 
 typedef NS_ENUM(NSInteger, SDLSystemCapabilityManagerError) {
-    SDLSystemCapabilityManagerErrorModuleDoesNotSupportCapabilityType = -1
+    SDLSystemCapabilityManagerErrorModuleDoesNotSupportSystemCapabilities = -1
 };
 
 /**

--- a/SmartDeviceLink/SDLErrorConstants.h
+++ b/SmartDeviceLink/SDLErrorConstants.h
@@ -152,6 +152,10 @@ typedef NS_ENUM(NSInteger, SDLChoiceSetManagerError) {
     SDLChoiceSetManagerErrorInvalidState = -5
 };
 
+typedef NS_ENUM(NSInteger, SDLSystemCapabilityManagerError) {
+    SDLSystemCapabilityManagerErrorModuleDoesNotSupportCapabilityType = -1
+};
+
 /**
  *  Errors associated with transport.
  */

--- a/SmartDeviceLink/SDLErrorConstants.h
+++ b/SmartDeviceLink/SDLErrorConstants.h
@@ -153,7 +153,9 @@ typedef NS_ENUM(NSInteger, SDLChoiceSetManagerError) {
 };
 
 typedef NS_ENUM(NSInteger, SDLSystemCapabilityManagerError) {
-    SDLSystemCapabilityManagerErrorModuleDoesNotSupportSystemCapabilities = -1
+    SDLSystemCapabilityManagerErrorModuleDoesNotSupportSystemCapabilities = -1,
+    SDLSystemCapabilityManagerErrorHMINone = -2,
+    SDLSystemCapabilityManagerErrorCannotUpdateTypeDisplays = -3
 };
 
 /**

--- a/SmartDeviceLink/SDLSystemCapabilityManager.h
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.h
@@ -292,44 +292,41 @@ typedef void (^SDLCapabilityUpdateWithErrorHandler)(SDLSystemCapability * _Nulla
 ///
 /// On sub-v5.1.0 systems (where `supportsSubscriptions == NO`):
 /// The method will be called immediately with the current value and will _not_ be automatically called every time the value is updated, unless the `type` is `DISPLAYS` which is supported on every version. If `updateCapabilityType:completionHandler` is called and a new value is retrieved, this value will be updated then. If this is the first subscription of this `SDLSystemCapabilityType`, then the value will be retrieved and returned.
-
+///
 /// @param type The type of capability to subscribe to
 /// @param handler The block to be called when the capability is updated with an error if one occurs
 /// @return An object that can be used to unsubscribe the block using unsubscribeFromCapabilityType:withObserver: by passing it in the observer callback, or nil if the manager can't attempt the subscription for some reason (such as the app being in HMI_NONE and the type is not DISPLAYS).
 - (nullable id<NSObject>)subscribeToCapabilityType:(SDLSystemCapabilityType)type withUpdateHandler:(SDLCapabilityUpdateWithErrorHandler)handler NS_SWIFT_NAME(subscribe(capabilityType:updateHandler:));
 
-/**
- * Subscribe to a particular capability type with a selector callback.
- *
- * The selector supports the following parameters:
- *
- * 1. No parameters e.g. `- (void)phoneCapabilityUpdated;`
- *
- * 2. One `SDLSystemCapability *` parameter, e.g. `- (void)phoneCapabilityUpdated:(SDLSystemCapability *)capability`
- *
- * 3. Two parameters, one `SDLSystemCapability *` parameter, and one `NSError` parameter, e.g. `- (void)phoneCapabilityUpdated:(SDLSystemCapability *)capability error:(NSError *)error`
- *
- * 4. Three parameters, one `SDLSystemCapability *` parameter, one `NSError` parameter, and one `BOOL` parameter e.g. `- (void)phoneCapabilityUpdated:(SDLSystemCapability *)capability error:(NSError *)error subscribed:(BOOL)subscribed`
- *
- * On v5.1.0+ systems (where `supportsSubscriptions == YES`):
- * This method will be called immediately with the current value if a subscription already exists and will be called every time the value is updated.
- *
- * On sub-v5.1.0 systems (where `supportsSubscriptions == NO`):
- * The method will be called immediately with the current value and will _not_ be automatically called every time the value is updated, unless the `type` is `DISPLAYS` which is supported on every version. If `updateCapabilityType:completionHandler` is called and a new value is retrieved, this value will be updated then. If this is the first subscription of this `SDLSystemCapabilityType`, then the value will be retrieved and returned.
- *
- * @param type The type of the system capability to subscribe to
- * @param observer The object that will have `selector` called whenever the capability is updated
- * @param selector The selector on `observer` that will be called whenever the capability is updated
- * @return YES if the manager is attempting the subscription, or NO if the manager can't attempt the subscription for some reason (such as the app being in HMI_NONE and the type is not DISPLAYS), or the selector doesn't contain the correct number of parameters.
- */
+
+/// Subscribe to a particular capability type with a selector callback.
+///
+/// The selector supports the following parameters:
+///
+/// 1. No parameters e.g. `- (void)phoneCapabilityUpdated;`
+///
+/// 2. One `SDLSystemCapability *` parameter, e.g. `- (void)phoneCapabilityUpdated:(SDLSystemCapability *)capability`
+///
+/// 3. Two parameters, one `SDLSystemCapability *` parameter, and one `NSError` parameter, e.g. `- (void)phoneCapabilityUpdated:(SDLSystemCapability *)capability error:(NSError *)error`
+///
+/// 4. Three parameters, one `SDLSystemCapability *` parameter, one `NSError` parameter, and one `BOOL` parameter e.g. `- (void)phoneCapabilityUpdated:(SDLSystemCapability *)capability error:(NSError *)error subscribed:(BOOL)subscribed`
+///
+/// On v5.1.0+ systems (where `supportsSubscriptions == YES`):
+/// This method will be called immediately with the current value if a subscription already exists and will be called every time the value is updated.
+///
+/// On sub-v5.1.0 systems (where `supportsSubscriptions == NO`):
+/// The method will be called immediately with the current value and will _not_ be automatically called every time the value is updated, unless the `type` is `DISPLAYS` which is supported on every version. If `updateCapabilityType:completionHandler` is called and a new value is retrieved, this value will be updated then. If this is the first subscription of this `SDLSystemCapabilityType`, then the value will be retrieved and returned.
+///
+/// @param type The type of the system capability to subscribe to
+/// @param observer The object that will have `selector` called whenever the capability is updated
+/// @param selector The selector on `observer` that will be called whenever the capability is updated
+/// @return YES if the manager is attempting the subscription, or NO if the manager can't attempt the subscription for some reason (such as the app being in HMI_NONE and the type is not DISPLAYS), or the selector doesn't contain the correct number of parameters.
 - (BOOL)subscribeToCapabilityType:(SDLSystemCapabilityType)type withObserver:(id)observer selector:(SEL)selector;
 
-/**
- * Unsubscribe from a particular capability type. If it was subscribed with a block / handler, the return value should be passed to the `observer` to unsubscribe the block. If it was subscribed with a selector, the `observer` object (on which the selector exists and is called) should be passed to unsubscribe the object selector.
- *
- * @param type The type of the system capability to unsubscribe from
- * @param observer The object that will be unsubscribed. If a block was subscribed, the return value should be passed. If a selector was subscribed, the observer object should be passed.
- */
+/// Unsubscribe from a particular capability type. If it was subscribed with a block / handler, the return value should be passed to the `observer` to unsubscribe the block. If it was subscribed with a selector, the `observer` object (on which the selector exists and is called) should be passed to unsubscribe the object selector.
+///
+/// @param type The type of the system capability to unsubscribe from
+/// @param observer The object that will be unsubscribed. If a block was subscribed, the return value should be passed. If a selector was subscribed, the observer object should be passed.
 - (void)unsubscribeFromCapabilityType:(SDLSystemCapabilityType)type withObserver:(id)observer;
 
 @end

--- a/SmartDeviceLink/SDLSystemCapabilityManager.h
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.h
@@ -51,6 +51,14 @@ typedef void (^SDLUpdateCapabilityHandler)(NSError * _Nullable error, SDLSystemC
 typedef void (^SDLCapabilityUpdateHandler)(SDLSystemCapability *capability);
 
 /**
+ An observer block for whenever a subscription or value is retrieved.
+
+ @param capability The capability that was updated.
+ @param error An error that occurred.
+ */
+typedef void (^SDLCapabilityUpdateWithErrorHandler)(SDLSystemCapability *capability, NSError *error);
+
+/**
  A manager that handles updating and subscribing to SDL capabilities.
  */
 @interface SDLSystemCapabilityManager : NSObject
@@ -246,6 +254,11 @@ typedef void (^SDLCapabilityUpdateHandler)(SDLSystemCapability *capability);
  */
 - (void)updateCapabilityType:(SDLSystemCapabilityType)type completionHandler:(SDLUpdateCapabilityHandler)handler;
 
+/// Returns whether or not the capability type is supported on the system. You can use this to check if subscribing to the capability will work.
+/// @param type The SystemCapabilityType that will be checked.
+/// @return Whether or not `type` is supported by the connected head unit.
+- (BOOL)isCapabilitySupported:(SDLSystemCapabilityType)type;
+
 /**
  Subscribe to a particular capability type using a block callback
 
@@ -259,7 +272,8 @@ typedef void (^SDLCapabilityUpdateHandler)(SDLSystemCapability *capability);
  * Subscribe to a particular capability type with a selector callback. The selector supports the following parameters:
  *
  * 1. No parameters e.g. `- (void)phoneCapabilityUpdated;`
- * 2. One `SDLSystemCapability *` parameter e.g. `- (void)phoneCapabilityUpdated:(SDLSystemCapability *)capability`
+ * 2. One `SDLSystemCapability *` parameter, e.g. `- (void)phoneCapabilityUpdated:(SDLSystemCapability *)capability`
+ * 3. Two parameters, one `SDLSystemCapability *` parameter, and one `NSError *` parameter, e.g. `- (void)phoneCapabilityUpdated:(SDLSystemCapability *)capability error:(NSError *)error`
  *
  * This method will be called immediately with the current value and called every time the value is updated on RPC v5.1.0+ systems (`supportsSubscriptions == YES`). If this method is called on a sub-v5.1.0 system (`supportsSubscriptions == NO`), the method will return `NO` and the selector will never be called.
  *

--- a/SmartDeviceLink/SDLSystemCapabilityManager.h
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.h
@@ -217,7 +217,7 @@ typedef void (^SDLCapabilityUpdateWithErrorHandler)(SDLSystemCapability * _Nulla
 @property (nullable, strong, nonatomic, readonly) SDLWindowCapability *defaultMainWindowCapability;
 
 /**
- YES if subscriptions are available on the connected module and you will automatically be notified if the value changes on the module. If NO, calls to `subscribe` methods will subscribe to updates, but the module will not automatically notify you. You will need to call `updateWithCapabilityType:completionHandler:` to force an update if you need one (though this should be rare).
+ YES if subscriptions are available on the connected module and you will automatically be notified if the value changes on the module. If NO, calls to `subscribe` methods will subscribe to updates, but the module will not automatically notify you. You will need to call `updateWithCapabilityType:completionHandler:` to force an update if you need one (though this should be rare). This does not apply to the `DISPLAYS` capability type which you can always subscribe to.
  */
 @property (assign, nonatomic, readonly) BOOL supportsSubscriptions;
 
@@ -248,10 +248,12 @@ typedef void (^SDLCapabilityUpdateWithErrorHandler)(SDLSystemCapability * _Nulla
 - (void)stop;
 
 /**
- * Returns the window capability object of the primary display with the specified window ID. This is a convenient method to easily access capabilities of windows for instance widget windows of the main display.
+ * Returns the window capability of one of your app's windows with the specified window ID that is on the primary display (i.e. the head unit itself). This is a convenience method to easily access capabilities of windows such as your apps' widget windows.
  *
- * @param windowID The ID of the window to get capabilities
- * @returns The window capability object representing the window capabilities of the window with the specified window ID or nil if the window is not known or no window capabilities exist.
+ * To get the capabilities of the main window on the main display (i.e. your app's primary app screen on the head unit itself).
+ *
+ * @param windowID The ID of the window from which to get capabilities
+ * @returns The window window capabilities of the window with the specified windowID, or nil if the window is not known or no window capabilities exist.
  */
 - (nullable SDLWindowCapability *)windowCapabilityWithWindowID:(NSUInteger)windowID;
 
@@ -261,22 +263,20 @@ typedef void (^SDLCapabilityUpdateWithErrorHandler)(SDLSystemCapability * _Nulla
 - (BOOL)isCapabilitySupported:(SDLSystemCapabilityType)type NS_SWIFT_NAME(isCapabilitySupported(type:));
 
 /**
- *  This method has been superceded by `subscribeToCapabilityType:` methods. You should use one of those instead, unless you only want a value once, and it must be updated. If you subscribe to a capability and are connected to a head unit that does not support subscriptions, when this method returns, it will also call all subscriptions. Therefore, you can use this method to force an update to all subscriptions of that particular type.
+ * This method has been superseded by the `subscribeToCapabilityType:` methods. You should use one of those methods instead unless you only want a value once (you don't want to keep a long-lasting observer) and it must be current (most capabilities do not need to be updated). If you have a separate subscription observer and are connected to a head unit that does not support subscriptions, when this method returns, it will also call all subscription callbacks that you've set up with the new value if there is one. Therefore, you can use this method to force an update to all subscriptions of that particular type on head units that don't support subscriptions (`supportsSubscriptions == NO`).
  *
- *  Retrieves and updates a capability type from the remote system. This function must be called in order to retrieve the values for `navigationCapability`, `phoneCapability`, `videoStreamingCapability`, `remoteControlCapability`, and `appServicesCapabilities`. If you do not call this method first, those values will be nil. After calling this method, assuming there is no error in the handler, you may retrieve the capability you requested from the manager within the handler.
- *
- *  @param type The type of capability to retrieve
- *  @param handler The handler to be called when the retrieval is complete
+ * @param type The type of capability to retrieve
+ * @param handler The handler to be called when the retrieval is complete
  */
 - (void)updateCapabilityType:(SDLSystemCapabilityType)type completionHandler:(SDLUpdateCapabilityHandler)handler;
 
 /// Subscribe to a particular capability type using a block callback.
 ///
 /// On v5.1.0+ systems (where `supportsSubscriptions == YES`):
-/// This method will be called immediately with the current value and will be called every time the value is updated. If this is the first subscription of this `SDLSystemCapabilityType`, then the value will be retrieved and a subscription will be attempted. The current cached value (`nil`) will nevertheless be returned immediately.
+/// This method will be called immediately with the current value and will be called every time the value is updated. If this is the first subscription of this `SDLSystemCapabilityType`, then the current cached value of `nil` will be returned immediately, an updated value will be retrieved, and a subscription will be attempted.
 ///
 /// On sub-v5.1.0 systems (where `supportsSubscriptions == NO`):
-/// The method will be called immediately with the current value and will _not_ be automatically called every time the value is updated, unless the `type` is `DISPLAYS` which is supported on every version. If `updateCapabilityType:completionHandler` is called and a new value is retrieved, this value will be updated then. If this is the first subscription of this `SDLSystemCapabilityType`, then the value will be retrieved and returned. The current cached value (`nil`) will nevertheless be returned immediately.
+/// The method will be called immediately with the current value and will _not_ be automatically called every time the value is updated, unless the `type` is `DISPLAYS` which is supported on every version. If `updateCapabilityType:completionHandler` is called and a new value is retrieved, this value will be updated then. If this is the first subscription of this `SDLSystemCapabilityType`, then the current cached value of `nil` will be returned immediately, an updated value will be retrieved, and a subscription will be attempted.
 ///
 /// @param type The type of capability to subscribe to
 /// @param block The block to be called when the capability is updated

--- a/SmartDeviceLink/SDLSystemCapabilityManager.h
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.h
@@ -286,7 +286,9 @@ typedef void (^SDLCapabilityUpdateWithErrorHandler)(SDLSystemCapability * _Nulla
 /// Subscribe to a particular capability type using a handler callback.
 ///
 /// On v5.1.0+ systems (where `supportsSubscriptions == YES`):
-/// This method will be called immediately with the current value and will be called every time the value is updated. If this is the first subscription of this `SDLSystemCapabilityType`, then the value will be retrieved and a subscription will be attempted. The current cached value (`nil`) will nevertheless be returned immediately.
+/// This method will be called immediately with the current value and will be called every time the value is updated. If this is the first subscription of this `SDLSystemCapabilityType`, then the current cached value of `nil` will be returned immediately, an updated value will be retrieved, and a subscription will be attempted.
+///
+/// Note that when the cached value is returned, the `subscribed` flag on the handler will be false until the subscription completes successfully and a new value is retrieved.
 ///
 /// On sub-v5.1.0 systems (where `supportsSubscriptions == NO`):
 /// The method will be called immediately with the current value and will _not_ be automatically called every time the value is updated, unless the `type` is `DISPLAYS` which is supported on every version. If `updateCapabilityType:completionHandler` is called and a new value is retrieved, this value will be updated then. If this is the first subscription of this `SDLSystemCapabilityType`, then the value will be retrieved and returned. The current cached value (`nil`) will nevertheless be returned immediately.

--- a/SmartDeviceLink/SDLSystemCapabilityManager.h
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.h
@@ -273,7 +273,7 @@ typedef void (^SDLCapabilityUpdateWithErrorHandler)(SDLSystemCapability * _Nulla
 /// Subscribe to a particular capability type using a block callback.
 ///
 /// On v5.1.0+ systems (where `supportsSubscriptions == YES`):
-/// This method will be called immediately with the current value and will be called every time the value is updated. If this is the first subscription of this `SDLSystemCapabilityType`, then the current cached value of `nil` will be returned immediately, an updated value will be retrieved, and a subscription will be attempted.
+/// This method will be called immediately with the current value if a subscription already exists and will be called every time the value is updated.
 ///
 /// On sub-v5.1.0 systems (where `supportsSubscriptions == NO`):
 /// The method will be called immediately with the current value and will _not_ be automatically called every time the value is updated, unless the `type` is `DISPLAYS` which is supported on every version. If `updateCapabilityType:completionHandler` is called and a new value is retrieved, this value will be updated then. If this is the first subscription of this `SDLSystemCapabilityType`, then the value will be retrieved and returned.
@@ -286,7 +286,7 @@ typedef void (^SDLCapabilityUpdateWithErrorHandler)(SDLSystemCapability * _Nulla
 /// Subscribe to a particular capability type using a handler callback.
 ///
 /// On v5.1.0+ systems (where `supportsSubscriptions == YES`):
-/// This method will be called immediately with the current value and will be called every time the value is updated. If this is the first subscription of this `SDLSystemCapabilityType`, then the current cached value of `nil` will be returned immediately, an updated value will be retrieved, and a subscription will be attempted.
+/// This method will be called immediately with the current value if a subscription already exists and will be called every time the value is updated.
 ///
 /// Note that when the cached value is returned, the `subscribed` flag on the handler will be false until the subscription completes successfully and a new value is retrieved.
 ///
@@ -312,7 +312,7 @@ typedef void (^SDLCapabilityUpdateWithErrorHandler)(SDLSystemCapability * _Nulla
  * 4. Three parameters, one `SDLSystemCapability *` parameter, one `NSError` parameter, and one `BOOL` parameter e.g. `- (void)phoneCapabilityUpdated:(SDLSystemCapability *)capability error:(NSError *)error subscribed:(BOOL)subscribed`
  *
  * On v5.1.0+ systems (where `supportsSubscriptions == YES`):
- * This method will be called immediately with the current value and will be called every time the value is updated. If this is the first subscription of this `SDLSystemCapabilityType`, then the value will be retrieved and a subscription will be attempted. The current cached value (`nil`) will nevertheless be returned immediately.
+ * This method will be called immediately with the current value if a subscription already exists and will be called every time the value is updated.
  *
  * On sub-v5.1.0 systems (where `supportsSubscriptions == NO`):
  * The method will be called immediately with the current value and will _not_ be automatically called every time the value is updated, unless the `type` is `DISPLAYS` which is supported on every version. If `updateCapabilityType:completionHandler` is called and a new value is retrieved, this value will be updated then. If this is the first subscription of this `SDLSystemCapabilityType`, then the value will be retrieved and returned.

--- a/SmartDeviceLink/SDLSystemCapabilityManager.h
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.h
@@ -255,7 +255,7 @@ typedef void (^SDLCapabilityUpdateWithErrorHandler)(SDLSystemCapability * _Nulla
  */
 - (nullable SDLWindowCapability *)windowCapabilityWithWindowID:(NSUInteger)windowID;
 
-/// Returns whether or not the capability type is supported on the system. You can use this to check if subscribing to the capability will work.
+/// Returns whether or not the capability type is supported on the system. You can use this to check if subscribing to the capability will work. If this returns NO, then the feature is not supported by the head unit. If YES, the feature is supported by the head unit. You can subscribe to the capability type to get more information about the capability's support and features on the connected module.
 /// @param type The SystemCapabilityType that will be checked.
 /// @return Whether or not `type` is supported by the connected head unit.
 - (BOOL)isCapabilitySupported:(SDLSystemCapabilityType)type;

--- a/SmartDeviceLink/SDLSystemCapabilityManager.h
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.h
@@ -65,11 +65,6 @@ typedef void (^SDLCapabilityUpdateWithErrorHandler)(SDLSystemCapability * _Nulla
 @interface SDLSystemCapabilityManager : NSObject
 
 /**
- YES if subscriptions are available on the connected head unit. If NO, calls to `subscribeToCapabilityType:withBlock` and `subscribeToCapabilityType:withObserver:selector` will fail.
- */
-@property (assign, nonatomic, readonly) BOOL supportsSubscriptions;
-
-/**
  * Provides window capabilities of all displays connected with SDL. By default, one display is connected and supported which includes window capability information of the default main window of the display. May be nil if the system has not provided display and window capability information yet.
  *
  * @see SDLDisplayCapability
@@ -222,6 +217,11 @@ typedef void (^SDLCapabilityUpdateWithErrorHandler)(SDLSystemCapability * _Nulla
 @property (nullable, strong, nonatomic, readonly) SDLWindowCapability *defaultMainWindowCapability;
 
 /**
+ YES if subscriptions are available on the connected module and you will automatically be notified if the value changes on the module. If NO, calls to `subscribe` methods will subscribe to updates, but the module will not automatically notify you. You will need to call `updateWithCapabilityType:completionHandler:` to force an update if you need one (though this should be rare).
+ */
+@property (assign, nonatomic, readonly) BOOL supportsSubscriptions;
+
+/**
  Init is unavailable. Dependencies must be injected using initWithConnectionManager:
 
  @return nil
@@ -258,7 +258,7 @@ typedef void (^SDLCapabilityUpdateWithErrorHandler)(SDLSystemCapability * _Nulla
 /// Returns whether or not the capability type is supported on the system. You can use this to check if subscribing to the capability will work. If this returns NO, then the feature is not supported by the head unit. If YES, the feature is supported by the head unit. You can subscribe to the capability type to get more information about the capability's support and features on the connected module.
 /// @param type The SystemCapabilityType that will be checked.
 /// @return Whether or not `type` is supported by the connected head unit.
-- (BOOL)isCapabilitySupported:(SDLSystemCapabilityType)type;
+- (BOOL)isCapabilitySupported:(SDLSystemCapabilityType)type NS_SWIFT_NAME(isCapabilitySupported(type:));
 
 /**
  *  This method has been superceded by `subscribeToCapabilityType:` methods. You should use one of those instead, unless you only want a value once, and it must be updated. If you subscribe to a capability and are connected to a head unit that does not support subscriptions, when this method returns, it will also call all subscriptions. Therefore, you can use this method to force an update to all subscriptions of that particular type.
@@ -294,7 +294,7 @@ typedef void (^SDLCapabilityUpdateWithErrorHandler)(SDLSystemCapability * _Nulla
 /// @param type The type of capability to subscribe to
 /// @param handler The block to be called when the capability is updated with an error if one occurs
 /// @return An object that can be used to unsubscribe the block using unsubscribeFromCapabilityType:withObserver: by passing it in the observer callback, or nil if subscriptions aren't available on this head unit
-- (nullable id<NSObject>)subscribeToCapabilityType:(SDLSystemCapabilityType)type withUpdateHandler:(SDLCapabilityUpdateWithErrorHandler)handler;
+- (nullable id<NSObject>)subscribeToCapabilityType:(SDLSystemCapabilityType)type withUpdateHandler:(SDLCapabilityUpdateWithErrorHandler)handler NS_SWIFT_NAME(subscribe(capabilityType:updateHandler:));
 
 /**
  * Subscribe to a particular capability type with a selector callback.

--- a/SmartDeviceLink/SDLSystemCapabilityManager.h
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.h
@@ -280,7 +280,7 @@ typedef void (^SDLCapabilityUpdateWithErrorHandler)(SDLSystemCapability * _Nulla
 ///
 /// @param type The type of capability to subscribe to
 /// @param block The block to be called when the capability is updated
-/// @return An object that can be used to unsubscribe the block using unsubscribeFromCapabilityType:withObserver: by passing it in the observer callback, or nil if subscriptions aren't available on this head unit
+/// @return An object that can be used to unsubscribe the block using unsubscribeFromCapabilityType:withObserver: by passing it in the observer callback, or nil if the manager can't attempt the subscription for some reason (such as the app being in HMI_NONE and the type is not DISPLAYS).
 - (nullable id<NSObject>)subscribeToCapabilityType:(SDLSystemCapabilityType)type withBlock:(SDLCapabilityUpdateHandler)block __deprecated_msg("use subscribeToCapabilityType:withUpdateHandler: instead");
 
 /// Subscribe to a particular capability type using a handler callback.
@@ -293,7 +293,7 @@ typedef void (^SDLCapabilityUpdateWithErrorHandler)(SDLSystemCapability * _Nulla
 
 /// @param type The type of capability to subscribe to
 /// @param handler The block to be called when the capability is updated with an error if one occurs
-/// @return An object that can be used to unsubscribe the block using unsubscribeFromCapabilityType:withObserver: by passing it in the observer callback, or nil if subscriptions aren't available on this head unit
+/// @return An object that can be used to unsubscribe the block using unsubscribeFromCapabilityType:withObserver: by passing it in the observer callback, or nil if the manager can't attempt the subscription for some reason (such as the app being in HMI_NONE and the type is not DISPLAYS).
 - (nullable id<NSObject>)subscribeToCapabilityType:(SDLSystemCapabilityType)type withUpdateHandler:(SDLCapabilityUpdateWithErrorHandler)handler NS_SWIFT_NAME(subscribe(capabilityType:updateHandler:));
 
 /**
@@ -318,7 +318,7 @@ typedef void (^SDLCapabilityUpdateWithErrorHandler)(SDLSystemCapability * _Nulla
  * @param type The type of the system capability to subscribe to
  * @param observer The object that will have `selector` called whenever the capability is updated
  * @param selector The selector on `observer` that will be called whenever the capability is updated
- * @return Whether or not the subscription succeeded. `NO` if the connected system doesn't support capability subscriptions, or if the `selector` doesn't support the correct parameters (see above).
+ * @return YES if the manager is attempting the subscription, or NO if the manager can't attempt the subscription for some reason (such as the app being in HMI_NONE and the type is not DISPLAYS), or the selector doesn't contain the correct number of parameters.
  */
 - (BOOL)subscribeToCapabilityType:(SDLSystemCapabilityType)type withObserver:(id)observer selector:(SEL)selector;
 

--- a/SmartDeviceLink/SDLSystemCapabilityManager.h
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.h
@@ -255,6 +255,11 @@ typedef void (^SDLCapabilityUpdateWithErrorHandler)(SDLSystemCapability * _Nulla
  */
 - (nullable SDLWindowCapability *)windowCapabilityWithWindowID:(NSUInteger)windowID;
 
+/// Returns whether or not the capability type is supported on the system. You can use this to check if subscribing to the capability will work.
+/// @param type The SystemCapabilityType that will be checked.
+/// @return Whether or not `type` is supported by the connected head unit.
+- (BOOL)isCapabilitySupported:(SDLSystemCapabilityType)type;
+
 /**
  *  This method has been superceded by `subscribeToCapabilityType:` methods. You should use one of those instead, unless you only want a value once, and it must be updated. If you subscribe to a capability and are connected to a head unit that does not support subscriptions, when this method returns, it will also call all subscriptions. Therefore, you can use this method to force an update to all subscriptions of that particular type.
  *
@@ -264,12 +269,6 @@ typedef void (^SDLCapabilityUpdateWithErrorHandler)(SDLSystemCapability * _Nulla
  *  @param handler The handler to be called when the retrieval is complete
  */
 - (void)updateCapabilityType:(SDLSystemCapabilityType)type completionHandler:(SDLUpdateCapabilityHandler)handler;
-
-
-/// Returns whether or not the capability type is supported on the system. You can use this to check if subscribing to the capability will work.
-/// @param type The SystemCapabilityType that will be checked.
-/// @return Whether or not `type` is supported by the connected head unit.
-- (BOOL)isCapabilitySupported:(SDLSystemCapabilityType)type;
 
 /// Subscribe to a particular capability type using a block callback.
 ///
@@ -282,7 +281,7 @@ typedef void (^SDLCapabilityUpdateWithErrorHandler)(SDLSystemCapability * _Nulla
 /// @param type The type of capability to subscribe to
 /// @param block The block to be called when the capability is updated
 /// @return An object that can be used to unsubscribe the block using unsubscribeFromCapabilityType:withObserver: by passing it in the observer callback, or nil if subscriptions aren't available on this head unit
-- (nullable id<NSObject>)subscribeToCapabilityType:(SDLSystemCapabilityType)type withBlock:(SDLCapabilityUpdateHandler)block __deprecated_msg("use subscribeToCapabilityType:withUpdateBlock: instead");
+- (nullable id<NSObject>)subscribeToCapabilityType:(SDLSystemCapabilityType)type withBlock:(SDLCapabilityUpdateHandler)block __deprecated_msg("use subscribeToCapabilityType:withUpdateHandler: instead");
 
 /// Subscribe to a particular capability type using a handler callback.
 ///
@@ -311,7 +310,7 @@ typedef void (^SDLCapabilityUpdateWithErrorHandler)(SDLSystemCapability * _Nulla
  * 4. Three parameters, one `SDLSystemCapability *` parameter, one `NSError` parameter, and one `BOOL` parameter e.g. `- (void)phoneCapabilityUpdated:(SDLSystemCapability *)capability error:(NSError *)error subscribed:(BOOL)subscribed`
  *
  * On v5.1.0+ systems (where `supportsSubscriptions == YES`):
-   This method will be called immediately with the current value and will be called every time the value is updated. If this is the first subscription of this `SDLSystemCapabilityType`, then the value will be retrieved and a subscription will be attempted. The current cached value (`nil`) will nevertheless be returned immediately.
+ * This method will be called immediately with the current value and will be called every time the value is updated. If this is the first subscription of this `SDLSystemCapabilityType`, then the value will be retrieved and a subscription will be attempted. The current cached value (`nil`) will nevertheless be returned immediately.
  *
  * On sub-v5.1.0 systems (where `supportsSubscriptions == NO`):
  * The method will be called immediately with the current value and will _not_ be automatically called every time the value is updated, unless the `type` is `DISPLAYS` which is supported on every version. If `updateCapabilityType:completionHandler` is called and a new value is retrieved, this value will be updated then. If this is the first subscription of this `SDLSystemCapabilityType`, then the value will be retrieved and returned. The current cached value (`nil`) will nevertheless be returned immediately.

--- a/SmartDeviceLink/SDLSystemCapabilityManager.h
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.h
@@ -276,7 +276,7 @@ typedef void (^SDLCapabilityUpdateWithErrorHandler)(SDLSystemCapability * _Nulla
 /// This method will be called immediately with the current value and will be called every time the value is updated. If this is the first subscription of this `SDLSystemCapabilityType`, then the current cached value of `nil` will be returned immediately, an updated value will be retrieved, and a subscription will be attempted.
 ///
 /// On sub-v5.1.0 systems (where `supportsSubscriptions == NO`):
-/// The method will be called immediately with the current value and will _not_ be automatically called every time the value is updated, unless the `type` is `DISPLAYS` which is supported on every version. If `updateCapabilityType:completionHandler` is called and a new value is retrieved, this value will be updated then. If this is the first subscription of this `SDLSystemCapabilityType`, then the current cached value of `nil` will be returned immediately, an updated value will be retrieved, and a subscription will be attempted.
+/// The method will be called immediately with the current value and will _not_ be automatically called every time the value is updated, unless the `type` is `DISPLAYS` which is supported on every version. If `updateCapabilityType:completionHandler` is called and a new value is retrieved, this value will be updated then. If this is the first subscription of this `SDLSystemCapabilityType`, then the value will be retrieved and returned.
 ///
 /// @param type The type of capability to subscribe to
 /// @param block The block to be called when the capability is updated
@@ -291,7 +291,7 @@ typedef void (^SDLCapabilityUpdateWithErrorHandler)(SDLSystemCapability * _Nulla
 /// Note that when the cached value is returned, the `subscribed` flag on the handler will be false until the subscription completes successfully and a new value is retrieved.
 ///
 /// On sub-v5.1.0 systems (where `supportsSubscriptions == NO`):
-/// The method will be called immediately with the current value and will _not_ be automatically called every time the value is updated, unless the `type` is `DISPLAYS` which is supported on every version. If `updateCapabilityType:completionHandler` is called and a new value is retrieved, this value will be updated then. If this is the first subscription of this `SDLSystemCapabilityType`, then the value will be retrieved and returned. The current cached value (`nil`) will nevertheless be returned immediately.
+/// The method will be called immediately with the current value and will _not_ be automatically called every time the value is updated, unless the `type` is `DISPLAYS` which is supported on every version. If `updateCapabilityType:completionHandler` is called and a new value is retrieved, this value will be updated then. If this is the first subscription of this `SDLSystemCapabilityType`, then the value will be retrieved and returned.
 
 /// @param type The type of capability to subscribe to
 /// @param handler The block to be called when the capability is updated with an error if one occurs
@@ -315,7 +315,7 @@ typedef void (^SDLCapabilityUpdateWithErrorHandler)(SDLSystemCapability * _Nulla
  * This method will be called immediately with the current value and will be called every time the value is updated. If this is the first subscription of this `SDLSystemCapabilityType`, then the value will be retrieved and a subscription will be attempted. The current cached value (`nil`) will nevertheless be returned immediately.
  *
  * On sub-v5.1.0 systems (where `supportsSubscriptions == NO`):
- * The method will be called immediately with the current value and will _not_ be automatically called every time the value is updated, unless the `type` is `DISPLAYS` which is supported on every version. If `updateCapabilityType:completionHandler` is called and a new value is retrieved, this value will be updated then. If this is the first subscription of this `SDLSystemCapabilityType`, then the value will be retrieved and returned. The current cached value (`nil`) will nevertheless be returned immediately.
+ * The method will be called immediately with the current value and will _not_ be automatically called every time the value is updated, unless the `type` is `DISPLAYS` which is supported on every version. If `updateCapabilityType:completionHandler` is called and a new value is retrieved, this value will be updated then. If this is the first subscription of this `SDLSystemCapabilityType`, then the value will be retrieved and returned.
  *
  * @param type The type of the system capability to subscribe to
  * @param observer The object that will have `selector` called whenever the capability is updated

--- a/SmartDeviceLink/SDLSystemCapabilityManager.h
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.h
@@ -288,7 +288,9 @@ typedef void (^SDLCapabilityUpdateWithErrorHandler)(SDLSystemCapability * _Nulla
  *
  * 2. One `SDLSystemCapability *` parameter, e.g. `- (void)phoneCapabilityUpdated:(SDLSystemCapability *)capability`
  *
- * 3. Two parameters, one `SDLSystemCapability *` parameter, and one `BOOL` parameter, e.g. `- (void)phoneCapabilityUpdated:(SDLSystemCapability *)capability error:(NSError *)error`
+ * 3. Two parameters, one `SDLSystemCapability *` parameter, and one `NSError` parameter, e.g. `- (void)phoneCapabilityUpdated:(SDLSystemCapability *)capability error:(NSError *)error`
+ *
+ * 4. Three parameters, one `SDLSystemCapability *` parameter, one `NSError` parameter, and one `BOOL` parameter e.g. `- (void)phoneCapabilityUpdated:(SDLSystemCapability *)capability error:(NSError *)error subscribed:(BOOL)subscribed`
  *
  * This method will be called immediately with the current value and called every time the value is updated on RPC v5.1.0+ systems (`supportsSubscriptions == YES`). If this method is called on a sub-v5.1.0 system (`supportsSubscriptions == NO`), the method will return `NO` and the selector will never be called, unless the `type` is `DISPLAYS` which is supported on every version.
  *

--- a/SmartDeviceLink/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.m
@@ -608,7 +608,6 @@ typedef NSString * SDLServiceID;
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_displayLayoutResponse:) name:SDLDidReceiveSetDisplayLayoutResponse object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_systemCapabilityUpdatedNotification:) name:SDLDidReceiveSystemCapabilityUpdatedNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_systemCapabilityResponseNotification:) name:SDLDidReceiveGetSystemCapabilitiesResponse object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_hmiStatusNotification:) name:SDLDidChangeHMIStatusNotification object:nil];
 }
 
 /**

--- a/SmartDeviceLink/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.m
@@ -338,7 +338,6 @@ typedef NSString * SDLServiceID;
 /// @param handler The handler to be returned
 - (void)sdl_sendGetSystemCapabilityWithType:(SDLSystemCapabilityType)type subscribe:(nullable NSNumber<SDLBool> *)subscribe completionHandler:(nullable SDLCapabilityUpdateWithErrorHandler)handler {
     SDLLogV(@"Sending GetSystemCapability with type: %@, subscribe: %@", type, subscribe);
-    __weak typeof(self) weakSelf = self;
     SDLGetSystemCapability *getSystemCapability = [[SDLGetSystemCapability alloc] initWithType:type];
     getSystemCapability.subscribe = subscribe;
 
@@ -366,7 +365,7 @@ typedef NSString * SDLServiceID;
             weakself.subscriptionStatus[type] = subscribe;
         }
 
-        [weakSelf sdl_saveSystemCapability:getSystemCapabilityResponse.systemCapability error:error completionHandler:handler];
+        [weakself sdl_saveSystemCapability:getSystemCapabilityResponse.systemCapability error:error completionHandler:handler];
     }];
 }
 
@@ -507,7 +506,11 @@ typedef NSString * SDLServiceID;
     if (self.capabilityObservers[type] == nil) {
         SDLLogD(@"This is the first subscription to capability type: %@, sending a GetSystemCapability with subscribe true", type);
         self.capabilityObservers[type] = [NSMutableArray array];
-        [self sdl_sendGetSystemCapabilityWithType:type subscribe:@YES completionHandler:nil];
+        
+        // We don't want to send this for the displays type because that's automatically subscribed
+        if (![type isEqualToEnum:SDLSystemCapabilityTypeDisplays]) {
+            [self sdl_sendGetSystemCapabilityWithType:type subscribe:@YES completionHandler:nil];
+        }
     }
     [self.capabilityObservers[type] addObject:observerObject];
 
@@ -523,9 +526,12 @@ typedef NSString * SDLServiceID;
 
     if (self.capabilityObservers[type] == nil) {
         SDLLogD(@"This is the first subscription to capability type: %@, sending a GetSystemCapability with subscribe true", type);
-
         self.capabilityObservers[type] = [NSMutableArray array];
-        [self sdl_sendGetSystemCapabilityWithType:type subscribe:@YES completionHandler:nil];
+
+        // We don't want to send this for the displays type because that's automatically subscribed
+        if (![type isEqualToEnum:SDLSystemCapabilityTypeDisplays]) {
+            [self sdl_sendGetSystemCapabilityWithType:type subscribe:@YES completionHandler:nil];
+        }
     }
     [self.capabilityObservers[type] addObject:observerObject];
 
@@ -547,9 +553,12 @@ typedef NSString * SDLServiceID;
 
     if (self.capabilityObservers[type] == nil) {
         SDLLogD(@"This is the first subscription to capability type: %@, sending a GetSystemCapability with subscribe true", type);
-
         self.capabilityObservers[type] = [NSMutableArray array];
-        [self sdl_sendGetSystemCapabilityWithType:type subscribe:@YES completionHandler:nil];
+
+        // We don't want to send this for the displays type because that's automatically subscribed
+        if (![type isEqualToEnum:SDLSystemCapabilityTypeDisplays]) {
+            [self sdl_sendGetSystemCapabilityWithType:type subscribe:@YES completionHandler:nil];
+        }
     }
     [self.capabilityObservers[type] addObject:observerObject];
 
@@ -571,6 +580,7 @@ typedef NSString * SDLServiceID;
 
             if (self.capabilityObservers[type].count == 0 && self.supportsSubscriptions) {
                 SDLLogD(@"Removing the last subscription to type %@, sending a GetSystemCapability with subscribe false (will unsubscribe)", type);
+                self.capabilityObservers[type] = nil;
                 [self sdl_sendGetSystemCapabilityWithType:type subscribe:@NO completionHandler:nil];
             }
 

--- a/SmartDeviceLink/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.m
@@ -530,7 +530,7 @@ typedef NSString * SDLServiceID;
     [self.capabilityObservers[type] addObject:observerObject];
 
     // Call the block immediately with the cached value
-    [self sdl_invokeObserver:observerObject withCapability:[self sdl_cachedCapabilityForType:type] error:nil];
+    [self sdl_invokeObserver:observerObject withCapabilityType:type capability:[self sdl_cachedCapabilityForType:type] error:nil];
 
     return observerObject.observer;
 }
@@ -556,7 +556,7 @@ typedef NSString * SDLServiceID;
     [self.capabilityObservers[type] addObject:observerObject];
 
     // Call the block immediately with the cached value
-    [self sdl_invokeObserver:observerObject withCapability:[self sdl_cachedCapabilityForType:type] error:nil];
+    [self sdl_invokeObserver:observerObject withCapabilityType:type capability:[self sdl_cachedCapabilityForType:type] error:nil];
 
     return observerObject.observer;
 }
@@ -592,7 +592,7 @@ typedef NSString * SDLServiceID;
 
     // Store the observer and call it immediately with the cached value
     [self.capabilityObservers[type] addObject:observerObject];
-    [self sdl_invokeObserver:observerObject withCapability:[self sdl_cachedCapabilityForType:type] error:nil];
+    [self sdl_invokeObserver:observerObject withCapabilityType:type capability:[self sdl_cachedCapabilityForType:type] error:nil];
 
     return YES;
 }
@@ -619,15 +619,14 @@ typedef NSString * SDLServiceID;
     [self sdl_removeNilObserversAndUnsubscribeIfNecessary];
 
     for (SDLSystemCapabilityObserver *observer in self.capabilityObservers[type]) {
-        [self sdl_invokeObserver:observer withCapability:capability error:error];
+        [self sdl_invokeObserver:observer withCapabilityType:type capability:capability error:error];
     }
 
     if (handler == nil) { return; }
     handler(capability, self.subscriptionStatus[type].boolValue, error);
 }
 
-- (void)sdl_invokeObserver:(SDLSystemCapabilityObserver *)observer withCapability:(nullable SDLSystemCapability *)capability error:(nullable NSError *)error {
-    SDLSystemCapabilityType type = capability.systemCapabilityType;
+- (void)sdl_invokeObserver:(SDLSystemCapabilityObserver *)observer withCapabilityType:(SDLSystemCapabilityType)type capability:(nullable SDLSystemCapability *)capability error:(nullable NSError *)error {
     BOOL subscribed = self.subscriptionStatus[type].boolValue || [type isEqualToEnum:SDLSystemCapabilityTypeDisplays];
 
 #pragma clang diagnostic push

--- a/SmartDeviceLink/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.m
@@ -96,6 +96,8 @@ typedef NSString * SDLServiceID;
     _capabilityObservers = [NSMutableDictionary dictionary];
     _subscriptionStatus = [NSMutableDictionary dictionary];
 
+    _currentHMILevel = SDLHMILevelNone;
+
     [self sdl_registerForNotifications];    
 
     return self;
@@ -130,6 +132,8 @@ typedef NSString * SDLServiceID;
     _supportsSubscriptions = NO;
     [_capabilityObservers removeAllObjects];
     [_subscriptionStatus removeAllObjects];
+
+    _currentHMILevel = SDLHMILevelNone;
 
     _shouldConvertDeprecatedDisplayCapabilities = YES;
 }

--- a/SmartDeviceLink/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.m
@@ -517,17 +517,20 @@ typedef NSString * SDLServiceID;
 
     if (self.capabilityObservers[type] == nil) {
         SDLLogD(@"This is the first subscription to capability type: %@, sending a GetSystemCapability with subscribe true", type);
-        self.capabilityObservers[type] = [NSMutableArray array];
+        self.capabilityObservers[type] = [NSMutableArray arrayWithObject:observerObject];
 
         // We don't want to send this for the displays type because that's automatically subscribed
         if (![type isEqualToEnum:SDLSystemCapabilityTypeDisplays]) {
             [self sdl_sendGetSystemCapabilityWithType:type subscribe:@YES completionHandler:nil];
+        } else {
+            // If we're not calling the GSC RPC we should invoke the observer with the cached data
+            [self sdl_invokeObserver:observerObject withCapabilityType:type capability:[self sdl_cachedCapabilityForType:type] error:nil];
         }
+    } else {
+        // Store the observer and call it immediately with the cached value
+        [self.capabilityObservers[type] addObject:observerObject];
+        [self sdl_invokeObserver:observerObject withCapabilityType:type capability:[self sdl_cachedCapabilityForType:type] error:nil];
     }
-    [self.capabilityObservers[type] addObject:observerObject];
-
-    // Call the block immediately with the cached value
-    [self sdl_invokeObserver:observerObject withCapabilityType:type capability:[self sdl_cachedCapabilityForType:type] error:nil];
 
     return observerObject.observer;
 }
@@ -544,17 +547,20 @@ typedef NSString * SDLServiceID;
 
     if (self.capabilityObservers[type] == nil) {
         SDLLogD(@"This is the first subscription to capability type: %@, sending a GetSystemCapability with subscribe true", type);
-        self.capabilityObservers[type] = [NSMutableArray array];
+        self.capabilityObservers[type] = [NSMutableArray arrayWithObject:observerObject];
 
         // We don't want to send this for the displays type because that's automatically subscribed
         if (![type isEqualToEnum:SDLSystemCapabilityTypeDisplays]) {
             [self sdl_sendGetSystemCapabilityWithType:type subscribe:@YES completionHandler:nil];
+        } else {
+            // If we're not calling the GSC RPC we should invoke the observer with the cached data
+            [self sdl_invokeObserver:observerObject withCapabilityType:type capability:[self sdl_cachedCapabilityForType:type] error:nil];
         }
+    } else {
+        // Store the observer and call it immediately with the cached value
+        [self.capabilityObservers[type] addObject:observerObject];
+        [self sdl_invokeObserver:observerObject withCapabilityType:type capability:[self sdl_cachedCapabilityForType:type] error:nil];
     }
-    [self.capabilityObservers[type] addObject:observerObject];
-
-    // Call the block immediately with the cached value
-    [self sdl_invokeObserver:observerObject withCapabilityType:type capability:[self sdl_cachedCapabilityForType:type] error:nil];
 
     return observerObject.observer;
 }
@@ -581,17 +587,20 @@ typedef NSString * SDLServiceID;
 
     if (self.capabilityObservers[type] == nil) {
         SDLLogD(@"This is the first subscription to capability type: %@, sending a GetSystemCapability with subscribe true", type);
-        self.capabilityObservers[type] = [NSMutableArray array];
+        self.capabilityObservers[type] = [NSMutableArray arrayWithObject:observerObject];
 
         // We don't want to send this for the displays type because that's automatically subscribed
         if (![type isEqualToEnum:SDLSystemCapabilityTypeDisplays]) {
             [self sdl_sendGetSystemCapabilityWithType:type subscribe:@YES completionHandler:nil];
+        } else {
+            // If we're not calling the GSC RPC we should invoke the observer with the cached data
+            [self sdl_invokeObserver:observerObject withCapabilityType:type capability:[self sdl_cachedCapabilityForType:type] error:nil];
         }
+    } else {
+        // Store the observer and call it immediately with the cached value
+        [self.capabilityObservers[type] addObject:observerObject];
+        [self sdl_invokeObserver:observerObject withCapabilityType:type capability:[self sdl_cachedCapabilityForType:type] error:nil];
     }
-
-    // Store the observer and call it immediately with the cached value
-    [self.capabilityObservers[type] addObject:observerObject];
-    [self sdl_invokeObserver:observerObject withCapabilityType:type capability:[self sdl_cachedCapabilityForType:type] error:nil];
 
     return YES;
 }

--- a/SmartDeviceLink/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.m
@@ -19,6 +19,7 @@
 #import "SDLGetSystemCapability.h"
 #import "SDLGetSystemCapabilityResponse.h"
 #import "SDLGlobals.h"
+#import "SDLHMICapabilities.h"
 #import "SDLLogMacros.h"
 #import "SDLNavigationCapability.h"
 #import "SDLNotificationConstants.h"
@@ -277,8 +278,35 @@ typedef NSString * SDLServiceID;
     if ([self sdl_cachedCapabilityForType:type] != nil) {
         return YES;
     } else if (self.hmiCapabilities != nil) {
-        SDLHMICapabilities *hmiCapabilities = self.hmiCapabilities;
+        if ([type isEqualToEnum:SDLSystemCapabilityTypePhoneCall]) {
+            return self.hmiCapabilities.phoneCall.boolValue;
+        } else if ([type isEqualToEnum:SDLSystemCapabilityTypeNavigation]) {
+            return self.hmiCapabilities.navigation.boolValue;
+        } else if ([type isEqualToEnum:SDLSystemCapabilityTypeDisplays]) {
+            return self.hmiCapabilities.displays.boolValue;
+        } else if ([type isEqualToEnum:SDLSystemCapabilityTypeRemoteControl]) {
+            return self.hmiCapabilities.remoteControl.boolValue;
+        } else if ([type isEqualToEnum:SDLSystemCapabilityTypeSeatLocation]) {
+            return self.hmiCapabilities.seatLocation.boolValue;
+        } else if ([type isEqualToEnum:SDLSystemCapabilityTypeAppServices]) {
+            //This is a corner case that the param was not available in 5.1.0, but the app services feature was available. We have to say it's available because we don't know.
+            if ([[SDLGlobals sharedGlobals].rpcVersion isEqualToVersion:[SDLVersion versionWithString:@"5.1.0"]]) {
+                return YES;
+            }
+
+            return self.hmiCapabilities.appServices.boolValue;
+        } else if ([type isEqualToEnum:SDLSystemCapabilityTypeVideoStreaming]) {
+            if ([[SDLGlobals sharedGlobals].rpcVersion isGreaterThanOrEqualToVersion:[SDLVersion versionWithString:@"3.0.0"]] && [[SDLGlobals sharedGlobals].rpcVersion isLessThanOrEqualToVersion:[SDLVersion versionWithString:@"4.4.0"]]) {
+                // This was before the system capability feature was added so check if graphics are supported instead using the deprecated display capabilities
+                return self.displayCapabilities.graphicSupported;
+            }
+
+            return self.hmiCapabilities.videoStreaming.boolValue;
+        } else {
+            return NO;
+        }
     }
+
 
     return NO;
 }

--- a/SmartDeviceLink/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.m
@@ -264,34 +264,32 @@ typedef NSString * SDLServiceID;
 - (BOOL)isCapabilitySupported:(SDLSystemCapabilityType)type {
     if ([self sdl_cachedCapabilityForType:type] != nil) {
         return YES;
-    } else if (self.hmiCapabilities != nil) {
-        if ([type isEqualToEnum:SDLSystemCapabilityTypePhoneCall]) {
-            return self.hmiCapabilities.phoneCall.boolValue;
-        } else if ([type isEqualToEnum:SDLSystemCapabilityTypeNavigation]) {
-            return self.hmiCapabilities.navigation.boolValue;
-        } else if ([type isEqualToEnum:SDLSystemCapabilityTypeDisplays]) {
-            return self.hmiCapabilities.displays.boolValue;
-        } else if ([type isEqualToEnum:SDLSystemCapabilityTypeRemoteControl]) {
-            return self.hmiCapabilities.remoteControl.boolValue;
-        } else if ([type isEqualToEnum:SDLSystemCapabilityTypeSeatLocation]) {
-            return self.hmiCapabilities.seatLocation.boolValue;
-        } else if ([type isEqualToEnum:SDLSystemCapabilityTypeAppServices]) {
-            //This is a corner case that the param was not available in 5.1.0, but the app services feature was available. We have to say it's available because we don't know.
-            if ([[SDLGlobals sharedGlobals].rpcVersion isEqualToVersion:[SDLVersion versionWithString:@"5.1.0"]]) {
-                return YES;
-            }
-
-            return self.hmiCapabilities.appServices.boolValue;
-        } else if ([type isEqualToEnum:SDLSystemCapabilityTypeVideoStreaming]) {
-            if ([[SDLGlobals sharedGlobals].rpcVersion isGreaterThanOrEqualToVersion:[SDLVersion versionWithString:@"3.0.0"]] && [[SDLGlobals sharedGlobals].rpcVersion isLessThanOrEqualToVersion:[SDLVersion versionWithString:@"4.4.0"]]) {
-                // This was before the system capability feature was added so check if graphics are supported instead using the deprecated display capabilities
-                return self.displayCapabilities.graphicSupported.boolValue;
-            }
-
-            return self.hmiCapabilities.videoStreaming.boolValue;
-        } else {
-            return NO;
+    } else if ([type isEqualToEnum:SDLSystemCapabilityTypePhoneCall]) {
+        return self.hmiCapabilities.phoneCall.boolValue;
+    } else if ([type isEqualToEnum:SDLSystemCapabilityTypeNavigation]) {
+        return self.hmiCapabilities.navigation.boolValue;
+    } else if ([type isEqualToEnum:SDLSystemCapabilityTypeDisplays]) {
+        return self.hmiCapabilities.displays.boolValue;
+    } else if ([type isEqualToEnum:SDLSystemCapabilityTypeRemoteControl]) {
+        return self.hmiCapabilities.remoteControl.boolValue;
+    } else if ([type isEqualToEnum:SDLSystemCapabilityTypeSeatLocation]) {
+        return self.hmiCapabilities.seatLocation.boolValue;
+    } else if ([type isEqualToEnum:SDLSystemCapabilityTypeAppServices]) {
+        //This is a corner case that the param was not available in 5.1.0, but the app services feature was available. We have to say it's available because we don't know.
+        if ([[SDLGlobals sharedGlobals].rpcVersion isEqualToVersion:[SDLVersion versionWithString:@"5.1.0"]]) {
+            return YES;
         }
+
+        return self.hmiCapabilities.appServices.boolValue;
+    } else if ([type isEqualToEnum:SDLSystemCapabilityTypeVideoStreaming]) {
+        if ([[SDLGlobals sharedGlobals].rpcVersion isGreaterThanOrEqualToVersion:[SDLVersion versionWithString:@"3.0.0"]] && [[SDLGlobals sharedGlobals].rpcVersion isLessThanOrEqualToVersion:[SDLVersion versionWithString:@"4.4.0"]]) {
+            // This was before the system capability feature was added so check if graphics are supported instead using the deprecated display capabilities
+            return self.displayCapabilities.graphicSupported.boolValue;
+        }
+
+        return self.hmiCapabilities.videoStreaming.boolValue;
+    } else {
+        return NO;
     }
 
 

--- a/SmartDeviceLink/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.m
@@ -506,7 +506,7 @@ typedef NSString * SDLServiceID;
     if (self.capabilityObservers[type] == nil) {
         SDLLogD(@"This is the first subscription to capability type: %@, sending a GetSystemCapability with subscribe true", type);
         self.capabilityObservers[type] = [NSMutableArray array];
-        
+
         // We don't want to send this for the displays type because that's automatically subscribed
         if (![type isEqualToEnum:SDLSystemCapabilityTypeDisplays]) {
             [self sdl_sendGetSystemCapabilityWithType:type subscribe:@YES completionHandler:nil];
@@ -581,7 +581,11 @@ typedef NSString * SDLServiceID;
             if (self.capabilityObservers[type].count == 0 && self.supportsSubscriptions) {
                 SDLLogD(@"Removing the last subscription to type %@, sending a GetSystemCapability with subscribe false (will unsubscribe)", type);
                 self.capabilityObservers[type] = nil;
-                [self sdl_sendGetSystemCapabilityWithType:type subscribe:@NO completionHandler:nil];
+
+                // We don't want to send this for the displays type because that's automatically subscribed
+                if (![type isEqualToEnum:SDLSystemCapabilityTypeDisplays]) {
+                    [self sdl_sendGetSystemCapabilityWithType:type subscribe:@NO completionHandler:nil];
+                }
             }
 
             break;

--- a/SmartDeviceLink/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.m
@@ -623,13 +623,16 @@ typedef NSString * SDLServiceID;
 }
 
 - (void)sdl_invokeObserver:(SDLSystemCapabilityObserver *)observer withCapability:(nullable SDLSystemCapability *)capability error:(nullable NSError *)error {
+    SDLSystemCapabilityType type = capability.systemCapabilityType;
+    BOOL subscribed = self.subscriptionStatus[type].boolValue || [type isEqualToEnum:SDLSystemCapabilityTypeDisplays];
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     if (observer.block != nil) {
         observer.block(capability);
 #pragma clang diagnostic pop
     } else if (observer.updateBlock != nil) {
-        observer.updateBlock(capability, self.subscriptionStatus[capability.systemCapabilityType].boolValue, error);
+        observer.updateBlock(capability, subscribed, error);
     } else {
         if (![observer.observer respondsToSelector:observer.selector]) {
             @throw [NSException sdl_invalidSelectorExceptionWithSelector:observer.selector];
@@ -647,8 +650,7 @@ typedef NSString * SDLServiceID;
             [invocation setArgument:&error atIndex:3];
         }
         if (numberOfParametersInSelector >= 3) {
-            BOOL argVal = self.subscriptionStatus[capability.systemCapabilityType].boolValue;
-            [invocation setArgument:&argVal atIndex:4];
+            [invocation setArgument:&subscribed atIndex:4];
         }
         if (numberOfParametersInSelector >= 4) {
             @throw [NSException sdl_invalidSelectorExceptionWithSelector:observer.selector];

--- a/SmartDeviceLink/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.m
@@ -604,7 +604,7 @@ typedef NSString * SDLServiceID;
     } else if (observer.updateBlock != nil) {
         observer.updateBlock(capability, self.subscriptionStatus[capability.systemCapabilityType].boolValue, error);
     } else {
-        if (![observer respondsToSelector:observer.selector]) {
+        if (![observer.observer respondsToSelector:observer.selector]) {
             @throw [NSException sdl_invalidSelectorExceptionWithSelector:observer.selector];
         }
 

--- a/SmartDeviceLink/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.m
@@ -380,8 +380,9 @@ typedef NSString * SDLServiceID;
  */
 - (BOOL)sdl_saveSystemCapability:(nullable SDLSystemCapability *)systemCapability error:(nullable NSError *)error completionHandler:(nullable SDLCapabilityUpdateWithErrorHandler)handler {
     SDLLogV(@"Saving system capability type: %@", systemCapability);
+
+    // If this is equal to the last received capability (e.g. a notification and GetSystemCapabilityResponse), don't save twice or call the observer twice.
     if ([self.lastReceivedCapability isEqual:systemCapability]) {
-        [self sdl_callObserversForUpdate:systemCapability error:error handler:handler];
         return NO;
     }
     self.lastReceivedCapability = systemCapability;

--- a/SmartDeviceLink/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.m
@@ -346,7 +346,7 @@ typedef NSString * SDLServiceID;
         if (![response isKindOfClass:[SDLGetSystemCapabilityResponse class]]) {
             SDLLogE(@"GetSystemCapability failed, type: %@, did not return a GetSystemCapability response", type);
             if (handler == nil) { return; }
-            handler(nil, NO, error);
+            handler(nil, NO, [NSError sdl_systemCapabilityManager_moduleDoesNotSupportCapabilityType]);
             return;
         }
 
@@ -510,7 +510,12 @@ typedef NSString * SDLServiceID;
 
         // We don't want to send this for the displays type because that's automatically subscribed
         if (![type isEqualToEnum:SDLSystemCapabilityTypeDisplays]) {
-            [self sdl_sendGetSystemCapabilityWithType:type subscribe:@YES completionHandler:nil];
+            __weak typeof(self) weakself = self;
+            [self sdl_sendGetSystemCapabilityWithType:type subscribe:@YES completionHandler:^(SDLSystemCapability * _Nullable capability, BOOL subscribed, NSError * _Nullable error) {
+                if (error != nil) {
+                    [weakself sdl_invokeObserver:observerObject withCapability:capability error:error];
+                }
+            }];
         }
     }
     [self.capabilityObservers[type] addObject:observerObject];
@@ -531,7 +536,12 @@ typedef NSString * SDLServiceID;
 
         // We don't want to send this for the displays type because that's automatically subscribed
         if (![type isEqualToEnum:SDLSystemCapabilityTypeDisplays]) {
-            [self sdl_sendGetSystemCapabilityWithType:type subscribe:@YES completionHandler:nil];
+            __weak typeof(self) weakself = self;
+            [self sdl_sendGetSystemCapabilityWithType:type subscribe:@YES completionHandler:^(SDLSystemCapability * _Nullable capability, BOOL subscribed, NSError * _Nullable error) {
+                if (error != nil) {
+                    [weakself sdl_invokeObserver:observerObject withCapability:capability error:error];
+                }
+            }];
         }
     }
     [self.capabilityObservers[type] addObject:observerObject];
@@ -551,14 +561,18 @@ typedef NSString * SDLServiceID;
     }
 
     SDLSystemCapabilityObserver *observerObject = [[SDLSystemCapabilityObserver alloc] initWithObserver:observer selector:selector];
-
     if (self.capabilityObservers[type] == nil) {
         SDLLogD(@"This is the first subscription to capability type: %@, sending a GetSystemCapability with subscribe true", type);
         self.capabilityObservers[type] = [NSMutableArray array];
 
         // We don't want to send this for the displays type because that's automatically subscribed
         if (![type isEqualToEnum:SDLSystemCapabilityTypeDisplays]) {
-            [self sdl_sendGetSystemCapabilityWithType:type subscribe:@YES completionHandler:nil];
+            __weak typeof(self) weakself = self;
+            [self sdl_sendGetSystemCapabilityWithType:type subscribe:@YES completionHandler:^(SDLSystemCapability * _Nullable capability, BOOL subscribed, NSError * _Nullable error) {
+                if (error != nil) {
+                    [weakself sdl_invokeObserver:observerObject withCapability:capability error:error];
+                }
+            }];
         }
     }
     [self.capabilityObservers[type] addObject:observerObject];

--- a/SmartDeviceLink/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.m
@@ -346,7 +346,7 @@ typedef NSString * SDLServiceID;
         if (![response isKindOfClass:[SDLGetSystemCapabilityResponse class]]) {
             SDLLogE(@"GetSystemCapability failed, type: %@, did not return a GetSystemCapability response", type);
             if (handler == nil) { return; }
-            handler(nil, NO, [NSError sdl_systemCapabilityManager_moduleDoesNotSupportCapabilityType]);
+            handler(nil, NO, [NSError sdl_systemCapabilityManager_moduleDoesNotSupportSystemCapabilities]);
             return;
         }
 

--- a/SmartDeviceLink/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.m
@@ -596,39 +596,39 @@ typedef NSString * SDLServiceID;
 }
 
 - (void)sdl_invokeObserver:(SDLSystemCapabilityObserver *)observer withCapability:(nullable SDLSystemCapability *)capability error:(nullable NSError *)error {
-    #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-            if (observer.block != nil) {
-                observer.block(capability);
-    #pragma clang diagnostic pop
-            } else if (observer.updateBlock != nil) {
-                observer.updateBlock(capability, self.subscriptionStatus[capability.systemCapabilityType].boolValue, error);
-            } else {
-                if (![observer respondsToSelector:observer.selector]) {
-                    @throw [NSException sdl_invalidSelectorExceptionWithSelector:observer.selector];
-                }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    if (observer.block != nil) {
+        observer.block(capability);
+#pragma clang diagnostic pop
+    } else if (observer.updateBlock != nil) {
+        observer.updateBlock(capability, self.subscriptionStatus[capability.systemCapabilityType].boolValue, error);
+    } else {
+        if (![observer respondsToSelector:observer.selector]) {
+            @throw [NSException sdl_invalidSelectorExceptionWithSelector:observer.selector];
+        }
 
-                NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[(NSObject *)observer.observer methodSignatureForSelector:observer.selector]];
-                [invocation setSelector:observer.selector];
-                [invocation setTarget:observer.observer];
+        NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[(NSObject *)observer.observer methodSignatureForSelector:observer.selector]];
+        [invocation setSelector:observer.selector];
+        [invocation setTarget:observer.observer];
 
-                NSUInteger numberOfParametersInSelector = [NSStringFromSelector(observer.selector) componentsSeparatedByString:@":"].count - 1;
-                if (numberOfParametersInSelector >= 1) {
-                    [invocation setArgument:&capability atIndex:2];
-                }
-                if (numberOfParametersInSelector >= 2) {
-                    [invocation setArgument:&error atIndex:3];
-                }
-                if (numberOfParametersInSelector >= 3) {
-                    BOOL argVal = self.subscriptionStatus[capability.systemCapabilityType].boolValue;
-                    [invocation setArgument:&argVal atIndex:4];
-                }
-                if (numberOfParametersInSelector >= 4) {
-                    @throw [NSException sdl_invalidSelectorExceptionWithSelector:observer.selector];
-                }
+        NSUInteger numberOfParametersInSelector = [NSStringFromSelector(observer.selector) componentsSeparatedByString:@":"].count - 1;
+        if (numberOfParametersInSelector >= 1) {
+            [invocation setArgument:&capability atIndex:2];
+        }
+        if (numberOfParametersInSelector >= 2) {
+            [invocation setArgument:&error atIndex:3];
+        }
+        if (numberOfParametersInSelector >= 3) {
+            BOOL argVal = self.subscriptionStatus[capability.systemCapabilityType].boolValue;
+            [invocation setArgument:&argVal atIndex:4];
+        }
+        if (numberOfParametersInSelector >= 4) {
+            @throw [NSException sdl_invalidSelectorExceptionWithSelector:observer.selector];
+        }
 
-                [invocation invoke];
-            }
+        [invocation invoke];
+    }
 }
 
 #pragma mark - Notifications
@@ -674,7 +674,7 @@ typedef NSString * SDLServiceID;
 
     // Call the observers in case the new display capability list is created from deprecated types
     SDLSystemCapability *systemCapability = [[SDLSystemCapability alloc] initWithDisplayCapabilities:self.displays];
-    [self sdl_callObserversForType:systemCapability.systemCapabilityType update:systemCapability error:nil handler:nil];
+    [self sdl_callObserversForUpdate:systemCapability error:nil handler:nil];
 }
 
 /**
@@ -703,7 +703,7 @@ typedef NSString * SDLServiceID;
 
     // Call the observers in case the new display capability list is created from deprecated types
     SDLSystemCapability *systemCapability = [[SDLSystemCapability alloc] initWithDisplayCapabilities:self.displays];
-    [self sdl_callObserversForType:systemCapability.systemCapabilityType update:systemCapability error:nil handler:nil];
+    [self sdl_callObserversForUpdate:systemCapability error:nil handler:nil];
 }
 
 

--- a/SmartDeviceLink/SDLSystemCapabilityObserver.h
+++ b/SmartDeviceLink/SDLSystemCapabilityObserver.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^SDLCapabilityUpdateHandler)(SDLSystemCapability *capability);
 
-typedef void (^SDLCapabilityUpdateWithErrorHandler)(SDLSystemCapability *capability, NSError *error);
+typedef void (^SDLCapabilityUpdateWithErrorHandler)(SDLSystemCapability *_Nullable capability, BOOL subscribed, NSError *_Nullable error);
 
 /**
  An observer object for SDLSystemCapabilityManager
@@ -34,7 +34,10 @@ typedef void (^SDLCapabilityUpdateWithErrorHandler)(SDLSystemCapability *capabil
 /**
  A block called when the observer is triggered
  */
-@property (copy, nonatomic) SDLCapabilityUpdateHandler block;
+@property (copy, nonatomic) SDLCapabilityUpdateHandler block __deprecated_msg("use updateBlock instead");
+
+/// A block called when the observer is triggered
+@property (copy, nonatomic) SDLCapabilityUpdateWithErrorHandler updateBlock;
 
 /**
  Create an observer using an object and a selector on that object
@@ -52,7 +55,7 @@ typedef void (^SDLCapabilityUpdateWithErrorHandler)(SDLSystemCapability *capabil
  @param block The block that will be called when the subscription triggers
  @return The observer
  */
-- (instancetype)initWithObserver:(id<NSObject>)observer block:(SDLCapabilityUpdateHandler)block;
+- (instancetype)initWithObserver:(id<NSObject>)observer block:(SDLCapabilityUpdateHandler)block __deprecated_msg("use initWithObserver:updateHandler: instead");
 
 /// Create an observer using an object and a callback block
 

--- a/SmartDeviceLink/SDLSystemCapabilityObserver.h
+++ b/SmartDeviceLink/SDLSystemCapabilityObserver.h
@@ -14,6 +14,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^SDLCapabilityUpdateHandler)(SDLSystemCapability *capability);
 
+typedef void (^SDLCapabilityUpdateWithErrorHandler)(SDLSystemCapability *capability, NSError *error);
+
 /**
  An observer object for SDLSystemCapabilityManager
  */
@@ -51,6 +53,13 @@ typedef void (^SDLCapabilityUpdateHandler)(SDLSystemCapability *capability);
  @return The observer
  */
 - (instancetype)initWithObserver:(id<NSObject>)observer block:(SDLCapabilityUpdateHandler)block;
+
+/// Create an observer using an object and a callback block
+
+/// @param observer The object that can be used to unsubscribe the block
+/// @param block The block that will be called when the subscription triggers
+/// @return The observer
+- (instancetype)initWithObserver:(id<NSObject>)observer updateHandler:(SDLCapabilityUpdateWithErrorHandler)block;
 
 @end
 

--- a/SmartDeviceLink/SDLSystemCapabilityObserver.h
+++ b/SmartDeviceLink/SDLSystemCapabilityObserver.h
@@ -12,8 +12,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/// A handler mirroring the one in SDLSystemCapabilityManager.h for `initWithObserver:block:`
 typedef void (^SDLCapabilityUpdateHandler)(SDLSystemCapability *capability);
 
+/// A handler mirroring the one in SDLSystemCapabilityManager.h for `initWithObserver:updateHandler:`
 typedef void (^SDLCapabilityUpdateWithErrorHandler)(SDLSystemCapability *_Nullable capability, BOOL subscribed, NSError *_Nullable error);
 
 /**

--- a/SmartDeviceLink/SDLSystemCapabilityObserver.m
+++ b/SmartDeviceLink/SDLSystemCapabilityObserver.m
@@ -32,12 +32,12 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (instancetype)initWithObserver:(id<NSObject>)observer block:(SDLCapabilityUpdateWithErrorHandler)block {
+- (instancetype)initWithObserver:(id<NSObject>)observer updateHandler:(SDLCapabilityUpdateWithErrorHandler)block {
     self = [super init];
     if (!self) { return nil; }
 
     _observer = observer;
-    _block = block;
+    _updateBlock = block;
 
     return self;
 }

--- a/SmartDeviceLink/SDLSystemCapabilityObserver.m
+++ b/SmartDeviceLink/SDLSystemCapabilityObserver.m
@@ -32,6 +32,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (instancetype)initWithObserver:(id<NSObject>)observer block:(SDLCapabilityUpdateWithErrorHandler)block {
+    self = [super init];
+    if (!self) { return nil; }
+
+    _observer = observer;
+    _block = block;
+
+    return self;
+}
+
 - (NSString *)description {
     if (self.selector) {
         return [NSString stringWithFormat:@"Observer: %@[%@] - %@", [_observer class], _observer, NSStringFromSelector(_selector)];

--- a/SmartDeviceLinkTests/DevAPISpecs/TestSystemCapabilityObserver.h
+++ b/SmartDeviceLinkTests/DevAPISpecs/TestSystemCapabilityObserver.h
@@ -15,6 +15,9 @@ NS_ASSUME_NONNULL_BEGIN
 @interface TestSystemCapabilityObserver : NSObject
 
 @property (assign, nonatomic) NSUInteger selectorCalledCount;
+@property (strong, nonatomic, nullable) NSMutableArray<SDLSystemCapability *> *capabilitiesReceived;
+@property (strong, nonatomic, nullable) NSMutableArray<NSError *> *errorsReceived;
+@property (strong, nonatomic, nullable) NSMutableArray<NSNumber *> *subscribedValuesReceived;
 
 - (void)capabilityUpdated;
 - (void)capabilityUpdatedWithCapability:(SDLSystemCapability *)capability;

--- a/SmartDeviceLinkTests/DevAPISpecs/TestSystemCapabilityObserver.h
+++ b/SmartDeviceLinkTests/DevAPISpecs/TestSystemCapabilityObserver.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-@class SDLSystemCapabilityManager;
+@class SDLSystemCapability;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -17,7 +17,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic) NSUInteger selectorCalledCount;
 
 - (void)capabilityUpdated;
-- (void)capabilityUpdatedWithNotification:(SDLSystemCapabilityManager *)capabilityManager;
+- (void)capabilityUpdatedWithCapability:(SDLSystemCapability *)capability;
+- (void)capabilityUpdatedWithCapability:(SDLSystemCapability *)capability error:(NSError *)error;
+- (void)capabilityUpdatedWithCapability:(SDLSystemCapability *)capability error:(NSError *)error subscribed:(BOOL)subscribed;
 
 @end
 

--- a/SmartDeviceLinkTests/DevAPISpecs/TestSystemCapabilityObserver.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/TestSystemCapabilityObserver.m
@@ -25,7 +25,7 @@
     self.selectorCalledCount++;
 }
 
-- (void)capabilityUpdatedWithNotification:(SDLSystemCapability *)capability {
+- (void)capabilityUpdatedWithCapability:(SDLSystemCapability *)capability {
     self.selectorCalledCount++;
 }
 

--- a/SmartDeviceLinkTests/DevAPISpecs/TestSystemCapabilityObserver.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/TestSystemCapabilityObserver.m
@@ -8,6 +8,8 @@
 
 #import "TestSystemCapabilityObserver.h"
 
+#import "SDLSystemCapability.h"
+
 @implementation TestSystemCapabilityObserver
 
 - (instancetype)init {
@@ -23,7 +25,15 @@
     self.selectorCalledCount++;
 }
 
-- (void)capabilityUpdatedWithNotification:(SDLSystemCapabilityManager *)capabilityManager {
+- (void)capabilityUpdatedWithNotification:(SDLSystemCapability *)capability {
+    self.selectorCalledCount++;
+}
+
+- (void)capabilityUpdatedWithCapability:(SDLSystemCapability *)capability error:(NSError *)error {
+    self.selectorCalledCount++;
+}
+
+- (void)capabilityUpdatedWithCapability:(SDLSystemCapability *)capability error:(NSError *)error subscribed:(BOOL)subscribed {
     self.selectorCalledCount++;
 }
 

--- a/SmartDeviceLinkTests/DevAPISpecs/TestSystemCapabilityObserver.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/TestSystemCapabilityObserver.m
@@ -17,6 +17,9 @@
     if (!self) { return nil; }
 
     _selectorCalledCount = 0;
+    _capabilitiesReceived = [NSMutableArray<SDLSystemCapability *> array];
+    _errorsReceived = [NSMutableArray<NSError *> array];
+    _subscribedValuesReceived = [NSMutableArray<NSNumber *> array];
 
     return self;
 }
@@ -27,14 +30,36 @@
 
 - (void)capabilityUpdatedWithCapability:(SDLSystemCapability *)capability {
     self.selectorCalledCount++;
+
+    if (capability != nil) {
+        [self.capabilitiesReceived addObject:capability];
+    }
 }
 
 - (void)capabilityUpdatedWithCapability:(SDLSystemCapability *)capability error:(NSError *)error {
     self.selectorCalledCount++;
+
+    if (capability != nil) {
+        [self.capabilitiesReceived addObject:capability];
+    }
+
+    if (error != nil) {
+        [self.errorsReceived addObject:error];
+    }
 }
 
 - (void)capabilityUpdatedWithCapability:(SDLSystemCapability *)capability error:(NSError *)error subscribed:(BOOL)subscribed {
     self.selectorCalledCount++;
+
+    if (capability != nil) {
+        [self.capabilitiesReceived addObject:capability];
+    }
+
+    if (error != nil) {
+        [self.errorsReceived addObject:error];
+    }
+    
+    [self.subscribedValuesReceived addObject:@(subscribed)];
 }
 
 @end

--- a/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
+++ b/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
@@ -631,6 +631,7 @@ fdescribe(@"System capability manager", ^{
             [testSystemCapabilityManager subscribeToCapabilityType:SDLSystemCapabilityTypeNavigation withObserver:navigationObserver selector:@selector(capabilityUpdatedWithCapability:error:)];
             videoStreamingObserver = [[TestSystemCapabilityObserver alloc] init];
             [testSystemCapabilityManager subscribeToCapabilityType:SDLSystemCapabilityTypeVideoStreaming withObserver:videoStreamingObserver selector:@selector(capabilityUpdatedWithCapability:error:subscribed:)];
+            displaysObserver = [[TestSystemCapabilityObserver alloc] init];
             [testSystemCapabilityManager subscribeToCapabilityType:SDLSystemCapabilityTypeDisplays withObserver:displaysObserver selector:@selector(capabilityUpdatedWithCapability:error:subscribed:)];
         });
 
@@ -739,7 +740,7 @@ fdescribe(@"System capability manager", ^{
             it(@"should notify subscribers of the new data", ^{
                 expect(handlerTriggeredCount).toEventually(equal(2));
                 expect(observerTriggeredCount).toEventually(equal(2));
-                
+
                 expect(phoneObserver.selectorCalledCount).toEventually(equal(2));
 
                 expect(navigationObserver.selectorCalledCount).toEventually(equal(1));

--- a/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
+++ b/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
@@ -681,6 +681,8 @@ fdescribe(@"System capability manager", ^{
                 expect(navigationObserver.selectorCalledCount).toEventually(equal(1));
 
                 expect(videoStreamingObserver.selectorCalledCount).toEventually(equal(1));
+                expect(videoStreamingObserver.subscribedValuesReceived).toEventually(haveCount(1));
+                expect(videoStreamingObserver.subscribedValuesReceived.firstObject).toEventually(beFalse());
 
                 expect(displaysObserver.selectorCalledCount).toEventually(equal(1));
                 expect(displaysObserver.subscribedValuesReceived).toEventually(haveCount(1));
@@ -746,6 +748,8 @@ fdescribe(@"System capability manager", ^{
                 expect(navigationObserver.selectorCalledCount).toEventually(equal(1));
 
                 expect(videoStreamingObserver.selectorCalledCount).toEventually(equal(1));
+                expect(videoStreamingObserver.subscribedValuesReceived).toEventually(haveCount(1));
+                expect(videoStreamingObserver.subscribedValuesReceived.firstObject).toEventually(beFalse());
 
                 expect(displaysObserver.selectorCalledCount).toEventually(equal(1));
                 expect(displaysObserver.subscribedValuesReceived).toEventually(haveCount(1));

--- a/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
+++ b/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
@@ -656,7 +656,7 @@ describe(@"System capability manager", ^{
             [testSystemCapabilityManager subscribeToCapabilityType:SDLSystemCapabilityTypeDisplays withObserver:displaysObserver selector:@selector(capabilityUpdatedWithCapability:error:subscribed:)];
         });
 
-        describe(@"when observers aren't supported", ^{
+        context(@"when observers aren't supported", ^{
             __block BOOL observationSuccess = NO;
 
             beforeEach(^{
@@ -693,11 +693,11 @@ describe(@"System capability manager", ^{
                 [[NSNotificationCenter defaultCenter] postNotification:notification];
             });
 
-            it(@"should notify subscribers of the new data", ^{
-                expect(handlerTriggeredCount).toEventually(equal(2));
-                expect(observerTriggeredCount).toEventually(equal(2));
+            it(@"should not notify subscribers of new data because it was sent outside of the SCM", ^{
+                expect(handlerTriggeredCount).toEventually(equal(1));
+                expect(observerTriggeredCount).toEventually(equal(1));
 
-                expect(phoneObserver.selectorCalledCount).toEventually(equal(2));
+                expect(phoneObserver.selectorCalledCount).toEventually(equal(1));
 
                 expect(navigationObserver.selectorCalledCount).toEventually(equal(1));
 
@@ -724,10 +724,10 @@ describe(@"System capability manager", ^{
                 });
 
                 it(@"should not notify the subscriber of the new data", ^{
-                    expect(handlerTriggeredCount).toEventually(equal(2));
-                    expect(observerTriggeredCount).toEventually(equal(2));
+                    expect(handlerTriggeredCount).toEventually(equal(1));
+                    expect(observerTriggeredCount).toEventually(equal(1));
 
-                    expect(phoneObserver.selectorCalledCount).toEventually(equal(2)); // No change from above
+                    expect(phoneObserver.selectorCalledCount).toEventually(equal(1)); // No change from above
 
                     expect(navigationObserver.selectorCalledCount).toEventually(equal(1));
 

--- a/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
+++ b/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
@@ -254,7 +254,7 @@ describe(@"System capability manager", ^{
                             testSystemCapabilityManager.displayCapabilities.graphicSupported = @YES;
                         });
 
-                        fit(@"should return true", ^{
+                        it(@"should return true", ^{
                             expect([testSystemCapabilityManager isCapabilitySupported:SDLSystemCapabilityTypeVideoStreaming]).to(beTrue());
                         });
                     });


### PR DESCRIPTION
Fixes #1535 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
- [x] New `subscribe` method
- [x] `isCapabilitySupported` method

#### Core Tests
- [x] Test Obj-C subscribe with 0, 1, 2, and 3 parameters
  - Test cached capability
  - Test updated capability
  - Test unsubscribe
- [x] Test Obj-C subscribe with update handler
  - Test cached capability
  - Test updated capability
  - Test unsubscribe
- [x] Test Obj-C subscribe with block (deprecated)
  - Test cached capability
  - Test updated capability
  - Test unsubscribe
- [x] Test isCapabilitySupported

- [x] Check method signatures for Swift

Core version / branch / commit hash / module tested against: Sync Gen 3.2 (18124_DEVTEST), Manticore v.2.4.2 (SDL Core v6.0.1)
HMI name / version / branch / commit hash / module tested against: Sync Gen 3.2 (18124_DEVTEST), Manticore v.2.4.2 (Generic HMI v0.7.2)

### Summary
This PR makes additions and some minor behavioral changes to existing system capability manager methods in order to bring behavior into alignment with the Java Suite SCM as much as is reasonable.

### Changelog
##### Enhancements
* Added a `SystemCapabilityManager.subscribeToCapabilityType:withUpdateHandler:` method with more verbose error reporting than the now deprecated `SystemCapabilityManager.subscribeToCapabilityType:withBlock:` method.
* The `SystemCapabilityManager.subscribeToCapabilityType:withObserver:selector:` selector now supports up to three parameters, adding an `error` parameter and boolean `subscribed` parameter.
* All `subscribe` methods now immediately return the cached value.
* Added `isCapabilitySupported:` method that can be used to quickly determine if the feature is supported by the head unit or not.

##### Bug Fixes
* All capability data is no longer downloaded on first HMI_FULL. Instead the data will be downloaded when the first `updateCapabilityType:completionHandler:` call or the first `subscribe` to that capability type is made.
* Calling `unsubscribeFromCapabilityType:withObserver:` such that no observers remain for that type will now unsubscribe the `SystemCapabilityManager` from receiving any more data about that type until `updateCapabilityType:completionHandler:` or another `subscribe` call is made for that type.
* Removed caching data from GSC responses sent outside of the SCM. This simplifies the manager, tests, and aligns with the Java Suite SCM.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
