### PR TITLE
Fix SDLManagerDelegate missing videoStreamingState callback

### DIFF
--- a/SmartDeviceLink/SDLLifecycleManager.h
+++ b/SmartDeviceLink/SDLLifecycleManager.h
@@ -13,6 +13,7 @@
 #import "SDLHMILevel.h"
 #import "SDLLanguage.h"
 #import "SDLSystemContext.h"
+#import "SDLVideoStreamingState.h"
 
 @class SDLConfiguration;
 @class SDLFileManager;
@@ -85,6 +86,7 @@ typedef void (^SDLManagerReadyBlock)(BOOL success, NSError *_Nullable error);
 @property (copy, nonatomic, readonly) SDLLifecycleState *lifecycleState;
 @property (copy, nonatomic, nullable) SDLHMILevel hmiLevel;
 @property (copy, nonatomic, nullable) SDLAudioStreamingState audioStreamingState;
+@property (copy, nonatomic, nullable) SDLVideoStreamingState videoStreamingState;
 @property (copy, nonatomic, nullable) SDLSystemContext systemContext;
 @property (strong, nonatomic, nullable) SDLRegisterAppInterfaceResponse *registerResponse;
 

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -245,14 +245,7 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
         self.proxy = [SDLProxy iapProxyWithListener:self.notificationDispatcher secondaryTransportManager:nil encryptionLifecycleManager:self.encryptionLifecycleManager];
     } else {
         // We reuse our queue to run secondary transport manager's state machine
-        if([self.configuration.lifecycleConfig.appType isEqualToEnum:SDLAppHMITypeNavigation] ||
-           [self.configuration.lifecycleConfig.appType isEqualToEnum:SDLAppHMITypeProjection] ||
-           [self.configuration.lifecycleConfig.additionalAppTypes containsObject:SDLAppHMITypeNavigation] ||
-           [self.configuration.lifecycleConfig.additionalAppTypes containsObject:SDLAppHMITypeProjection]) {
-            // We reuse our queue to run secondary transport manager's state machine
-            self.secondaryTransportManager = [[SDLSecondaryTransportManager alloc] initWithStreamingProtocolDelegate:self serialQueue:self.lifecycleQueue];
-        }
-        
+        self.secondaryTransportManager = [[SDLSecondaryTransportManager alloc] initWithStreamingProtocolDelegate:self serialQueue:self.lifecycleQueue];
         self.proxy = [SDLProxy iapProxyWithListener:self.notificationDispatcher secondaryTransportManager:self.secondaryTransportManager encryptionLifecycleManager:self.encryptionLifecycleManager];
     }
 #pragma clang diagnostic pop

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -817,8 +817,8 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
         SDLLogD(@"Audio streaming state changed from %@ to %@", oldAudioStreamingState, self.audioStreamingState);
     }
 
-    if (![oldAudioStreamingState isEqualToEnum:self.videoStreamingState]) {
-        SDLLogD(@"Video streaming state changed from %@ to %@", oldAudioStreamingState, self.videoStreamingState);
+    if (![oldVideoStreamingState isEqualToEnum:self.videoStreamingState]) {
+        SDLLogD(@"Video streaming state changed from %@ to %@", oldVideoStreamingState, self.videoStreamingState);
     }
 
     if (![oldSystemContext isEqualToEnum:self.systemContext]) {

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -245,7 +245,14 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
         self.proxy = [SDLProxy iapProxyWithListener:self.notificationDispatcher secondaryTransportManager:nil encryptionLifecycleManager:self.encryptionLifecycleManager];
     } else {
         // We reuse our queue to run secondary transport manager's state machine
-        self.secondaryTransportManager = [[SDLSecondaryTransportManager alloc] initWithStreamingProtocolDelegate:self serialQueue:self.lifecycleQueue];
+        if([self.configuration.lifecycleConfig.appType isEqualToEnum:SDLAppHMITypeNavigation] ||
+           [self.configuration.lifecycleConfig.appType isEqualToEnum:SDLAppHMITypeProjection] ||
+           [self.configuration.lifecycleConfig.additionalAppTypes containsObject:SDLAppHMITypeNavigation] ||
+           [self.configuration.lifecycleConfig.additionalAppTypes containsObject:SDLAppHMITypeProjection]) {
+            // We reuse our queue to run secondary transport manager's state machine
+            self.secondaryTransportManager = [[SDLSecondaryTransportManager alloc] initWithStreamingProtocolDelegate:self serialQueue:self.lifecycleQueue];
+        }
+        
         self.proxy = [SDLProxy iapProxyWithListener:self.notificationDispatcher secondaryTransportManager:self.secondaryTransportManager encryptionLifecycleManager:self.encryptionLifecycleManager];
     }
 #pragma clang diagnostic pop

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -284,6 +284,7 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
     self.lastCorrelationId = 0;
     self.hmiLevel = nil;
     self.audioStreamingState = nil;
+    self.videoStreamingState = nil;
     self.systemContext = nil;
 
     // Due to a race condition internally with EAStream, we cannot immediately attempt to restart the proxy, as we will randomly crash.
@@ -527,6 +528,10 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
     // Send the audio streaming state going from NOT_AUDIBLE to whatever we're at now (could still be NOT_AUDIBLE)
     if ([self.delegate respondsToSelector:@selector(audioStreamingState:didChangeToState:)]) {
         [self.delegate audioStreamingState:SDLAudioStreamingStateNotAudible didChangeToState:self.audioStreamingState];
+    }
+
+    if ([self.delegate respondsToSelector:@selector(videoStreamingState:didChangetoState:)]) {
+        [self.delegate videoStreamingState:SDLVideoStreamingStateNotStreamable didChangetoState:self.videoStreamingState];
     }
 
     // Stop the background task now that setup has completed
@@ -795,8 +800,11 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
     SDLHMILevel oldHMILevel = self.hmiLevel;
     self.hmiLevel = hmiStatusNotification.hmiLevel;
 
-    SDLAudioStreamingState oldStreamingState = self.audioStreamingState;
+    SDLAudioStreamingState oldAudioStreamingState = self.audioStreamingState;
     self.audioStreamingState = hmiStatusNotification.audioStreamingState;
+
+    SDLVideoStreamingState oldVideoStreamingState = self.videoStreamingState;
+    self.videoStreamingState = hmiStatusNotification.videoStreamingState;
 
     SDLSystemContext oldSystemContext = self.systemContext;
     self.systemContext = hmiStatusNotification.systemContext;
@@ -805,8 +813,12 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
         SDLLogD(@"HMI level changed from %@ to %@", oldHMILevel, self.hmiLevel);
     }
 
-    if (![oldStreamingState isEqualToEnum:self.audioStreamingState]) {
-        SDLLogD(@"Audio streaming state changed from %@ to %@", oldStreamingState, self.audioStreamingState);
+    if (![oldAudioStreamingState isEqualToEnum:self.audioStreamingState]) {
+        SDLLogD(@"Audio streaming state changed from %@ to %@", oldAudioStreamingState, self.audioStreamingState);
+    }
+
+    if (![oldAudioStreamingState isEqualToEnum:self.videoStreamingState]) {
+        SDLLogD(@"Video streaming state changed from %@ to %@", oldAudioStreamingState, self.videoStreamingState);
     }
 
     if (![oldSystemContext isEqualToEnum:self.systemContext]) {
@@ -826,10 +838,16 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
         [self.delegate hmiLevel:oldHMILevel didChangeToLevel:self.hmiLevel];
     }
 
-    if (![oldStreamingState isEqualToEnum:self.audioStreamingState]
-        && !(oldStreamingState == nil && self.audioStreamingState == nil)
+    if (![oldAudioStreamingState isEqualToEnum:self.audioStreamingState]
+        && !(oldAudioStreamingState == nil && self.audioStreamingState == nil)
         && [self.delegate respondsToSelector:@selector(audioStreamingState:didChangeToState:)]) {
-        [self.delegate audioStreamingState:oldStreamingState didChangeToState:self.audioStreamingState];
+        [self.delegate audioStreamingState:oldAudioStreamingState didChangeToState:self.audioStreamingState];
+    }
+
+    if (![oldVideoStreamingState isEqualToEnum:self.videoStreamingState]
+        && !(oldVideoStreamingState == nil && self.videoStreamingState == nil)
+        && [self.delegate respondsToSelector:@selector(videoStreamingState:didChangetoState:)]) {
+        [self.delegate videoStreamingState:oldVideoStreamingState didChangetoState:self.videoStreamingState];
     }
 
     if (![oldSystemContext isEqualToEnum:self.systemContext]

--- a/SmartDeviceLink/SDLManagerDelegate.h
+++ b/SmartDeviceLink/SDLManagerDelegate.h
@@ -13,6 +13,7 @@
 #import "SDLSystemContext.h"
 #import "SDLLifecycleConfigurationUpdate.h"
 #import "SDLLanguage.h"
+#import "SDLVideoStreamingState.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -41,6 +42,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)audioStreamingState:(nullable SDLAudioStreamingState)oldState didChangeToState:(SDLAudioStreamingState)newState;
 
+/// Called when the video streaming state of this application changes. This refers to streaming video for navigation purposes. If you are "autostreaming" via CarWindow, you should not do anything with this method. Everything should be handled for you automatically.
+/// @param oldState The previous state
+/// @param newState The current state
+- (void)videoStreamingState:(nullable SDLVideoStreamingState)oldState didChangetoState:(SDLVideoStreamingState)newState;
+
 /**
  *  Called when the system context of this application changes on the remote system. This refers to whether or not a user-initiated interaction is in progress, and if so, what it is.
  *
@@ -56,7 +62,6 @@ NS_ASSUME_NONNULL_BEGIN
  * @return An object of SDLLifecycleConfigurationUpdate if the head unit language is supported, otherwise nil to indicate that the language is not supported.
  */
 - (nullable SDLLifecycleConfigurationUpdate *)managerShouldUpdateLifecycleToLanguage:(SDLLanguage)language;
-
 
 @end
 

--- a/SmartDeviceLink/SDLManagerDelegate.h
+++ b/SmartDeviceLink/SDLManagerDelegate.h
@@ -43,6 +43,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)audioStreamingState:(nullable SDLAudioStreamingState)oldState didChangeToState:(SDLAudioStreamingState)newState;
 
 /// Called when the video streaming state of this application changes. This refers to streaming video for navigation purposes. If you are "autostreaming" via CarWindow, you should not do anything with this method. Everything should be handled for you automatically.
+///
+/// Only supported on RPC v5.0+ connections.
+///
 /// @param oldState The previous state
 /// @param newState The current state
 - (void)videoStreamingState:(nullable SDLVideoStreamingState)oldState didChangetoState:(SDLVideoStreamingState)newState;


### PR DESCRIPTION
Fixes #1546 

This PR is **not ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Added unit tests to ensure that `videoStreamingState` callback was called when it changed.

#### Core Tests
No head unit was available that supports `VideoStreamingState.STREAMABLE`, so this was tested to ensure that the initial callback was received.

Core version / branch / commit hash / module tested against: Manticore v2.4.2 (SDL Core v6.0.1)
HMI name / version / branch / commit hash / module tested against: Manticore v2.4.2 (Generic HMI v0.7.2).

### Summary
This PR adds an `SDLManagerDelegate` callback for `videoStreamingState` from `OnHMIStatus` to match other `OnHMIStatus` callbacks. This will only be possibly useful in situations when the developer is not "autostreaming" via `CarWindow`.

### Changelog
##### Enhancements
* Added `SDLManagerDelegate.videoStreamingState:didChangeToState:` to match other `OnHMIStatus` based callbacks in `SDLManagerDelegate`.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
