### PR TITLE
Fix slider / scrollable message time out message

### DIFF
--- a/Example Apps/Example ObjC/MenuManager.m
+++ b/Example Apps/Example ObjC/MenuManager.m
@@ -137,7 +137,11 @@ NS_ASSUME_NONNULL_BEGIN
         SDLSlider *sliderRPC = [[SDLSlider alloc] initWithNumTicks:3 position:1 sliderHeader:@"Select a letter" sliderFooters:@[@"A", @"B", @"C"] timeout:10000];
         [manager sendRequest:sliderRPC withResponseHandler:^(__kindof SDLRPCRequest * _Nullable request, __kindof SDLRPCResponse * _Nullable response, NSError * _Nullable error) {
             if(![response.resultCode isEqualToEnum:SDLResultSuccess]) {
-                [manager sendRequest:[AlertManager alertWithMessageAndCloseButton:@"Slider could not be displayed" textField2:nil iconName:nil]];
+                if ([response.resultCode isEqualToEnum:SDLResultTimedOut]) {
+                    [manager sendRequest:[AlertManager alertWithMessageAndCloseButton:@"Slider timed out" textField2:nil iconName:nil]];
+                } else {
+                    [manager sendRequest:[AlertManager alertWithMessageAndCloseButton:@"Slider could not be displayed" textField2:nil iconName:nil]];
+                }
             }
         }];
     }];
@@ -148,8 +152,11 @@ NS_ASSUME_NONNULL_BEGIN
         SDLScrollableMessage *messageRPC = [[SDLScrollableMessage alloc] initWithMessage:@"This is a scrollable message\nIt can contain many lines"];
         [manager sendRequest:messageRPC withResponseHandler:^(__kindof SDLRPCRequest * _Nullable request, __kindof SDLRPCResponse * _Nullable response, NSError * _Nullable error) {
            if(![response.resultCode isEqualToEnum:SDLResultSuccess]) {
-                [manager sendRequest:[AlertManager alertWithMessageAndCloseButton:@"Scrollable Message could not be displayed" textField2:nil iconName:nil]];
-            }
+                if ([response.resultCode isEqualToEnum:SDLResultTimedOut]) {
+                    [manager sendRequest:[AlertManager alertWithMessageAndCloseButton:@"Scrollable Message timed out" textField2:nil iconName:nil]];
+                } else {
+                    [manager sendRequest:[AlertManager alertWithMessageAndCloseButton:@"Scrollable Message could not be displayed" textField2:nil iconName:nil]];
+                }            }
         }];
     }];
 }

--- a/Example Apps/Example ObjC/MenuManager.m
+++ b/Example Apps/Example ObjC/MenuManager.m
@@ -139,6 +139,8 @@ NS_ASSUME_NONNULL_BEGIN
             if(![response.resultCode isEqualToEnum:SDLResultSuccess]) {
                 if ([response.resultCode isEqualToEnum:SDLResultTimedOut]) {
                     [manager sendRequest:[AlertManager alertWithMessageAndCloseButton:@"Slider timed out" textField2:nil iconName:nil]];
+                } else if ([response.resultCode isEqualToEnum:SDLResultAborted]) {
+                    [manager sendRequest:[AlertManager alertWithMessageAndCloseButton:@"Slider cancelled" textField2:nil iconName:nil]];
                 } else {
                     [manager sendRequest:[AlertManager alertWithMessageAndCloseButton:@"Slider could not be displayed" textField2:nil iconName:nil]];
                 }
@@ -154,9 +156,12 @@ NS_ASSUME_NONNULL_BEGIN
            if(![response.resultCode isEqualToEnum:SDLResultSuccess]) {
                 if ([response.resultCode isEqualToEnum:SDLResultTimedOut]) {
                     [manager sendRequest:[AlertManager alertWithMessageAndCloseButton:@"Scrollable Message timed out" textField2:nil iconName:nil]];
+                } else if ([response.resultCode isEqualToEnum:SDLResultAborted]) {
+                    [manager sendRequest:[AlertManager alertWithMessageAndCloseButton:@"Scrollable Message cancelled" textField2:nil iconName:nil]];
                 } else {
                     [manager sendRequest:[AlertManager alertWithMessageAndCloseButton:@"Scrollable Message could not be displayed" textField2:nil iconName:nil]];
-                }            }
+                }
+           }
         }];
     }];
 }

--- a/Example Apps/Example Swift/MenuManager.swift
+++ b/Example Apps/Example Swift/MenuManager.swift
@@ -181,8 +181,13 @@ private extension MenuManager {
         return SDLMenuCell(title: ACSliderMenuName, icon: nil, voiceCommands: [ACSliderMenuName], handler: { _ in
             let slider = SDLSlider(numTicks: 3, position: 1, sliderHeader: "Select a letter", sliderFooters: ["A", "B", "C"], timeout: 3000)
             manager.send(request: slider, responseHandler: { (request, response, error) in
-                guard let response = response, response.resultCode == .success else {
-                    manager.send(AlertManager.alertWithMessageAndCloseButton("Slider could not be displayed"))
+                guard let response = response else { return }
+                guard response.resultCode == .success else {
+                    if response.resultCode == .timedOut {
+                        manager.send(AlertManager.alertWithMessageAndCloseButton("Slider timed out"))
+                    } else {
+                        manager.send(AlertManager.alertWithMessageAndCloseButton("Slider could not be displayed"))
+                    }
                     return
                 }
             })
@@ -193,8 +198,13 @@ private extension MenuManager {
         return SDLMenuCell(title: ACScrollableMessageMenuName, icon: nil, voiceCommands: [ACScrollableMessageMenuName], handler: { _ in
             let scrollableMessage = SDLScrollableMessage(message: "This is a scrollable message\nIt can contain many lines")
             manager.send(request: scrollableMessage, responseHandler: { (request, response, error) in
-                guard let response = response, response.resultCode == .success else {
-                    manager.send(AlertManager.alertWithMessageAndCloseButton("Scrollable could not be displayed"))
+                guard let response = response else { return }
+                guard response.resultCode == .success else {
+                    if response.resultCode == .timedOut {
+                        manager.send(AlertManager.alertWithMessageAndCloseButton("Scrollable Message timed out"))
+                    } else {
+                        manager.send(AlertManager.alertWithMessageAndCloseButton("Scrollable Message could not be displayed"))
+                    }
                     return
                 }
             })

--- a/Example Apps/Example Swift/MenuManager.swift
+++ b/Example Apps/Example Swift/MenuManager.swift
@@ -185,6 +185,8 @@ private extension MenuManager {
                 guard response.resultCode == .success else {
                     if response.resultCode == .timedOut {
                         manager.send(AlertManager.alertWithMessageAndCloseButton("Slider timed out"))
+                    } else if response.resultCode == .aborted {
+                        manager.send(AlertManager.alertWithMessageAndCloseButton("Slider cancelled"))
                     } else {
                         manager.send(AlertManager.alertWithMessageAndCloseButton("Slider could not be displayed"))
                     }
@@ -202,6 +204,8 @@ private extension MenuManager {
                 guard response.resultCode == .success else {
                     if response.resultCode == .timedOut {
                         manager.send(AlertManager.alertWithMessageAndCloseButton("Scrollable Message timed out"))
+                    } else if response.resultCode == .aborted {
+                        manager.send(AlertManager.alertWithMessageAndCloseButton("Scrollable Message cancelled"))
                     } else {
                         manager.send(AlertManager.alertWithMessageAndCloseButton("Scrollable Message could not be displayed"))
                     }


### PR DESCRIPTION
Fixes #1526

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [ ] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
All changes are example app only, so no unit tests are needed.

#### Core Tests
* Time out scrollable message and slider on both Obj-C and Swift example apps

Core version / branch / commit hash / module tested against: Sync 3.0 19205_DEVTEST
HMI name / version / branch / commit hash / module tested against: Sync 3.0 19205_DEVTEST

### Summary
This PR changes the error handling the Obj-C and Swift example app menu options to display a `Slider` and `ScrollableMessage`. If they timeout, they now display an appropriate alert instead of a confusing one.

### Changelog
##### Bug Fixes
* Improved the example apps' slider and scrollable message timeout alerts.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
