### PR TITLE
Remove the delay on data sessions

### DIFF
--- a/SmartDeviceLink/SDLIAPDataSession.m
+++ b/SmartDeviceLink/SDLIAPDataSession.m
@@ -110,6 +110,9 @@ NS_ASSUME_NONNULL_BEGIN
     [self sdl_isIOThreadCanceled:self.canceledSemaphore completionHandler:^(BOOL success) {
         if (success == NO) {
             SDLLogE(@"Destroying thread (IOStreamThread) for data session when I/O streams have not yet closed.");
+            
+            // FIX: Try to close the session if the canceledSemaphore is never triggered by the `sdl_accessoryEventLoop`
+            [self sdl_closeSession];
         }
         self.ioStreamThread = nil;
         [super cleanupClosedSession];

--- a/SmartDeviceLink/SDLIAPTransport.m
+++ b/SmartDeviceLink/SDLIAPTransport.m
@@ -98,11 +98,8 @@ int const CreateSessionRetries = 3;
         return;
     }
 
-    double retryDelay = self.sdl_retryDelay;
-    SDLLogD(@"Accessory Connected (%@), Opening in %0.03fs", notification.userInfo[EAAccessoryKey], retryDelay);
-
     self.retryCounter = 0;
-    [self performSelector:@selector(sdl_connect:) withObject:nil afterDelay:retryDelay];
+    [self sdl_connect:newAccessory];
 }
 
 /**
@@ -508,10 +505,16 @@ int const CreateSessionRetries = 3;
         return YES;
     } else if ([protocolString isEqualToString:ControlProtocolString]) {
         self.controlSession = [[SDLIAPControlSession alloc] initWithAccessory:accessory delegate:self];
-        [self.controlSession startSession];
+
+        double retryDelay = [self sdl_retryDelay];
+        SDLLogD(@"Accessory Connected (%@), Opening in %0.03fs", accessory, retryDelay);
+        [self.controlSession performSelector:@selector(startSession) withObject:nil afterDelay:retryDelay];
+
         return YES;
     } else if ([protocolString isEqualToString:LegacyProtocolString]) {
         self.dataSession = [[SDLIAPDataSession alloc] initWithAccessory:accessory delegate:self forProtocol:protocolString];
+
+        SDLLogD(@"Accessory Connected (%@), Opening immediately", accessory);
         [self.dataSession startSession];
         return YES;
     }


### PR DESCRIPTION
Fixes #1240

Recreates #1385, which was reverted

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Smoke tests were performed with the following scenarios:
1. 6 apps were forced to connect with this branch on the control protocol repeatedly.
2. 13 apps were forced to connect with this branch on the multisession protocol repeatedly.

### Summary
This PR updates the IAP transport to only delay apps from connecting with their retry delay when the control session is being used for connection, not when the multisession protocol (direct to data session) is being used.

### Changelog
##### Bug Fixes
* Connecting to newer head units using the multisession protocol is sped up.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
