### PR TITLE
Fix lock screen dismiss animation not working on certain older systems

### DIFF
--- a/SmartDeviceLink/SDLLockScreenManager.m
+++ b/SmartDeviceLink/SDLLockScreenManager.m
@@ -65,19 +65,23 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)start {
     self.canPresent = NO;
 
+    __weak typeof(self) weakSelf = self;
     [self sdl_runOnMainQueue:^{
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+
         if (UIApplication.sharedApplication.applicationState != UIApplicationStateActive) {
             SDLLogW(@"Attempted to start lock screen manager, but we are in the background. We will attempt to start again when we are in the foreground.");
             return;
         }
 
         // This usually means that we disconnected and connected with the device in the background. We will need to check and dismiss the view controller if it's presented before setting up a new one.
-        if (self.presenter.lockViewController != nil) {
-            [self.presenter stopWithCompletionHandler:^{
-                [self sdl_start];
+        if (strongSelf.presenter.lockViewController != nil) {
+            [strongSelf.presenter stopWithCompletionHandler:^{
+                __strong typeof(weakSelf) strongSelf2 = weakSelf;
+                [strongSelf2 sdl_start];
             }];
         } else {
-            [self sdl_start];
+            [strongSelf sdl_start];
         }
     }];
 }
@@ -153,12 +157,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)sdl_appDidBecomeActive:(NSNotification *)notification {
     __weak typeof(self) weakSelf = self;
     [self sdl_runOnMainQueue:^{
+        __strong typeof(weakSelf) strongSelf = weakSelf;
         // Restart, and potentially dismiss the lock screen if the app was disconnected in the background
-        if (!weakSelf.canPresent) {
-            [weakSelf start];
+        if (!strongSelf.canPresent) {
+            [strongSelf start];
         }
 
-        [self sdl_checkLockScreen];
+        [strongSelf sdl_checkLockScreen];
     }];
 }
 
@@ -230,9 +235,9 @@ NS_ASSUME_NONNULL_BEGIN
         return;
     }
     
-    __weak typeof(self) weakself = self;
+    __weak typeof(self) weakSelf = self;
     [self sdl_runOnMainQueue:^{
-        __strong typeof(self) strongSelf = weakself;
+        __strong typeof(self) strongSelf = weakSelf;
         SDLLockScreenViewController *lockscreenViewController = (SDLLockScreenViewController *)strongSelf.lockScreenViewController;
         if (enabled) {
             [lockscreenViewController addDismissGestureWithCallback:^{

--- a/SmartDeviceLink/SDLLockScreenManager.m
+++ b/SmartDeviceLink/SDLLockScreenManager.m
@@ -112,6 +112,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)stop {
     // Don't allow the lockscreen to present again until we start
     self.canPresent = NO;
+    self.lastLockNotification = nil;
+    self.lastDriverDistractionNotification = nil;
     [self.presenter stopWithCompletionHandler:nil];
 }
 

--- a/SmartDeviceLink/SDLLockScreenManager.m
+++ b/SmartDeviceLink/SDLLockScreenManager.m
@@ -73,8 +73,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         // This usually means that we disconnected and connected with the device in the background. We will need to check and dismiss the view controller if it's presented before setting up a new one.
         if (self.presenter.lockViewController != nil) {
-            [self.presenter updateLockScreenToShow:NO withCompletionHandler:^{
-                [self.presenter stop];
+            [self.presenter stopWithCompletionHandler:^{
                 [self sdl_start];
             }];
         } else {
@@ -106,12 +105,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     self.canPresent = YES;
+
+    [self sdl_checkLockScreen];
 }
 
 - (void)stop {
     // Don't allow the lockscreen to present again until we start
     self.canPresent = NO;
-    [self.presenter stop];
+    [self.presenter stopWithCompletionHandler:nil];
 }
 
 - (nullable UIViewController *)lockScreenViewController {

--- a/SmartDeviceLink/SDLLockScreenPresenter.m
+++ b/SmartDeviceLink/SDLLockScreenPresenter.m
@@ -41,14 +41,20 @@ NS_ASSUME_NONNULL_BEGIN
     self.shouldShowLockScreen = NO;
 
     if (self.lockWindow == nil) {
+        if (completionHandler != nil) {
+            completionHandler();
+        }
         return;
     }
 
     // Dismiss and destroy the lockscreen window
+    __weak typeof(self) weakSelf = self;
     [self sdl_dismissWithCompletionHandler:^(BOOL success) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+
         if (success) {
-            self.lockWindow = nil;
-            self.lockViewController = nil;
+            strongSelf.lockWindow = nil;
+            strongSelf.lockViewController = nil;
         }
 
         if (completionHandler != nil) {
@@ -63,27 +69,30 @@ NS_ASSUME_NONNULL_BEGIN
     // Store the expected state of the lockscreen
     self.shouldShowLockScreen = show;
 
+    __weak typeof(self) weakSelf = self;
     if (show) {
         [self sdl_presentWithCompletionHandler:^{
-            if (self.shouldShowLockScreen) {
+            __strong typeof(weakSelf) strongSelf = weakSelf;
+            if (strongSelf.shouldShowLockScreen) {
                 if (completionHandler != nil) { completionHandler(); }
                 return;
             }
 
             SDLLogV(@"The lockscreen has been presented but needs to be dismissed");
-            [self sdl_dismissWithCompletionHandler:^(BOOL success) {
+            [strongSelf sdl_dismissWithCompletionHandler:^(BOOL success) {
                 if (completionHandler != nil) { completionHandler(); }
             }];
         }];
     } else {
         [self sdl_dismissWithCompletionHandler:^(BOOL success) {
-            if (!self.shouldShowLockScreen) {
+            __strong typeof(weakSelf) strongSelf = weakSelf;
+            if (!strongSelf.shouldShowLockScreen) {
                 if (completionHandler != nil) { completionHandler(); }
                 return;
             }
 
             SDLLogV(@"The lockscreen has been dismissed but needs to be presented");
-            [self sdl_presentWithCompletionHandler:completionHandler];
+            [strongSelf sdl_presentWithCompletionHandler:completionHandler];
         }];
     }
 }

--- a/SmartDeviceLink/SDLLockScreenPresenter.m
+++ b/SmartDeviceLink/SDLLockScreenPresenter.m
@@ -136,7 +136,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Checks if the lockscreen can be dismissed and if so dismisses the lockscreen on the main thread.
 /// @param completionHandler Called when the lockscreen has finished its animation or if the lockscreen can not be dismissed
 - (void)sdl_dismissWithCompletionHandler:(void (^ _Nullable)(void))completionHandler {
-    if (self.lockViewController == nil || !self.isPresentedOrPresenting) {
+    if (self.lockViewController == nil) {
         SDLLogW(@"Attempted to dismiss lockscreen, but lockViewController is not set");
         if (completionHandler == nil) { return; }
         return completionHandler();
@@ -156,7 +156,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Handles the dismissal of the lockscreen with animation.
 /// @param completionHandler Called when the lockscreen is dismissed successfully or if it is already in the process of being dismissed
 - (void)sdl_dismissLockscreenWithCompletionHandler:(void (^ _Nullable)(void))completionHandler {
-    if (self.isDismissing) {
+    if (self.isDismissing || !self.isPresentedOrPresenting) {
         // Make sure we are not already animating, otherwise the app may crash
         SDLLogV(@"The lockscreen is already being dismissed");
         if (completionHandler == nil) { return; }

--- a/SmartDeviceLink/SDLLockScreenPresenter.m
+++ b/SmartDeviceLink/SDLLockScreenPresenter.m
@@ -20,7 +20,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic, nullable) UIWindow *lockWindow;
 @property (assign, nonatomic) BOOL shouldShowLockScreen;
 @property (assign, nonatomic) BOOL isDismissing;
-@property (assign, nonatomic) BOOL isPresentedOrPresenting;
 
 @end
 
@@ -168,9 +167,12 @@ NS_ASSUME_NONNULL_BEGIN
     [[NSNotificationCenter defaultCenter] postNotificationName:SDLLockScreenManagerWillDismissLockScreenViewController object:nil];
 
     SDLLogD(@"Dismissing the lockscreen window");
+    _isDismissing = YES;
     __weak typeof(self) weakSelf = self;
     [self.lockViewController dismissViewControllerAnimated:YES completion:^{
-        [weakSelf.lockWindow setHidden:YES];
+        __strong typeof(self) strongSelf = weakSelf;
+        strongSelf->_isDismissing = NO;
+        [strongSelf.lockWindow setHidden:YES];
 
         // Tell everyone we are done so video streaming can resume
         [[NSNotificationCenter defaultCenter] postNotificationName:SDLLockScreenManagerDidDismissLockScreenViewController object:nil];
@@ -190,7 +192,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Returns whether or not the lockViewController is currently animating the dismissal of the lockscreen
 - (BOOL)isDismissing {
-    return (self.lockViewController.isBeingDismissed || self.lockViewController.isMovingFromParentViewController);
+    return (_isDismissing || self.lockViewController.isBeingDismissed || self.lockViewController.isMovingFromParentViewController);
 }
 
 #pragma mark - Window Helpers

--- a/SmartDeviceLink/SDLLockScreenPresenter.m
+++ b/SmartDeviceLink/SDLLockScreenPresenter.m
@@ -136,7 +136,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Checks if the lockscreen can be dismissed and if so dismisses the lockscreen on the main thread.
 /// @param completionHandler Called when the lockscreen has finished its animation or if the lockscreen can not be dismissed
 - (void)sdl_dismissWithCompletionHandler:(void (^ _Nullable)(void))completionHandler {
-    if (self.lockViewController == nil) {
+    if (self.lockViewController == nil || !self.isPresentedOrPresenting) {
         SDLLogW(@"Attempted to dismiss lockscreen, but lockViewController is not set");
         if (completionHandler == nil) { return; }
         return completionHandler();
@@ -170,6 +170,7 @@ NS_ASSUME_NONNULL_BEGIN
     _isDismissing = YES;
     __weak typeof(self) weakSelf = self;
     [self.lockViewController dismissViewControllerAnimated:YES completion:^{
+        SDLLogD(@"Lockscreen window dismissed");
         __strong typeof(self) strongSelf = weakSelf;
         strongSelf->_isDismissing = NO;
         [strongSelf.lockWindow setHidden:YES];

--- a/SmartDeviceLink/SDLViewControllerPresentable.h
+++ b/SmartDeviceLink/SDLViewControllerPresentable.h
@@ -22,7 +22,7 @@ typedef void (^SDLLockScreenDidFinishHandler)(void);
 @property (assign, nonatomic, readonly) BOOL shouldShowLockScreen;
 
 /// Dismisses and destroys the lock screen window
-- (void)stop;
+- (void)stopWithCompletionHandler:(nullable SDLLockScreenDidFinishHandler)completionHandler;
 
 /// Shows or hides the lock screen with animation
 /// @param show True if the lock screen should be presented; false if dismissed.

--- a/SmartDeviceLink/SDLViewControllerPresentable.h
+++ b/SmartDeviceLink/SDLViewControllerPresentable.h
@@ -10,6 +10,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef void (^SDLLockScreenDidFinishHandler)(void);
+
 /// A protocol used to tell a view controller to present another view controller. This makes testing of modal VCs' presentation easier.
 @protocol SDLViewControllerPresentable <NSObject>
 
@@ -24,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Shows or hides the lock screen with animation
 /// @param show True if the lock screen should be presented; false if dismissed.
-- (void)updateLockScreenToShow:(BOOL)show;
+- (void)updateLockScreenToShow:(BOOL)show withCompletionHandler:(nullable SDLLockScreenDidFinishHandler)completionHandler;
 
 @end
 

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLFakeViewControllerPresenter.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLFakeViewControllerPresenter.m
@@ -27,10 +27,14 @@
     return self;
 }
 
-- (void)stop {
+- (void)stopWithCompletionHandler:(nullable SDLLockScreenDidFinishHandler)completionHandler {
     if (!self.lockViewController) { return; }
 
     _shouldShowLockScreen = NO;
+
+    if (completionHandler != nil) {
+        completionHandler();
+    }
 }
 
 - (void)updateLockScreenToShow:(BOOL)show withCompletionHandler:(nullable SDLLockScreenDidFinishHandler)completionHandler {

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLFakeViewControllerPresenter.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLFakeViewControllerPresenter.m
@@ -33,8 +33,12 @@
     _shouldShowLockScreen = NO;
 }
 
-- (void)updateLockScreenToShow:(BOOL)show {
+- (void)updateLockScreenToShow:(BOOL)show withCompletionHandler:(nullable SDLLockScreenDidFinishHandler)completionHandler {
     _shouldShowLockScreen = show;
+
+    if (completionHandler != nil) {
+        completionHandler();
+    }
 }
 
 

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLLockScreenManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLLockScreenManagerSpec.m
@@ -437,7 +437,7 @@ describe(@"a lock screen manager", ^{
 
                 // Since lock screen must be presented/dismissed on the main thread, force the test to execute manually on the main thread. If this is not done, the test case may fail.
                 [[NSRunLoop mainRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
-                OCMVerify([mockViewControllerPresenter updateLockScreenToShow:YES]);
+                OCMVerify([mockViewControllerPresenter updateLockScreenToShow:YES withCompletionHandler:nil]);
             });
         });
 
@@ -460,7 +460,7 @@ describe(@"a lock screen manager", ^{
 
                 // Since lock screen must be presented/dismissed on the main thread, force the test to execute manually on the main thread. If this is not done, the test case may fail.
                 [[NSRunLoop mainRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
-                OCMVerify([mockViewControllerPresenter updateLockScreenToShow:NO]);
+                OCMVerify([mockViewControllerPresenter updateLockScreenToShow:NO withCompletionHandler:nil]);
             });
         });
     });

--- a/SmartDeviceLinkTests/LoggingSpecs/SDLLogFilterSpec.m
+++ b/SmartDeviceLinkTests/LoggingSpecs/SDLLogFilterSpec.m
@@ -6,7 +6,7 @@
 #import "SDLLogModel.h"
 
 
-QuickSpecBegin(SDLfilterspec)
+QuickSpecBegin(SDLFilterSpec)
 
 describe(@"a filter by a string", ^{
     __block NSString *testFilterString = @"filter string";


### PR DESCRIPTION
Fixes #1504, #1565 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Unit tests currently do not exist for the `SDLLockScreenPresenter` class, so no new unit tests were added in this bugfix PR. They were run and pass.

#### Core Tests
- [x] Connected while DD_OFF.
- [x] Repeatedly enable / disable DD as fast as possible.
- [x] Connected, backgrounded app, disconnected, reconnected, foregrounded app

Core version / branch / commit hash / module tested against: Sync Gen 3.0 (19205_DEVTEST), Sync Gen 3.0 (17276_DEVTEST)
HMI name / version / branch / commit hash / module tested against: Same as above

### Summary
* This PR tracks dismissals to prevent "double" dismissals causing the dismiss animation to break.
* Changes the synchronization of the lock manager to not run a bunch of code async. 
* Changes the startup sequence to account for cases where the app is backgrounded when starting.

### Changelog
##### Bug Fixes
* The lock screen dismiss animation will no longer break on older SDL systems.
* Disconnecting and reconnecting an app in the background will no longer prevent the lock screen from being dismissed in certain cases.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
