### PR TITLE
Add synchronization around SDLResponseDispatcher

### DIFF
--- a/SmartDeviceLink/SDLResponseDispatcher.m
+++ b/SmartDeviceLink/SDLResponseDispatcher.m
@@ -151,14 +151,13 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)sdl_addToCustomButtonHandlerMap:(NSArray<SDLSoftButton *> *)softButtons {
-    @synchronized (self) {
-        for (SDLSoftButton *sb in softButtons) {
-            if (!sb.softButtonID) {
-                @throw [NSException sdl_missingIdException];
-            }
-            if (sb.handler) {
-                self.customButtonHandlerMap[sb.softButtonID] = sb.handler;
-            }
+    // Don't need to synchronize this method because it's only called from `storeRequest:handler:`
+    for (SDLSoftButton *sb in softButtons) {
+        if (!sb.softButtonID) {
+            @throw [NSException sdl_missingIdException];
+        }
+        if (sb.handler) {
+            self.customButtonHandlerMap[sb.softButtonID] = sb.handler;
         }
     }
 }

--- a/SmartDeviceLinkTests/Notifications/SDLResponseDispatcherSpec.m
+++ b/SmartDeviceLinkTests/Notifications/SDLResponseDispatcherSpec.m
@@ -90,11 +90,11 @@ describe(@"a response dispatcher", ^{
         });
         
         it(@"should store the request and response", ^{
-            expect(testDispatcher.rpcRequestDictionary[testCorrelationId]).toNot(beNil());
-            expect(testDispatcher.rpcRequestDictionary).to(haveCount(@1));
+            expect(testDispatcher.rpcRequestDictionary[testCorrelationId]).toEventuallyNot(beNil());
+            expect(testDispatcher.rpcRequestDictionary).toEventually(haveCount(@1));
             
-            expect(testDispatcher.rpcResponseHandlerMap[testCorrelationId]).toNot(beNil());
-            expect(testDispatcher.rpcResponseHandlerMap).to(haveCount(@1));
+            expect(testDispatcher.rpcResponseHandlerMap[testCorrelationId]).toEventuallyNot(beNil());
+            expect(testDispatcher.rpcResponseHandlerMap).toEventually(haveCount(@1));
         });
         
         describe(@"when a response arrives", ^{
@@ -139,8 +139,8 @@ describe(@"a response dispatcher", ^{
             });
             
             it(@"should add the soft button to the map", ^{
-                expect(testDispatcher.customButtonHandlerMap[testSoftButton1.softButtonID]).toNot(beNil());
-                expect(testDispatcher.customButtonHandlerMap).to(haveCount(@1));
+                expect(testDispatcher.customButtonHandlerMap[testSoftButton1.softButtonID]).toEventuallyNot(beNil());
+                expect(testDispatcher.customButtonHandlerMap).toEventually(haveCount(@1));
             });
             
             describe(@"when button press and button event notifications arrive", ^{
@@ -249,8 +249,8 @@ describe(@"a response dispatcher", ^{
             it(@"should add the command to the map", ^{
                 [testDispatcher storeRequest:testAddCommand handler:nil];
                 
-                expect(testDispatcher.commandHandlerMap[testAddCommand.cmdID]).toNot(beNil());
-                expect(testDispatcher.commandHandlerMap).to(haveCount(@1));
+                expect(testDispatcher.commandHandlerMap[testAddCommand.cmdID]).toEventuallyNot(beNil());
+                expect(testDispatcher.commandHandlerMap).toEventually(haveCount(@1));
             });
             
             it(@"should throw an exception if there's no command id", ^{
@@ -369,8 +369,8 @@ describe(@"a response dispatcher", ^{
             it(@"should add the subscription to the map", ^{
                 [testDispatcher storeRequest:testSubscribeButton handler:nil];
                 
-                expect(testDispatcher.buttonHandlerMap[testSubscribeButton.buttonName]).toNot(beNil());
-                expect(testDispatcher.buttonHandlerMap).to(haveCount(@1));
+                expect(testDispatcher.buttonHandlerMap[testSubscribeButton.buttonName]).toEventuallyNot(beNil());
+                expect(testDispatcher.buttonHandlerMap).toEventually(haveCount(@1));
             });
             
             it(@"should throw an exception if there's no button name", ^{
@@ -499,8 +499,8 @@ describe(@"a response dispatcher", ^{
             });
             
             it(@"should add the soft button to the map", ^{
-                expect(testDispatcher.customButtonHandlerMap[testSoftButton1.softButtonID]).toNot(beNil());
-                expect(testDispatcher.customButtonHandlerMap).to(haveCount(@1));
+                expect(testDispatcher.customButtonHandlerMap[testSoftButton1.softButtonID]).toEventuallyNot(beNil());
+                expect(testDispatcher.customButtonHandlerMap).toEventually(haveCount(@1));
             });
             
             describe(@"when button press and button event notifications arrive", ^{
@@ -610,8 +610,8 @@ describe(@"a response dispatcher", ^{
             });
             
             it(@"should add the soft button to the map", ^{
-                expect(testDispatcher.customButtonHandlerMap[testSoftButton1.softButtonID]).toNot(beNil());
-                expect(testDispatcher.customButtonHandlerMap).to(haveCount(@1));
+                expect(testDispatcher.customButtonHandlerMap[testSoftButton1.softButtonID]).toEventuallyNot(beNil());
+                expect(testDispatcher.customButtonHandlerMap).toEventually(haveCount(@1));
             });
             
             describe(@"when button press and button event notifications arrive", ^{


### PR DESCRIPTION
Fixes #1515 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
No unit tests were added, they were run and pass.

#### Core Tests
* Tested example app with numerous menu cells, submenu cells, soft buttons, etc. to stress test RPCs waiting for synchronization.

Core version / branch / commit hash / module tested against: Sync 3.0 (19205_DEVTEST), Manticore v2.4.2 (SDL Core v6.0.1)
HMI name / version / branch / commit hash / module tested against: Sync 3.0 (19205_DEVTEST), Manticore v2.4.2 (Generic HMI v0.7.2.)

### Summary
* Methods that alter the internal dictionaries and map tables of the `SDLResponseDispatcher` are now synchronized.

### Changelog
##### Bug Fixes
* Fix concurrent setting to dictionaries and map tables causing crashes by synchronizing setter access.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
