### PR TITLE
Implement SDL-0214 Secondary Transport Optimization

### DIFF
--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -161,7 +161,7 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
     // Notifications
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(transportDidConnect) name:SDLTransportDidConnect object:_notificationDispatcher];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(transportDidDisconnect) name:SDLTransportDidDisconnect object:_notificationDispatcher];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(hmiStatusDidChange:) name:SDLDidChangeHMIStatusNotification object:_notificationDispatcher];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(hmiStatusDidChange:) name:SDLDidChangeHMIStatusNotification object: _notificationDispatcher];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(remoteHardwareDidUnregister:) name:SDLDidReceiveAppUnregisteredNotification object:_notificationDispatcher];
 
     _backgroundTaskManager = [[SDLBackgroundTaskManager alloc] initWithBackgroundTaskName: BackgroundTaskTransportName];
@@ -244,8 +244,13 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
     } else if (self.configuration.lifecycleConfig.allowedSecondaryTransports == SDLSecondaryTransportsNone) {
         self.proxy = [SDLProxy iapProxyWithListener:self.notificationDispatcher secondaryTransportManager:nil encryptionLifecycleManager:self.encryptionLifecycleManager];
     } else {
-        // We reuse our queue to run secondary transport manager's state machine
-        self.secondaryTransportManager = [[SDLSecondaryTransportManager alloc] initWithStreamingProtocolDelegate:self serialQueue:self.lifecycleQueue];
+        if([self.configuration.lifecycleConfig.appType isEqualToEnum:SDLAppHMITypeNavigation] ||
+           [self.configuration.lifecycleConfig.appType isEqualToEnum:SDLAppHMITypeProjection] ||
+           [self.configuration.lifecycleConfig.additionalAppTypes containsObject:SDLAppHMITypeNavigation] ||
+           [self.configuration.lifecycleConfig.additionalAppTypes containsObject:SDLAppHMITypeProjection]) {
+            // We reuse our queue to run secondary transport manager's state machine
+            self.secondaryTransportManager = [[SDLSecondaryTransportManager alloc] initWithStreamingProtocolDelegate:self serialQueue:self.lifecycleQueue];
+        }
         self.proxy = [SDLProxy iapProxyWithListener:self.notificationDispatcher secondaryTransportManager:self.secondaryTransportManager encryptionLifecycleManager:self.encryptionLifecycleManager];
     }
 #pragma clang diagnostic pop

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -244,8 +244,14 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
     } else if (self.configuration.lifecycleConfig.allowedSecondaryTransports == SDLSecondaryTransportsNone) {
         self.proxy = [SDLProxy iapProxyWithListener:self.notificationDispatcher secondaryTransportManager:nil encryptionLifecycleManager:self.encryptionLifecycleManager];
     } else {
-        // We reuse our queue to run secondary transport manager's state machine
-        self.secondaryTransportManager = [[SDLSecondaryTransportManager alloc] initWithStreamingProtocolDelegate:self serialQueue:self.lifecycleQueue];
+        if([self.configuration.lifecycleConfig.appType isEqualToEnum:SDLAppHMITypeNavigation] ||
+           [self.configuration.lifecycleConfig.appType isEqualToEnum:SDLAppHMITypeProjection] ||
+           [self.configuration.lifecycleConfig.additionalAppTypes containsObject:SDLAppHMITypeNavigation] ||
+           [self.configuration.lifecycleConfig.additionalAppTypes containsObject:SDLAppHMITypeProjection]) {
+            // We reuse our queue to run secondary transport manager's state machine
+            self.secondaryTransportManager = [[SDLSecondaryTransportManager alloc] initWithStreamingProtocolDelegate:self serialQueue:self.lifecycleQueue];
+        }
+
         self.proxy = [SDLProxy iapProxyWithListener:self.notificationDispatcher secondaryTransportManager:self.secondaryTransportManager encryptionLifecycleManager:self.encryptionLifecycleManager];
     }
 #pragma clang diagnostic pop

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -161,7 +161,7 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
     // Notifications
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(transportDidConnect) name:SDLTransportDidConnect object:_notificationDispatcher];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(transportDidDisconnect) name:SDLTransportDidDisconnect object:_notificationDispatcher];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(hmiStatusDidChange:) name:SDLDidChangeHMIStatusNotification object: _notificationDispatcher];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(hmiStatusDidChange:) name:SDLDidChangeHMIStatusNotification object:_notificationDispatcher];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(remoteHardwareDidUnregister:) name:SDLDidReceiveAppUnregisteredNotification object:_notificationDispatcher];
 
     _backgroundTaskManager = [[SDLBackgroundTaskManager alloc] initWithBackgroundTaskName: BackgroundTaskTransportName];
@@ -244,13 +244,7 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
     } else if (self.configuration.lifecycleConfig.allowedSecondaryTransports == SDLSecondaryTransportsNone) {
         self.proxy = [SDLProxy iapProxyWithListener:self.notificationDispatcher secondaryTransportManager:nil encryptionLifecycleManager:self.encryptionLifecycleManager];
     } else {
-        if([self.configuration.lifecycleConfig.appType isEqualToEnum:SDLAppHMITypeNavigation] ||
-           [self.configuration.lifecycleConfig.appType isEqualToEnum:SDLAppHMITypeProjection] ||
-           [self.configuration.lifecycleConfig.additionalAppTypes containsObject:SDLAppHMITypeNavigation] ||
-           [self.configuration.lifecycleConfig.additionalAppTypes containsObject:SDLAppHMITypeProjection]) {
-            // We reuse our queue to run secondary transport manager's state machine
-            self.secondaryTransportManager = [[SDLSecondaryTransportManager alloc] initWithStreamingProtocolDelegate:self serialQueue:self.lifecycleQueue];
-        }
+        self.secondaryTransportManager = [[SDLSecondaryTransportManager alloc] initWithStreamingProtocolDelegate:self serialQueue:self.lifecycleQueue];
         self.proxy = [SDLProxy iapProxyWithListener:self.notificationDispatcher secondaryTransportManager:self.secondaryTransportManager encryptionLifecycleManager:self.encryptionLifecycleManager];
     }
 #pragma clang diagnostic pop

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -244,6 +244,7 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
     } else if (self.configuration.lifecycleConfig.allowedSecondaryTransports == SDLSecondaryTransportsNone) {
         self.proxy = [SDLProxy iapProxyWithListener:self.notificationDispatcher secondaryTransportManager:nil encryptionLifecycleManager:self.encryptionLifecycleManager];
     } else {
+        // We reuse our queue to run secondary transport manager's state machine
         self.secondaryTransportManager = [[SDLSecondaryTransportManager alloc] initWithStreamingProtocolDelegate:self serialQueue:self.lifecycleQueue];
         self.proxy = [SDLProxy iapProxyWithListener:self.notificationDispatcher secondaryTransportManager:self.secondaryTransportManager encryptionLifecycleManager:self.encryptionLifecycleManager];
     }

--- a/SmartDeviceLink/SDLLogFileModuleMap.m
+++ b/SmartDeviceLink/SDLLogFileModuleMap.m
@@ -14,6 +14,9 @@
 
 + (NSSet<SDLLogFileModule *> *)sdlModuleMap {
     return [NSSet setWithArray:@[[self sdl_transportModule],
+                                 [self sdl_tcpTransportModule],
+                                 [self sdl_iapTransportModule],
+                                 [self sdl_secondaryTransportModule],
                                  [self sdl_proxyModule],
                                  [self sdl_protocolModule],
                                  [self sdl_rpcModule],
@@ -33,9 +36,25 @@
                                  [self sdl_utilitiesModule]]];
 }
 
+#pragma mark Transport
+
 + (SDLLogFileModule *)sdl_transportModule {
-    return [SDLLogFileModule moduleWithName:@"Transport" files:[NSSet setWithArray:@[@"SDLIAPSession", @"SDLIAPTransport", @"SDLIAPDataSession", @"SDLIAPControlSession", @"SDLSecondaryTransportManager", @"SDLSecondaryTransportPrimaryProtocolHandler", @"SDLStreamDelegate", @"SDLTCPTransport"]]];
+    return [SDLLogFileModule moduleWithName:@"Transport" files:[NSSet setWithArray:@[@"SDLStreamDelegate"]]];
 }
+
++ (SDLLogFileModule *)sdl_tcpTransportModule {
+    return [SDLLogFileModule moduleWithName:@"Transport/TCP" files:[NSSet setWithArray:@[@"SDLTCPTransport"]]];
+}
+
++ (SDLLogFileModule *)sdl_iapTransportModule {
+    return [SDLLogFileModule moduleWithName:@"Transport/IAP" files:[NSSet setWithArray:@[@"SDLIAPSession", @"SDLIAPTransport", @"SDLIAPDataSession", @"SDLIAPControlSession"]]];
+}
+
++ (SDLLogFileModule *)sdl_secondaryTransportModule {
+    return [SDLLogFileModule moduleWithName:@"Transport/Secondary" files:[NSSet setWithArray:@[@"SDLSecondaryTransportManager", @"SDLSecondaryTransportPrimaryProtocolHandler"]]];
+}
+
+#pragma mark Low-Level
 
 + (SDLLogFileModule *)sdl_proxyModule {
     return [SDLLogFileModule moduleWithName:@"Proxy" files:[NSSet setWithArray:@[@"SDLProxy", @"SDLPolicyDataParser"]]];
@@ -49,12 +68,11 @@
     return [SDLLogFileModule moduleWithName:@"RPC" files:[NSSet setWithArray:@[@"SDLRPCPayload", @"NSMutableDictionary+Store"]]];
 }
 
+#pragma mark Managers
+
 + (SDLLogFileModule *)sdl_dispatcherModule {
     return [SDLLogFileModule moduleWithName:@"Dispatcher" files:[NSSet setWithArray:@[@"SDLNotificationDispatcher", @"SDLResponseDispatcher"]]];
 }
-
-
-#pragma mark Managers
 
 + (SDLLogFileModule *)sdl_fileManagerModule {
     return [SDLLogFileModule moduleWithName:@"File" files:[NSSet setWithArray:@[@"SDLFileManager", @"SDLFile", @"SDLArtwork", @"SDLListFilesOperation", @"SDLUploadFileOperation", @"SDLDeleteFileOperation"]]];

--- a/SmartDeviceLink/SDLSecondaryTransportManager.m
+++ b/SmartDeviceLink/SDLSecondaryTransportManager.m
@@ -125,7 +125,7 @@ static const int TCPPortUnspecified = -1;
     _tcpPort = TCPPortUnspecified;
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_hmiStatusDidChange:) name:SDLDidChangeHMIStatusNotification object:nil];
-    
+
     return self;
 }
 

--- a/SmartDeviceLink/SDLTCPTransport.m
+++ b/SmartDeviceLink/SDLTCPTransport.m
@@ -309,24 +309,23 @@ NSTimeInterval ConnectionTimeoutSecs = 30.0;
         NSError *error;
         switch (stream.streamError.code) {
             case ECONNREFUSED: {
-                SDLLogD(@"TCP connection error: ECONNREFUSED");
+                SDLLogE(@"TCP connection error: ECONNREFUSED (connection refused)");
                 error = [NSError sdl_transport_connectionRefusedError];
             } break;
             case ETIMEDOUT: {
-                SDLLogD(@"TCP connection error: ETIMEDOUT");
+                SDLLogE(@"TCP connection error: ETIMEDOUT (connection timed out)");
                 error = [NSError sdl_transport_connectionTimedOutError];
             } break;
             case ENETDOWN: {
-                SDLLogD(@"TCP connection error: ENETDOWN");
+                SDLLogE(@"TCP connection error: ENETDOWN (network down)");
                 error = [NSError sdl_transport_networkDownError];
             } break;
             case ENETUNREACH: {
-                // This is just for safe. I did not observe ENETUNREACH error on iPhone.
-                SDLLogD(@"TCP connection error: ENETUNREACH");
+                SDLLogE(@"TCP connection error: ENETUNREACH (network unreachable)");
                 error = [NSError sdl_transport_networkDownError];
             } break;
             default: {
-                SDLLogD(@"TCP connection error: unknown error %ld", (long)stream.streamError.code);
+                SDLLogE(@"TCP connection error: unknown error %ld", (long)stream.streamError.code);
                 error = [NSError sdl_transport_unknownError];
             } break;
         }
@@ -338,6 +337,7 @@ NSTimeInterval ConnectionTimeoutSecs = 30.0;
 }
 
 - (void)sdl_onStreamEnd:(NSStream *)stream {
+    SDLLogD(@"Stream ended");
     NSAssert([[NSThread currentThread] isEqual:self.ioThread], @"sdl_onStreamEnd is called on a wrong thread!");
 
     [self sdl_cancelIOThread];

--- a/SmartDeviceLinkTests/ProxySpecs/SDLSecondaryTransportManagerSpec.m
+++ b/SmartDeviceLinkTests/ProxySpecs/SDLSecondaryTransportManagerSpec.m
@@ -148,7 +148,7 @@ describe(@"the secondary transport manager ", ^{
          [[NSNotificationCenter defaultCenter] postNotification:notification];
 
          [NSThread sleepForTimeInterval:0.3];
-         };
+    };
 
     beforeEach(^{
         [SDLSecondaryTransportManager swapGetAppStateMethod];

--- a/SmartDeviceLinkTests/ProxySpecs/SDLSecondaryTransportManagerSpec.m
+++ b/SmartDeviceLinkTests/ProxySpecs/SDLSecondaryTransportManagerSpec.m
@@ -134,7 +134,7 @@ static const int TCPPortUnspecified = -1;
 
 QuickSpecBegin(SDLSecondaryTransportManagerSpec)
 
-fdescribe(@"the secondary transport manager ", ^{
+describe(@"the secondary transport manager ", ^{
     __block SDLSecondaryTransportManager *manager = nil;
     __block dispatch_queue_t testStateMachineQueue;
     __block SDLProtocol *testPrimaryProtocol = nil;

--- a/SmartDeviceLinkTests/ProxySpecs/SDLSecondaryTransportManagerSpec.m
+++ b/SmartDeviceLinkTests/ProxySpecs/SDLSecondaryTransportManagerSpec.m
@@ -15,12 +15,15 @@
 #import "SDLControlFramePayloadTransportEventUpdate.h"
 #import "SDLIAPTransport.h"
 #import "SDLNotificationConstants.h"
+#import "SDLRPCNotificationNotification.h"
 #import "SDLProtocol.h"
 #import "SDLSecondaryTransportManager.h"
 #import "SDLStateMachine.h"
 #import "SDLTCPTransport.h"
 #import "SDLV2ProtocolMessage.h"
 #import "SDLFakeSecurityManager.h"
+#import "SDLHMILevel.h"
+#import "SDLOnHMIStatus.h"
 
 /* copied from SDLSecondaryTransportManager.m */
 typedef NSNumber SDLServiceTypeBox;
@@ -55,7 +58,7 @@ static const int TCPPortUnspecified = -1;
 @property (strong, nonatomic) NSMutableDictionary<SDLServiceTypeBox *, SDLTransportClassBox *> *streamingServiceTransportMap;
 @property (strong, nonatomic, nullable) NSString *ipAddress;
 @property (assign, nonatomic) int tcpPort;
-@property (assign, nonatomic, getter=isAppReady) BOOL appReady;
+@property (assign, nonatomic) BOOL shouldOpenConnection;
 
 @end
 
@@ -136,6 +139,15 @@ describe(@"the secondary transport manager ", ^{
     __block SDLProtocol *testPrimaryProtocol = nil;
     __block id<SDLTransportType> testPrimaryTransport = nil;
     __block id testStreamingProtocolDelegate = nil;
+
+    __block void (^sendNotificationForHMILevel)(SDLHMILevel hmiLevel) = ^(SDLHMILevel hmiLevel) {
+         SDLOnHMIStatus *hmiStatus = [[SDLOnHMIStatus alloc] init];
+         hmiStatus.hmiLevel = hmiLevel;
+         SDLRPCNotificationNotification *notification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidChangeHMIStatusNotification object:self rpcNotification:hmiStatus];
+         [[NSNotificationCenter defaultCenter] postNotification:notification];
+
+         [NSThread sleepForTimeInterval:0.3];
+         };
 
     beforeEach(^{
         [SDLSecondaryTransportManager swapGetAppStateMethod];
@@ -413,7 +425,7 @@ describe(@"the secondary transport manager ", ^{
 
                     testStartServiceACKPayload = [[SDLControlFramePayloadRPCStartServiceAck alloc] initWithHashId:testHashId mtu:testMtu authToken:nil protocolVersion:testProtocolVersion secondaryTransports:testSecondaryTransports audioServiceTransports:testAudioServiceTransports videoServiceTransports:testVideoServiceTransports];
                     testStartServiceACKMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testStartServiceACKHeader andPayload:testStartServiceACKPayload.data];
-                    manager.appReady = YES;
+                    manager.shouldOpenConnection = YES;
                 });
 
                 it(@"should configure its properties and immediately transition to Connecting state", ^{
@@ -507,27 +519,23 @@ describe(@"the secondary transport manager ", ^{
                 });
             });
 
-            context(@"before the security manager is set by register app interface response", ^{
+            context(@"before the app context is HMI FULL", ^{
                 it(@"should stay in state Configured", ^{
                     expect(manager.stateMachine.currentState).to(equal(SDLSecondaryTransportStateConfigured));
-                    expect(manager.secondaryProtocol.securityManager).to(beNil());
-                    expect(manager.isAppReady).to(equal(NO));
+                    expect(manager.shouldOpenConnection).to(equal(NO));
 
                     OCMVerifyAll(testStreamingProtocolDelegate);
                 });
             });
 
-            context(@"after the security manager is set by register app interface response", ^{
+            context(@"app becomes HMI FULL", ^{
                 beforeEach(^{
-                    testPrimaryProtocol.securityManager = OCMClassMock([SDLFakeSecurityManager class]);
-                    // By the time this notification is recieved the RAIR should have been sent and the security manager should exist if available
-                    [[NSNotificationCenter defaultCenter] postNotificationName:SDLDidBecomeReady object:nil];
+                    sendNotificationForHMILevel(SDLHMILevelFull);
                 });
 
                 it(@"should transition to Connecting state", ^{
                     expect(manager.stateMachine.currentState).to(equal(SDLSecondaryTransportStateConnecting));
-                    expect(manager.secondaryProtocol.securityManager).to(equal(testPrimaryProtocol.securityManager));
-                    expect(manager.isAppReady).to(equal(YES));
+                    expect(manager.shouldOpenConnection).to(equal(YES));
 
                     OCMVerifyAll(testStreamingProtocolDelegate);
                 });
@@ -561,7 +569,7 @@ describe(@"the secondary transport manager ", ^{
                 });
             });
 
-            describe(@"and Transport Event Update is received", ^{
+            describe(@"and a Transport Event Update has been received", ^{
                 __block SDLProtocolHeader *testTransportEventUpdateHeader = nil;
                 __block SDLProtocolMessage *testTransportEventUpdateMessage = nil;
                 __block SDLControlFramePayloadTransportEventUpdate *testTransportEventUpdatePayload = nil;
@@ -584,24 +592,23 @@ describe(@"the secondary transport manager ", ^{
 
                 });
 
-                context(@"before the security manager is set by register app interface response", ^{
+                context(@"before the app context is HMI FULL", ^{
                     it(@"should stay in Configured state", ^{
                         expect(manager.stateMachine.currentState).to(equal(SDLSecondaryTransportStateConfigured));
-                        expect(manager.secondaryProtocol.securityManager).to(beNil());
+                        expect(manager.shouldOpenConnection).to(equal(NO));
+
                         OCMVerifyAll(testStreamingProtocolDelegate);
                     });
                 });
 
-                context(@"after the security manager is set by register app interface response", ^{
+                context(@"app becomes HMI FULL", ^{
                     beforeEach(^{
-                        testPrimaryProtocol.securityManager = OCMClassMock([SDLFakeSecurityManager class]);
-                        // By the time this notification is recieved the RAIR should have been sent and the security manager should exist if available
-                        [[NSNotificationCenter defaultCenter] postNotificationName:SDLDidBecomeReady object:nil];
+                        sendNotificationForHMILevel(SDLHMILevelFull);
                     });
                     
                     it(@"should transition to Connecting", ^{
                         expect(manager.stateMachine.currentState).to(equal(SDLSecondaryTransportStateConnecting));
-                        expect(manager.secondaryProtocol.securityManager).to(equal(testPrimaryProtocol.securityManager));
+                        expect(manager.shouldOpenConnection).to(equal(YES));
 
                         OCMVerifyAll(testStreamingProtocolDelegate);
                     });
@@ -731,7 +738,6 @@ describe(@"the secondary transport manager ", ^{
                 [NSThread sleepForTimeInterval:0.1];
 
                 expect(manager.stateMachine.currentState).to(equal(SDLSecondaryTransportStateReconnecting));
-                expect(manager.isAppReady).to(equal(NO));
                 OCMVerifyAll(testStreamingProtocolDelegate);
             });
         });
@@ -776,7 +782,7 @@ describe(@"the secondary transport manager ", ^{
                 beforeEach(^{
                     testTcpIpAddress = @"172.16.12.34";
                     testTcpPort = 12345;
-                    manager.appReady = YES;
+                    manager.shouldOpenConnection = YES;
 
                     testTransportEventUpdatePayload = [[SDLControlFramePayloadTransportEventUpdate alloc] initWithTcpIpAddress:testTcpIpAddress tcpPort:testTcpPort];
                     testTransportEventUpdateMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testTransportEventUpdateHeader andPayload:testTransportEventUpdatePayload.data];
@@ -864,7 +870,7 @@ describe(@"the secondary transport manager ", ^{
                 manager.secondaryTransportType = SDLTransportSelectionTCP;
                 manager.ipAddress = @"192.168.1.1";
                 manager.tcpPort = 12345;
-                manager.appReady = YES;
+                manager.shouldOpenConnection = YES;
 
                 testTransportEventUpdateHeader = [SDLProtocolHeader headerForVersion:5];
                 testTransportEventUpdateHeader.frameType = SDLFrameTypeControl;
@@ -1023,7 +1029,6 @@ describe(@"the secondary transport manager ", ^{
                 manager.secondaryTransportType = SDLTransportSelectionTCP;
                 manager.ipAddress = @"192.168.1.1";
                 manager.tcpPort = 12345;
-                manager.appReady = YES;
 
                 testTransportEventUpdateHeader = [SDLProtocolHeader headerForVersion:5];
                 testTransportEventUpdateHeader.frameType = SDLFrameTypeControl;
@@ -1053,6 +1058,7 @@ describe(@"the secondary transport manager ", ^{
                 beforeEach(^{
                     testTcpIpAddress = @"172.16.12.34";
                     testTcpPort = 12345;
+                    manager.shouldOpenConnection = YES;
 
                     testTransportEventUpdatePayload = [[SDLControlFramePayloadTransportEventUpdate alloc] initWithTcpIpAddress:testTcpIpAddress tcpPort:testTcpPort];
                     testTransportEventUpdateMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testTransportEventUpdateHeader andPayload:testTransportEventUpdatePayload.data];


### PR DESCRIPTION
Fixes #1145 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
* Add unit tests around the `currentHMILevel` property.

#### Core Tests
* Tested navigation app starting secondary transport at the correct time
* Tested background / foreground app triggers correct sequence

Core version / branch / commit hash / module tested against: Sync 4 (20016_DEVTEST)
HMI name / version / branch / commit hash / module tested against: Sync 4 (20016_DEVTEST)

### Summary
This PR implements [SDL-0214 Secondary Transport Optimization](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0214-secondary-transport-optimization.md). This proposal updates the secondary transport manager to only start its connection process once the app is in HMI_FULL.

### Changelog
##### Bug Fixes
* Fixes a case where the secondary transport wouldn't start properly if the `TransportEventUpdate` packet was sent before the app is in HMI level `FULL`.

### Tasks Remaining:
- [x] Determine if state machine is a better option
- [x] Add unit tests
- [x] Test with Core

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
