### PR TITLE
Remove deprecations of structs -> dictionary and visa versa

### DIFF
--- a/SmartDeviceLink/SDLProtocol.m
+++ b/SmartDeviceLink/SDLProtocol.m
@@ -286,11 +286,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)sendRPC:(SDLRPCMessage *)message encrypted:(BOOL)encryption error:(NSError *__autoreleasing *)error {
     NSParameterAssert(message != nil);
-    
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     NSData *jsonData = [NSJSONSerialization dataWithJSONObject:[message serializeAsDictionary:(Byte)[SDLGlobals sharedGlobals].protocolVersion.major] options:kNilOptions error:error];
-#pragma clang diagnostic pop
 
     if (error != nil) {
         SDLLogW(@"Error encoding JSON data: %@", *error);

--- a/SmartDeviceLink/SDLRPCStruct.h
+++ b/SmartDeviceLink/SDLRPCStruct.h
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param dict A dictionary
  *  @return     A SDLRPCStruct object
  */
-- (instancetype)initWithDictionary:(NSDictionary<NSString *, id> *)dict __deprecated_msg("This is not intended for public use");
+- (instancetype)initWithDictionary:(NSDictionary<NSString *, id> *)dict;
 
 /**
  *  Converts struct to JSON formatted data
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param version The protocol version
  *  @return        JSON formatted data
  */
-- (NSDictionary<NSString *, id> *)serializeAsDictionary:(Byte)version __deprecated_msg("This is not intended for public use");
+- (NSDictionary<NSString *, id> *)serializeAsDictionary:(Byte)version;
 
 @end
 

--- a/SmartDeviceLink/SDLRPCStruct.m
+++ b/SmartDeviceLink/SDLRPCStruct.m
@@ -54,8 +54,6 @@ NS_ASSUME_NONNULL_BEGIN
     return [self.store description];
 }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 + (NSDictionary<NSString *, id> *)sdl_serializeDictionary:(NSDictionary *)dict version:(Byte)version {
     NSMutableDictionary<NSString *, id> *ret = [NSMutableDictionary dictionaryWithCapacity:dict.count];
     for (NSString *key in dict.keyEnumerator) {
@@ -82,7 +80,6 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return ret;
 }
-#pragma clang diagnostic pop
 
 - (id)copyWithZone:(nullable NSZone *)zone {
     SDLRPCStruct *newStruct = [[[self class] allocWithZone:zone] initWithDictionary:_store];

--- a/SmartDeviceLinkTests/ProtocolSpecs/MessageSpecs/SDLProtocolSpec.m
+++ b/SmartDeviceLinkTests/ProtocolSpecs/MessageSpecs/SDLProtocolSpec.m
@@ -215,10 +215,7 @@ describe(@"SendRPCRequest Tests", ^ {
     
     context(@"During V1 session", ^ {
         it(@"Should send the correct data", ^ {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             [[[[mockRequest stub] andReturn:dictionaryV1] ignoringNonObjectArgs] serializeAsDictionary:1];
-#pragma clang diagnostic pop
             
             SDLProtocol* testProtocol = [[SDLProtocol alloc] init];
             SDLV1ProtocolHeader *testHeader = [[SDLV1ProtocolHeader alloc] init];
@@ -255,10 +252,7 @@ describe(@"SendRPCRequest Tests", ^ {
     
     context(@"During V2 session", ^ {
         it(@"Should send the correct data bulk data when bulk data is available", ^ {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             [[[[mockRequest stub] andReturn:dictionaryV2] ignoringNonObjectArgs] serializeAsDictionary:2];
-#pragma clang diagnostic pop
             [[[mockRequest stub] andReturn:@0x98765] correlationID];
             [[[mockRequest stub] andReturn:@"DeleteCommand"] name];
             [[[mockRequest stub] andReturn:[NSData dataWithBytes:"COMMAND" length:strlen("COMMAND")]] bulkData];

--- a/SmartDeviceLinkTests/RPCSpecs/SuperclassSpecs/SDLRPCStructSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/SuperclassSpecs/SDLRPCStructSpec.m
@@ -14,13 +14,10 @@ QuickSpecBegin(SDLRPCStructSpec)
 
 describe(@"SerializeAsDictionary Tests", ^ {
     it(@"Should serialize correctly", ^ {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         NSMutableDictionary<NSString *, id> *dict = [@{@"Key":@"Value", @"Answer":@42, @"Struct":[[SDLRPCStruct alloc] initWithDictionary:[@{@"Array":@[@1, @1, @1, @1]} mutableCopy]]} mutableCopy];
         SDLRPCStruct* testStruct = [[SDLRPCStruct alloc] initWithDictionary:dict];
         
         expect([testStruct serializeAsDictionary:2]).to(equal([@{@"Key":@"Value", @"Answer":@42, @"Struct":@{@"Array":@[@1, @1, @1, @1]}} mutableCopy]));
-#pragma clang diagnostic pop
     });
 });
 


### PR DESCRIPTION
Fixes #1557 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
No unit tests were added due to merely un-deprecating existing code

#### Core Tests
None due to merely un-deprecating existing code

Core version / branch / commit hash / module tested against: n/a
HMI name / version / branch / commit hash / module tested against: n/a

### Summary
This PR un-deprecates `SDLRPCStruct.initWithDictionary:` and `SDLRPCStruct.serializeAsDictionary:` due to valid use-cases being presented to serialize RPC data to disk for later restoration.

### Changelog
##### Enhancements
* Un-deprecate `SDLRPCStruct.initWithDictionary:` and `SDLRPCStruct.serializeAsDictionary:`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
