### PR TITLE
Scale Workaround for legacy high-res displays

### DIFF
--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -592,7 +592,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
 #pragma clang diagnostic pop
     if (resolution != nil) {
         self.videoScaleManager.displayViewportResolution = CGSizeMake(resolution.resolutionWidth.floatValue,
-                                                                      resolution.resolutionHeight.floatValue);
+                                 resolution.resolutionHeight.floatValue);
         // workaround for older high resolution displays that don't support scaling
         NSString *make = registerResponse.vehicleType.make;
         CGSize resolution = self.videoScaleManager.displayViewportResolution;

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -592,7 +592,13 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
 #pragma clang diagnostic pop
     if (resolution != nil) {
         self.videoScaleManager.displayViewportResolution = CGSizeMake(resolution.resolutionWidth.floatValue,
-                                 resolution.resolutionHeight.floatValue);
+                                                                      resolution.resolutionHeight.floatValue);
+        // workaround for older high resolution displays that don't support scaling
+        NSString *make = registerResponse.vehicleType.make;
+        CGSize resolution = self.videoScaleManager.displayViewportResolution;
+        if (([make containsString:@"Ford"] || [make containsString:@"Lincoln"]) && (resolution.width > 800 || resolution.height > 800)) {
+            self.videoScaleManager.scale = 1.0f / 0.75f; // Scale by 1.333333
+        }
     }
 
     self.connectedVehicleMake = registerResponse.vehicleType.make;


### PR DESCRIPTION
Fixes #1567 

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests
The change was tested primarily on a Lincoln 10" test bench to confirm the code serves the expected behavior. It was also tested against other OEM specific vehicles that have smaller displays to confirm the code does not cause unexpected changes. Finally it was tested against Core on a test bench that provides actual scaling values to confirm the actual scaling value is used instead of the fake value.

### Summary
Adds a condition for OEM specific head units that have larger screens than 800 pixels per edge. The faked scale value is preset upon RAI response and will be overwritten if the IVI provides actual video streaming capabilities.

### Changelog
##### Bug Fixes
* Fixes an issue on older high-res IVIs that were produced before pixel scale proposal.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
