### PR TITLE
Ensure RPC Request thread safety

### DIFF
--- a/SmartDeviceLink/SDLGlobals.h
+++ b/SmartDeviceLink/SDLGlobals.h
@@ -26,6 +26,9 @@ extern NSUInteger const SDLDefaultMTUSize;
 extern NSUInteger const SDLV1MTUSize;
 extern NSUInteger const SDLV3MTUSize;
 
+extern void *const SDLProcessingQueueName;
+extern void *const SDLConcurrentQueueName;
+
 @interface SDLGlobals : NSObject
 
 @property (copy, nonatomic, readonly) SDLVersion *protocolVersion;

--- a/SmartDeviceLink/SDLGlobals.m
+++ b/SmartDeviceLink/SDLGlobals.m
@@ -61,8 +61,12 @@ typedef NSNumber *MTUBox;
     dispatch_queue_attr_t qosSerial = dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL, QOS_CLASS_USER_INITIATED, 0);
     dispatch_queue_attr_t qosConcurrent = dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_CONCURRENT, QOS_CLASS_USER_INITIATED, 0);
 
+    static void *processingQueueKey = "com.sdl.serialProcessing";
+    static void *concurrentQueueKey = "com.sdl.concurrentProcessing";
     _sdlProcessingQueue = dispatch_queue_create("com.sdl.serialProcessing", qosSerial);
+    dispatch_queue_set_specific(_sdlProcessingQueue, processingQueueKey, (void *)processingQueueKey, NULL);
     _sdlConcurrentQueue = dispatch_queue_create("com.sdl.concurrentProcessing", qosConcurrent);
+    dispatch_queue_set_specific(_sdlConcurrentQueue, concurrentQueueKey, (void *)concurrentQueueKey, NULL);
 
     return self;
 }

--- a/SmartDeviceLink/SDLGlobals.m
+++ b/SmartDeviceLink/SDLGlobals.m
@@ -22,6 +22,8 @@ NSUInteger const SDLDefaultMTUSize = UINT32_MAX;
 NSUInteger const SDLV1MTUSize = 1024;
 NSUInteger const SDLV3MTUSize = 131024;
 
+void *const SDLProcessingQueueName = "com.sdl.serialProcessing";
+void *const SDLConcurrentQueueName = "com.sdl.concurrentProcessing";
 
 typedef NSNumber *ServiceTypeBox;
 typedef NSNumber *MTUBox;
@@ -61,12 +63,10 @@ typedef NSNumber *MTUBox;
     dispatch_queue_attr_t qosSerial = dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL, QOS_CLASS_USER_INITIATED, 0);
     dispatch_queue_attr_t qosConcurrent = dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_CONCURRENT, QOS_CLASS_USER_INITIATED, 0);
 
-    static void *processingQueueKey = "com.sdl.serialProcessing";
-    static void *concurrentQueueKey = "com.sdl.concurrentProcessing";
-    _sdlProcessingQueue = dispatch_queue_create("com.sdl.serialProcessing", qosSerial);
-    dispatch_queue_set_specific(_sdlProcessingQueue, processingQueueKey, (void *)processingQueueKey, NULL);
-    _sdlConcurrentQueue = dispatch_queue_create("com.sdl.concurrentProcessing", qosConcurrent);
-    dispatch_queue_set_specific(_sdlConcurrentQueue, concurrentQueueKey, (void *)concurrentQueueKey, NULL);
+    _sdlProcessingQueue = dispatch_queue_create(SDLProcessingQueueName, qosSerial);
+    dispatch_queue_set_specific(_sdlProcessingQueue, SDLProcessingQueueName, SDLProcessingQueueName, NULL);
+    _sdlConcurrentQueue = dispatch_queue_create(SDLConcurrentQueueName, qosConcurrent);
+    dispatch_queue_set_specific(_sdlConcurrentQueue, SDLConcurrentQueueName, SDLConcurrentQueueName, NULL);
 
     return self;
 }

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -739,7 +739,7 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
 
 // this is to make sure that the transition happens on the dedicated queue
 - (void)sdl_runOnProcessingQueue:(void (^)(void))block {
-    if (dispatch_get_specific("com.sdl.serialProcessing") != nil) {
+    if (dispatch_get_specific(SDLProcessingQueueName) != nil) {
         block();
     } else {
         dispatch_sync(self.lifecycleQueue, block);


### PR DESCRIPTION
Fixes #1564 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Unit tests were run, but no new tests were added to the PR because threading issues like this are very difficult to unit test.

#### Core Tests
An app was run against Core and various functions were tested to ensure that RPC requests continued to function properly.

Core version / branch / commit hash / module tested against: Manticore v2.4.2 (Core v6.0.1)
HMI name / version / branch / commit hash / module tested against: Manticore v2.4.2 (Generic HMI 0.7.2)

### Summary
This PR updates lifecycle manager RPC requests to always run on the lifecycle processing queue. This ensures that all access to protected resources will occur both synchronously and on the same queue.

### Changelog
##### Bug Fixes
* Fix occasional crashes or RPC failures due to accessing an unprotected resource from multiple threads simultaneously.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
