### PR TITLE
WIP: Bugfix/issue 1562 streaming video audio handle end session

### DIFF
--- a/SmartDeviceLink/SDLProtocol.h
+++ b/SmartDeviceLink/SDLProtocol.h
@@ -138,13 +138,12 @@ extern NSString *const SDLProtocolSecurityErrorDomain;
 - (void)sendEncryptedRawData:(NSData *)data onService:(SDLServiceType)serviceType;
 
 /**
- * Sends a message to core
+ * Sends an end service ACK to Core
  *
- * @param data The data to send
- * @param priority The priority to use when determining the location of the object in the collection. A lower number is considered a higher priority
- *
- */
-- (void)sdl_sendDataToTransport:(NSData *)data onService:(NSInteger)priority;
+ * @param serviceType A SDLServiceType object
+ * @param session Session number
+*/
+- (void)endServiceAckWithType:(SDLServiceType)serviceType forSession:(Byte)session;
 
 #pragma mark - Recieving
 

--- a/SmartDeviceLink/SDLProtocol.h
+++ b/SmartDeviceLink/SDLProtocol.h
@@ -137,6 +137,15 @@ extern NSString *const SDLProtocolSecurityErrorDomain;
  */
 - (void)sendEncryptedRawData:(NSData *)data onService:(SDLServiceType)serviceType;
 
+/**
+ * Sends a message to core
+ *
+ * @param data The data to send
+ * @param priority The priority to use when determining the location of the object in the collection. A lower number is considered a higher priority
+ *
+ */
+- (void)sdl_sendDataToTransport:(NSData *)data onService:(NSInteger)priority;
+
 #pragma mark - Recieving
 
 /**

--- a/SmartDeviceLink/SDLProtocol.m
+++ b/SmartDeviceLink/SDLProtocol.m
@@ -251,6 +251,16 @@ NS_ASSUME_NONNULL_BEGIN
     [self sdl_sendDataToTransport:message.data onService:serviceType];
 }
 
+- (void)endServiceAckWithType:(SDLServiceType)serviceType forSession:(Byte)session {
+    SDLProtocolHeader *header = [SDLProtocolHeader headerForVersion:(UInt8)[SDLGlobals sharedGlobals].protocolVersion.major];
+    header.frameType = SDLFrameTypeControl;
+    header.serviceType = SDLServiceTypeControl;
+    header.frameData = SDLFrameInfoEndServiceACK;
+    header.sessionID = session;
+    
+    SDLProtocolMessage *message = [SDLProtocolMessage messageWithHeader:header andPayload:nil];
+    [self sdl_sendDataToTransport:message.data onService:serviceType];
+}
 
 #pragma mark - Register Secondary Transport
 

--- a/SmartDeviceLink/SDLProtocol.m
+++ b/SmartDeviceLink/SDLProtocol.m
@@ -635,15 +635,6 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)handleProtocolEndService:(SDLProtocolMessage *)endService forSession:(Byte)session {
-    // Respond with EndService ACK
-    SDLProtocolHeader *header = [SDLProtocolHeader headerForVersion:(UInt8)[SDLGlobals sharedGlobals].protocolVersion.major];
-    header.frameType = SDLFrameTypeControl;
-    header.serviceType = SDLServiceTypeControl;
-    header.frameData = SDLFrameInfoEndServiceACK;
-    header.sessionID = session;
-    SDLProtocolMessage *message = [SDLProtocolMessage messageWithHeader:header andPayload:nil];
-    [self sdl_sendDataToTransport:message.data onService:header.serviceType];
-    
     NSArray<id<SDLProtocolListener>> *listeners = [self sdl_getProtocolListeners];
     for (id<SDLProtocolListener> listener in listeners) {
         if ([listener respondsToSelector:@selector(handleProtocolEndService:forSession:)]) {

--- a/SmartDeviceLink/SDLProtocolListener.h
+++ b/SmartDeviceLink/SDLProtocolListener.h
@@ -43,6 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)handleProtocolRegisterSecondaryTransportACKMessage:(SDLProtocolMessage *)registerSecondaryTransportACK;
 - (void)handleProtocolRegisterSecondaryTransportNAKMessage:(SDLProtocolMessage *)registerSecondaryTransportNAK;
 - (void)handleTransportEventUpdateMessage:(SDLProtocolMessage *)transportEventUpdate;
+- (void)handleProtocolEndService:(SDLProtocolMessage *)endService forSession:(Byte)session;
 
 #pragma mark - Older protocol handlers
 

--- a/SmartDeviceLink/SDLProtocolReceivedMessageRouter.m
+++ b/SmartDeviceLink/SDLProtocolReceivedMessageRouter.m
@@ -97,6 +97,11 @@ NS_ASSUME_NONNULL_BEGIN
                 [self.delegate handleTransportEventUpdateMessage:message];
             }
         } break;
+        case SDLFrameInfoEndService: {
+            if ([self.delegate respondsToSelector:@selector(handleProtocolEndService:forSession:)]) {
+                [self.delegate handleProtocolEndService:message forSession:message.header.sessionID];
+            }
+        }
         default: break; // Other frame data is possible, but we don't care about them
     }
 }

--- a/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
@@ -28,7 +28,6 @@
 #import "SDLStreamingMediaConfiguration.h"
 #import "SDLEncryptionConfiguration.h"
 #import "SDLVehicleType.h"
-#import "SDLVersion.h"
 
 
 NS_ASSUME_NONNULL_BEGIN

--- a/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
@@ -195,6 +195,10 @@ NS_ASSUME_NONNULL_BEGIN
     [self.audioStreamStateMachine transitionToState:SDLAudioStreamManagerStateReady];
 }
 
+- (void)handleProtocolEndService:(SDLProtocolMessage *)endService forSession:(Byte)session {
+    // to do
+}
+
 #pragma mark Video / Audio Start Service NAK
 
 - (void)handleProtocolStartServiceNAKMessage:(SDLProtocolMessage *)startServiceNAK {

--- a/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
@@ -28,6 +28,7 @@
 #import "SDLStreamingMediaConfiguration.h"
 #import "SDLEncryptionConfiguration.h"
 #import "SDLVehicleType.h"
+#import "SDLVersion.h"
 
 
 NS_ASSUME_NONNULL_BEGIN
@@ -196,7 +197,17 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)handleProtocolEndService:(SDLProtocolMessage *)endService forSession:(Byte)session {
-    // to do
+    // Respond with EndService ACK to address SYNC bug
+    SDLProtocol *sdlProtocol = [[SDLProtocol alloc] init];
+    SDLProtocolHeader *header = [SDLProtocolHeader headerForVersion:(UInt8)[SDLGlobals sharedGlobals].protocolVersion.major];
+    header.frameType = SDLFrameTypeControl;
+    header.serviceType = SDLServiceTypeControl;
+    header.frameData = SDLFrameInfoEndServiceACK;
+    header.sessionID = session;
+    SDLProtocolMessage *message = [SDLProtocolMessage messageWithHeader:header andPayload:nil];
+    [sdlProtocol sdl_sendDataToTransport:message.data onService:header.serviceType];
+    
+    [self sdl_stopAudioSession];
 }
 
 #pragma mark Video / Audio Start Service NAK

--- a/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
@@ -197,16 +197,10 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)handleProtocolEndService:(SDLProtocolMessage *)endService forSession:(Byte)session {
-    // Respond with EndService ACK to address SYNC bug
-    SDLProtocol *sdlProtocol = [[SDLProtocol alloc] init];
-    SDLProtocolHeader *header = [SDLProtocolHeader headerForVersion:(UInt8)[SDLGlobals sharedGlobals].protocolVersion.major];
-    header.frameType = SDLFrameTypeControl;
-    header.serviceType = SDLServiceTypeControl;
-    header.frameData = SDLFrameInfoEndServiceACK;
-    header.sessionID = session;
-    SDLProtocolMessage *message = [SDLProtocolMessage messageWithHeader:header andPayload:nil];
-    [sdlProtocol sdl_sendDataToTransport:message.data onService:header.serviceType];
+    if (endService.header.serviceType != SDLServiceTypeAudio) { return; }
     
+    // Respond with EndService ACK to address SYNC bug
+    [self.protocol endServiceAckWithType:endService.header.serviceType forSession:session];
     [self sdl_stopAudioSession];
 }
 

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -562,6 +562,10 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
     [self sdl_transitionToStoppedState:endServiceNAK.header.serviceType];
 }
 
+- (void)handleProtocolEndService:(SDLProtocolMessage *)endService forSession:(Byte)session {
+    // to do
+}
+
 #pragma mark - SDL RPC Notification callbacks
 
 - (void)sdl_didReceiveRegisterAppInterfaceResponse:(SDLRPCResponseNotification *)notification {

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -563,7 +563,17 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
 }
 
 - (void)handleProtocolEndService:(SDLProtocolMessage *)endService forSession:(Byte)session {
-    // to do
+    // Respond with EndService ACK to address SYNC bug
+    SDLProtocol *sdlProtocol = [[SDLProtocol alloc] init];
+    SDLProtocolHeader *header = [SDLProtocolHeader headerForVersion:(UInt8)[SDLGlobals sharedGlobals].protocolVersion.major];
+    header.frameType = SDLFrameTypeControl;
+    header.serviceType = SDLServiceTypeControl;
+    header.frameData = SDLFrameInfoEndServiceACK;
+    header.sessionID = session;
+    SDLProtocolMessage *message = [SDLProtocolMessage messageWithHeader:header andPayload:nil];
+    [sdlProtocol sdl_sendDataToTransport:message.data onService:header.serviceType];
+    
+    [self sdl_stopVideoSession];
 }
 
 #pragma mark - SDL RPC Notification callbacks

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -563,16 +563,10 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
 }
 
 - (void)handleProtocolEndService:(SDLProtocolMessage *)endService forSession:(Byte)session {
-    // Respond with EndService ACK to address SYNC bug
-    SDLProtocol *sdlProtocol = [[SDLProtocol alloc] init];
-    SDLProtocolHeader *header = [SDLProtocolHeader headerForVersion:(UInt8)[SDLGlobals sharedGlobals].protocolVersion.major];
-    header.frameType = SDLFrameTypeControl;
-    header.serviceType = SDLServiceTypeControl;
-    header.frameData = SDLFrameInfoEndServiceACK;
-    header.sessionID = session;
-    SDLProtocolMessage *message = [SDLProtocolMessage messageWithHeader:header andPayload:nil];
-    [sdlProtocol sdl_sendDataToTransport:message.data onService:header.serviceType];
+    if (endService.header.serviceType != SDLServiceTypeVideo) { return; }
     
+    // Respond with EndService ACK to address SYNC bug
+    [self.protocol endServiceAckWithType:endService.header.serviceType forSession:session];
     [self sdl_stopVideoSession];
 }
 


### PR DESCRIPTION
Fixes #1562 

This PR is **not ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [ ] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests


#### Core Tests
Run through the steps to reproduce per issue 1562. Confirm whether or not we are receiving and EndService and if ACKing and sending our own prevents the issue.
1. Connect a video streaming app with secondary transports enabled to a head unit that supports secondary transports. Launch the SDL app if necessary and wait for video to start streaming.
2. Put the app on the device in the background.
3. Bring the app to the foreground.

Tests will be run on the SYNC versions listed below.

Core version / branch / commit hash / module tested against:
SYNC 3.0
SYNC 3.2
SYNC 3.4
SYNC 4.0

HMI name / version / branch / commit hash / module tested against:

### Summary
This PR adds a new listener function to send an EndService ACK to Core when an EndService is received in the audio and video lifecycle managers. An EndService is then sent to work around a SYNC bug.

### Changelog
##### Bug Fixes
* tbd

### Tasks Remaining:
- [x] Initial Review
- [ ] Come up with test plan
- [ ] Testing against Core
- [ ] Update unit tests

### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
