### PR TITLE
Fixed checking if streaming is supported returning wrong value

### DIFF
--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -149,7 +149,7 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
         [configuration.lifecycleConfig.appType isEqualToEnum:SDLAppHMITypeProjection] ||
         [configuration.lifecycleConfig.additionalAppTypes containsObject:SDLAppHMITypeNavigation] ||
         [configuration.lifecycleConfig.additionalAppTypes containsObject:SDLAppHMITypeProjection]) {
-        _streamManager = [[SDLStreamingMediaManager alloc] initWithConnectionManager:self configuration:configuration];
+        _streamManager = [[SDLStreamingMediaManager alloc] initWithConnectionManager:self configuration:configuration systemCapabilityManager:self.systemCapabilityManager];
     } else {
         SDLLogV(@"Skipping StreamingMediaManager setup due to app type");
     }

--- a/SmartDeviceLink/SDLStreamingAudioLifecycleManager.h
+++ b/SmartDeviceLink/SDLStreamingAudioLifecycleManager.h
@@ -8,16 +8,16 @@
 
 #import <Foundation/Foundation.h>
 
-#import "SDLConfiguration.h"
 #import "SDLHMILevel.h"
 #import "SDLProtocolListener.h"
 #import "SDLStreamingAudioManagerType.h"
 #import "SDLStreamingMediaManagerConstants.h"
-#import "SDLSystemCapabilityManager.h"
 
 @class SDLAudioStreamManager;
+@class SDLConfiguration;
 @class SDLProtocol;
 @class SDLStateMachine;
+@class SDLSystemCapabilityManager;
 @class SDLEncryptionConfiguration;
 
 @protocol SDLConnectionManagerType;
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (assign, nonatomic, readonly, getter=isAudioEncrypted) BOOL audioEncrypted;
 
-/// Whether or not vidoe/audio streaming is supported
+/// Whether or not video/audio streaming is supported
 /// @discussion If connected to a module pre-SDL v4.5 there is no way to check if streaming is supported so `YES` is returned by default even though the module may NOT support video/audio streaming.
 @property (assign, nonatomic, readonly, getter=isStreamingSupported) BOOL streamingSupported;
 

--- a/SmartDeviceLink/SDLStreamingAudioLifecycleManager.h
+++ b/SmartDeviceLink/SDLStreamingAudioLifecycleManager.h
@@ -8,10 +8,12 @@
 
 #import <Foundation/Foundation.h>
 
+#import "SDLConfiguration.h"
 #import "SDLHMILevel.h"
 #import "SDLProtocolListener.h"
 #import "SDLStreamingAudioManagerType.h"
 #import "SDLStreamingMediaManagerConstants.h"
+#import "SDLSystemCapabilityManager.h"
 
 @class SDLAudioStreamManager;
 @class SDLProtocol;
@@ -62,14 +64,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init NS_UNAVAILABLE;
 
 /**
- Create a new streaming media manager for navigation and VPM apps with a specified configuration
+ Create a new streaming media manager for navigation and projection apps with a specified configuration
 
  @param connectionManager The pass-through for RPCs
- @param streamingConfiguration The configuration of this streaming media session
- @param encryptionConfiguration The encryption configuration with security managers
+ @param configuration This session's configuration
+ @param systemCapabilityManager The system capability manager object for reading window capabilities
  @return A new streaming manager
  */
-- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager streamingConfiguration:(SDLStreamingMediaConfiguration *)streamingConfiguration encryptionConfiguration:(SDLEncryptionConfiguration *)encryptionConfiguration NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager configuration:(SDLConfiguration *)configuration systemCapabilityManager:(nullable SDLSystemCapabilityManager *)systemCapabilityManager NS_DESIGNATED_INITIALIZER;
 
 /**
  *  Start the manager with a completion block that will be called when startup completes. This is used internally. To use an SDLStreamingMediaManager, you should use the manager found on `SDLManager`.

--- a/SmartDeviceLink/SDLStreamingAudioLifecycleManager.h
+++ b/SmartDeviceLink/SDLStreamingAudioLifecycleManager.h
@@ -47,11 +47,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (assign, nonatomic, readonly, getter=isAudioEncrypted) BOOL audioEncrypted;
 
-/**
- *  Whether or not video streaming is supported
- *
- *  @see SDLRegisterAppInterface SDLDisplayCapabilities
- */
+/// Whether or not vidoe/audio streaming is supported
+/// @discussion If connected to a module pre-SDL v4.5 there is no way to check if streaming is supported so `YES` is returned by default even though the module may NOT support video/audio streaming.
 @property (assign, nonatomic, readonly, getter=isStreamingSupported) BOOL streamingSupported;
 
 /**

--- a/SmartDeviceLink/SDLStreamingAudioLifecycleManager.h
+++ b/SmartDeviceLink/SDLStreamingAudioLifecycleManager.h
@@ -18,7 +18,6 @@
 @class SDLAudioStreamManager;
 @class SDLProtocol;
 @class SDLStateMachine;
-@class SDLStreamingMediaConfiguration;
 @class SDLEncryptionConfiguration;
 
 @protocol SDLConnectionManagerType;

--- a/SmartDeviceLink/SDLStreamingAudioLifecycleManager.h
+++ b/SmartDeviceLink/SDLStreamingAudioLifecycleManager.h
@@ -63,14 +63,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 
-/**
- Create a new streaming media manager for navigation and projection apps with a specified configuration
-
- @param connectionManager The pass-through for RPCs
- @param configuration This session's configuration
- @param systemCapabilityManager The system capability manager object for reading window capabilities
- @return A new streaming manager
- */
+/// Create a new streaming audio manager for navigation and projection apps with a specified configuration.
+/// @param connectionManager The pass-through for RPCs
+/// @param configuration This session's configuration
+/// @param systemCapabilityManager The system capability manager object for reading window capabilities
 - (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager configuration:(SDLConfiguration *)configuration systemCapabilityManager:(nullable SDLSystemCapabilityManager *)systemCapabilityManager NS_DESIGNATED_INITIALIZER;
 
 /**

--- a/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
@@ -28,8 +28,6 @@
 #import "SDLStreamingMediaConfiguration.h"
 #import "SDLEncryptionConfiguration.h"
 #import "SDLVehicleType.h"
-#import "SDLVersion.h"
-
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
@@ -305,7 +305,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (BOOL)isStreamingSupported {
-    return self.systemCapabilityManager != nil ? [self.systemCapabilityManager isCapabilitySupported:SDLSystemCapabilityTypeVideoStreaming] : YES;
+    return (self.systemCapabilityManager != nil) ? [self.systemCapabilityManager isCapabilitySupported:SDLSystemCapabilityTypeVideoStreaming] : YES;
 }
 
 @end

--- a/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
@@ -9,6 +9,7 @@
 #import "SDLStreamingAudioLifecycleManager.h"
 
 #import "SDLAudioStreamManager.h"
+#import "SDLConfiguration.h"
 #import "SDLConnectionManagerType.h"
 #import "SDLControlFramePayloadAudioStartServiceAck.h"
 #import "SDLControlFramePayloadConstants.h"
@@ -26,6 +27,7 @@
 #import "SDLRPCResponseNotification.h"
 #import "SDLStateMachine.h"
 #import "SDLStreamingMediaConfiguration.h"
+#import "SDLSystemCapabilityManager.h"
 #import "SDLEncryptionConfiguration.h"
 #import "SDLVehicleType.h"
 

--- a/SmartDeviceLink/SDLStreamingMediaManager.h
+++ b/SmartDeviceLink/SDLStreamingMediaManager.h
@@ -122,7 +122,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Create a new streaming media manager for navigation and projection apps with a specified configuration.
 /// @param connectionManager The pass-through for RPCs
 /// @param configuration This session's configuration
-- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager configuration:(SDLConfiguration *)configuration;
+- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager configuration:(SDLConfiguration *)configuration __deprecated_msg("Use initWithConnectionManager:configuration:systemCapabilityManager: instead");
 
 /// Create a new streaming media manager for navigation and projection apps with a specified configuration.
 /// @param connectionManager The pass-through for RPCs

--- a/SmartDeviceLink/SDLStreamingMediaManager.h
+++ b/SmartDeviceLink/SDLStreamingMediaManager.h
@@ -119,22 +119,15 @@ NS_ASSUME_NONNULL_BEGIN
 /// Initializer unavailable
 - (instancetype)init NS_UNAVAILABLE;
 
-/**
- Create a new streaming media manager for navigation and VPM apps with a specified configuration
-
- @param connectionManager The pass-through for RPCs
- @param configuration This session's configuration
- @return A new streaming manager
- */
+/// Create a new streaming media manager for navigation and projection apps with a specified configuration.
+/// @param connectionManager The pass-through for RPCs
+/// @param configuration This session's configuration
 - (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager configuration:(SDLConfiguration *)configuration;
 
-/**
- Create a new streaming media manager for navigation and VPM apps with a specified configuration
-
- @param connectionManager The pass-through for RPCs
- @param configuration This session's configuration
- @return A new streaming manager
- */
+/// Create a new streaming media manager for navigation and projection apps with a specified configuration.
+/// @param connectionManager The pass-through for RPCs
+/// @param configuration This session's configuration
+/// @param systemCapabilityManager The system capability manager object for reading window capabilities
 - (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager configuration:(SDLConfiguration *)configuration systemCapabilityManager:(nullable SDLSystemCapabilityManager *)systemCapabilityManager NS_DESIGNATED_INITIALIZER;
 
 /**

--- a/SmartDeviceLink/SDLStreamingMediaManager.h
+++ b/SmartDeviceLink/SDLStreamingMediaManager.h
@@ -11,11 +11,11 @@
 
 #import "SDLStreamingAudioManagerType.h"
 #import "SDLStreamingMediaManagerConstants.h"
-#import "SDLSystemCapabilityManager.h"
 
 @class SDLAudioStreamManager;
 @class SDLConfiguration;
 @class SDLProtocol;
+@class SDLSystemCapabilityManager;
 @class SDLTouchManager;
 @class SDLVideoStreamingFormat;
 

--- a/SmartDeviceLink/SDLStreamingMediaManager.h
+++ b/SmartDeviceLink/SDLStreamingMediaManager.h
@@ -11,6 +11,7 @@
 
 #import "SDLStreamingAudioManagerType.h"
 #import "SDLStreamingMediaManagerConstants.h"
+#import "SDLSystemCapabilityManager.h"
 
 @class SDLAudioStreamManager;
 @class SDLConfiguration;
@@ -125,7 +126,16 @@ NS_ASSUME_NONNULL_BEGIN
  @param configuration This session's configuration
  @return A new streaming manager
  */
-- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager configuration:(SDLConfiguration *)configuration NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager configuration:(SDLConfiguration *)configuration;
+
+/**
+ Create a new streaming media manager for navigation and VPM apps with a specified configuration
+
+ @param connectionManager The pass-through for RPCs
+ @param configuration This session's configuration
+ @return A new streaming manager
+ */
+- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager configuration:(SDLConfiguration *)configuration systemCapabilityManager:(nullable SDLSystemCapabilityManager *)systemCapabilityManager NS_DESIGNATED_INITIALIZER;
 
 /**
  *  Start the manager with a completion block that will be called when startup completes. This is used internally. To use an SDLStreamingMediaManager, you should use the manager found on `SDLManager`.

--- a/SmartDeviceLink/SDLStreamingMediaManager.m
+++ b/SmartDeviceLink/SDLStreamingMediaManager.m
@@ -113,7 +113,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (BOOL)isStreamingSupported {
-    // Since both audio and video lifecycle managers check the same parameter in the `RegisterAppInterface` response the flag should be same between two managers
+    // Since both the audio and video lifecycle managers check the same parameter in the `RegisterAppInterface` response, the flag is the same between the two managers
     return self.videoLifecycleManager.isStreamingSupported;
 }
 

--- a/SmartDeviceLink/SDLStreamingMediaManager.m
+++ b/SmartDeviceLink/SDLStreamingMediaManager.m
@@ -117,7 +117,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (BOOL)isStreamingSupported {
-    // Since both the audio and video lifecycle managers check the same parameter in the `RegisterAppInterface` response, the flag is the same between the two managers
+    // The flag is the same between the video and audio managers so just one needs to be returned.
     return self.videoLifecycleManager.isStreamingSupported;
 }
 

--- a/SmartDeviceLink/SDLStreamingMediaManager.m
+++ b/SmartDeviceLink/SDLStreamingMediaManager.m
@@ -34,16 +34,20 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Public
 #pragma mark Lifecycle
 
-- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager configuration:(SDLConfiguration *)configuration {
+- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager configuration:(SDLConfiguration *)configuration systemCapabilityManager:(nullable SDLSystemCapabilityManager *)systemCapabilityManager {
     self = [super init];
     if (!self) {
         return nil;
     }
 
-    _audioLifecycleManager = [[SDLStreamingAudioLifecycleManager alloc] initWithConnectionManager:connectionManager streamingConfiguration: configuration.streamingMediaConfig encryptionConfiguration:configuration.encryptionConfig];
-    _videoLifecycleManager = [[SDLStreamingVideoLifecycleManager alloc] initWithConnectionManager:connectionManager configuration:configuration];
+    _audioLifecycleManager = [[SDLStreamingAudioLifecycleManager alloc] initWithConnectionManager:connectionManager configuration:configuration systemCapabilityManager:systemCapabilityManager];
+    _videoLifecycleManager = [[SDLStreamingVideoLifecycleManager alloc] initWithConnectionManager:connectionManager configuration:configuration systemCapabilityManager:systemCapabilityManager];
 
     return self;
+}
+
+- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager configuration:(SDLConfiguration *)configuration {
+    return [self initWithConnectionManager:connectionManager configuration:configuration systemCapabilityManager:nil];
 }
 
 - (void)dealloc {

--- a/SmartDeviceLink/SDLStreamingMediaManager.m
+++ b/SmartDeviceLink/SDLStreamingMediaManager.m
@@ -113,14 +113,8 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (BOOL)isStreamingSupported {
-    // both audio and video lifecycle managers checks the param in Register App Interface response,
-    // hence the flag should be same between two managers if they are started
-    if (self.videoStarted) {
-        return self.videoLifecycleManager.isStreamingSupported;
-    } else if (self.audioStarted) {
-        return self.audioLifecycleManager.isStreamingSupported;
-    }
-    return NO;
+    // Since both audio and video lifecycle managers check the same parameter in the `RegisterAppInterface` response the flag should be same between two managers
+    return self.videoLifecycleManager.isStreamingSupported;
 }
 
 - (BOOL)isAudioConnected {

--- a/SmartDeviceLink/SDLStreamingMediaManager.m
+++ b/SmartDeviceLink/SDLStreamingMediaManager.m
@@ -14,6 +14,7 @@
 #import "SDLStreamingAudioLifecycleManager.h"
 #import "SDLStreamingVideoLifecycleManager.h"
 #import "SDLStreamingVideoScaleManager.h"
+#import "SDLSystemCapabilityManager.h"
 #import "SDLTouchManager.h"
 
 

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.h
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.h
@@ -142,13 +142,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 
-/**
- Create a new streaming media manager for navigation and VPM apps with a specified configuration
-
- @param connectionManager The pass-through for RPCs
- @param configuration This session's configuration
- @return A new streaming manager
- */
+/// Create a new streaming video manager for navigation and projection apps with a specified configuration.
+/// @param connectionManager The pass-through for RPCs
+/// @param configuration This session's configuration
+/// @param systemCapabilityManager The system capability manager object for reading window capabilities
 - (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager configuration:(SDLConfiguration *)configuration systemCapabilityManager:(nullable SDLSystemCapabilityManager *)systemCapabilityManager NS_DESIGNATED_INITIALIZER;
 
 /**

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.h
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.h
@@ -12,6 +12,7 @@
 #import "SDLHMILevel.h"
 #import "SDLProtocolListener.h"
 #import "SDLStreamingMediaManagerConstants.h"
+#import "SDLSystemCapabilityManager.h"
 #import "SDLVideoStreamingFormat.h"
 #import "SDLVideoStreamingState.h"
 
@@ -148,7 +149,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param configuration This session's configuration
  @return A new streaming manager
  */
-- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager configuration:(SDLConfiguration *)configuration;
+- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager configuration:(SDLConfiguration *)configuration systemCapabilityManager:(nullable SDLSystemCapabilityManager *)systemCapabilityManager NS_DESIGNATED_INITIALIZER;
 
 /**
  *  Start the manager with a completion block that will be called when startup completes. This is used internally. To use an SDLStreamingMediaManager, you should use the manager found on `SDLManager`.

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.h
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.h
@@ -61,7 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (weak, nonatomic, nullable) id<SDLStreamingMediaManagerDataSource> dataSource;
 
 /// Whether or not video/audio streaming is supported
-/// @discussion If connected to a module pre-SDL v4.5 there is no way to check if streaming is supported so `YES` is returned by default even though the module may NOT support video/audio streaming.
+/// @discussion If connected to a module pre-SDL v4.5 there is no way to check if streaming is supported so `YES` is returned by default even though the module may not support video/audio streaming.
 @property (assign, nonatomic, readonly, getter=isStreamingSupported) BOOL streamingSupported;
 
 /**

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.h
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.h
@@ -60,13 +60,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (weak, nonatomic, nullable) id<SDLStreamingMediaManagerDataSource> dataSource;
 
-/**
- *  Whether or not video streaming is supported
- *
- *  @discussion If connected to a module pre-SDL v4.5 there is no way to check if streaming is supported so `true` is returned by default even though the module may NOT support video/audio streaming.
- *
- *  @see SDLRegisterAppInterface SDLDisplayCapabilities
- */
+/// Whether or not vidoe/audio streaming is supported
+/// @discussion If connected to a module pre-SDL v4.5 there is no way to check if streaming is supported so `YES` is returned by default even though the module may NOT support video/audio streaming.
 @property (assign, nonatomic, readonly, getter=isStreamingSupported) BOOL streamingSupported;
 
 /**

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.h
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.h
@@ -12,7 +12,6 @@
 #import "SDLHMILevel.h"
 #import "SDLProtocolListener.h"
 #import "SDLStreamingMediaManagerConstants.h"
-#import "SDLSystemCapabilityManager.h"
 #import "SDLVideoStreamingFormat.h"
 #import "SDLVideoStreamingState.h"
 
@@ -23,6 +22,7 @@
 @class SDLStateMachine;
 @class SDLStreamingMediaConfiguration;
 @class SDLStreamingVideoScaleManager;
+@class SDLSystemCapabilityManager;
 @class SDLTouchManager;
 
 @protocol SDLConnectionManagerType;
@@ -60,7 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (weak, nonatomic, nullable) id<SDLStreamingMediaManagerDataSource> dataSource;
 
-/// Whether or not vidoe/audio streaming is supported
+/// Whether or not video/audio streaming is supported
 /// @discussion If connected to a module pre-SDL v4.5 there is no way to check if streaming is supported so `YES` is returned by default even though the module may NOT support video/audio streaming.
 @property (assign, nonatomic, readonly, getter=isStreamingSupported) BOOL streamingSupported;
 

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.h
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.h
@@ -62,6 +62,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Whether or not video streaming is supported
  *
+ *  @discussion If connected to a module pre-SDL v4.5 there is no way to check if streaming is supported so `true` is returned by default even though the module may NOT support video/audio streaming.
+ *
  *  @see SDLRegisterAppInterface SDLDisplayCapabilities
  */
 @property (assign, nonatomic, readonly, getter=isStreamingSupported) BOOL streamingSupported;

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -572,7 +572,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
     }
 
     SDLLogD(@"Received Register App Interface");
-    SDLRegisterAppInterfaceResponse *registerResponse = (SDLRegisterAppInterfaceResponse*)notification.response;
+    SDLRegisterAppInterfaceResponse *registerResponse = (SDLRegisterAppInterfaceResponse *)notification.response;
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
@@ -827,7 +827,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
 }
 
 - (BOOL)isStreamingSupported {
-    return self.systemCapabilityManager != nil ? [self.systemCapabilityManager isCapabilitySupported:SDLSystemCapabilityTypeVideoStreaming] : YES;
+    return (self.systemCapabilityManager != nil) ? [self.systemCapabilityManager isCapabilitySupported:SDLSystemCapabilityTypeVideoStreaming] : YES;
 }
 
 @end

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -23,7 +23,6 @@
 #import "SDLGetSystemCapabilityResponse.h"
 #import "SDLGlobals.h"
 #import "SDLH264VideoEncoder.h"
-#import "SDLHMICapabilities.h"
 #import "SDLHMILevel.h"
 #import "SDLImageResolution.h"
 #import "SDLLifecycleConfiguration.h"
@@ -46,7 +45,6 @@
 #import "SDLVehicleType.h"
 #import "SDLVideoEncoderDelegate.h"
 #import "SDLVideoStreamingCapability.h"
-#import "SDLVersion.h"
 
 static NSUInteger const FramesToSendOnBackground = 30;
 

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -41,6 +41,7 @@
 #import "SDLStreamingMediaManagerDataSource.h"
 #import "SDLStreamingVideoScaleManager.h"
 #import "SDLSystemCapability.h"
+#import "SDLSystemCapabilityManager.h"
 #import "SDLTouchManager.h"
 #import "SDLVehicleType.h"
 #import "SDLVideoEncoderDelegate.h"

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingAudioLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingAudioLifecycleManagerSpec.m
@@ -6,7 +6,6 @@
 #import "SDLControlFramePayloadAudioStartServiceAck.h"
 #import "SDLDisplayCapabilities.h"
 #import "SDLGlobals.h"
-#import "SDLHMICapabilities.h"
 #import "SDLImageResolution.h"
 #import "SDLOnHMIStatus.h"
 #import "SDLProtocol.h"
@@ -21,7 +20,6 @@
 #import "SDLV2ProtocolHeader.h"
 #import "SDLV2ProtocolMessage.h"
 #import "SDLVehicleType.h"
-#import "SDLVersion.h"
 #import "TestConnectionManager.h"
 
 @interface SDLStreamingAudioLifecycleManager()

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingAudioLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingAudioLifecycleManagerSpec.m
@@ -23,7 +23,9 @@
 #import "TestConnectionManager.h"
 
 @interface SDLStreamingAudioLifecycleManager()
+
 @property (copy, nonatomic) NSString *connectedVehicleMake;
+
 @end
 
 QuickSpecBegin(SDLStreamingAudioLifecycleManagerSpec)

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingVideoLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingVideoLifecycleManagerSpec.m
@@ -202,6 +202,7 @@ describe(@"the streaming video manager", ^{
 #pragma clang diagnostic ignored "-Wdeprecated"
                     someRegisterAppInterfaceResponse.displayCapabilities = someDisplayCapabilities;
 #pragma clang diagnostic pop
+                    someRegisterAppInterfaceResponse.vehicleType = testVehicleType;
 
                     SDLRPCResponseNotification *notification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveRegisterAppInterfaceResponse object:self rpcResponse:someRegisterAppInterfaceResponse];
 
@@ -211,7 +212,7 @@ describe(@"the streaming video manager", ^{
 
                 it(@"should save the connected vehicle make and the screen size", ^{
                     expect(@(CGSizeEqualToSize(streamingLifecycleManager.videoScaleManager.displayViewportResolution, CGSizeMake(600, 100)))).to(equal(@YES));
-                    expect(streamingLifecycleManager.connectedVehicleMake).to(equal(testVehicleType.make));
+                    expect(streamingLifecycleManager.connectedVehicleMake).toEventually(equal(testVehicleType.make));
                 });
             });
         });


### PR DESCRIPTION
Fixes #1569 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
* Fixed test cases in the `SDLStreamingAudioLifecycleManagerSpec` and `SDLStreamingVideoLifecycleManagerSpec`.

#### Core Tests
Core version / branch / commit hash / module tested against: SYNC 3.0 and Manticore (SDL Core v6.0.1 and Generic HMI v0.7.2)
HMI name / version / branch / commit hash / module tested against: SYNC 3.0 and Manticore (SDL Core v6.0.1 and Generic HMI v0.7.2)

### Summary
Fixed the `SDLStreamingMediaManager` returning `false` for `isStreamingSupported` if video/audio has not yet started streaming.

### Changelog
##### Bug Fixes
* Fixed the `SDLStreamingMediaManager` returning `false` for `isStreamingSupported` if video/audio has not yet started streaming. Since `isStreamingSupported` is set based on the value returned in the `RegisterAppInterface` response there is no need to wait for video or audio to start streaming in order to return an accurate value.
* Fixed the `SDLStreamingAudioLifecycleManager` possibly setting the wrong value for `isStreamingSupported` on pre-4.5.0 head units. 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
