### PR TITLE
removed code from swift example that checks for first time hmiLevel i…

### DIFF
--- a/Example Apps/Example Swift/ProxyManager.swift
+++ b/Example Apps/Example Swift/ProxyManager.swift
@@ -173,11 +173,6 @@ extension ProxyManager: SDLManagerDelegate {
             vehicleDataManager.subscribeToVehicleOdometer()
         }
 
-        if newLevel == .full && firstHMILevelState != .full {
-            // This is our first time in a `FULL` state.
-            firstHMILevelState = newLevel
-        }
-
         switch newLevel {
         case .full:                // The SDL app is in the foreground
             // Always try to show the initial state to guard against some possible weird states. Duplicates will be ignored by Core.


### PR DESCRIPTION
Fixes #1554 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [ ] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
All changes are in example app, unit tests not needed.

#### Core Tests
n/a Core unaffected by changes.

### Summary
Removed the check in the example Swift app that checks for first `hmiLevel` `FULL`.

### Changelog
##### Bug Fixes
* Removed unused method if statement.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
