### PR TITLE
Fix ScreenManager not sending updates in certain cases that it should

### DIFF
--- a/Example Apps/Example ObjC/PerformInteractionManager.m
+++ b/Example Apps/Example ObjC/PerformInteractionManager.m
@@ -66,16 +66,19 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - SDLChoiceSetDelegate
 
 - (void)choiceSet:(SDLChoiceSet *)choiceSet didSelectChoice:(SDLChoiceCell *)choice withSource:(SDLTriggerSource)source atRowIndex:(NSUInteger)rowIndex {
+    SDLLogD(@"User selected row: %lu, choice: %@", (unsigned long)rowIndex, choice);
     [self.manager sendRequest:[[SDLSpeak alloc] initWithTTS:TTSGoodJob]];
 }
 
 - (void)choiceSet:(SDLChoiceSet *)choiceSet didReceiveError:(NSError *)error {
+    SDLLogE(@"Error presenting choice set: %@", error);
     [self.manager sendRequest:[[SDLSpeak alloc] initWithTTS:TTSYouMissed]];
 }
 
 #pragma mark - SDLKeyboardDelegate
 
 - (void)userDidSubmitInput:(NSString *)inputText withEvent:(SDLKeyboardEvent)source {
+    SDLLogD(@"User did submit keyboard input: %@, with event: %@", inputText, source);
     if ([source isEqualToEnum:SDLKeyboardEventSubmitted]) {
         [self.manager sendRequest:[[SDLSpeak alloc] initWithTTS:TTSGoodJob]];
     } else if ([source isEqualToEnum:SDLKeyboardEventVoice]) {
@@ -84,6 +87,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)keyboardDidAbortWithReason:(SDLKeyboardEvent)event {
+    SDLLogW(@"Keyboard aborted with reason: %@", event);
     [self.manager sendRequest:[[SDLSpeak alloc] initWithTTS:TTSYouMissed]];
 }
 

--- a/Example Apps/Example Swift/PerformInteractionManager.swift
+++ b/Example Apps/Example Swift/PerformInteractionManager.swift
@@ -56,16 +56,19 @@ private extension PerformInteractionManager {
 
 extension PerformInteractionManager: SDLChoiceSetDelegate {
     func choiceSet(_ choiceSet: SDLChoiceSet, didSelectChoice choice: SDLChoiceCell, withSource source: SDLTriggerSource, atRowIndex rowIndex: UInt) {
+        SDLLog.d("User selected row: \(rowIndex), choice: \(choice)")
         manager.send(SDLSpeak(tts: TTSGoodJob))
     }
 
     func choiceSet(_ choiceSet: SDLChoiceSet, didReceiveError error: Error) {
+        SDLLog.e("Error presenting choice set: \(error)")
         manager.send(SDLSpeak(tts: TTSYouMissed))
     }
 }
 
 extension PerformInteractionManager: SDLKeyboardDelegate {
     func keyboardDidAbort(withReason event: SDLKeyboardEvent) {
+        SDLLog.w("Keyboard aborted with reason: \(event)")
         switch event {
         case SDLKeyboardEvent.cancelled:
             manager.send(SDLSpeak(tts: TTSYouMissed))
@@ -76,6 +79,7 @@ extension PerformInteractionManager: SDLKeyboardDelegate {
     }
 
     func userDidSubmitInput(_ inputText: String, withEvent source: SDLKeyboardEvent) {
+        SDLLog.d("User did submit keyboard input: \(inputText), with event: \(source)")
         switch source {
         case SDLKeyboardEvent.voice: break
             // Start Voice search

--- a/SmartDeviceLink/SDLChoiceSetManager.m
+++ b/SmartDeviceLink/SDLChoiceSetManager.m
@@ -145,7 +145,7 @@ UInt16 const ChoiceCellCancelIdMin = 1;
 }
 
 /// Suspend the transaction queue if we are in HMI NONE
-/// OR if we don't know what text fields are allowed, or if the text field name "menu name" (this is the primary choice text) we assume we cannot present a PI.
+/// OR if the text field name "menu name" (i.e. is the primary choice text) cannot be used, we assume we cannot present a PI.
 - (void)sdl_updateTransactionQueueSuspended {
     if ([self.currentHMILevel isEqualToEnum:SDLHMILevelNone]
         || (![self.currentWindowCapability hasTextFieldOfName:SDLTextFieldNameMenuName])) {
@@ -481,9 +481,10 @@ UInt16 const ChoiceCellCancelIdMin = 1;
         SDLDisplayCapability *mainDisplay = capabilities[0];
         for (SDLWindowCapability *windowCapability in mainDisplay.windowCapabilities) {
             NSUInteger currentWindowID = windowCapability.windowID != nil ? windowCapability.windowID.unsignedIntegerValue : SDLPredefinedWindowsDefaultWindow;
-            if (currentWindowID == SDLPredefinedWindowsDefaultWindow) {
-                self.currentWindowCapability = windowCapability;
-            }
+            if (currentWindowID != SDLPredefinedWindowsDefaultWindow) { continue; }
+
+            self.currentWindowCapability = windowCapability;
+            break;
         }
     }
 

--- a/SmartDeviceLink/SDLChoiceSetManager.m
+++ b/SmartDeviceLink/SDLChoiceSetManager.m
@@ -149,7 +149,7 @@ UInt16 const ChoiceCellCancelIdMin = 1;
     if ([self.currentHMILevel isEqualToEnum:SDLHMILevelNone]
         || [self.currentSystemContext isEqualToEnum:SDLSystemContextHMIObscured]
         || [self.currentSystemContext isEqualToEnum:SDLSystemContextAlert]
-        || ![self.currentWindowCapability hasTextFieldOfName:SDLTextFieldNameMenuName]) {
+        || (self.currentWindowCapability.textFields != nil && ![self.currentWindowCapability hasTextFieldOfName:SDLTextFieldNameMenuName])) {
         SDLLogD(@"Suspending the choice set manager transaction queue. Current HMI level is NONE: %@, current system context is HMIObscured or Alert: %@, window capability has MenuName (choice primary text): %@", ([self.currentHMILevel isEqualToEnum:SDLHMILevelNone] ? @"YES" : @"NO"), (([self.currentSystemContext isEqualToEnum:SDLSystemContextHMIObscured] || [self.currentSystemContext isEqualToEnum:SDLSystemContextAlert]) ? @"YES" : @"NO"), ([self.currentWindowCapability hasTextFieldOfName:SDLTextFieldNameMenuName] ? @"YES" : @"NO"));
         self.transactionQueue.suspended = YES;
     } else {

--- a/SmartDeviceLink/SDLChoiceSetManager.m
+++ b/SmartDeviceLink/SDLChoiceSetManager.m
@@ -106,6 +106,7 @@ UInt16 const ChoiceCellCancelIdMin = 1;
     _nextCancelId = ChoiceCellCancelIdMin;
     _vrOptional = YES;
     _keyboardConfiguration = [self sdl_defaultKeyboardConfiguration];
+    _currentHMILevel = SDLHMILevelNone;
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_hmiStatusNotification:) name:SDLDidChangeHMIStatusNotification object:nil];
 
@@ -150,10 +151,10 @@ UInt16 const ChoiceCellCancelIdMin = 1;
         || [self.currentSystemContext isEqualToEnum:SDLSystemContextHMIObscured]
         || [self.currentSystemContext isEqualToEnum:SDLSystemContextAlert]
         || (self.currentWindowCapability.textFields != nil && ![self.currentWindowCapability hasTextFieldOfName:SDLTextFieldNameMenuName])) {
-        SDLLogD(@"Suspending the choice set manager transaction queue. Current HMI level is NONE: %@, current system context is HMIObscured or Alert: %@, window capability has MenuName (choice primary text): %@", ([self.currentHMILevel isEqualToEnum:SDLHMILevelNone] ? @"YES" : @"NO"), (([self.currentSystemContext isEqualToEnum:SDLSystemContextHMIObscured] || [self.currentSystemContext isEqualToEnum:SDLSystemContextAlert]) ? @"YES" : @"NO"), ([self.currentWindowCapability hasTextFieldOfName:SDLTextFieldNameMenuName] ? @"YES" : @"NO"));
+        SDLLogD(@"Suspending the transaction queue. Current HMI level is NONE: %@, current system context is HMIObscured or Alert: %@, window capability has MenuName (choice primary text): %@", ([self.currentHMILevel isEqualToEnum:SDLHMILevelNone] ? @"YES" : @"NO"), (([self.currentSystemContext isEqualToEnum:SDLSystemContextHMIObscured] || [self.currentSystemContext isEqualToEnum:SDLSystemContextAlert]) ? @"YES" : @"NO"), ([self.currentWindowCapability hasTextFieldOfName:SDLTextFieldNameMenuName] ? @"YES" : @"NO"));
         self.transactionQueue.suspended = YES;
     } else {
-        SDLLogD(@"Starting the choice set manager transaction queue");
+        SDLLogD(@"Starting the transaction queue");
         self.transactionQueue.suspended = NO;
     }
 }

--- a/SmartDeviceLink/SDLChoiceSetManager.m
+++ b/SmartDeviceLink/SDLChoiceSetManager.m
@@ -160,7 +160,7 @@ UInt16 const ChoiceCellCancelIdMin = 1;
 #pragma mark - State Management
 
 - (void)didEnterStateShutdown {
-    _currentHMILevel = nil;
+    _currentHMILevel = SDLHMILevelNone;
 
     [self.transactionQueue cancelAllOperations];
     self.transactionQueue = [self sdl_newTransactionQueue];
@@ -494,10 +494,7 @@ UInt16 const ChoiceCellCancelIdMin = 1;
 - (void)sdl_hmiStatusNotification:(SDLRPCNotificationNotification *)notification {
     // We can only present a choice set if we're in FULL
     SDLOnHMIStatus *hmiStatus = (SDLOnHMIStatus *)notification.notification;
-    
-    if (hmiStatus.windowID != nil && hmiStatus.windowID.integerValue != SDLPredefinedWindowsDefaultWindow) {
-        return;
-    }
+    if (hmiStatus.windowID != nil && hmiStatus.windowID.integerValue != SDLPredefinedWindowsDefaultWindow) { return; }
 
     self.currentHMILevel = hmiStatus.hmiLevel;
 

--- a/SmartDeviceLink/SDLDisplayCapability.h
+++ b/SmartDeviceLink/SDLDisplayCapability.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param windowTypeSupported Informs the application how many windows the app is allowed to create per type.
  @param windowCapabilities Contains a list of capabilities of all windows related to the app. @see windowCapabilities
  */
-- (instancetype)initWithDisplayName:(NSString *)displayName windowTypeSupported:(nullable NSArray<SDLWindowCapability *> *)windowTypeSupported windowCapabilities:(nullable NSArray<SDLWindowTypeCapabilities *> *)windowCapabilities;
+- (instancetype)initWithDisplayName:(NSString *)displayName windowTypeSupported:(nullable NSArray<SDLWindowTypeCapabilities *> *)windowTypeSupported windowCapabilities:(nullable NSArray<SDLWindowCapability *> *)windowCapabilities;
 
 
 /**

--- a/SmartDeviceLink/SDLDisplayCapability.h
+++ b/SmartDeviceLink/SDLDisplayCapability.h
@@ -23,15 +23,17 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (instancetype)initWithDisplayName:(NSString *)displayName;
 
+/// This method is broken (the types don't match the parameter names) and will always return nil. Use initWithDisplayName:windowCapabilities:windowTypeSupported: instead.
+- (instancetype)initWithDisplayName:(NSString *)displayName windowTypeSupported:(nullable NSArray<SDLWindowCapability *> *)windowTypeSupported windowCapabilities:(nullable NSArray<SDLWindowTypeCapabilities *> *)windowCapabilities __deprecated_msg("This method is broken and will return nil every time. Use initWithDisplayName:windowCapabilities:windowTypeSupported: instead");
 
 /**
  Init with all the properities
 
  @param displayName Name of the display.
- @param windowTypeSupported Informs the application how many windows the app is allowed to create per type.
  @param windowCapabilities Contains a list of capabilities of all windows related to the app. @see windowCapabilities
+ @param windowTypeSupported Informs the application how many windows the app is allowed to create per type.
  */
-- (instancetype)initWithDisplayName:(NSString *)displayName windowTypeSupported:(nullable NSArray<SDLWindowTypeCapabilities *> *)windowTypeSupported windowCapabilities:(nullable NSArray<SDLWindowCapability *> *)windowCapabilities;
+- (instancetype)initWithDisplayName:(NSString *)displayName windowCapabilities:(nullable NSArray<SDLWindowCapability *> *)windowCapabilities windowTypeSupported:(nullable NSArray<SDLWindowTypeCapabilities *> *)windowTypeSupported;
 
 
 /**

--- a/SmartDeviceLink/SDLDisplayCapability.m
+++ b/SmartDeviceLink/SDLDisplayCapability.m
@@ -28,7 +28,13 @@
     return self;
 }
 
-- (instancetype)initWithDisplayName:(NSString *)displayName windowTypeSupported:(nullable NSArray<SDLWindowTypeCapabilities *> *)windowTypeSupported windowCapabilities:(nullable NSArray<SDLWindowCapability *> *)windowCapabilities{
+- (instancetype)initWithDisplayName:(NSString *)displayName windowTypeSupported:(NSArray<SDLWindowCapability *> *)windowTypeSupported windowCapabilities:(NSArray<SDLWindowTypeCapabilities *> *)windowCapabilities {
+    SDLLogE(@"This method is broken (the types don't match the parameter names) and will always return nil. Use initWithDisplayName:windowCapabilities:windowTypeSupported: instead.");
+
+    return nil;
+}
+
+- (instancetype)initWithDisplayName:(NSString *)displayName windowCapabilities:(nullable NSArray<SDLWindowCapability *> *)windowCapabilities windowTypeSupported:(nullable NSArray<SDLWindowTypeCapabilities *> *)windowTypeSupported {
     self = [self initWithDisplayName:displayName];
     if (!self) {
         return nil;

--- a/SmartDeviceLink/SDLError.m
+++ b/SmartDeviceLink/SDLError.m
@@ -70,8 +70,7 @@ SDLErrorDomain *const SDLErrorDomainRPCStore = @"com.sdl.rpcStore.error";
 + (NSError *)sdl_lifecycle_rpcErrorWithDescription:(NSString *)description andReason:(NSString *)reason {
     NSDictionary<NSString *, NSString *> *userInfo = @{
                                                        NSLocalizedDescriptionKey: NSLocalizedString(description, nil),
-                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(reason, nil),
-                                                       NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"Have you tried turning it off and on again?", nil)
+                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(reason, nil)
                                                        };
     return [NSError errorWithDomain:SDLErrorDomainLifecycleManager
                                code:SDLManagerErrorRPCRequestFailed
@@ -81,8 +80,7 @@ SDLErrorDomain *const SDLErrorDomainRPCStore = @"com.sdl.rpcStore.error";
 + (NSError *)sdl_lifecycle_notConnectedError {
     NSDictionary<NSString *, NSString *> *userInfo = @{
                                                        NSLocalizedDescriptionKey: NSLocalizedString(@"Could not find a connection", nil),
-                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"The SDL library could not find a current connection to an SDL hardware device", nil),
-                                                       NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"Have you tried turning it off and on again?", nil)
+                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"The SDL library could not find a current connection to an SDL hardware device", nil)
                                                        };
 
     return [NSError errorWithDomain:SDLErrorDomainLifecycleManager
@@ -93,8 +91,7 @@ SDLErrorDomain *const SDLErrorDomainRPCStore = @"com.sdl.rpcStore.error";
 + (NSError *)sdl_lifecycle_notReadyError {
     NSDictionary<NSString *, NSString *> *userInfo = @{
                                                        NSLocalizedDescriptionKey: NSLocalizedString(@"Lifecycle manager not ready", nil),
-                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"The SDL library is not finished setting up the connection, please wait until the lifecycleState is SDLLifecycleStateReady", nil),
-                                                       NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"Have you tried turning it off and on again?", nil)
+                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"The SDL library is not finished setting up the connection, please wait until the lifecycleState is SDLLifecycleStateReady", nil)
                                                        };
 
     return [NSError errorWithDomain:SDLErrorDomainLifecycleManager
@@ -105,8 +102,7 @@ SDLErrorDomain *const SDLErrorDomainRPCStore = @"com.sdl.rpcStore.error";
 + (NSError *)sdl_lifecycle_unknownRemoteErrorWithDescription:(NSString *)description andReason:(NSString *)reason {
     NSDictionary<NSString *, NSString *> *userInfo = @{
                                                        NSLocalizedDescriptionKey: NSLocalizedString(description, nil),
-                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(reason, nil),
-                                                       NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"Have you tried turning it off and on again?", nil)
+                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(reason, nil)
                                                        };
     return [NSError errorWithDomain:SDLErrorDomainLifecycleManager
                                code:SDLManagerErrorUnknownRemoteError

--- a/SmartDeviceLink/SDLImageField.h
+++ b/SmartDeviceLink/SDLImageField.h
@@ -36,6 +36,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nullable, strong, nonatomic) SDLImageResolution *imageResolution;
 
+/// Convenience initalizer for the ImageField RPC struct
+/// @param name The name identifying this image field
+/// @param imageTypeSupported The image data types this field supports
+/// @param imageResolution The native resolution of this image field
+- (instancetype)initWithName:(SDLImageFieldName)name imageTypeSupported:(NSArray<SDLFileType> *)imageTypeSupported imageResolution:(SDLImageResolution *)imageResolution;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLImageField.m
+++ b/SmartDeviceLink/SDLImageField.m
@@ -38,6 +38,17 @@ NS_ASSUME_NONNULL_BEGIN
     return [self.store sdl_objectForName:SDLRPCParameterNameImageResolution ofClass:SDLImageResolution.class error:nil];
 }
 
+- (instancetype)initWithName:(SDLImageFieldName)name imageTypeSupported:(NSArray<SDLFileType> *)imageTypeSupported imageResolution:(SDLImageResolution *)imageResolution {
+    self = [self init];
+    if (!self) { return nil; }
+
+    self.name = name;
+    self.imageTypeSupported = imageTypeSupported;
+    self.imageResolution = imageResolution;
+
+    return self;
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLMenuManager.m
+++ b/SmartDeviceLink/SDLMenuManager.m
@@ -208,8 +208,12 @@ UInt32 const MenuCellIdMin = 1;
     SDLShowAppMenu *openMenu = [[SDLShowAppMenu alloc] init];
 
     [self.connectionManager sendConnectionRequest:openMenu withResponseHandler:^(__kindof SDLRPCRequest * _Nullable request, __kindof SDLRPCResponse * _Nullable response, NSError * _Nullable error) {
-        if (error != nil) {
+        if ([response.resultCode isEqualToEnum:SDLResultWarnings]) {
+            SDLLogW(@"Warning opening application menu: %@", error);
+        } else if (![response.resultCode isEqualToEnum:SDLResultSuccess]) {
             SDLLogE(@"Error opening application menu: %@", error);
+        } else {
+            SDLLogD(@"Successfully opened application main menu");
         }
     }];
 
@@ -231,8 +235,12 @@ UInt32 const MenuCellIdMin = 1;
     SDLShowAppMenu *subMenu = [[SDLShowAppMenu alloc] initWithMenuID:cell.cellId];
 
     [self.connectionManager sendConnectionRequest:subMenu withResponseHandler:^(__kindof SDLRPCRequest * _Nullable request, __kindof SDLRPCResponse * _Nullable response, NSError * _Nullable error) {
-        if (error != nil) {
-            SDLLogE(@"Error opening application to submenu cell: %@, with error: %@", cell, error);
+        if ([response.resultCode isEqualToEnum:SDLResultWarnings]) {
+            SDLLogW(@"Warning opening application menu to submenu cell %@, with error: %@", cell, error);
+        } else if (![response.resultCode isEqualToEnum:SDLResultSuccess]) {
+            SDLLogE(@"Error opening application menu to submenu cell %@, with error: %@", cell, error);
+        } else {
+            SDLLogD(@"Successfully opened application menu to submenu cell: %@", cell);
         }
     }];
 

--- a/SmartDeviceLink/SDLMenuManager.m
+++ b/SmartDeviceLink/SDLMenuManager.m
@@ -197,6 +197,48 @@ UInt32 const MenuCellIdMin = 1;
     }
 }
 
+#pragma mark - Open Menu
+
+- (BOOL)openMenu {
+    if ([SDLGlobals.sharedGlobals.rpcVersion isLessThanVersion:[[SDLVersion alloc] initWithMajor:6 minor:0 patch:0]]) {
+        SDLLogE(@"The openMenu method is not supported on this head unit.");
+        return NO;
+    }
+
+    SDLShowAppMenu *openMenu = [[SDLShowAppMenu alloc] init];
+
+    [self.connectionManager sendConnectionRequest:openMenu withResponseHandler:^(__kindof SDLRPCRequest * _Nullable request, __kindof SDLRPCResponse * _Nullable response, NSError * _Nullable error) {
+        if (error != nil) {
+            SDLLogE(@"Error opening application menu: %@", error);
+        }
+    }];
+
+    return YES;
+}
+
+- (BOOL)openSubmenu:(SDLMenuCell *)cell {
+    if (cell.subCells.count == 0) {
+        SDLLogE(@"The cell %@ does not contain any sub cells, so no submenu can be opened", cell);
+        return NO;
+    } else if ([SDLGlobals.sharedGlobals.rpcVersion isLessThanVersion:[[SDLVersion alloc] initWithMajor:6 minor:0 patch:0]]) {
+        SDLLogE(@"The openSubmenu method is not supported on this head unit.");
+        return NO;
+    } else if (![self.menuCells containsObject:cell]) {
+        SDLLogE(@"This cell has not been sent to the head unit, so no submenu can be opened. Make sure that the cell exists in the SDLManager.menu array");
+        return NO;
+    }
+
+    SDLShowAppMenu *subMenu = [[SDLShowAppMenu alloc] initWithMenuID:cell.cellId];
+
+    [self.connectionManager sendConnectionRequest:subMenu withResponseHandler:^(__kindof SDLRPCRequest * _Nullable request, __kindof SDLRPCResponse * _Nullable response, NSError * _Nullable error) {
+        if (error != nil) {
+            SDLLogE(@"Error opening application to submenu cell: %@, with error: %@", cell, error);
+        }
+    }];
+
+    return YES;
+}
+
 #pragma mark - Build Deletes, Keeps, Adds
 
 - (void)sdl_startSubMenuUpdatesWithOldKeptCells:(NSArray<SDLMenuCell *> *)oldKeptCells newKeptCells:(NSArray<SDLMenuCell *> *)newKeptCells atIndex:(NSUInteger)startIndex {
@@ -670,46 +712,6 @@ UInt32 const MenuCellIdMin = 1;
             self.waitingUpdateMenuCells = @[];
         }
     }
-}
-
-- (BOOL)openMenu {
-    if ([SDLGlobals.sharedGlobals.rpcVersion isLessThanVersion:[[SDLVersion alloc] initWithMajor:6 minor:0 patch:0]]) {
-        SDLLogE(@"The openMenu method is not supported on this head unit.");
-        return NO;
-    }
-
-    SDLShowAppMenu *openMenu = [[SDLShowAppMenu alloc] init];
-
-    [self.connectionManager sendConnectionRequest:openMenu withResponseHandler:^(__kindof SDLRPCRequest * _Nullable request, __kindof SDLRPCResponse * _Nullable response, NSError * _Nullable error) {
-        if (error != nil) {
-            SDLLogE(@"Error opening application menu: %@", error);
-        }
-    }];
-
-    return YES;
-}
-
-- (BOOL)openSubmenu:(SDLMenuCell *)cell {
-    if (cell.subCells.count == 0) {
-        SDLLogE(@"The cell %@ does not contain any sub cells, so no submenu can be opened", cell);
-        return NO;
-    } else if ([SDLGlobals.sharedGlobals.rpcVersion isLessThanVersion:[[SDLVersion alloc] initWithMajor:6 minor:0 patch:0]]) {
-        SDLLogE(@"The openSubmenu method is not supported on this head unit.");
-        return NO;
-    } else if (![self.menuCells containsObject:cell]) {
-        SDLLogE(@"This cell has not been sent to the head unit, so no submenu can be opened. Make sure that the cell exists in the SDLManager.menu array");
-        return NO;
-    }
-
-    SDLShowAppMenu *subMenu = [[SDLShowAppMenu alloc] initWithMenuID:cell.cellId];
-
-    [self.connectionManager sendConnectionRequest:subMenu withResponseHandler:^(__kindof SDLRPCRequest * _Nullable request, __kindof SDLRPCResponse * _Nullable response, NSError * _Nullable error) {
-        if (error != nil) {
-            SDLLogE(@"Error opening application to submenu cell: %@, with error: %@", cell, error);
-        }
-    }];
-
-    return YES;
 }
 
 @end

--- a/SmartDeviceLink/SDLOnHMIStatus.h
+++ b/SmartDeviceLink/SDLOnHMIStatus.h
@@ -51,6 +51,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (strong, nonatomic, nullable) NSNumber<SDLUInt> *windowID;
 
+/// Initialize an SDLOnHMIStatus RPC with initial parameters
+/// @param hmiLevel The HMI level
+/// @param systemContext The system context
+/// @param audioStreamingState The ability for an audio app to be heard
+/// @param videoStreamingState The ability for a video straming app to stream
+/// @param windowID Which window this status relates to
+- (instancetype)initWithHMILevel:(SDLHMILevel)hmiLevel systemContext:(SDLSystemContext)systemContext audioStreamingState:(SDLAudioStreamingState)audioStreamingState videoStreamingState:(nullable SDLVideoStreamingState)videoStreamingState windowID:(nullable NSNumber<SDLUInt> *)windowID;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLOnHMIStatus.m
+++ b/SmartDeviceLink/SDLOnHMIStatus.m
@@ -23,6 +23,19 @@ NS_ASSUME_NONNULL_BEGIN
 }
 #pragma clang diagnostic pop
 
+- (instancetype)initWithHMILevel:(SDLHMILevel)hmiLevel systemContext:(SDLSystemContext)systemContext audioStreamingState:(SDLAudioStreamingState)audioStreamingState videoStreamingState:(nullable SDLVideoStreamingState)videoStreamingState windowID:(nullable NSNumber<SDLUInt> *)windowID {
+    self = [self init];
+    if (!self) { return nil; }
+
+    self.hmiLevel = hmiLevel;
+    self.systemContext = systemContext;
+    self.audioStreamingState = audioStreamingState;
+    self.videoStreamingState = videoStreamingState;
+    self.windowID = windowID;
+
+    return self;
+}
+
 - (void)setHmiLevel:(SDLHMILevel)hmiLevel {
     [self.parameters sdl_setObject:hmiLevel forName:SDLRPCParameterNameHMILevel];
 }

--- a/SmartDeviceLink/SDLPreloadChoicesOperation.h
+++ b/SmartDeviceLink/SDLPreloadChoicesOperation.h
@@ -29,7 +29,7 @@ typedef NS_ENUM(NSUInteger, SDLPreloadChoicesOperationState) {
 
 @property (assign, nonatomic) SDLPreloadChoicesOperationState currentState;
 
-- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager fileManager:(SDLFileManager *)fileManager displayName:(NSString *)displayName defaultMainWindowCapability:(SDLWindowCapability *)defaultMainWindowCapability isVROptional:(BOOL)isVROptional cellsToPreload:(NSSet<SDLChoiceCell *> *)cells;
+- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager fileManager:(SDLFileManager *)fileManager displayName:(NSString *)displayName windowCapability:(SDLWindowCapability *)defaultMainWindowCapability isVROptional:(BOOL)isVROptional cellsToPreload:(NSSet<SDLChoiceCell *> *)cells;
 
 - (BOOL)removeChoicesFromUpload:(NSSet<SDLChoiceCell *> *)choices;
 

--- a/SmartDeviceLink/SDLPreloadChoicesOperation.m
+++ b/SmartDeviceLink/SDLPreloadChoicesOperation.m
@@ -165,27 +165,51 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     NSString *menuName = nil;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    if ([self.displayName isEqualToString:SDLDisplayTypeGen38Inch] || [self.defaultMainWindowCapability hasTextFieldOfName:SDLTextFieldNameMenuName]) {
+    if ([self sdl_shouldSendChoiceText]) {
         menuName = cell.text;
     }
-#pragma clang diagnostic pop
 
     if(!menuName) {
         SDLLogE(@"Could not convert SDLChoiceCell to SDLCreateInteractionChoiceSet. It will not be shown. Cell: %@", cell);
         return nil;
     }
     
-    NSString *secondaryText = [self.defaultMainWindowCapability hasTextFieldOfName:SDLTextFieldNameSecondaryText] ? cell.secondaryText : nil;
-    NSString *tertiaryText = [self.defaultMainWindowCapability hasTextFieldOfName:SDLTextFieldNameTertiaryText] ? cell.tertiaryText : nil;
+    NSString *secondaryText = [self sdl_shouldSendChoiceSecondaryText] ? cell.secondaryText : nil;
+    NSString *tertiaryText = [self sdl_shouldSendChoiceTertiaryText] ? cell.tertiaryText : nil;
 
-    SDLImage *image = ([self.defaultMainWindowCapability hasImageFieldOfName:SDLImageFieldNameChoiceImage] && cell.artwork != nil) ? cell.artwork.imageRPC : nil;
-    SDLImage *secondaryImage = ([self.defaultMainWindowCapability hasImageFieldOfName:SDLImageFieldNameChoiceSecondaryImage] && cell.secondaryArtwork != nil) ? cell.secondaryArtwork.imageRPC : nil;
+    SDLImage *image = [self sdl_shouldSendChoicePrimaryImage] ? cell.artwork.imageRPC : nil;
+    SDLImage *secondaryImage = [self sdl_shouldSendChoiceSecondaryImage] ? cell.secondaryArtwork.imageRPC : nil;
 
     SDLChoice *choice = [[SDLChoice alloc] initWithId:cell.choiceId menuName:(NSString *_Nonnull)menuName vrCommands:(NSArray<NSString *> * _Nonnull)vrCommands image:image secondaryText:secondaryText secondaryImage:secondaryImage tertiaryText:tertiaryText];
 
     return [[SDLCreateInteractionChoiceSet alloc] initWithId:(UInt32)choice.choiceID.unsignedIntValue choiceSet:@[choice]];
+}
+
+- (BOOL)sdl_shouldSendChoiceText {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    if ([self.displayName isEqualToString:SDLDisplayTypeGen38Inch]) {
+        return YES;
+    }
+#pragma clang diagnostic pop
+
+    return (self.defaultMainWindowCapability.textFields != nil) ? [self.defaultMainWindowCapability hasTextFieldOfName:SDLTextFieldNameMenuName] : YES;
+}
+
+- (BOOL)sdl_shouldSendChoiceSecondaryText {
+    return (self.defaultMainWindowCapability.textFields != nil) ? [self.defaultMainWindowCapability hasTextFieldOfName:SDLTextFieldNameSecondaryText] : YES;
+}
+
+- (BOOL)sdl_shouldSendChoiceTertiaryText {
+    return (self.defaultMainWindowCapability.textFields != nil) ? [self.defaultMainWindowCapability hasTextFieldOfName:SDLTextFieldNameTertiaryText] : YES;
+}
+
+- (BOOL)sdl_shouldSendChoicePrimaryImage {
+    return (self.defaultMainWindowCapability.imageFields != nil) ? [self.defaultMainWindowCapability hasImageFieldOfName:SDLImageFieldNameChoiceImage] : YES;
+}
+
+- (BOOL)sdl_shouldSendChoiceSecondaryImage {
+    return (self.defaultMainWindowCapability.imageFields != nil) ? [self.defaultMainWindowCapability hasImageFieldOfName:SDLImageFieldNameChoiceSecondaryImage] : YES;
 }
 
 #pragma mark - Property Overrides

--- a/SmartDeviceLink/SDLPreloadChoicesOperation.m
+++ b/SmartDeviceLink/SDLPreloadChoicesOperation.m
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (strong, nonatomic) NSUUID *operationId;
 @property (strong, nonatomic) NSMutableSet<SDLChoiceCell *> *cellsToUpload;
-@property (strong, nonatomic) SDLWindowCapability *defaultMainWindowCapability;
+@property (strong, nonatomic) SDLWindowCapability *windowCapability;
 @property (strong, nonatomic) NSString *displayName;
 @property (assign, nonatomic, getter=isVROptional) BOOL vrOptional;
 
@@ -45,14 +45,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLPreloadChoicesOperation
 
-- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager fileManager:(SDLFileManager *)fileManager displayName:(NSString *)displayName defaultMainWindowCapability:(SDLWindowCapability *)defaultMainWindowCapability isVROptional:(BOOL)isVROptional cellsToPreload:(NSSet<SDLChoiceCell *> *)cells {
+- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager fileManager:(SDLFileManager *)fileManager displayName:(NSString *)displayName windowCapability:(SDLWindowCapability *)defaultMainWindowCapability isVROptional:(BOOL)isVROptional cellsToPreload:(NSSet<SDLChoiceCell *> *)cells {
     self = [super init];
     if (!self) { return nil; }
 
     _connectionManager = connectionManager;
     _fileManager = fileManager;
     _displayName = displayName;
-    _defaultMainWindowCapability = defaultMainWindowCapability;
+    _windowCapability = defaultMainWindowCapability;
     _vrOptional = isVROptional;
     _cellsToUpload = [cells mutableCopy];
     _operationId = [NSUUID UUID];
@@ -87,11 +87,11 @@ NS_ASSUME_NONNULL_BEGIN
 
     NSMutableArray<SDLArtwork *> *artworksToUpload = [NSMutableArray arrayWithCapacity:self.cellsToUpload.count];
     for (SDLChoiceCell *cell in self.cellsToUpload) {
-        if ([self.defaultMainWindowCapability hasImageFieldOfName:SDLImageFieldNameChoiceImage]
+        if ([self.windowCapability hasImageFieldOfName:SDLImageFieldNameChoiceImage]
             && [self sdl_artworkNeedsUpload:cell.artwork]) {
             [artworksToUpload addObject:cell.artwork];
         }
-        if ([self.defaultMainWindowCapability hasImageFieldOfName:SDLImageFieldNameChoiceSecondaryImage]
+        if ([self.windowCapability hasImageFieldOfName:SDLImageFieldNameChoiceSecondaryImage]
             && [self sdl_artworkNeedsUpload:cell.secondaryArtwork]) {
             [artworksToUpload addObject:cell.secondaryArtwork];
         }
@@ -193,23 +193,23 @@ NS_ASSUME_NONNULL_BEGIN
     }
 #pragma clang diagnostic pop
 
-    return (self.defaultMainWindowCapability.textFields != nil) ? [self.defaultMainWindowCapability hasTextFieldOfName:SDLTextFieldNameMenuName] : YES;
+    return (self.windowCapability.textFields != nil) ? [self.windowCapability hasTextFieldOfName:SDLTextFieldNameMenuName] : YES;
 }
 
 - (BOOL)sdl_shouldSendChoiceSecondaryText {
-    return (self.defaultMainWindowCapability.textFields != nil) ? [self.defaultMainWindowCapability hasTextFieldOfName:SDLTextFieldNameSecondaryText] : YES;
+    return (self.windowCapability.textFields != nil) ? [self.windowCapability hasTextFieldOfName:SDLTextFieldNameSecondaryText] : YES;
 }
 
 - (BOOL)sdl_shouldSendChoiceTertiaryText {
-    return (self.defaultMainWindowCapability.textFields != nil) ? [self.defaultMainWindowCapability hasTextFieldOfName:SDLTextFieldNameTertiaryText] : YES;
+    return (self.windowCapability.textFields != nil) ? [self.windowCapability hasTextFieldOfName:SDLTextFieldNameTertiaryText] : YES;
 }
 
 - (BOOL)sdl_shouldSendChoicePrimaryImage {
-    return (self.defaultMainWindowCapability.imageFields != nil) ? [self.defaultMainWindowCapability hasImageFieldOfName:SDLImageFieldNameChoiceImage] : YES;
+    return (self.windowCapability.imageFields != nil) ? [self.windowCapability hasImageFieldOfName:SDLImageFieldNameChoiceImage] : YES;
 }
 
 - (BOOL)sdl_shouldSendChoiceSecondaryImage {
-    return (self.defaultMainWindowCapability.imageFields != nil) ? [self.defaultMainWindowCapability hasImageFieldOfName:SDLImageFieldNameChoiceSecondaryImage] : YES;
+    return (self.windowCapability.imageFields != nil) ? [self.windowCapability hasImageFieldOfName:SDLImageFieldNameChoiceSecondaryImage] : YES;
 }
 
 #pragma mark - Property Overrides

--- a/SmartDeviceLink/SDLSoftButtonManager.m
+++ b/SmartDeviceLink/SDLSoftButtonManager.m
@@ -140,7 +140,7 @@ NS_ASSUME_NONNULL_BEGIN
     _softButtonObjects = softButtonObjects;
 
     // We assume that all soft button capabilities are the same, so we only need to send one
-    SDLSoftButtonReplaceOperation *op = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:self.connectionManager fileManager:self.fileManager capabilities:self.windowCapability.softButtonCapabilities[0] softButtonObjects:_softButtonObjects mainField1:self.currentMainField1];
+    SDLSoftButtonReplaceOperation *op = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:self.connectionManager fileManager:self.fileManager capabilities:self.windowCapability.softButtonCapabilities.firstObject softButtonObjects:_softButtonObjects mainField1:self.currentMainField1];
 
     if (self.isBatchingUpdates) {
         [self.batchQueue removeAllObjects];

--- a/SmartDeviceLink/SDLSoftButtonManager.m
+++ b/SmartDeviceLink/SDLSoftButtonManager.m
@@ -221,10 +221,10 @@ NS_ASSUME_NONNULL_BEGIN
         SDLDisplayCapability *mainDisplay = capabilities[0];
         for (SDLWindowCapability *windowCapability in mainDisplay.windowCapabilities) {
             NSUInteger currentWindowID = windowCapability.windowID != nil ? windowCapability.windowID.unsignedIntegerValue : SDLPredefinedWindowsDefaultWindow;
-            if (currentWindowID == SDLPredefinedWindowsDefaultWindow) {
-                self.softButtonCapabilities = windowCapability.softButtonCapabilities.firstObject;
-                break;
-            }
+            if (currentWindowID != SDLPredefinedWindowsDefaultWindow) { continue; }
+            
+            self.softButtonCapabilities = windowCapability.softButtonCapabilities.firstObject;
+            break;
         }
     }
 

--- a/SmartDeviceLink/SDLSoftButtonManager.m
+++ b/SmartDeviceLink/SDLSoftButtonManager.m
@@ -100,6 +100,8 @@ NS_ASSUME_NONNULL_BEGIN
     return queue;
 }
 
+/// Suspend the queue if the soft button capabilities are nil or there are no capability objects in the array (we assume that soft buttons are not supported)
+/// OR if the HMI level is NONE since we want to delay sending RPCs until we're in non-NONE
 - (void)sdl_updateTransactionQueueSuspended {
     if (self.windowCapability.softButtonCapabilities == nil
         || self.windowCapability.softButtonCapabilities.count == 0

--- a/SmartDeviceLink/SDLSoftButtonManager.m
+++ b/SmartDeviceLink/SDLSoftButtonManager.m
@@ -101,7 +101,9 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)sdl_updateTransactionQueueSuspended {
-    if (self.windowCapability.softButtonCapabilities == nil || self.windowCapability.softButtonCapabilities.count == 0 || [self.currentLevel isEqualToEnum:SDLHMILevelNone]) {
+    if (self.windowCapability.softButtonCapabilities == nil
+        || self.windowCapability.softButtonCapabilities.count == 0
+        || [self.currentLevel isEqualToEnum:SDLHMILevelNone]) {
         self.transactionQueue.suspended = YES;
     } else {
         self.transactionQueue.suspended = NO;

--- a/SmartDeviceLink/SDLSoftButtonManager.m
+++ b/SmartDeviceLink/SDLSoftButtonManager.m
@@ -104,8 +104,10 @@ NS_ASSUME_NONNULL_BEGIN
 /// OR if the HMI level is NONE since we want to delay sending RPCs until we're in non-NONE
 - (void)sdl_updateTransactionQueueSuspended {
     if (self.softButtonCapabilities == nil || [self.currentLevel isEqualToEnum:SDLHMILevelNone]) {
+        SDLLogD(@"Suspending the transaction queue. Current HMI level is NONE: %@, soft button capabilities are nil: %@", ([self.currentLevel isEqualToEnum:SDLHMILevelNone] ? @"YES" : @"NO"), (self.softButtonCapabilities == nil ? @"YES" : @"NO"));
         self.transactionQueue.suspended = YES;
     } else {
+        SDLLogD(@"Starting the transaction queue");
         self.transactionQueue.suspended = NO;
     }
 }

--- a/SmartDeviceLink/SDLSoftButtonReplaceOperation.h
+++ b/SmartDeviceLink/SDLSoftButtonReplaceOperation.h
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param mainField1 The primary text field of the system template
  @return The operation
  */
-- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager fileManager:(SDLFileManager *)fileManager capabilities:(SDLSoftButtonCapabilities *)capabilities softButtonObjects:(NSArray<SDLSoftButtonObject *> *)softButtonObjects mainField1:(NSString *)mainField1;
+- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager fileManager:(SDLFileManager *)fileManager capabilities:(nullable SDLSoftButtonCapabilities *)capabilities softButtonObjects:(NSArray<SDLSoftButtonObject *> *)softButtonObjects mainField1:(NSString *)mainField1;
 
 @end
 

--- a/SmartDeviceLink/SDLSoftButtonReplaceOperation.m
+++ b/SmartDeviceLink/SDLSoftButtonReplaceOperation.m
@@ -273,7 +273,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (BOOL)sdl_supportsSoftButtonImages {
-    return self.softButtonCapabilities ? self.softButtonCapabilities.imageSupported.boolValue : NO;
+    return (self.softButtonCapabilities != nil) ? self.softButtonCapabilities.imageSupported.boolValue : NO;
 }
 
 #pragma mark - Property Overrides

--- a/SmartDeviceLink/SDLSoftButtonReplaceOperation.m
+++ b/SmartDeviceLink/SDLSoftButtonReplaceOperation.m
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SDLSoftButtonReplaceOperation ()
 
-@property (strong, nonatomic) SDLSoftButtonCapabilities *softButtonCapabilities;
+@property (strong, nonatomic, nullable) SDLSoftButtonCapabilities *softButtonCapabilities;
 @property (strong, nonatomic) NSArray<SDLSoftButtonObject *> *softButtonObjects;
 
 @property (weak, nonatomic) id<SDLConnectionManagerType> connectionManager;

--- a/SmartDeviceLink/SDLSoftButtonReplaceOperation.m
+++ b/SmartDeviceLink/SDLSoftButtonReplaceOperation.m
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLSoftButtonReplaceOperation
 
-- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager fileManager:(SDLFileManager *)fileManager capabilities:(SDLSoftButtonCapabilities *)capabilities softButtonObjects:(NSArray<SDLSoftButtonObject *> *)softButtonObjects mainField1:(NSString *)mainField1 {
+- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager fileManager:(SDLFileManager *)fileManager capabilities:(nullable SDLSoftButtonCapabilities *)capabilities softButtonObjects:(NSArray<SDLSoftButtonObject *> *)softButtonObjects mainField1:(NSString *)mainField1 {
     self = [super init];
     if (!self) { return nil; }
 

--- a/SmartDeviceLink/SDLSoftButtonReplaceOperation.m
+++ b/SmartDeviceLink/SDLSoftButtonReplaceOperation.m
@@ -273,7 +273,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (BOOL)sdl_supportsSoftButtonImages {
-    return (self.softButtonCapabilities != nil) ? self.softButtonCapabilities.imageSupported.boolValue : NO;
+    return self.softButtonCapabilities.imageSupported.boolValue;
 }
 
 #pragma mark - Property Overrides

--- a/SmartDeviceLink/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.m
@@ -779,7 +779,6 @@ typedef NSString * SDLServiceID;
     [self sdl_callObserversForUpdate:systemCapability error:nil handler:nil];
 }
 
-
 /**
  *  Called when an `OnSystemCapabilityUpdated` notification is received from Core. The updated system capabilty is saved.
  *

--- a/SmartDeviceLink/SDLTextAndGraphicManager.m
+++ b/SmartDeviceLink/SDLTextAndGraphicManager.m
@@ -286,15 +286,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (SDLShow *)sdl_assembleShowText:(SDLShow *)show {
     [self sdl_setBlankTextFieldsWithShow:show];
 
-    BOOL canShowMediaField = (self.windowCapability.textFields != nil) ? [self.windowCapability hasTextFieldOfName:SDLTextFieldNameMediaTrack] : YES;
-    if (self.mediaTrackTextField != nil && canShowMediaField) {
+    if (self.mediaTrackTextField != nil && [self sdl_shouldUpdateMediaTextField]) {
         show.mediaTrack = self.mediaTrackTextField;
     } else {
         show.mediaTrack = @"";
     }
 
-    BOOL canShowTitle = (self.windowCapability.textFields != nil) ? [self.windowCapability hasTextFieldOfName:SDLTextFieldNameTemplateTitle] : YES;
-    if (self.title != nil && canShowTitle) {
+    if (self.title != nil && [self sdl_shouldUpdateTitleField]) {
         show.templateTitle = self.title;
     } else {
         show.templateTitle = @"";
@@ -530,6 +528,14 @@ NS_ASSUME_NONNULL_BEGIN
             && self.secondaryGraphic != nil);
 }
 
+- (BOOL)sdl_shouldUpdateMediaTextField {
+    return (self.windowCapability.textFields != nil) ? [self.windowCapability hasTextFieldOfName:SDLTextFieldNameMediaTrack] : YES;
+}
+
+- (BOOL)sdl_shouldUpdateTitleField {
+    return (self.windowCapability.textFields != nil) ? [self.windowCapability hasTextFieldOfName:SDLTextFieldNameTemplateTitle] : YES;
+}
+
 - (NSArray<NSString *> *)sdl_findNonNilTextFields {
     NSMutableArray *array = [NSMutableArray array];
     self.textField1.length > 0 ? [array addObject:self.textField1] : nil;
@@ -551,7 +557,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (BOOL)sdl_hasData {
-    BOOL hasTextFields = ([self sdl_findNonNilTextFields].count > 0);
+    BOOL hasTextFields = ([self sdl_findNonNilTextFields].count > 0) || (self.title.length > 0) || (self.mediaTrackTextField.length > 0);
     BOOL hasImageFields = (self.primaryGraphic != nil) || (self.secondaryGraphic != nil);
 
     return hasTextFields || hasImageFields;

--- a/SmartDeviceLink/SDLTextAndGraphicManager.m
+++ b/SmartDeviceLink/SDLTextAndGraphicManager.m
@@ -286,13 +286,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (SDLShow *)sdl_assembleShowText:(SDLShow *)show {
     [self sdl_setBlankTextFieldsWithShow:show];
 
-    if (self.mediaTrackTextField != nil) {
+    BOOL canShowMediaField = (self.windowCapability.textFields != nil) ? [self.windowCapability hasTextFieldOfName:SDLTextFieldNameMediaTrack] : YES;
+    if (self.mediaTrackTextField != nil && canShowMediaField) {
         show.mediaTrack = self.mediaTrackTextField;
     } else {
         show.mediaTrack = @"";
     }
 
-    if (self.title != nil) {
+    BOOL canShowTitle = (self.windowCapability.textFields != nil) ? [self.windowCapability hasTextFieldOfName:SDLTextFieldNameTemplateTitle] : YES;
+    if (self.title != nil && canShowTitle) {
         show.templateTitle = self.title;
     } else {
         show.templateTitle = @"";
@@ -301,7 +303,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSArray *nonNilFields = [self sdl_findNonNilTextFields];
     if (nonNilFields.count == 0) { return show; }
 
-    NSUInteger numberOfLines = self.windowCapability ? self.windowCapability.maxNumberOfMainFieldLines : 4;
+    NSUInteger numberOfLines = (self.windowCapability.textFields != nil) ? self.windowCapability.maxNumberOfMainFieldLines : 4;
     if (numberOfLines == 1) {
         show = [self sdl_assembleOneLineShowText:show withShowFields:nonNilFields];
     } else if (numberOfLines == 2) {
@@ -512,7 +514,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (BOOL)sdl_shouldUpdatePrimaryImage {
-    BOOL templateSupportsPrimaryArtwork = self.windowCapability ? [self.windowCapability hasImageFieldOfName:SDLImageFieldNameGraphic] : YES;
+    BOOL templateSupportsPrimaryArtwork = (self.windowCapability.imageFields != nil) ? [self.windowCapability hasImageFieldOfName:SDLImageFieldNameGraphic] : YES;
 
     return (templateSupportsPrimaryArtwork
             && ![self.currentScreenData.graphic.value isEqualToString:self.primaryGraphic.name]
@@ -520,7 +522,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (BOOL)sdl_shouldUpdateSecondaryImage {
-    BOOL templateSupportsSecondaryArtwork = self.windowCapability ? ([self.windowCapability hasImageFieldOfName:SDLImageFieldNameGraphic] || [self.windowCapability hasImageFieldOfName:SDLImageFieldNameSecondaryGraphic]) : YES;
+    BOOL templateSupportsSecondaryArtwork = (self.windowCapability.imageFields != nil) ? ([self.windowCapability hasImageFieldOfName:SDLImageFieldNameGraphic] || [self.windowCapability hasImageFieldOfName:SDLImageFieldNameSecondaryGraphic]) : YES;
 
     // Cannot detect if there is a secondary image, so we'll just try to detect if there's a primary image and allow it if there is.
     return (templateSupportsSecondaryArtwork

--- a/SmartDeviceLink/SDLTextField.h
+++ b/SmartDeviceLink/SDLTextField.h
@@ -48,6 +48,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (strong, nonatomic) NSNumber<SDLInt> *rows;
 
+/// Convenience initalizer for the TextField RPC struct
+/// @param name The name identifying this text field
+/// @param characterSet The character set of this text field
+/// @param width The number of characters per row allowed in this text field
+/// @param rows The number of rows allowed in this text field, deliniated by a newline character "\n"
+- (instancetype)initWithName:(SDLTextFieldName)name characterSet:(SDLCharacterSet)characterSet width:(NSUInteger)width rows:(NSUInteger)rows;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLTextField.h
+++ b/SmartDeviceLink/SDLTextField.h
@@ -52,7 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param name The name identifying this text field
 /// @param characterSet The character set of this text field
 /// @param width The number of characters per row allowed in this text field
-/// @param rows The number of rows allowed in this text field, deliniated by a newline character "\n"
+/// @param rows The number of rows allowed in this text field
 - (instancetype)initWithName:(SDLTextFieldName)name characterSet:(SDLCharacterSet)characterSet width:(NSUInteger)width rows:(NSUInteger)rows;
 
 @end

--- a/SmartDeviceLink/SDLTextField.m
+++ b/SmartDeviceLink/SDLTextField.m
@@ -48,6 +48,18 @@ NS_ASSUME_NONNULL_BEGIN
     return [self.store sdl_objectForName:SDLRPCParameterNameRows ofClass:NSNumber.class error:&error];
 }
 
+- (instancetype)initWithName:(SDLTextFieldName)name characterSet:(SDLCharacterSet)characterSet width:(NSUInteger)width rows:(NSUInteger)rows {
+    self = [self init];
+    if (!self) { return nil; }
+
+    self.name = name;
+    self.characterSet = characterSet;
+    self.width = @(width);
+    self.rows = @(rows);
+
+    return self;
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLChoiceSetManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLChoiceSetManagerSpec.m
@@ -119,7 +119,6 @@ describe(@"choice set manager tests", ^{
             beforeEach(^{
                 testManager.transactionQueue.suspended = YES;
                 testManager.currentHMILevel = SDLHMILevelFull;
-                testManager.currentSystemContext = SDLSystemContextMain;
                 testManager.currentWindowCapability = enabledWindowCapability;
             });
 
@@ -133,20 +132,10 @@ describe(@"choice set manager tests", ^{
                 expect(testManager.transactionQueue.isSuspended).to(beFalse());
             });
 
-            it(@"should enable the queue when entering SystemContext Main", ^{
-                testManager.currentSystemContext = SDLSystemContextAlert;
-
-                SDLOnHMIStatus *newHMIStatus = [[SDLOnHMIStatus alloc] initWithHMILevel:SDLHMILevelFull systemContext:SDLSystemContextMain audioStreamingState:SDLAudioStreamingStateNotAudible videoStreamingState:nil windowID:@0];
-                SDLRPCNotificationNotification *notification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidChangeHMIStatusNotification object:nil rpcNotification:newHMIStatus];
-                [testManager sdl_hmiStatusNotification:notification];
-
-                expect(testManager.transactionQueue.isSuspended).to(beFalse());
-            });
-
             it(@"should enable the queue when receiving a good window capability", ^{
                 testManager.currentWindowCapability = disabledWindowCapability;
 
-                SDLDisplayCapability *displayCapability = [[SDLDisplayCapability alloc] initWithDisplayName:@"TEST" windowTypeSupported:nil windowCapabilities:@[enabledWindowCapability]];
+                SDLDisplayCapability *displayCapability = [[SDLDisplayCapability alloc] initWithDisplayName:@"TEST" windowCapabilities:@[enabledWindowCapability] windowTypeSupported:nil];
                 [testManager sdl_displayCapabilityDidUpdate:[[SDLSystemCapability alloc] initWithDisplayCapabilities:@[displayCapability]]];
 
                 expect(testManager.transactionQueue.isSuspended).to(beFalse());
@@ -157,7 +146,6 @@ describe(@"choice set manager tests", ^{
             beforeEach(^{
                 testManager.transactionQueue.suspended = NO;
                 testManager.currentHMILevel = SDLHMILevelFull;
-                testManager.currentSystemContext = SDLSystemContextMain;
                 testManager.currentWindowCapability = enabledWindowCapability;
             });
 
@@ -169,31 +157,15 @@ describe(@"choice set manager tests", ^{
                 expect(testManager.transactionQueue.isSuspended).to(beTrue());
             });
 
-            it(@"should suspend the queue when entering SystemContext Alert", ^{
-                SDLOnHMIStatus *newHMIStatus = [[SDLOnHMIStatus alloc] initWithHMILevel:SDLHMILevelFull systemContext:SDLSystemContextAlert audioStreamingState:SDLAudioStreamingStateNotAudible videoStreamingState:nil windowID:@0];
-                SDLRPCNotificationNotification *notification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidChangeHMIStatusNotification object:nil rpcNotification:newHMIStatus];
-                [testManager sdl_hmiStatusNotification:notification];
-
-                expect(testManager.transactionQueue.isSuspended).to(beTrue());
-            });
-
-            it(@"should suspend the queue when entering SystemContext HMIObscured", ^{
-                SDLOnHMIStatus *newHMIStatus = [[SDLOnHMIStatus alloc] initWithHMILevel:SDLHMILevelFull systemContext:SDLSystemContextHMIObscured audioStreamingState:SDLAudioStreamingStateNotAudible videoStreamingState:nil windowID:@0];
-                SDLRPCNotificationNotification *notification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidChangeHMIStatusNotification object:nil rpcNotification:newHMIStatus];
-                [testManager sdl_hmiStatusNotification:notification];
-
-                expect(testManager.transactionQueue.isSuspended).to(beTrue());
-            });
-
             it(@"should suspend the queue when receiving a bad display capability", ^{
-                SDLDisplayCapability *displayCapability = [[SDLDisplayCapability alloc] initWithDisplayName:@"TEST" windowTypeSupported:nil windowCapabilities:@[disabledWindowCapability]];
+                SDLDisplayCapability *displayCapability = [[SDLDisplayCapability alloc] initWithDisplayName:@"TEST" windowCapabilities:@[disabledWindowCapability] windowTypeSupported:nil];
                 [testManager sdl_displayCapabilityDidUpdate:[[SDLSystemCapability alloc] initWithDisplayCapabilities:@[displayCapability]]];
 
                 expect(testManager.transactionQueue.isSuspended).to(beTrue());
             });
 
             it(@"should not suspend the queue when receiving an empty display capability", ^{
-                SDLDisplayCapability *displayCapability = [[SDLDisplayCapability alloc] initWithDisplayName:@"TEST" windowTypeSupported:nil windowCapabilities:@[blankWindowCapability]];
+                SDLDisplayCapability *displayCapability = [[SDLDisplayCapability alloc] initWithDisplayName:@"TEST" windowCapabilities:@[blankWindowCapability] windowTypeSupported:nil];
                 [testManager sdl_displayCapabilityDidUpdate:[[SDLSystemCapability alloc] initWithDisplayCapabilities:@[displayCapability]]];
 
                 expect(testManager.transactionQueue.isSuspended).to(beTrue());

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLChoiceSetManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLChoiceSetManagerSpec.m
@@ -77,6 +77,7 @@ describe(@"choice set manager tests", ^{
 
     __block SDLWindowCapability *enabledWindowCapability = nil;
     __block SDLWindowCapability *disabledWindowCapability = nil;
+    __block SDLWindowCapability *blankWindowCapability = nil;
 
     __block SDLChoiceCell *testCell1 = nil;
     __block SDLChoiceCell *testCell2 = nil;
@@ -96,6 +97,8 @@ describe(@"choice set manager tests", ^{
         enabledWindowCapability = [[SDLWindowCapability alloc] init];
         enabledWindowCapability.textFields = @[[[SDLTextField alloc] initWithName:SDLTextFieldNameMenuName characterSet:SDLCharacterSetType5 width:500 rows:1]];
         disabledWindowCapability = [[SDLWindowCapability alloc] init];
+        disabledWindowCapability.textFields = @[];
+        blankWindowCapability = [[SDLWindowCapability alloc] init];
     });
 
     it(@"should be in the correct startup state", ^{
@@ -105,7 +108,7 @@ describe(@"choice set manager tests", ^{
         expect(testManager.keyboardConfiguration).to(equal(defaultProperties));
     });
 
-    describe(@"receiving an HMI status update", ^{
+    fdescribe(@"receiving an HMI status update", ^{
         __block SDLOnHMIStatus *newStatus = nil;
         beforeEach(^{
             newStatus = [[SDLOnHMIStatus alloc] init];
@@ -183,6 +186,13 @@ describe(@"choice set manager tests", ^{
 
             it(@"should suspend the queue when receiving a bad display capability", ^{
                 SDLDisplayCapability *displayCapability = [[SDLDisplayCapability alloc] initWithDisplayName:@"TEST" windowTypeSupported:nil windowCapabilities:@[disabledWindowCapability]];
+                [testManager sdl_displayCapabilityDidUpdate:[[SDLSystemCapability alloc] initWithDisplayCapabilities:@[displayCapability]]];
+
+                expect(testManager.transactionQueue.isSuspended).to(beTrue());
+            });
+
+            it(@"should not suspend the queue when receiving an empty display capability", ^{
+                SDLDisplayCapability *displayCapability = [[SDLDisplayCapability alloc] initWithDisplayName:@"TEST" windowTypeSupported:nil windowCapabilities:@[blankWindowCapability]];
                 [testManager sdl_displayCapabilityDidUpdate:[[SDLSystemCapability alloc] initWithDisplayCapabilities:@[displayCapability]]];
 
                 expect(testManager.transactionQueue.isSuspended).to(beTrue());

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLChoiceSetManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLChoiceSetManagerSpec.m
@@ -99,6 +99,7 @@ describe(@"choice set manager tests", ^{
         disabledWindowCapability = [[SDLWindowCapability alloc] init];
         disabledWindowCapability.textFields = @[];
         blankWindowCapability = [[SDLWindowCapability alloc] init];
+        blankWindowCapability.textFields = @[];
     });
 
     it(@"should be in the correct startup state", ^{
@@ -108,7 +109,7 @@ describe(@"choice set manager tests", ^{
         expect(testManager.keyboardConfiguration).to(equal(defaultProperties));
     });
 
-    fdescribe(@"receiving an HMI status update", ^{
+    describe(@"receiving an HMI status update", ^{
         __block SDLOnHMIStatus *newStatus = nil;
         beforeEach(^{
             newStatus = [[SDLOnHMIStatus alloc] init];

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLPreloadChoicesOperationSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLPreloadChoicesOperationSpec.m
@@ -80,7 +80,7 @@ describe(@"a preload choices operation", ^{
                     primaryTextField.name = SDLTextFieldNameMenuName;
                     windowCapability.textFields = @[];
 
-                    testOp = [[SDLPreloadChoicesOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager displayName:SDLDisplayTypeGeneric defaultMainWindowCapability:windowCapability isVROptional:NO cellsToPreload:cellsWithArtwork];
+                    testOp = [[SDLPreloadChoicesOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager displayName:SDLDisplayTypeGeneric windowCapability:windowCapability isVROptional:NO cellsToPreload:cellsWithArtwork];
                     [testOp start];
                 
                     NSArray<SDLCreateInteractionChoiceSet *> *receivedRequests = (NSArray<SDLCreateInteractionChoiceSet *> *)testConnectionManager.receivedRequests;
@@ -89,16 +89,16 @@ describe(@"a preload choices operation", ^{
                 });
             });
 
-            context(@"disallowed display capabilities", ^{
+            context(@"only main text capabilities", ^{
                 it(@"should skip to preloading cells", ^{
-                    testOp = [[SDLPreloadChoicesOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager displayName:SDLDisplayTypeGeneric defaultMainWindowCapability:windowCapability isVROptional:NO cellsToPreload:cellsWithArtwork];
+                    testOp = [[SDLPreloadChoicesOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager displayName:SDLDisplayTypeGeneric windowCapability:windowCapability isVROptional:NO cellsToPreload:cellsWithArtwork];
                     [testOp start];
 
                     expect(@(testOp.currentState)).to(equal(SDLPreloadChoicesOperationStatePreloadingChoices));
                 });
             });
 
-            context(@"mixed display capabilities", ^{
+            context(@"only main text and image capabilities", ^{
                 beforeEach(^{
                     SDLImageField *choiceField = [[SDLImageField alloc] init];
                     choiceField.name = SDLImageFieldNameChoiceImage;
@@ -106,7 +106,7 @@ describe(@"a preload choices operation", ^{
 
                     OCMStub([testFileManager hasUploadedFile:[OCMArg isNotNil]]).andReturn(NO);
 
-                    testOp = [[SDLPreloadChoicesOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager displayName:SDLDisplayTypeGeneric defaultMainWindowCapability:windowCapability isVROptional:NO cellsToPreload:cellsWithArtwork];
+                    testOp = [[SDLPreloadChoicesOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager displayName:SDLDisplayTypeGeneric windowCapability:windowCapability isVROptional:NO cellsToPreload:cellsWithArtwork];
                     [testOp start];
                 });
 
@@ -119,7 +119,7 @@ describe(@"a preload choices operation", ^{
                 });
             });
 
-            context(@"allowed display capabilities", ^{
+            context(@"main text and all image display capabilities", ^{
                 beforeEach(^{
                     SDLImageField *choiceField = [[SDLImageField alloc] init];
                     choiceField.name = SDLImageFieldNameChoiceImage;
@@ -133,7 +133,7 @@ describe(@"a preload choices operation", ^{
                     beforeEach(^{
                         OCMStub([testFileManager hasUploadedFile:[OCMArg isNotNil]]).andReturn(YES);
 
-                        testOp = [[SDLPreloadChoicesOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager displayName:SDLDisplayTypeGeneric defaultMainWindowCapability:windowCapability isVROptional:NO cellsToPreload:cellsWithArtwork];
+                        testOp = [[SDLPreloadChoicesOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager displayName:SDLDisplayTypeGeneric windowCapability:windowCapability isVROptional:NO cellsToPreload:cellsWithArtwork];
                         [testOp start];
                     });
 
@@ -148,7 +148,7 @@ describe(@"a preload choices operation", ^{
 
                 context(@"when artworks are static icons", ^{
                     beforeEach(^{
-                        testOp = [[SDLPreloadChoicesOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager displayName:SDLDisplayTypeGeneric defaultMainWindowCapability:windowCapability isVROptional:NO cellsToPreload:cellsWithStaticIcon];
+                        testOp = [[SDLPreloadChoicesOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager displayName:SDLDisplayTypeGeneric windowCapability:windowCapability isVROptional:NO cellsToPreload:cellsWithStaticIcon];
                         [testOp start];
                     });
 
@@ -161,7 +161,7 @@ describe(@"a preload choices operation", ^{
                     beforeEach(^{
                         OCMStub([testFileManager hasUploadedFile:[OCMArg isNotNil]]).andReturn(NO);
 
-                        testOp = [[SDLPreloadChoicesOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager displayName:SDLDisplayTypeGeneric defaultMainWindowCapability:windowCapability isVROptional:NO cellsToPreload:cellsWithArtwork];
+                        testOp = [[SDLPreloadChoicesOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager displayName:SDLDisplayTypeGeneric windowCapability:windowCapability isVROptional:NO cellsToPreload:cellsWithArtwork];
                         [testOp start];
                     });
 
@@ -191,7 +191,7 @@ describe(@"a preload choices operation", ^{
 
             describe(@"assembling choices", ^{
                 it(@"should be correct with no text and VR required", ^{
-                    testOp = [[SDLPreloadChoicesOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager displayName:SDLDisplayTypeGeneric defaultMainWindowCapability:windowCapability isVROptional:NO cellsToPreload:cellsWithoutArtwork];
+                    testOp = [[SDLPreloadChoicesOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager displayName:SDLDisplayTypeGeneric windowCapability:windowCapability isVROptional:NO cellsToPreload:cellsWithoutArtwork];
                     [testOp start];
                     NSArray<SDLCreateInteractionChoiceSet *> *receivedRequests = (NSArray<SDLCreateInteractionChoiceSet *> *)testConnectionManager.receivedRequests;
 
@@ -207,7 +207,7 @@ describe(@"a preload choices operation", ^{
                     primaryTextField.name = SDLTextFieldNameMenuName;
                     windowCapability.textFields = @[primaryTextField];
 
-                    testOp = [[SDLPreloadChoicesOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager displayName:SDLDisplayTypeGeneric defaultMainWindowCapability:windowCapability isVROptional:NO cellsToPreload:cellsWithoutArtwork];
+                    testOp = [[SDLPreloadChoicesOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager displayName:SDLDisplayTypeGeneric windowCapability:windowCapability isVROptional:NO cellsToPreload:cellsWithoutArtwork];
                     [testOp start];
 
                     NSArray<SDLCreateInteractionChoiceSet *> *receivedRequests = (NSArray<SDLCreateInteractionChoiceSet *> *)testConnectionManager.receivedRequests;
@@ -226,7 +226,7 @@ describe(@"a preload choices operation", ^{
                     secondaryTextField.name = SDLTextFieldNameSecondaryText;
                     windowCapability.textFields = @[primaryTextField, secondaryTextField];
 
-                    testOp = [[SDLPreloadChoicesOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager displayName:SDLDisplayTypeGeneric defaultMainWindowCapability:windowCapability isVROptional:NO cellsToPreload:cellsWithoutArtwork];
+                    testOp = [[SDLPreloadChoicesOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager displayName:SDLDisplayTypeGeneric windowCapability:windowCapability isVROptional:NO cellsToPreload:cellsWithoutArtwork];
                     [testOp start];
 
                     NSArray<SDLCreateInteractionChoiceSet *> *receivedRequests = (NSArray<SDLCreateInteractionChoiceSet *> *)testConnectionManager.receivedRequests;
@@ -247,7 +247,7 @@ describe(@"a preload choices operation", ^{
                     tertiaryTextField.name = SDLTextFieldNameTertiaryText;
                     windowCapability.textFields = @[primaryTextField, secondaryTextField, tertiaryTextField];
 
-                    testOp = [[SDLPreloadChoicesOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager displayName:SDLDisplayTypeGeneric defaultMainWindowCapability:windowCapability isVROptional:NO cellsToPreload:cellsWithoutArtwork];
+                    testOp = [[SDLPreloadChoicesOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager displayName:SDLDisplayTypeGeneric windowCapability:windowCapability isVROptional:NO cellsToPreload:cellsWithoutArtwork];
                     [testOp start];
 
                     NSArray<SDLCreateInteractionChoiceSet *> *receivedRequests = (NSArray<SDLCreateInteractionChoiceSet *> *)testConnectionManager.receivedRequests;
@@ -261,7 +261,7 @@ describe(@"a preload choices operation", ^{
 
                 it(@"should be correct with VR optional", ^{
 
-                    testOp = [[SDLPreloadChoicesOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager displayName:SDLDisplayTypeGeneric defaultMainWindowCapability:windowCapability isVROptional:YES cellsToPreload:cellsWithoutArtwork];
+                    testOp = [[SDLPreloadChoicesOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager displayName:SDLDisplayTypeGeneric windowCapability:windowCapability isVROptional:YES cellsToPreload:cellsWithoutArtwork];
                     [testOp start];
 
                     NSArray<SDLCreateInteractionChoiceSet *> *receivedRequests = (NSArray<SDLCreateInteractionChoiceSet *> *)testConnectionManager.receivedRequests;

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLSoftButtonManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLSoftButtonManagerSpec.m
@@ -40,7 +40,7 @@
 
 @property (strong, nonatomic) NSOperationQueue *transactionQueue;
 
-@property (strong, nonatomic, nullable, readwrite) SDLWindowCapability *windowCapability;
+@property (strong, nonatomic, nullable) SDLSoftButtonCapabilities *softButtonCapabilities;
 @property (copy, nonatomic, nullable) SDLHMILevel currentLevel;
 
 @property (strong, nonatomic) NSMutableArray<SDLAsynchronousOperation *> *batchQueue;
@@ -96,7 +96,7 @@ describe(@"a soft button manager", ^{
 
         SDLWindowCapability *windowCapability = [[SDLWindowCapability alloc] init];
         windowCapability.softButtonCapabilities = @[softButtonCapabilities];
-        SDLDisplayCapability *displayCapability = [[SDLDisplayCapability alloc] initWithDisplayName:@"TEST" windowTypeSupported:nil windowCapabilities:@[windowCapability]];
+        SDLDisplayCapability *displayCapability = [[SDLDisplayCapability alloc] initWithDisplayName:@"TEST" windowCapabilities:@[windowCapability] windowTypeSupported:nil];
         [testManager sdl_displayCapabilityDidUpdate:[[SDLSystemCapability alloc] initWithDisplayCapabilities:@[displayCapability]]];
     });
 
@@ -108,7 +108,7 @@ describe(@"a soft button manager", ^{
         expect(testManager.currentMainField1).to(beNil());
         expect(testManager.transactionQueue).toNot(beNil());
         expect(testManager.transactionQueue.isSuspended).to(beFalse());
-        expect(testManager.windowCapability).toNot(beNil());
+        expect(testManager.softButtonCapabilities).toNot(beNil());
         expect(testManager.currentLevel).to(equal(SDLHMILevelFull));
 
         // These are set up earlier for future tests and therefore won't be nil
@@ -137,7 +137,7 @@ describe(@"a soft button manager", ^{
     context(@"when there are no soft button capabilities", ^{
         beforeEach(^{
             SDLWindowCapability *windowCapability = [[SDLWindowCapability alloc] init];
-            SDLDisplayCapability *displayCapability = [[SDLDisplayCapability alloc] initWithDisplayName:@"TEST" windowTypeSupported:nil windowCapabilities:@[windowCapability]];
+            SDLDisplayCapability *displayCapability = [[SDLDisplayCapability alloc] initWithDisplayName:@"TEST" windowCapabilities:@[windowCapability] windowTypeSupported:nil];
             [testManager sdl_displayCapabilityDidUpdate:[[SDLSystemCapability alloc] initWithDisplayCapabilities:@[displayCapability]]];
         });
 
@@ -169,21 +169,6 @@ describe(@"a soft button manager", ^{
             testManager.softButtonObjects = @[testObject1, testObject2];
         });
 
-        describe(@"while batching", ^{
-            beforeEach(^{
-                testManager.batchUpdates = YES;
-
-                [testObject1 transitionToNextState];
-                [testObject2 transitionToNextState];
-                testManager.softButtonObjects = @[testObject2, testObject1];
-            });
-
-            it(@"should properly queue the batching updates", ^{
-                expect(testManager.transactionQueue.operationCount).to(equal(1));
-                expect(testManager.batchQueue).to(haveCount(1));
-            });
-        });
-
         it(@"should set soft buttons correctly", ^{
             expect(testManager.softButtonObjects).toNot(beNil());
             expect(testObject1.buttonId).to(equal(0));
@@ -191,6 +176,7 @@ describe(@"a soft button manager", ^{
             expect(testObject1.manager).to(equal(testManager));
             expect(testObject2.manager).to(equal(testManager));
 
+            // One replace operation
             expect(testManager.transactionQueue.operationCount).to(equal(1));
         });
 
@@ -205,6 +191,21 @@ describe(@"a soft button manager", ^{
 
         it(@"should retrieve soft buttons correctly", ^{
             expect([testManager softButtonObjectNamed:object1Name].name).to(equal(object1Name));
+        });
+
+        describe(@"while batching", ^{
+            beforeEach(^{
+                testManager.batchUpdates = YES;
+
+                [testObject1 transitionToNextState];
+                [testObject2 transitionToNextState];
+                testManager.softButtonObjects = @[testObject2, testObject1];
+            });
+
+            it(@"should properly queue the batching updates", ^{
+                expect(testManager.transactionQueue.operationCount).to(equal(1));
+                expect(testManager.batchQueue).to(haveCount(1));
+            });
         });
 
         context(@"when the HMI level is now NONE", ^{
@@ -274,7 +275,7 @@ describe(@"a soft button manager", ^{
             expect(testManager.currentMainField1).to(beNil());
             expect(testManager.transactionQueue.operationCount).to(equal(0));
             expect(testManager.currentLevel).to(beNil());
-            expect(testManager.windowCapability).to(beNil());
+            expect(testManager.softButtonCapabilities).to(beNil());
         });
     });
 });

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicManagerSpec.m
@@ -370,6 +370,31 @@ describe(@"text and graphic manager", ^{
             testManager.textField4Type = nil;
         });
 
+        context(@"when textFields are nil", ^{
+            beforeEach(^{
+                testManager.windowCapability = [[SDLWindowCapability alloc] init];
+            });
+
+            it(@"should send everything", ^{
+                testManager.mediaTrackTextField = textMediaTrack;
+                testManager.title = textTitle;
+                testManager.textField1 = textLine1;
+                testManager.textField2 = textLine2;
+                testManager.textField3 = textLine3;
+                testManager.textField4 = textLine4;
+
+                testManager.batchUpdates = NO;
+                [testManager updateWithCompletionHandler:nil];
+
+                expect(testManager.inProgressUpdate.mediaTrack).to(equal(textMediaTrack));
+                expect(testManager.inProgressUpdate.templateTitle).to(equal(textTitle));
+                expect(testManager.inProgressUpdate.mainField1).to(equal(textLine1));
+                expect(testManager.inProgressUpdate.mainField2).to(equal(textLine2));
+                expect(testManager.inProgressUpdate.mainField3).to(equal(textLine3));
+                expect(testManager.inProgressUpdate.mainField4).to(equal(textLine4));
+            });
+        });
+
         context(@"with one line available", ^{
             beforeEach(^{
                 testManager.windowCapability = [[SDLWindowCapability alloc] init];
@@ -845,17 +870,34 @@ describe(@"text and graphic manager", ^{
             context(@"when the image is already on the head unit", ^{
                 beforeEach(^{
                     OCMStub([mockFileManager hasUploadedFile:[OCMArg isNotNil]]).andReturn(YES);
+                });
 
+                it(@"should immediately attempt to update", ^{
                     testManager.primaryGraphic = testArtwork;
                     testManager.secondaryGraphic = testArtwork;
                     testManager.batchUpdates = NO;
                     [testManager updateWithCompletionHandler:nil];
-                });
 
-                it(@"should immediately attempt to update", ^{
                     expect(testManager.inProgressUpdate.graphic.value).to(equal(testArtworkName));
                     expect(testManager.inProgressUpdate.secondaryGraphic.value).to(equal(testArtworkName));
                     expect(testManager.inProgressUpdate.mainField1).to(equal(testTextFieldText));
+                });
+
+                context(@"when imageFields are nil", ^{
+                    beforeEach(^{
+                        testManager.windowCapability = [[SDLWindowCapability alloc] init];
+                    });
+
+                    it(@"should send everything", ^{
+                        testManager.primaryGraphic = testArtwork;
+                        testManager.secondaryGraphic = testArtwork;
+                        testManager.batchUpdates = NO;
+                        [testManager updateWithCompletionHandler:nil];
+
+                        expect(testManager.inProgressUpdate.graphic.value).to(equal(testArtworkName));
+                        expect(testManager.inProgressUpdate.secondaryGraphic.value).to(equal(testArtworkName));
+                        expect(testManager.inProgressUpdate.mainField1).to(equal(testTextFieldText));
+                    });
                 });
             });
 

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicManagerSpec.m
@@ -469,6 +469,31 @@ describe(@"text and graphic manager", ^{
                 expect(testManager.inProgressUpdate.mainField2).to(beEmpty());
                 expect(testManager.inProgressUpdate.metadataTags.mainField2).to(beNil());
             });
+
+            context(@"when media track and title are available", ^{
+                beforeEach(^{
+                    NSMutableArray<SDLTextField *> *existingFieldsMutable = [testManager.windowCapability.textFields mutableCopy];
+                    SDLTextField *mediaTrack = [[SDLTextField alloc] init];
+                    mediaTrack.name = SDLTextFieldNameMediaTrack;
+                    [existingFieldsMutable addObject:mediaTrack];
+
+                    SDLTextField *title = [[SDLTextField alloc] init];
+                    title.name = SDLTextFieldNameTemplateTitle;
+                    [existingFieldsMutable addObject:title];
+                    testManager.windowCapability.textFields = [existingFieldsMutable copy];
+                });
+
+                it(@"should set media track and title properly", ^{
+                    testManager.mediaTrackTextField = textMediaTrack;
+                    testManager.title = textTitle;
+
+                    testManager.batchUpdates = NO;
+                    [testManager updateWithCompletionHandler:nil];
+
+                    expect(testManager.inProgressUpdate.mediaTrack).to(equal(textMediaTrack));
+                    expect(testManager.inProgressUpdate.templateTitle).to(equal(textTitle));
+                });
+            });
         });
 
         context(@"with two lines available", ^{

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicManagerSpec.m
@@ -378,24 +378,24 @@ describe(@"text and graphic manager", ^{
                 testManager.windowCapability.textFields = @[lineOneField];
             });
 
-            it(@"should set mediatrack properly", ^{
+            it(@"should not set mediatrack", ^{
                 testManager.mediaTrackTextField = textMediaTrack;
 
                 testManager.batchUpdates = NO;
                 [testManager updateWithCompletionHandler:nil];
 
-                expect(testManager.inProgressUpdate.mediaTrack).to(equal(textMediaTrack));
+                expect(testManager.inProgressUpdate.mediaTrack).toNot(equal(textMediaTrack));
                 expect(testManager.inProgressUpdate.mainField1).to(beEmpty());
                 expect(testManager.inProgressUpdate.metadataTags.mainField1).to(beNil());
             });
 
-            it(@"should set title properly", ^{
+            it(@"should not set title", ^{
                 testManager.title = textTitle;
 
                 testManager.batchUpdates = NO;
                 [testManager updateWithCompletionHandler:nil];
 
-                expect(testManager.inProgressUpdate.templateTitle).to(equal(textTitle));
+                expect(testManager.inProgressUpdate.templateTitle).toNot(equal(textTitle));
                 expect(testManager.inProgressUpdate.mainField1).to(beEmpty());
                 expect(testManager.inProgressUpdate.metadataTags.mainField1).to(beNil());
             });
@@ -479,24 +479,24 @@ describe(@"text and graphic manager", ^{
                 testManager.windowCapability.textFields = @[lineTwoField];
             });
 
-            it(@"should set mediatrack properly", ^{
+            it(@"should not set mediatrack", ^{
                 testManager.mediaTrackTextField = textMediaTrack;
 
                 testManager.batchUpdates = NO;
                 [testManager updateWithCompletionHandler:nil];
 
-                expect(testManager.inProgressUpdate.mediaTrack).to(equal(textMediaTrack));
+                expect(testManager.inProgressUpdate.mediaTrack).toNot(equal(textMediaTrack));
                 expect(testManager.inProgressUpdate.mainField1).to(beEmpty());
                 expect(testManager.inProgressUpdate.metadataTags.mainField1).to(beNil());
             });
 
-            it(@"should set title properly", ^{
+            it(@"should not set title", ^{
                 testManager.title = textTitle;
 
                 testManager.batchUpdates = NO;
                 [testManager updateWithCompletionHandler:nil];
 
-                expect(testManager.inProgressUpdate.templateTitle).to(equal(textTitle));
+                expect(testManager.inProgressUpdate.templateTitle).toNot(equal(textTitle));
                 expect(testManager.inProgressUpdate.mainField1).to(beEmpty());
                 expect(testManager.inProgressUpdate.metadataTags.mainField1).to(beNil());
             });
@@ -589,24 +589,24 @@ describe(@"text and graphic manager", ^{
                 testManager.windowCapability.textFields = @[lineThreeField];
             });
 
-            it(@"should set mediatrack properly", ^{
+            it(@"should not set mediatrack", ^{
                 testManager.mediaTrackTextField = textMediaTrack;
 
                 testManager.batchUpdates = NO;
                 [testManager updateWithCompletionHandler:nil];
 
-                expect(testManager.inProgressUpdate.mediaTrack).to(equal(textMediaTrack));
+                expect(testManager.inProgressUpdate.mediaTrack).toNot(equal(textMediaTrack));
                 expect(testManager.inProgressUpdate.mainField1).to(beEmpty());
                 expect(testManager.inProgressUpdate.metadataTags.mainField1).to(beNil());
             });
 
-            it(@"should set title properly", ^{
+            it(@"should not set title", ^{
                 testManager.title = textTitle;
 
                 testManager.batchUpdates = NO;
                 [testManager updateWithCompletionHandler:nil];
 
-                expect(testManager.inProgressUpdate.templateTitle).to(equal(textTitle));
+                expect(testManager.inProgressUpdate.templateTitle).toNot(equal(textTitle));
                 expect(testManager.inProgressUpdate.mainField1).to(beEmpty());
                 expect(testManager.inProgressUpdate.metadataTags.mainField1).to(beNil());
             });
@@ -703,24 +703,24 @@ describe(@"text and graphic manager", ^{
                 testManager.windowCapability.textFields = @[lineFourField];
             });
 
-            it(@"should set mediatrack properly", ^{
+            it(@"should not set mediatrack", ^{
                 testManager.mediaTrackTextField = textMediaTrack;
 
                 testManager.batchUpdates = NO;
                 [testManager updateWithCompletionHandler:nil];
 
-                expect(testManager.inProgressUpdate.mediaTrack).to(equal(textMediaTrack));
+                expect(testManager.inProgressUpdate.mediaTrack).toNot(equal(textMediaTrack));
                 expect(testManager.inProgressUpdate.mainField1).to(beEmpty());
                 expect(testManager.inProgressUpdate.metadataTags.mainField1).to(beNil());
             });
 
-            it(@"should set title properly", ^{
+            it(@"should not set title", ^{
                 testManager.title = textTitle;
 
                 testManager.batchUpdates = NO;
                 [testManager updateWithCompletionHandler:nil];
 
-                expect(testManager.inProgressUpdate.templateTitle).to(equal(textTitle));
+                expect(testManager.inProgressUpdate.templateTitle).toNot(equal(textTitle));
                 expect(testManager.inProgressUpdate.mainField1).to(beEmpty());
                 expect(testManager.inProgressUpdate.metadataTags.mainField1).to(beNil());
             });

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnHMIStatusSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnHMIStatusSpec.m
@@ -19,37 +19,55 @@
 QuickSpecBegin(SDLOnHMIStatusSpec)
 
 describe(@"Getter/Setter Tests", ^ {
+    __block SDLHMILevel testLevel = nil;
+    __block SDLSystemContext testContext = nil;
+    __block SDLAudioStreamingState testAudioState = nil;
+    __block SDLVideoStreamingState testVideoState = nil;
+    __block NSNumber<SDLInt> *testWindowID = nil;
+
+     beforeEach(^{
+        testLevel = SDLHMILevelFull;
+        testContext = SDLSystemContextAlert;
+        testAudioState = SDLAudioStreamingStateAttenuated;
+        testVideoState = SDLVideoStreamingStateStreamable;
+        testWindowID = @0;
+    });
+
     it(@"Should set and get correctly", ^ {
         SDLOnHMIStatus* testNotification = [[SDLOnHMIStatus alloc] init];
         
-        testNotification.hmiLevel = SDLHMILevelLimited;
-        testNotification.audioStreamingState = SDLAudioStreamingStateAttenuated;
-        testNotification.systemContext = SDLSystemContextHMIObscured;
-        testNotification.videoStreamingState = SDLVideoStreamingStateStreamable;
+        testNotification.hmiLevel = testLevel;
+        testNotification.audioStreamingState = testAudioState;
+        testNotification.systemContext = testContext;
+        testNotification.videoStreamingState = testVideoState;
+        testNotification.windowID = testWindowID;
         
-        expect(testNotification.hmiLevel).to(equal(SDLHMILevelLimited));
-        expect(testNotification.audioStreamingState).to(equal(SDLAudioStreamingStateAttenuated));
-        expect(testNotification.systemContext).to(equal(SDLSystemContextHMIObscured));
-        expect(testNotification.videoStreamingState).to(equal(SDLVideoStreamingStateStreamable));
+        expect(testNotification.hmiLevel).to(equal(testLevel));
+        expect(testNotification.audioStreamingState).to(equal(testAudioState));
+        expect(testNotification.systemContext).to(equal(testContext));
+        expect(testNotification.videoStreamingState).to(equal(testVideoState));
+        expect(testNotification.windowID).to(equal(testWindowID));
     });
     
     it(@"Should get correctly when initialized", ^ {
-        NSMutableDictionary* dict = [@{SDLRPCParameterNameNotification:
-                                           @{SDLRPCParameterNameParameters:
-                                                 @{SDLRPCParameterNameHMILevel: SDLHMILevelLimited,
-                                                   SDLRPCParameterNameAudioStreamingState: SDLAudioStreamingStateAttenuated,
-                                                   SDLRPCParameterNameSystemContext: SDLSystemContextHMIObscured,
-                                                   SDLRPCParameterNameVideoStreamingState: SDLVideoStreamingStateStreamable},
-                                             SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnHMIStatus}} mutableCopy];
+        NSDictionary* dict = @{SDLRPCParameterNameNotification:
+                                @{SDLRPCParameterNameParameters:
+                                      @{SDLRPCParameterNameHMILevel: testLevel,
+                                        SDLRPCParameterNameAudioStreamingState: testAudioState,
+                                        SDLRPCParameterNameSystemContext: testContext,
+                                        SDLRPCParameterNameVideoStreamingState: testVideoState,
+                                        SDLRPCParameterNameWindowId: testWindowID},
+                                  SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnHMIStatus}};
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnHMIStatus* testNotification = [[SDLOnHMIStatus alloc] initWithDictionary:dict];
 #pragma clang diagnostic pop
         
-        expect(testNotification.hmiLevel).to(equal(SDLHMILevelLimited));
-        expect(testNotification.audioStreamingState).to(equal(SDLAudioStreamingStateAttenuated));
-        expect(testNotification.systemContext).to(equal(SDLSystemContextHMIObscured));
-        expect(testNotification.videoStreamingState).to(equal(SDLVideoStreamingStateStreamable));
+        expect(testNotification.hmiLevel).to(equal(testLevel));
+        expect(testNotification.audioStreamingState).to(equal(testAudioState));
+        expect(testNotification.systemContext).to(equal(testContext));
+        expect(testNotification.videoStreamingState).to(equal(testVideoState));
+        expect(testNotification.windowID).to(equal(testWindowID));
     });
     
     it(@"Should return nil if not set", ^ {
@@ -59,6 +77,16 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testNotification.audioStreamingState).to(beNil());
         expect(testNotification.systemContext).to(beNil());
         expect(testNotification.videoStreamingState).to(beNil());
+        expect(testNotification.windowID).to(beNil());
+    });
+
+    it(@"should initialize properly with initWithHMILevel:systemContext:audioStreamingState:videoStreamingState:windowID:", ^{
+        SDLOnHMIStatus *testStatus = [[SDLOnHMIStatus alloc] initWithHMILevel:testLevel systemContext:testContext audioStreamingState:testAudioState videoStreamingState:testVideoState windowID:testWindowID];
+        expect(testStatus.hmiLevel).to(equal(testLevel));
+        expect(testStatus.systemContext).to(equal(testContext));
+        expect(testStatus.audioStreamingState).to(equal(testAudioState));
+        expect(testStatus.videoStreamingState).to(equal(testVideoState));
+        expect(testStatus.windowID).to(equal(testWindowID));
     });
 });
 

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLImageFieldSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLImageFieldSpec.m
@@ -17,33 +17,41 @@
 
 QuickSpecBegin(SDLImageFieldSpec)
 
-SDLImageResolution* resolution = [[SDLImageResolution alloc] init];
-
 describe(@"Getter/Setter Tests", ^ {
+     __block SDLImageFieldName testName = nil;
+     __block NSArray<SDLFileType> *testFileTypes = nil;
+     __block SDLImageResolution *testResolution = nil;
+
+    beforeEach(^{
+        testName = SDLImageFieldNameAppIcon;
+        testFileTypes = @[SDLFileTypePNG, SDLFileTypeJPEG];
+        testResolution = [[SDLImageResolution alloc] initWithWidth:800 height:800];
+    });
+
     it(@"Should set and get correctly", ^ {
         SDLImageField* testStruct = [[SDLImageField alloc] init];
         
-        testStruct.name = SDLImageFieldNameTurnIcon;
-        testStruct.imageTypeSupported = [@[SDLFileTypePNG, SDLFileTypeJPEG] copy];
-        testStruct.imageResolution = resolution;
+        testStruct.name = testName;
+        testStruct.imageTypeSupported = testFileTypes;
+        testStruct.imageResolution = testResolution;
         
-        expect(testStruct.name).to(equal(SDLImageFieldNameTurnIcon));
-        expect(testStruct.imageTypeSupported).to(equal([@[SDLFileTypePNG, SDLFileTypeJPEG] copy]));
-        expect(testStruct.imageResolution).to(equal(resolution));
+        expect(testStruct.name).to(equal(testName));
+        expect(testStruct.imageTypeSupported).to(equal(testFileTypes));
+        expect(testStruct.imageResolution).to(equal(testResolution));
     });
     
     it(@"Should get correctly when initialized", ^ {
-        NSMutableDictionary* dict = [@{SDLRPCParameterNameName:SDLImageFieldNameTurnIcon,
-                                       SDLRPCParameterNameImageTypeSupported:[@[SDLFileTypePNG, SDLFileTypeJPEG] copy],
-                                       SDLRPCParameterNameImageResolution:resolution} mutableCopy];
+        NSDictionary *dict = @{SDLRPCParameterNameName: testName,
+                               SDLRPCParameterNameImageTypeSupported: testFileTypes,
+                               SDLRPCParameterNameImageResolution: testResolution};
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLImageField* testStruct = [[SDLImageField alloc] initWithDictionary:dict];
 #pragma clang diagnostic pop
         
-        expect(testStruct.name).to(equal(SDLImageFieldNameTurnIcon));
-        expect(testStruct.imageTypeSupported).to(equal([@[SDLFileTypePNG, SDLFileTypeJPEG] copy]));
-        expect(testStruct.imageResolution).to(equal(resolution));
+        expect(testStruct.name).to(equal(testName));
+        expect(testStruct.imageTypeSupported).to(equal(testFileTypes));
+        expect(testStruct.imageResolution).to(equal(testResolution));
     });
     
     it(@"Should return nil if not set", ^ {
@@ -52,6 +60,14 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testStruct.name).to(beNil());
         expect(testStruct.imageTypeSupported).to(beNil());
         expect(testStruct.imageResolution).to(beNil());
+    });
+
+    it(@"should initialize correctly with initWithName:imageTypeSupported:imageResolution:", ^{
+        SDLImageField *testStruct = [[SDLImageField alloc] initWithName:testName imageTypeSupported:testFileTypes imageResolution:testResolution];
+
+        expect(testStruct.name).to(equal(testName));
+        expect(testStruct.imageTypeSupported).to(equal(testFileTypes));
+        expect(testStruct.imageResolution).to(equal(testResolution));
     });
 });
 

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTextFieldSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTextFieldSpec.m
@@ -17,34 +17,39 @@
 QuickSpecBegin(SDLTextFieldSpec)
 
 describe(@"Getter/Setter Tests", ^ {
+    __block SDLTextFieldName testName = SDLTextFieldNameETA;
+    __block SDLCharacterSet testCharacterSet = SDLCharacterSetCID1;
+    __block NSUInteger testWidth = 100;
+    __block NSUInteger testRows = 4;
+
     it(@"Should set and get correctly", ^ {
         SDLTextField* testStruct = [[SDLTextField alloc] init];
         
-        testStruct.name = SDLTextFieldNameTertiaryText;
-        testStruct.characterSet = SDLCharacterSetType5;
-        testStruct.width = @111;
-        testStruct.rows = @4;
+        testStruct.name = testName;
+        testStruct.characterSet = testCharacterSet;
+        testStruct.width = @(testWidth);
+        testStruct.rows = @(testRows);
         
-        expect(testStruct.name).to(equal(SDLTextFieldNameTertiaryText));
-        expect(testStruct.characterSet).to(equal(SDLCharacterSetType5));
-        expect(testStruct.width).to(equal(@111));
-        expect(testStruct.rows).to(equal(@4));
+        expect(testStruct.name).to(equal(testName));
+        expect(testStruct.characterSet).to(equal(testCharacterSet));
+        expect(testStruct.width).to(equal(@(testWidth)));
+        expect(testStruct.rows).to(equal(@(testRows)));
     });
     
     it(@"Should get correctly when initialized", ^ {
-        NSMutableDictionary* dict = [@{SDLRPCParameterNameName:SDLTextFieldNameTertiaryText,
-                                       SDLRPCParameterNameCharacterSet:SDLCharacterSetType5,
-                                       SDLRPCParameterNameWidth:@111,
-                                       SDLRPCParameterNameRows:@4} mutableCopy];
+        NSDictionary *dict = @{SDLRPCParameterNameName:testName,
+                               SDLRPCParameterNameCharacterSet:testCharacterSet,
+                               SDLRPCParameterNameWidth:@(testWidth),
+                               SDLRPCParameterNameRows:@(testRows)};
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLTextField* testStruct = [[SDLTextField alloc] initWithDictionary:dict];
 #pragma clang diagnostic pop
         
-        expect(testStruct.name).to(equal(SDLTextFieldNameTertiaryText));
-        expect(testStruct.characterSet).to(equal(SDLCharacterSetType5));
-        expect(testStruct.width).to(equal(@111));
-        expect(testStruct.rows).to(equal(@4));
+        expect(testStruct.name).to(equal(testName));
+        expect(testStruct.characterSet).to(equal(testCharacterSet));
+        expect(testStruct.width).to(equal(@(testWidth)));
+        expect(testStruct.rows).to(equal(@(testRows)));
     });
     
     it(@"Should return nil if not set", ^ {
@@ -54,6 +59,15 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testStruct.characterSet).to(beNil());
         expect(testStruct.width).to(beNil());
         expect(testStruct.rows).to(beNil());
+    });
+
+    it(@"should initialize correctly with initWithName:characterSet:width:rows:", ^{
+        SDLTextField *testStruct = [[SDLTextField alloc] initWithName:testName characterSet:testCharacterSet width:testWidth rows:testRows];
+
+        expect(testStruct.name).to(equal(testName));
+        expect(testStruct.characterSet).to(equal(testCharacterSet));
+        expect(testStruct.width).to(equal(@(testWidth)));
+        expect(testStruct.rows).to(equal(@(testRows)));
     });
 });
 

--- a/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
+++ b/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
@@ -697,13 +697,12 @@ describe(@"System capability manager", ^{
                 expect(handlerTriggeredCount).toEventually(equal(1));
                 expect(observerTriggeredCount).toEventually(equal(1));
 
-                expect(phoneObserver.selectorCalledCount).toEventually(equal(1));
+                expect(phoneObserver.selectorCalledCount).toEventually(equal(0));
+                expect(navigationObserver.selectorCalledCount).toEventually(equal(0));
 
-                expect(navigationObserver.selectorCalledCount).toEventually(equal(1));
-
-                expect(videoStreamingObserver.selectorCalledCount).toEventually(equal(1));
-                expect(videoStreamingObserver.subscribedValuesReceived).toEventually(haveCount(1));
-                expect(videoStreamingObserver.subscribedValuesReceived.firstObject).toEventually(beFalse());
+                expect(videoStreamingObserver.selectorCalledCount).toEventually(equal(0));
+                expect(videoStreamingObserver.subscribedValuesReceived).toEventually(haveCount(0));
+                expect(videoStreamingObserver.subscribedValuesReceived.firstObject).toEventually(beNil());
 
                 expect(displaysObserver.selectorCalledCount).toEventually(equal(1));
                 expect(displaysObserver.subscribedValuesReceived).toEventually(haveCount(1));
@@ -727,11 +726,9 @@ describe(@"System capability manager", ^{
                     expect(handlerTriggeredCount).toEventually(equal(1));
                     expect(observerTriggeredCount).toEventually(equal(1));
 
-                    expect(phoneObserver.selectorCalledCount).toEventually(equal(1)); // No change from above
-
-                    expect(navigationObserver.selectorCalledCount).toEventually(equal(1));
-
-                    expect(videoStreamingObserver.selectorCalledCount).toEventually(equal(1));
+                    expect(phoneObserver.selectorCalledCount).toEventually(equal(0)); // No change from above
+                    expect(navigationObserver.selectorCalledCount).toEventually(equal(0));
+                    expect(videoStreamingObserver.selectorCalledCount).toEventually(equal(0));
 
                     expect(displaysObserver.selectorCalledCount).toEventually(equal(1));
                 });
@@ -764,13 +761,12 @@ describe(@"System capability manager", ^{
                 expect(handlerTriggeredCount).toEventually(equal(2));
                 expect(observerTriggeredCount).toEventually(equal(2));
 
-                expect(phoneObserver.selectorCalledCount).toEventually(equal(2));
+                expect(phoneObserver.selectorCalledCount).toEventually(equal(1));
+                expect(navigationObserver.selectorCalledCount).toEventually(equal(0));
 
-                expect(navigationObserver.selectorCalledCount).toEventually(equal(1));
-
-                expect(videoStreamingObserver.selectorCalledCount).toEventually(equal(1));
-                expect(videoStreamingObserver.subscribedValuesReceived).toEventually(haveCount(1));
-                expect(videoStreamingObserver.subscribedValuesReceived.firstObject).toEventually(beFalse());
+                expect(videoStreamingObserver.selectorCalledCount).toEventually(equal(0));
+                expect(videoStreamingObserver.subscribedValuesReceived).toEventually(haveCount(0));
+                expect(videoStreamingObserver.subscribedValuesReceived.firstObject).toEventually(beNil());
 
                 expect(displaysObserver.selectorCalledCount).toEventually(equal(1));
                 expect(displaysObserver.subscribedValuesReceived).toEventually(haveCount(1));
@@ -790,10 +786,10 @@ describe(@"System capability manager", ^{
                 });
 
                 it(@"should not notify the subscriber of the new data", ^{
-                    expect(phoneObserver.selectorCalledCount).toEventually(equal(2)); // No change from above
+                    expect(phoneObserver.selectorCalledCount).toEventually(equal(1)); // No change from above
                     expect(observerTriggeredCount).toEventually(equal(2));
-                    expect(navigationObserver.selectorCalledCount).toEventually(equal(1));
-                    expect(videoStreamingObserver.selectorCalledCount).toEventually(equal(1));
+                    expect(navigationObserver.selectorCalledCount).toEventually(equal(0));
+                    expect(videoStreamingObserver.selectorCalledCount).toEventually(equal(0));
                     expect(displaysObserver.selectorCalledCount).toEventually(equal(1));
                 });
             });


### PR DESCRIPTION
Fixes #1536 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
- [x] Update unit tests to pass properly
- [x] Add new unit tests for sub-managers to ensure they send properly if `displayCapabilities` is `null`.

#### Core Tests
- [x] Tested the screen managers to ensure continued functionality.

Core version / branch / commit hash / module tested against: Sync 3.0 (17276_DEVTEST)
HMI name / version / branch / commit hash / module tested against: Sync 3.0 (17276_DEVTEST)

### Summary
This PR fixes a possible case where the head unit sends back a `nil` `displayCapabilities` or `displayCapabilities.textFields / imageFields` would cause the screen managers to not send data. Instead, we will now send all possible data and leave it to the head unit to reject or show what it determines is appropriate.

### Changelog
##### Enhancements
* Added a few RPC struct initializers.

##### Bug Fixes
* Fix a possible case where the head unit sends back a `nil` `displayCapabilities` or `displayCapabilities.textFields / imageFields` would cause the screen managers to not send data. Instead, we will now send all possible data and leave it to the head unit to reject or show what it determines is appropriate.
* Fixed the choice set manager sending data when the head unit sends `textFields` without the primary choice text.
* Fixed the soft button manager attempting to send soft buttons when no soft button capabilities are present.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
