### PR TITLE
OOM when the WiFi signal is extremely weak

### DIFF
--- a/SmartDeviceLink/SDLMutableDataQueue.m
+++ b/SmartDeviceLink/SDLMutableDataQueue.m
@@ -10,7 +10,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-NSInteger const MAXDATACOUNT = 200;
+//NSInteger const MAXDATACOUNT = 200;
 
 @interface SDLMutableDataQueue ()
 
@@ -35,15 +35,15 @@ NSInteger const MAXDATACOUNT = 200;
 - (void)enqueueBuffer:(NSMutableData *)data {
     // Since this method is being called from the main thread and the dequeue methods are being called from the data session stream thread, we need to put critical sections around the queue members. Use the @synchronized object level lock to do this.
     @synchronized(self) {
-        if ([_elements count] > MAXDATACOUNT) {
-            [_elements removeAllObjects];
-            [_elements addObject:data];
-            self.frontDequeued = NO;
-        }
-        else {
+//        if ([_elements count] > MAXDATACOUNT) {
+//            [_elements removeAllObjects];
+//            [_elements addObject:data];
+//            self.frontDequeued = NO;
+//        }
+//        else {
             [self.elements addObject:data];
             self.frontDequeued = NO;
-        }
+//        }
     }
 }
 

--- a/SmartDeviceLink/SDLMutableDataQueue.m
+++ b/SmartDeviceLink/SDLMutableDataQueue.m
@@ -10,6 +10,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+NSInteger const MAXDATACOUNT = 200;
+
 @interface SDLMutableDataQueue ()
 
 @property (nonatomic, strong) NSMutableArray *elements;
@@ -33,8 +35,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)enqueueBuffer:(NSMutableData *)data {
     // Since this method is being called from the main thread and the dequeue methods are being called from the data session stream thread, we need to put critical sections around the queue members. Use the @synchronized object level lock to do this.
     @synchronized(self) {
-        [self.elements addObject:data];
-        self.frontDequeued = NO;
+        if ([_elements count] > MAXDATACOUNT) {
+            [_elements removeAllObjects];
+            [_elements addObject:data];
+            self.frontDequeued = NO;
+        }
+        else {
+            [self.elements addObject:data];
+            self.frontDequeued = NO;
+        }
     }
 }
 

--- a/SmartDeviceLink/SDLMutableDataQueue.m
+++ b/SmartDeviceLink/SDLMutableDataQueue.m
@@ -10,7 +10,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-//NSInteger const MAXDATACOUNT = 200;
+NSInteger const MAXDATACOUNT = 200;
 
 @interface SDLMutableDataQueue ()
 
@@ -35,15 +35,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)enqueueBuffer:(NSMutableData *)data {
     // Since this method is being called from the main thread and the dequeue methods are being called from the data session stream thread, we need to put critical sections around the queue members. Use the @synchronized object level lock to do this.
     @synchronized(self) {
-//        if ([_elements count] > MAXDATACOUNT) {
-//            [_elements removeAllObjects];
-//            [_elements addObject:data];
-//            self.frontDequeued = NO;
-//        }
-//        else {
+        if ([_elements count] > MAXDATACOUNT) {
+            [_elements removeAllObjects];
+            [_elements addObject:data];
+            self.frontDequeued = NO;
+        }
+        else {
             [self.elements addObject:data];
             self.frontDequeued = NO;
-//        }
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #1529 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by Unit tests.

### Summary
**Reason** 
The data of video streaming and audio streaming is saved. There is no limit to the size of the Queue, so the app can save streaming data into the queue without limit. Queue's data can't be sent to HU via TCP immediately when the WiFi signal is extremely weak, so crash happens as OOM due to queue increases.

**Solution** 
Set a max value to the size of the Queue.                 
When the size of the Queue reaches the max value, clear all the data in the Queue.

max value is 200 (how to decide the max value, referred to as follows）

IOS   TestData | iPhone11pro(iOS13.2) | iPhoneXR(iOS13.3.1)
-- | -- | --
①nothing to do when VMP is   showing | size of Queue between 0 and 2 | the same as left
②touch playAudioStream | size of Queue between 0 and 3 | the same as left
③touch playAudioStream and   touch other button | size of Queue between 0 and 3 | the same as left
④repeat touch or move screen | size of Queue between 0 and 2 | the same as left
⑤when OOM | 500+ | the same as left





### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)