### PR TITLE
Fix App does not automatically reconnect to HU after changing language

### DIFF
--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -262,6 +262,7 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
 - (void)sdl_stopManager:(BOOL)shouldRestart {
     SDLLogV(@"Stopping manager, %@", (shouldRestart ? @"will restart" : @"will not restart"));
 
+    [self.proxy disconnectSession];
     self.proxy = nil;
 
     [self.fileManager stop];

--- a/SmartDeviceLink/SDLProxy.h
+++ b/SmartDeviceLink/SDLProxy.h
@@ -133,6 +133,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)putFileStream:(NSInputStream *)inputStream withRequest:(SDLPutFile *)putFileRPCRequest;
 
+/// Disconnects the current app session , including the security manager and primary transport.
+- (void)disconnectSession;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLProxy.h
+++ b/SmartDeviceLink/SDLProxy.h
@@ -133,7 +133,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)putFileStream:(NSInputStream *)inputStream withRequest:(SDLPutFile *)putFileRPCRequest;
 
-/// Disconnects the current app session , including the security manager and primary transport.
+/// Disconnects the current app session, including the security manager and primary transport.
 - (void)disconnectSession;
 
 @end

--- a/SmartDeviceLink/SDLProxy.m
+++ b/SmartDeviceLink/SDLProxy.m
@@ -174,7 +174,8 @@ static float DefaultConnectionTimeout = 45.0;
     return ret;
 }
 
-- (void)dealloc {
+- (void)disconnectSession {
+    SDLLogD(@"Disconnecting the proxy; stopping security manager and primary transport.");
     if (self.protocol.securityManager != nil) {
         [self.protocol.securityManager stop];
     }
@@ -186,6 +187,9 @@ static float DefaultConnectionTimeout = 45.0;
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 
     [_urlSession invalidateAndCancel];
+}
+
+- (void)dealloc {
     SDLLogV(@"Proxy dealloc");
 }
 


### PR DESCRIPTION
Fixes #1532 

This PR is **ready** for review.

### Risk 
This PR makes **no** API changes.

### Testing Plan
Covered by Unit tests.

### Summary
**Reason**
1. There are two threads (`ioStreamThread` and `lifecycleThread`)  have Proxy object
2. After HU changing language, Proxy's `UnregisterApp` is invoked
3. Then `lifecycleThread`'s `stopManager` is invoked
4. set `Proxy = nil` and then Proxy's reference count will reduce to `0` 
5. when Proxy's reference count reaches `0`，Proxy's `dealloc` method will be invoked

Normal case：
5.1.1 Proxy's `dealloc` is invoked in the `lifecycleThread`
5.1.2 set `ioStreamThread`'s cancel flag true
5.1.3 `ioStreamThread` exit
5.1.4 close Session
5.1.5 `ioStreamThread = nil`
5.1.6 create new session successfully
![image](https://user-images.githubusercontent.com/35795928/76811543-4a75a200-6835-11ea-864d-e3537e0342a1.png)


Abnormal case：
5.2.1 Proxy's `dealloc` is invoked in the `ioStreamThread`
5.2.2 set `ioStreamThread`'s cancel falg true
5.2.3 `ioStreamThread = nil`
5.2.4 `ioStreamThread` exit faild
5.2.5 create new session failed
![image](https://user-images.githubusercontent.com/35795928/76811549-53ff0a00-6835-11ea-8442-4892d6ff7a2d.png)

**Solution**
Avoid `ioStreamThread` do expensive operations, so move the methods in the `dealloc` to the new method of `disconnectSession`, before set `Proxy = nil`, execute `disconnectSession`.
	
1. There are two threads (`ioStreamThread` and `lifecycleThread`)  have Proxy object	
2. After HU changing language, Proxy's `UnregisterApp` is invoked	
3. Then `lifecycleThread`'s `stopManager` is invoked	
4. Invoke Proxy's `disconnectSession` method in the `lifecycleThread`	
5. Set `ioStreamThread`'s cancel flag true	
6. `ioStreamThread` exit	
7. Close Session
8. `ioStreamThread = nil`
9. Set `Proxy = nil` and then Proxy's reference count will reduce to `0` 	
10. When Proxy's reference count reaches `0`，Proxy's `dealloc` method will be invoked	
11. Create new session successful	
![image](https://user-images.githubusercontent.com/35795928/76811701-ddaed780-6835-11ea-8d8b-c1cefe72e35c.png)

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)