### PR TITLE
Fixed crash when an iAP control session is stopped

### DIFF
--- a/SmartDeviceLink/SDLIAPControlSession.m
+++ b/SmartDeviceLink/SDLIAPControlSession.m
@@ -54,27 +54,39 @@ int const ProtocolIndexTimeoutSeconds = 10;
     } else {
         SDLLogD(@"Starting a control session with accessory (%@)", self.accessory.name);
 
-        if (![self sdl_startStreams]) {
-            SDLLogW(@"Control session failed to setup with accessory: %@. Attempting to create a new control session", self.accessory);
-            [self destroySession];
-            if (self.delegate == nil) { return; }
-            [self.delegate controlSessionShouldRetry];
-        } else {
-            SDLLogD(@"Waiting for the protocol string from Core, setting timer for %d seconds", ProtocolIndexTimeoutSeconds);
-            self.protocolIndexTimer = [self sdl_createControlSessionProtocolIndexStringDataTimeoutTimer];
-        }
+        __weak typeof(self) weakSelf = self;
+        [self sdl_startStreamsWithCompletionHandler:^(BOOL success) {
+            __strong typeof(weakSelf) strongSelf = weakSelf;
+            if (!success) {
+                SDLLogW(@"Control session failed to setup with accessory: %@. Attempting to create a new control session", strongSelf.accessory);
+                [strongSelf destroySession];
+                if (strongSelf.delegate == nil) { return; }
+                [strongSelf.delegate controlSessionShouldRetry];
+            } else {
+                SDLLogD(@"Waiting for the protocol string from Core, setting timer for %d seconds", ProtocolIndexTimeoutSeconds);
+                strongSelf.protocolIndexTimer = [strongSelf sdl_createControlSessionProtocolIndexStringDataTimeoutTimer];
+            }
+        }];
     }
 }
 
-- (BOOL)sdl_startStreams {
-    if (![super createSession]) { return NO; }
+/// Opens the input and output streams for the session on the main thread.
+/// @discussion We must close the input/output streams from the same thread that owns the streams' run loop, otherwise if the streams are closed from another thread a random crash may occur. Since only a small amount of data will be transmitted on this stream before it is closed, we will open and close the streams on the main thread instead of creating a separate thread.
+- (void)sdl_startStreamsWithCompletionHandler:(void (^)(BOOL success))completionHandler {
+    if (![super createSession]) {
+        return completionHandler(NO);
+    }
 
-    // No need for its own thread as only a small amount of data will be transmitted before control session is destroyed
-    SDLLogD(@"Created the control session successfully");
-    [super startStream:self.eaSession.outputStream];
-    [super startStream:self.eaSession.inputStream];
+    __weak typeof(self) weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        __strong typeof(weakSelf) strongSelf = weakSelf;
 
-    return YES;
+        SDLLogD(@"Created the control session successfully");
+        [super startStream:strongSelf.eaSession.outputStream];
+        [super startStream:strongSelf.eaSession.inputStream];
+
+        return completionHandler(YES);
+    });
 }
 
 #pragma mark Stop

--- a/SmartDeviceLink/SDLIAPControlSession.m
+++ b/SmartDeviceLink/SDLIAPControlSession.m
@@ -63,7 +63,7 @@ int const ProtocolIndexTimeoutSeconds = 10;
                 if (strongSelf.delegate == nil) { return; }
                 [strongSelf.delegate controlSessionShouldRetry];
             } else {
-                SDLLogD(@"Waiting for the protocol string from Core, setting timer for %d seconds", ProtocolIndexTimeoutSeconds);
+                SDLLogD(@"Waiting for the protocol string from Core, setting timeout timer for %d seconds", ProtocolIndexTimeoutSeconds);
                 strongSelf.protocolIndexTimer = [strongSelf sdl_createControlSessionProtocolIndexStringDataTimeoutTimer];
             }
         }];


### PR DESCRIPTION
Fixes #1583 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
No additional test cases were added. Current unit tests passed.

#### Core Tests
1. Connected to a SYNC 3 v3.0 head unit and used code injection in the Xcode debugger to make the library create an iAP control session.    
2. Repeatedly connected and pulled the USB cord. 

Core version / branch / commit hash / module tested against: SYNC 3 v3.0
HMI name / version / branch / commit hash / module tested against: SYNC 3 v3.0

### Summary
All the crash logs attached to the issue show that the crash occurs when the IAP Control Session attempts to close the output stream. I believe the issue is that the output stream's run loop was created on the `lifecycle` thread, which means that the `lifecycle` thread owns the stream. The library then closes the output stream from the main thread. Apple's documentation for streams says [You should never attempt to access a scheduled stream from a thread different than the one owning the stream’s run loop](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Streams/Articles/WritingOutputStreams.html). 

The IAP Control Session is only created when connecting to legacy units that don't support the `multisession` protocol. The IAP Data Session opens and closes the streams on the `ioThread`, which explains why we have not seen this crash on head units that support the `multisession` protocol. 

I changed the code to make sure the iAP control session streams are started on the main thread instead of the `lifecycle` thread so the streams are started and stopped on the same thread.

### Changelog
##### Bug Fixes
* Changed the code to make sure the iAP control session streams are started and stopped on the same thread.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
