### PR TITLE
Ensure that text and graphic updates aren't sent before we are ready

### DIFF
--- a/SmartDeviceLink/SDLTextAndGraphicManager.m
+++ b/SmartDeviceLink/SDLTextAndGraphicManager.m
@@ -712,7 +712,7 @@ NS_ASSUME_NONNULL_BEGIN
     
     // Auto-send an updated show
     if ([self sdl_hasData]) {
-        [self sdl_updateWithCompletionHandler:nil];
+        [self updateWithCompletionHandler:nil];
     }
 }
 


### PR DESCRIPTION
Fixes #1595 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
No unit tests added, unit tests were run

#### Core Tests
Disconnect / reconnect tests were run repeatedly

Core version / branch / commit hash / module tested against: Sync Gen 3.4 (19353 DEVTEST)
HMI name / version / branch / commit hash / module tested against: Sync Gen 3.4 (19353 DEVTEST)

### Summary
When a display capability update comes in before the manager is ready, a crash will occur because the text and graphic manager is attempting to send an update.

A change was made to ensure that we are actually ready before sending the update.

### Changelog
N/A; intra-release issue

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
