### PR TITLE
Made the choice set manager thread safe

### DIFF
--- a/SmartDeviceLink/SDLChoiceSetManager.m
+++ b/SmartDeviceLink/SDLChoiceSetManager.m
@@ -129,7 +129,9 @@ UInt16 const ChoiceCellCancelIdMin = 1;
 }
 
 - (void)stop {
-    [self.stateMachine transitionToState:SDLChoiceManagerStateShutdown];
+    [self sdl_runSyncOnQueue:^{
+        [self.stateMachine transitionToState:SDLChoiceManagerStateShutdown];
+    }];
 }
 
 + (NSDictionary<SDLState *, SDLAllowableStateTransitions *> *)sdl_stateTransitionDictionary {
@@ -168,18 +170,17 @@ UInt16 const ChoiceCellCancelIdMin = 1;
 
 - (void)didEnterStateShutdown {
     SDLLogV(@"Manager shutting down");
+    _currentHMILevel = SDLHMILevelNone;
+
     [self.transactionQueue cancelAllOperations];
     self.transactionQueue = [self sdl_newTransactionQueue];
-    _vrOptional = YES;
-    _currentHMILevel = SDLHMILevelNone;
+    _preloadedMutableChoices = [NSMutableSet set];
+    _pendingMutablePreloadChoices = [NSMutableSet set];
     _pendingPresentationSet = nil;
 
-    [self sdl_runSyncOnQueue:^{
-        self->_preloadedMutableChoices = [NSMutableSet set];
-        self->_pendingMutablePreloadChoices = [NSMutableSet set];
-        self->_nextChoiceId = ChoiceCellIdMin;
-        self->_nextCancelId = ChoiceCellCancelIdMin;
-    }];
+    _vrOptional = YES;
+    _nextChoiceId = ChoiceCellIdMin;
+    _nextCancelId = ChoiceCellCancelIdMin;
 }
 
 - (void)didEnterStateCheckingVoiceOptional {

--- a/SmartDeviceLink/SDLChoiceSetManager.m
+++ b/SmartDeviceLink/SDLChoiceSetManager.m
@@ -119,6 +119,8 @@ UInt16 const ChoiceCellCancelIdMin = 1;
 }
 
 - (void)start {
+    SDLLogD(@"Starting manager");
+
     [self.systemCapabilityManager subscribeToCapabilityType:SDLSystemCapabilityTypeDisplays withObserver:self selector:@selector(sdl_displayCapabilityDidUpdate:)];
 
     if ([self.currentState isEqualToString:SDLChoiceManagerStateShutdown]) {
@@ -129,6 +131,8 @@ UInt16 const ChoiceCellCancelIdMin = 1;
 }
 
 - (void)stop {
+    SDLLogD(@"Stopping manager");
+    
     [self sdl_runSyncOnQueue:^{
         [self.stateMachine transitionToState:SDLChoiceManagerStateShutdown];
     }];

--- a/SmartDeviceLink/SDLChoiceSetManager.m
+++ b/SmartDeviceLink/SDLChoiceSetManager.m
@@ -171,9 +171,9 @@ UInt16 const ChoiceCellCancelIdMin = 1;
     [self.transactionQueue cancelAllOperations];
     self.transactionQueue = [self sdl_newTransactionQueue];
     _vrOptional = YES;
+    _currentHMILevel = SDLHMILevelNone;
 
     [self sdl_runSyncOnQueue:^{
-        self->_currentHMILevel = SDLHMILevelNone;
         self->_preloadedMutableChoices = [NSMutableSet set];
         self->_pendingMutablePreloadChoices = [NSMutableSet set];
         self->_nextChoiceId = ChoiceCellIdMin;
@@ -497,7 +497,7 @@ UInt16 const ChoiceCellCancelIdMin = 1;
 - (void)sdl_findIdsOnChoices:(NSSet<SDLChoiceCell *> *)choices {
     for (SDLChoiceCell *cell in choices) {
         SDLChoiceCell *uploadCell = [self.pendingPreloadChoices member:cell] ?: [self.preloadedChoices member:cell];
-        if (uploadCell == nil) { return; }
+        if (uploadCell == nil) { continue; }
         cell.choiceId = uploadCell.choiceId;
     }
 }
@@ -595,7 +595,7 @@ UInt16 const ChoiceCellCancelIdMin = 1;
 
 #pragma mark Utilities
 
-/// Checks if we are already on a serial queue. If so, the block is added to the queue; if not, the block is dipatched to the serial `readWrite` queue.
+/// Checks if we are already on a serial queue. If so, the block is added to the queue; if not, the block is dispatched to the serial `readWrite` queue.
 /// @discussion Used to synchronize access to class properties.
 /// @param block The block to be executed.
 - (void)sdl_runSyncOnQueue:(void (^)(void))block {

--- a/SmartDeviceLink/SDLChoiceSetManager.m
+++ b/SmartDeviceLink/SDLChoiceSetManager.m
@@ -260,7 +260,7 @@ UInt16 const ChoiceCellCancelIdMin = 1;
 
         // Check if the manager has shutdown because the list of uploaded and pending choices should not be updated
         if ([strongSelf.currentState isEqualToString:SDLChoiceManagerStateShutdown]) {
-            SDLLogD(@"The manager has shutdown");
+            SDLLogD(@"Cancelling preloading choices because the manager is shut down");
             return;
         }
 
@@ -326,7 +326,7 @@ UInt16 const ChoiceCellCancelIdMin = 1;
 
         // Check if the manager has shutdown because the list of uploaded choices should not be updated
         if ([strongSelf.currentState isEqualToString:SDLChoiceManagerStateShutdown]) {
-            SDLLogD(@"The manager has shutdown");
+            SDLLogD(@"Cancelling deleting choices because manager is shut down");
             return;
         }
 
@@ -351,7 +351,7 @@ UInt16 const ChoiceCellCancelIdMin = 1;
         return;
     }
 
-    if (self.pendingPresentationSet != nil && self.pendingPresentOperation.isFinished == NO) {
+    if (self.pendingPresentationSet != nil && !self.pendingPresentOperation.isFinished) {
         SDLLogW(@"A choice set is pending: %@. We will try to cancel it in favor of presenting a different choice set: %@. If it's already on screen it cannot be cancelled", self.pendingPresentationSet, choiceSet);
         [self.pendingPresentOperation cancel];
     }

--- a/SmartDeviceLink/SDLChoiceSetManager.m
+++ b/SmartDeviceLink/SDLChoiceSetManager.m
@@ -442,6 +442,7 @@ UInt16 const ChoiceCellCancelIdMin = 1;
 
 /// Checks the passed list of choices to be uploaded and returns the items that have not yet been uploaded to the module.
 /// @param choices The choices to be uploaded
+/// @return The choices that have not yet been uploaded to the module
 - (NSSet<SDLChoiceCell *> *)sdl_choicesToBeUploadedWithArray:(NSArray<SDLChoiceCell *> *)choices {
     NSMutableSet<SDLChoiceCell *> *choicesSet = [NSMutableSet setWithArray:choices];
     [choicesSet minusSet:self.preloadedChoices];
@@ -451,6 +452,7 @@ UInt16 const ChoiceCellCancelIdMin = 1;
 
 /// Checks the passed list of choices to be deleted and returns the items that have been uploaded to the module.
 /// @param choices The choices to be deleted
+/// @return The choices that have been uploaded to the module
 - (NSSet<SDLChoiceCell *> *)sdl_choicesToBeDeletedWithArray:(NSArray<SDLChoiceCell *> *)choices {
     NSMutableSet<SDLChoiceCell *> *choicesSet = [NSMutableSet setWithArray:choices];
     [choicesSet intersectSet:self.preloadedChoices];
@@ -460,6 +462,7 @@ UInt16 const ChoiceCellCancelIdMin = 1;
 
 /// Checks the passed list of choices to be deleted and returns the items that are waiting to be uploaded to the module.
 /// @param choices The choices to be deleted
+/// @return The choices that are waiting to be uploaded to the module
 - (NSSet<SDLChoiceCell *> *)sdl_choicesToBeRemovedFromPendingWithArray:(NSArray<SDLChoiceCell *> *)choices {
     NSMutableSet<SDLChoiceCell *> *choicesSet = [NSMutableSet setWithArray:choices];
     [choicesSet intersectSet:self.pendingPreloadChoices];

--- a/SmartDeviceLink/SDLChoiceSetManager.m
+++ b/SmartDeviceLink/SDLChoiceSetManager.m
@@ -171,7 +171,7 @@ UInt16 const ChoiceCellCancelIdMin = 1;
 - (void)didEnterStateShutdown {
     SDLLogV(@"Manager shutting down");
 
-    NSAssert(dispatch_get_specific(SDLProcessingQueueName) != nil, @"%@ must only be called on a serial queue", NSStringFromSelector(_cmd));
+    NSAssert(dispatch_get_specific(SDLProcessingQueueName) != nil, @"%@ must only be called on the SDL serial queue", NSStringFromSelector(_cmd));
 
     _currentHMILevel = SDLHMILevelNone;
 

--- a/SmartDeviceLink/SDLTextAndGraphicManager.m
+++ b/SmartDeviceLink/SDLTextAndGraphicManager.m
@@ -87,10 +87,23 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)start {
+    SDLLogD(@"Starting manager");
+
+    // Make sure none of the properties were set after the manager was shut down
+    [self sdl_reset];
+
     [self.systemCapabilityManager subscribeToCapabilityType:SDLSystemCapabilityTypeDisplays withObserver:self selector:@selector(sdl_displayCapabilityDidUpdate:)];
 }
 
 - (void)stop {
+    SDLLogD(@"Stopping manager");
+    [self sdl_reset];
+
+    [self.systemCapabilityManager unsubscribeFromCapabilityType:SDLSystemCapabilityTypeDisplays withObserver:self];
+}
+
+- (void)sdl_reset {
+    SDLLogV(@"Resetting properties");
     _textField1 = nil;
     _textField2 = nil;
     _textField3 = nil;
@@ -115,8 +128,6 @@ NS_ASSUME_NONNULL_BEGIN
     _blankArtwork = nil;
     _waitingOnHMILevelUpdateToUpdate = NO;
     _isDirty = NO;
-
-    [self.systemCapabilityManager unsubscribeFromCapabilityType:SDLSystemCapabilityTypeDisplays withObserver:self];
 }
 
 #pragma mark - Upload / Send


### PR DESCRIPTION
Fixes #1584

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Added test cases to the _SDLChoiceSetManagerSpec_ to verify that the list of pending and uploaded choice items is not updated after the choice set manager is shutdown. This can happen if the transport is destroyed while choice items are being preloaded, deleted or presented. 

#### Core Tests
1. Checked that destroying the transport while choices are being preloaded does not break the choice set manager when the transport is reestablished.
1. Checked that destroying the transport while choices are being presented does not break the choice set manager when the transport is reestablished.
1. Check that destroying the transport while the keyboard is being presented does not break the choice set manager when the transport is reestablished.  

Core version / branch / commit hash / module tested against: SYNC 3.0
HMI name / version / branch / commit hash / module tested against: SYNC 3.0

### Summary
Made the choice set manager thread safe.

### Changelog
##### Bug Fixes
* Fixed the library crashing due to multiple threads accessing `NSMutableSet`s at the same time.
* Made setting the choice set ids thread safe, so no two choices can be assigned the same `choiceId` or `cancelId`.
* Fixed the choice set manager failing to present a choice set due to an `INVALID_ID`. This was due to adding choice set items to the list of pending and presenting choice items after the transport was destroyed. Since the library thought those choice items were on the module, they were not uploaded, thus creating an error when trying to present the choice set items. 

### Tasks Remaining:
- [x] Unit tests
- [x] Smoke tests

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
