### PR TITLE
Deprecate all SyncPData structures

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "Quick/Nimble" "v8.0.5"
 github "Quick/Quick" "v2.2.0"
-github "erikdoe/ocmock" "v3.5"
+github "erikdoe/ocmock" "v3.6"
 github "uber/ios-snapshot-test-case" "6.2.0"

--- a/SmartDeviceLink/SDLEncodedSyncPData.h
+++ b/SmartDeviceLink/SDLEncodedSyncPData.h
@@ -12,6 +12,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+__deprecated
 @interface SDLEncodedSyncPData : SDLRPCRequest
 
 /**

--- a/SmartDeviceLink/SDLEncodedSyncPData.m
+++ b/SmartDeviceLink/SDLEncodedSyncPData.m
@@ -10,7 +10,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation SDLEncodedSyncPData
+#pragma clang diagnostic pop
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"

--- a/SmartDeviceLink/SDLEncodedSyncPDataResponse.h
+++ b/SmartDeviceLink/SDLEncodedSyncPDataResponse.h
@@ -11,6 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  **DEPRECATED**
  */
+__deprecated
 @interface SDLEncodedSyncPDataResponse : SDLRPCResponse
 
 @end

--- a/SmartDeviceLink/SDLEncodedSyncPDataResponse.m
+++ b/SmartDeviceLink/SDLEncodedSyncPDataResponse.m
@@ -10,7 +10,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation SDLEncodedSyncPDataResponse
+#pragma clang diagnostic pop
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"

--- a/SmartDeviceLink/SDLFunctionID.m
+++ b/SmartDeviceLink/SDLFunctionID.m
@@ -116,10 +116,13 @@ NS_ASSUME_NONNULL_BEGIN
                          @32785: SDLRPCFunctionNameOnRCStatus,
                          @32786: SDLRPCFunctionNameOnAppServiceData,
                          @32787: SDLRPCFunctionNameOnSystemCapabilityUpdated,
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                          @65536: SDLRPCFunctionNameEncodedSyncPData,
                          @65537: SDLRPCFunctionNameSyncPData,
                          @98304: SDLRPCFunctionNameOnEncodedSyncPData,
                          @98305: SDLRPCFunctionNameOnSyncPData
+#pragma clang diagnostic pop
                          };
     return self;
 }

--- a/SmartDeviceLink/SDLNotificationConstants.h
+++ b/SmartDeviceLink/SDLNotificationConstants.h
@@ -187,7 +187,7 @@ extern SDLNotificationName const SDLDidReceiveDiagnosticMessageResponse;
 extern SDLNotificationName const SDLDidReceiveDialNumberResponse;
 
 /// Name for an EncodedSyncPData response RPC
-extern SDLNotificationName const SDLDidReceiveEncodedSyncPDataResponse;
+extern SDLNotificationName const SDLDidReceiveEncodedSyncPDataResponse __deprecated;
 
 /// Name for an EndAudioPassThru response RPC
 extern SDLNotificationName const SDLDidReceiveEndAudioPassThruResponse;
@@ -304,7 +304,7 @@ extern SDLNotificationName const SDLDidReceiveSubscribeVehicleDataResponse;
 extern SDLNotificationName const SDLDidReceiveSubscribeWaypointsResponse;
 
 /// Name for a SyncPData response RPC
-extern SDLNotificationName const SDLDidReceiveSyncPDataResponse;
+extern SDLNotificationName const SDLDidReceiveSyncPDataResponse __deprecated;
 
 /// Name for an UpdateTurnList response RPC
 extern SDLNotificationName const SDLDidReceiveUpdateTurnListResponse;
@@ -381,7 +381,7 @@ extern SDLNotificationName const SDLDidReceiveDiagnosticMessageRequest;
 extern SDLNotificationName const SDLDidReceiveDialNumberRequest;
 
 /// Name for an EncodedSyncPData request RPC
-extern SDLNotificationName const SDLDidReceiveEncodedSyncPDataRequest;
+extern SDLNotificationName const SDLDidReceiveEncodedSyncPDataRequest __deprecated;
 
 /// Name for a EndAudioPass request RPC
 extern SDLNotificationName const SDLDidReceiveEndAudioPassThruRequest;
@@ -495,7 +495,7 @@ extern SDLNotificationName const SDLDidReceiveSubscribeVehicleDataRequest;
 extern SDLNotificationName const SDLDidReceiveSubscribeWayPointsRequest;
 
 /// Name for a SyncPData request RPC
-extern SDLNotificationName const SDLDidReceiveSyncPDataRequest;
+extern SDLNotificationName const SDLDidReceiveSyncPDataRequest __deprecated;
 
 /// Name for a SystemRequest request RPC
 extern SDLNotificationName const SDLDidReceiveSystemRequestRequest;
@@ -548,7 +548,7 @@ extern SDLNotificationName const SDLDidReceiveButtonPressNotification;
 extern SDLNotificationName const SDLDidReceiveCommandNotification;
 
 /// Name for a EncodedData notification RPC
-extern SDLNotificationName const SDLDidReceiveEncodedDataNotification;
+extern SDLNotificationName const SDLDidReceiveEncodedDataNotification __deprecated;
 
 /// Name for a InteriorVehicleData notification RPC
 extern SDLNotificationName const SDLDidReceiveInteriorVehicleDataNotification;
@@ -573,6 +573,9 @@ extern SDLNotificationName const SDLDidChangePermissionsNotification;
 
 /// Name for a RemoteControlStatus notification RPC
 extern SDLNotificationName const SDLDidReceiveRemoteControlStatusNotification;
+
+/// Name for an OnSyncPData notification RPC
+extern SDLNotificationName const SDLDidReceiveSyncPDataNotification __deprecated;
 
 /// Name for a SystemCapability notification RPC
 extern SDLNotificationName const SDLDidReceiveSystemCapabilityUpdatedNotification;

--- a/SmartDeviceLink/SDLNotificationConstants.m
+++ b/SmartDeviceLink/SDLNotificationConstants.m
@@ -170,6 +170,7 @@ SDLNotificationName const SDLDidChangeLockScreenStatusNotification = @"com.sdl.n
 SDLNotificationName const SDLDidReceiveNewHashNotification = @"com.sdl.notification.newHash";
 SDLNotificationName const SDLDidChangePermissionsNotification = @"com.sdl.notification.changePermission";
 SDLNotificationName const SDLDidReceiveRemoteControlStatusNotification = @"com.sdl.notification.rcStatus";
+SDLNotificationName const SDLDidReceiveSyncPDataNotification = @"com.sdl.notification.syncpdata";
 SDLNotificationName const SDLDidReceiveSystemCapabilityUpdatedNotification = @"com.sdl.notification.systemCapabilityUpdated";
 SDLNotificationName const SDLDidReceiveSystemRequestNotification = @"com.sdl.notification.receiveSystemRequest";
 SDLNotificationName const SDLDidChangeTurnByTurnStateNotification = @"com.sdl.notification.changeTurnByTurnState";
@@ -198,7 +199,10 @@ SDLNotificationName const SDLDidReceiveWaypointNotification = @"com.sdl.notifica
              SDLDidReceiveDeleteWindowResponse,
              SDLDidReceiveDiagnosticMessageResponse,
              SDLDidReceiveDialNumberResponse,
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
              SDLDidReceiveEncodedSyncPDataResponse,
+#pragma clang diagnostic pop
              SDLDidReceiveEndAudioPassThruResponse,
              SDLDidReceiveGenericResponse,
              SDLDidReceiveGetCloudAppPropertiesResponse,
@@ -237,7 +241,10 @@ SDLNotificationName const SDLDidReceiveWaypointNotification = @"com.sdl.notifica
              SDLDidReceiveSubscribeButtonResponse,
              SDLDidReceiveSubscribeVehicleDataResponse,
              SDLDidReceiveSubscribeWaypointsResponse,
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
              SDLDidReceiveSyncPDataResponse,
+#pragma clang diagnostic pop
              SDLDidReceiveUpdateTurnListResponse,
              SDLDidReceiveUnpublishAppServiceResponse,
              SDLDidReceiveUnregisterAppInterfaceResponse,

--- a/SmartDeviceLink/SDLNotificationDispatcher.m
+++ b/SmartDeviceLink/SDLNotificationDispatcher.m
@@ -425,12 +425,15 @@ NS_ASSUME_NONNULL_BEGIN
     [self postRPCRequestNotification:SDLDidReceiveDialNumberRequest request:request];
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (void)onEncodedSyncPData:(SDLEncodedSyncPData *)request {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [self postRPCRequestNotification:SDLDidReceiveEncodedSyncPDataRequest request:request];
 #pragma clang diagnostic pop
 }
+#pragma clang diagnostic pop
 
 - (void)onEndAudioPassThru:(SDLEndAudioPassThru *)request {
     [self postRPCRequestNotification:SDLDidReceiveEndAudioPassThruRequest request:request];
@@ -580,12 +583,15 @@ NS_ASSUME_NONNULL_BEGIN
     [self postRPCRequestNotification:SDLDidReceiveSubscribeWayPointsRequest request:request];
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (void)onSyncPData:(SDLSyncPData *)request {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [self postRPCRequestNotification:SDLDidReceiveSyncPDataRequest request:request];
 #pragma clang diagnostic pop
 }
+#pragma clang diagnostic pop
 
 -(void)onSystemRequest:(SDLSystemRequest *)request {
     [self postRPCRequestNotification:SDLDidReceiveSystemRequestRequest request:request];

--- a/SmartDeviceLink/SDLNotificationDispatcher.m
+++ b/SmartDeviceLink/SDLNotificationDispatcher.m
@@ -159,9 +159,15 @@ NS_ASSUME_NONNULL_BEGIN
     [self postRPCResponseNotification:SDLDidReceiveDialNumberResponse response:response];
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (void)onEncodedSyncPDataResponse:(SDLEncodedSyncPDataResponse *)response {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [self postRPCResponseNotification:SDLDidReceiveEncodedSyncPDataResponse response:response];
+#pragma clang diagnostic pop
 }
+#pragma clang diagnostic pop
 
 - (void)onEndAudioPassThruResponse:(SDLEndAudioPassThruResponse *)response {
     [self postRPCResponseNotification:SDLDidReceiveEndAudioPassThruResponse response:response];
@@ -315,9 +321,15 @@ NS_ASSUME_NONNULL_BEGIN
     [self postRPCResponseNotification:SDLDidReceiveSubscribeWaypointsResponse response:response];
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (void)onSyncPDataResponse:(SDLSyncPDataResponse *)response {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [self postRPCResponseNotification:SDLDidReceiveSyncPDataResponse response:response];
+#pragma clang diagnostic pop
 }
+#pragma clang diagnostic pop
 
 - (void)onUpdateTurnListResponse:(SDLUpdateTurnListResponse *)response {
     [self postRPCResponseNotification:SDLDidReceiveUpdateTurnListResponse response:response];
@@ -414,7 +426,10 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)onEncodedSyncPData:(SDLEncodedSyncPData *)request {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [self postRPCRequestNotification:SDLDidReceiveEncodedSyncPDataRequest request:request];
+#pragma clang diagnostic pop
 }
 
 - (void)onEndAudioPassThru:(SDLEndAudioPassThru *)request {
@@ -566,7 +581,10 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)onSyncPData:(SDLSyncPData *)request {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [self postRPCRequestNotification:SDLDidReceiveSyncPDataRequest request:request];
+#pragma clang diagnostic pop
 }
 
 -(void)onSystemRequest:(SDLSystemRequest *)request {
@@ -623,9 +641,15 @@ NS_ASSUME_NONNULL_BEGIN
     [self postRPCNotificationNotification:SDLDidReceiveCommandNotification notification:notification];
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (void)onOnEncodedSyncPData:(SDLOnEncodedSyncPData *)notification {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [self postRPCNotificationNotification:SDLDidReceiveEncodedDataNotification notification:notification];
+#pragma clang diagnostic pop
 }
+#pragma clang diagnostic pop
 
 - (void)onOnHashChange:(SDLOnHashChange *)notification {
     [self postRPCNotificationNotification:SDLDidReceiveNewHashNotification notification:notification];
@@ -655,9 +679,15 @@ NS_ASSUME_NONNULL_BEGIN
     [self postRPCNotificationNotification:SDLDidReceiveRemoteControlStatusNotification notification:notification];
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (void)onOnSyncPData:(SDLOnSyncPData *)notification {
-    [self postRPCNotificationNotification:SDLDidReceiveSystemRequestNotification notification:notification];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    [self postRPCNotificationNotification:SDLDidReceiveSyncPDataNotification notification:notification];
+#pragma clang diagnostic pop
 }
+#pragma clang diagnostic pop
 
 - (void)onOnSystemCapabilityUpdated:(SDLOnSystemCapabilityUpdated *)notification {
     [self postRPCNotificationNotification:SDLDidReceiveSystemCapabilityUpdatedNotification notification:notification];

--- a/SmartDeviceLink/SDLOnEncodedSyncPData.h
+++ b/SmartDeviceLink/SDLOnEncodedSyncPData.h
@@ -8,6 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Callback including encoded data of any SyncP packets that SYNC needs to send back to the mobile device. Legacy / v1 Protocol implementation; responds to EncodedSyncPData. *** DEPRECATED ***
  */
+__deprecated
 @interface SDLOnEncodedSyncPData : SDLRPCNotification
 
 /**

--- a/SmartDeviceLink/SDLOnEncodedSyncPData.m
+++ b/SmartDeviceLink/SDLOnEncodedSyncPData.m
@@ -9,7 +9,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation SDLOnEncodedSyncPData
+#pragma clang diagnostic pop
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"

--- a/SmartDeviceLink/SDLOnSyncPData.h
+++ b/SmartDeviceLink/SDLOnSyncPData.h
@@ -9,6 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  DEPRECATED
  */
+__deprecated
 @interface SDLOnSyncPData : SDLRPCNotification
 
 /// The url

--- a/SmartDeviceLink/SDLOnSyncPData.m
+++ b/SmartDeviceLink/SDLOnSyncPData.m
@@ -11,7 +11,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation SDLOnSyncPData
+#pragma clang diagnostic pop
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"

--- a/SmartDeviceLink/SDLProxy.m
+++ b/SmartDeviceLink/SDLProxy.m
@@ -1010,7 +1010,10 @@ static float DefaultConnectionTimeout = 45.0;
     NSError *JSONConversionError = nil;
     NSDictionary<NSString *, id> *responseDictionary = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:&JSONConversionError];
     if (!JSONConversionError) {
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLEncodedSyncPData *request = [[SDLEncodedSyncPData alloc] init];
+        #pragma clang diagnostic pop
         request.correlationID = [NSNumber numberWithInt:PoliciesCorrelationId];
         request.data = [responseDictionary objectForKey:@"data"];
 

--- a/SmartDeviceLink/SDLProxyListener.h
+++ b/SmartDeviceLink/SDLProxyListener.h
@@ -309,7 +309,10 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @param response A SDLEncodedSyncPDataResponse object
  */
-- (void)onEncodedSyncPDataResponse:(SDLEncodedSyncPDataResponse *)response;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+- (void)onEncodedSyncPDataResponse:(SDLEncodedSyncPDataResponse *)response __deprecated;
+#pragma clang diagnostic pop
 
 /**
  *  Called when an End Audio Pass Thru Response is received from Core
@@ -589,7 +592,10 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @param response A SDLSyncPDataResponse object
  */
-- (void)onSyncPDataResponse:(SDLSyncPDataResponse *)response;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+- (void)onSyncPDataResponse:(SDLSyncPDataResponse *)response __deprecated;
+#pragma clang diagnostic pop
 
 /**
  *  Called when an Update Turn List Response is received from Core
@@ -759,7 +765,10 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @param request A SDLEncodedSyncPData object
  */
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (void)onEncodedSyncPData:(SDLEncodedSyncPData *)request;
+#pragma clang diagnostic pop
 
 /**
  *  Called when a `EndAudioPassThru` request is received from Core
@@ -1025,7 +1034,10 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @param request A SDLSyncPData object
  */
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (void)onSyncPData:(SDLSyncPData *)request;
+#pragma clang diagnostic pop
 
 /**
  *  Called when a `SystemRequest` request is received from Core
@@ -1126,7 +1138,10 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @param notification A SDLOnEncodedSyncPData object
  */
-- (void)onOnEncodedSyncPData:(SDLOnEncodedSyncPData *)notification;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+- (void)onOnEncodedSyncPData:(SDLOnEncodedSyncPData *)notification __deprecated;
+#pragma clang diagnostic pop
 
 /**
  *  Called when an On Hash Change notification is received from Core
@@ -1185,7 +1200,10 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @param notification A SDLOnSyncPData object
  */
-- (void)onOnSyncPData:(SDLOnSyncPData *)notification;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+- (void)onOnSyncPData:(SDLOnSyncPData *)notification __deprecated;
+#pragma clang diagnostic pop
 
 /**
  *  Called when an `OnSystemCapabilityUpdated` notification is received from Core

--- a/SmartDeviceLink/SDLProxyListener.h
+++ b/SmartDeviceLink/SDLProxyListener.h
@@ -767,7 +767,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-- (void)onEncodedSyncPData:(SDLEncodedSyncPData *)request;
+- (void)onEncodedSyncPData:(SDLEncodedSyncPData *)request __deprecated;
 #pragma clang diagnostic pop
 
 /**
@@ -1036,7 +1036,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-- (void)onSyncPData:(SDLSyncPData *)request;
+- (void)onSyncPData:(SDLSyncPData *)request __deprecated;
 #pragma clang diagnostic pop
 
 /**

--- a/SmartDeviceLink/SDLRPCFunctionNames.h
+++ b/SmartDeviceLink/SDLRPCFunctionNames.h
@@ -59,7 +59,7 @@ extern SDLRPCFunctionName const SDLRPCFunctionNameDiagnosticMessage;
 extern SDLRPCFunctionName const SDLRPCFunctionNameDialNumber;
 
 /// Function name for an CreateInteractionChoiceSet RPC
-extern SDLRPCFunctionName const SDLRPCFunctionNameEncodedSyncPData;
+extern SDLRPCFunctionName const SDLRPCFunctionNameEncodedSyncPData __deprecated;
 
 /// Function name for an EndAudioPassThru RPC
 extern SDLRPCFunctionName const SDLRPCFunctionNameEndAudioPassThru;
@@ -119,7 +119,7 @@ extern SDLRPCFunctionName const SDLRPCFunctionNameOnCommand;
 extern SDLRPCFunctionName const SDLRPCFunctionNameOnDriverDistraction;
 
 /// Function name for an OnEncodedSyncPData notification RPC
-extern SDLRPCFunctionName const SDLRPCFunctionNameOnEncodedSyncPData;
+extern SDLRPCFunctionName const SDLRPCFunctionNameOnEncodedSyncPData __deprecated;
 
 /// Function name for an OnHashChange notification RPC
 extern SDLRPCFunctionName const SDLRPCFunctionNameOnHashChange;
@@ -146,7 +146,7 @@ extern SDLRPCFunctionName const SDLRPCFunctionNameOnPermissionsChange;
 extern SDLRPCFunctionName const SDLRPCFunctionNameOnRCStatus;
 
 /// Function name for an OnSyncPData notification RPC
-extern SDLRPCFunctionName const SDLRPCFunctionNameOnSyncPData;
+extern SDLRPCFunctionName const SDLRPCFunctionNameOnSyncPData __deprecated;
 
 /// Function name for an OnSystemCapabilityUpdated notification RPC
 extern SDLRPCFunctionName const SDLRPCFunctionNameOnSystemCapabilityUpdated;
@@ -248,7 +248,7 @@ extern SDLRPCFunctionName const SDLRPCFunctionNameSubscribeVehicleData;
 extern SDLRPCFunctionName const SDLRPCFunctionNameSubscribeWayPoints;
 
 /// Function name for a SyncPData RPC
-extern SDLRPCFunctionName const SDLRPCFunctionNameSyncPData;
+extern SDLRPCFunctionName const SDLRPCFunctionNameSyncPData __deprecated;
 
 /// Function name for a SystemRequest RPC
 extern SDLRPCFunctionName const SDLRPCFunctionNameSystemRequest;

--- a/SmartDeviceLink/SDLSyncPData.h
+++ b/SmartDeviceLink/SDLSyncPData.h
@@ -11,6 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  *** DEPRECATED ***
  */
+__deprecated
 @interface SDLSyncPData : SDLRPCRequest
 
 @end

--- a/SmartDeviceLink/SDLSyncPData.m
+++ b/SmartDeviceLink/SDLSyncPData.m
@@ -10,7 +10,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation SDLSyncPData
+#pragma clang diagnostic pop
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"

--- a/SmartDeviceLink/SDLSyncPDataResponse.h
+++ b/SmartDeviceLink/SDLSyncPDataResponse.h
@@ -11,6 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  DEPRECATED
  */
+__deprecated
 @interface SDLSyncPDataResponse : SDLRPCResponse
 
 @end

--- a/SmartDeviceLink/SDLSyncPDataResponse.m
+++ b/SmartDeviceLink/SDLSyncPDataResponse.m
@@ -10,7 +10,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation SDLSyncPDataResponse
+#pragma clang diagnostic pop
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"

--- a/SmartDeviceLinkTests/ProtocolSpecs/SDLFunctionIDSpec.m
+++ b/SmartDeviceLinkTests/ProtocolSpecs/SDLFunctionIDSpec.m
@@ -91,11 +91,14 @@ describe(@"GetFunctionName Tests", ^ {
         expect([functionID functionNameForId:32787]).to(equal(SDLRPCFunctionNameOnSystemCapabilityUpdated));
 
         //Not listed in Spec
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         expect([functionID functionNameForId:65536]).to(equal(SDLRPCFunctionNameEncodedSyncPData));
         expect([functionID functionNameForId:65537]).to(equal(SDLRPCFunctionNameSyncPData));
         
         expect([functionID functionNameForId:98304]).to(equal(SDLRPCFunctionNameOnEncodedSyncPData));
         expect([functionID functionNameForId:98305]).to(equal(SDLRPCFunctionNameOnSyncPData));
+#pragma clang diagnostic pop
     });
 });
 
@@ -152,6 +155,8 @@ describe(@"GetFunctionID Tests", ^ {
         expect([functionID functionIdForName:SDLRPCFunctionNameGetAppServiceData]).to(equal(@53));
         expect([functionID functionIdForName:SDLRPCFunctionNameGetFile]).to(equal(@54));
         expect([functionID functionIdForName:SDLRPCFunctionNamePerformAppServiceInteraction]).to(equal(@55));
+        expect([functionID functionIdForName:SDLRPCFunctionNameCreateWindow]).to(equal(@60));
+        expect([functionID functionIdForName:SDLRPCFunctionNameDeleteWindow]).to(equal(@61));
         expect([functionID functionIdForName:SDLRPCFunctionNameOnHMIStatus]).to(equal(@32768));
         expect([functionID functionIdForName:SDLRPCFunctionNameOnAppInterfaceUnregistered]).to(equal(@32769));
         expect([functionID functionIdForName:SDLRPCFunctionNameOnButtonEvent]).to(equal(@32770));
@@ -173,13 +178,14 @@ describe(@"GetFunctionID Tests", ^ {
         expect([functionID functionIdForName:SDLRPCFunctionNameOnSystemCapabilityUpdated]).to(equal(@32787));
 
         //Not listed in Spec
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         expect([functionID functionIdForName:SDLRPCFunctionNameEncodedSyncPData]).to(equal(@65536));
         expect([functionID functionIdForName:SDLRPCFunctionNameSyncPData]).to(equal(@65537));
         
         expect([functionID functionIdForName:SDLRPCFunctionNameOnEncodedSyncPData]).to(equal(@98304));
         expect([functionID functionIdForName:SDLRPCFunctionNameOnSyncPData]).to(equal(@98305));
-        expect([functionID functionIdForName:SDLRPCFunctionNameCreateWindow]).to(equal(@60));
-        expect([functionID functionIdForName:SDLRPCFunctionNameDeleteWindow]).to(equal(@61));
+#pragma clang diagnostic pop
     });
 });
 

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnEncodedSyncPDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnEncodedSyncPDataSpec.m
@@ -16,7 +16,10 @@ QuickSpecBegin(SDLOnEncodedSyncPDataSpec)
 
 describe(@"Getter/Setter Tests", ^ {
     it(@"Should set and get correctly", ^ {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnEncodedSyncPData* testNotification = [[SDLOnEncodedSyncPData alloc] init];
+#pragma clang diagnostic pop
         
         testNotification.data = [@[@"0"] mutableCopy];
         testNotification.URL = @"www.zombo.com";
@@ -28,12 +31,16 @@ describe(@"Getter/Setter Tests", ^ {
     });
     
     it(@"Should get correctly when initialized", ^ {
-        NSMutableDictionary<NSString *, id> *dict = [@{SDLRPCParameterNameNotification:
-                                                           @{SDLRPCParameterNameParameters:
-                                                                 @{SDLRPCParameterNameData:[@[@"0"] mutableCopy],
-                                                                   SDLRPCParameterNameURLUppercase:@"www.zombo.com",
-                                                                   SDLRPCParameterNameTimeoutCapitalized:@564},
-                                                             SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnEncodedSyncPData}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        NSDictionary<NSString *, id> *dict = @{SDLRPCParameterNameNotification:
+                                                   @{SDLRPCParameterNameParameters:
+                                                         @{SDLRPCParameterNameData:@[@"0"],
+                                                           SDLRPCParameterNameURLUppercase:@"www.zombo.com",
+                                                           SDLRPCParameterNameTimeoutCapitalized:@564},
+                                                     SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnEncodedSyncPData}};
+#pragma clang diagnostic pop
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnEncodedSyncPData* testNotification = [[SDLOnEncodedSyncPData alloc] initWithDictionary:dict];
@@ -45,7 +52,10 @@ describe(@"Getter/Setter Tests", ^ {
     });
     
     it(@"Should return nil if not set", ^ {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnEncodedSyncPData* testNotification = [[SDLOnEncodedSyncPData alloc] init];
+#pragma clang diagnostic pop
         
         expect(testNotification.data).to(beNil());
         expect(testNotification.URL).to(beNil());

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnSyncPDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnSyncPDataSpec.m
@@ -16,7 +16,10 @@ QuickSpecBegin(SDLOnSyncPDataSpec)
 
 describe(@"Getter/Setter Tests", ^ {
     it(@"Should set and get correctly", ^ {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnSyncPData* testNotification = [[SDLOnSyncPData alloc] init];
+#pragma clang diagnostic pop
         
         testNotification.URL = @"https://www.youtube.com/watch?v=ygr5AHufBN4";
         testNotification.Timeout = @8357;
@@ -26,11 +29,15 @@ describe(@"Getter/Setter Tests", ^ {
     });
     
     it(@"Should get correctly when initialized", ^ {
-        NSMutableDictionary<NSString *, id> *dict = [@{SDLRPCParameterNameNotification:
-                                                           @{SDLRPCParameterNameParameters:
-                                                                 @{SDLRPCParameterNameURLUppercase:@"https://www.youtube.com/watch?v=ygr5AHufBN4",
-                                                                   SDLRPCParameterNameTimeoutCapitalized:@8357},
-                                                             SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnSyncPData}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        NSDictionary<NSString *, id> *dict = @{SDLRPCParameterNameNotification:
+                                                   @{SDLRPCParameterNameParameters:
+                                                         @{SDLRPCParameterNameURLUppercase:@"https://www.youtube.com/watch?v=ygr5AHufBN4",
+                                                           SDLRPCParameterNameTimeoutCapitalized:@8357},
+                                                     SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnSyncPData}};
+#pragma clang diagnostic pop
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnSyncPData* testNotification = [[SDLOnSyncPData alloc] initWithDictionary:dict];
@@ -41,7 +48,10 @@ describe(@"Getter/Setter Tests", ^ {
     });
     
     it(@"Should return nil if not set", ^ {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnSyncPData* testNotification = [[SDLOnSyncPData alloc] init];
+#pragma clang diagnostic pop
         
         expect(testNotification.URL).to(beNil());
         expect(testNotification.Timeout).to(beNil());

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLEncodedSyncPDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLEncodedSyncPDataSpec.m
@@ -16,7 +16,10 @@ QuickSpecBegin(SDLEncodedSyncPDataSpec)
 
 describe(@"Getter/Setter Tests", ^ {
     it(@"Should set and get correctly", ^ {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLEncodedSyncPData* testRequest = [[SDLEncodedSyncPData alloc] init];
+#pragma clang diagnostic pop
         
 		testRequest.data = [@[@"2", @"2", @"2"] mutableCopy];
 
@@ -24,10 +27,14 @@ describe(@"Getter/Setter Tests", ^ {
     });
     
     it(@"Should get correctly when initialized", ^ {
-        NSMutableDictionary<NSString *, id> *dict = [@{SDLRPCParameterNameRequest:
-                                                           @{SDLRPCParameterNameParameters:
-                                                                 @{SDLRPCParameterNameData:[@[@"2", @"2", @"2"] mutableCopy]},
-                                                             SDLRPCParameterNameOperationName:SDLRPCFunctionNameEncodedSyncPData}} mutableCopy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        NSDictionary<NSString *, id> *dict = @{SDLRPCParameterNameRequest:
+                                                    @{SDLRPCParameterNameParameters:
+                                                          @{SDLRPCParameterNameData:@[@"2", @"2", @"2"]},
+                                                      SDLRPCParameterNameOperationName:SDLRPCFunctionNameEncodedSyncPData}};
+#pragma clang diagnostic pop
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLEncodedSyncPData* testRequest = [[SDLEncodedSyncPData alloc] initWithDictionary:dict];
@@ -37,7 +44,10 @@ describe(@"Getter/Setter Tests", ^ {
     });
 
     it(@"Should return nil if not set", ^ {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLEncodedSyncPData* testRequest = [[SDLEncodedSyncPData alloc] init];
+#pragma clang diagnostic pop
         
 		expect(testRequest.data).to(beNil());
 	});

--- a/SmartDeviceLinkTests/SDLRPCFunctionNamesSpec.m
+++ b/SmartDeviceLinkTests/SDLRPCFunctionNamesSpec.m
@@ -29,7 +29,10 @@ describe(@"Individual Enum Value Tests", ^ {
         expect(SDLRPCFunctionNameDeleteSubMenu).to(equal(@"DeleteSubMenu"));
         expect(SDLRPCFunctionNameDiagnosticMessage).to(equal(@"DiagnosticMessage"));
         expect(SDLRPCFunctionNameDialNumber).to(equal(@"DialNumber"));
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         expect(SDLRPCFunctionNameEncodedSyncPData).to(equal(@"EncodedSyncPData"));
+#pragma clang diagnostic pop
         expect(SDLRPCFunctionNameEndAudioPassThru).to(equal(@"EndAudioPassThru"));
         expect(SDLRPCFunctionNameGenericResponse).to(equal(@"GenericResponse"));
         expect(SDLRPCFunctionNameGetAppServiceData).to(equal(@"GetAppServiceData"));
@@ -47,7 +50,10 @@ describe(@"Individual Enum Value Tests", ^ {
         expect(SDLRPCFunctionNameOnButtonPress).to(equal(@"OnButtonPress"));
         expect(SDLRPCFunctionNameOnCommand).to(equal(@"OnCommand"));
         expect(SDLRPCFunctionNameOnDriverDistraction).to(equal(@"OnDriverDistraction"));
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         expect(SDLRPCFunctionNameOnEncodedSyncPData).to(equal(@"OnEncodedSyncPData"));
+#pragma clang diagnostic pop
         expect(SDLRPCFunctionNameOnHashChange).to(equal(@"OnHashChange"));
         expect(SDLRPCFunctionNameOnHMIStatus).to(equal(@"OnHMIStatus"));
         expect(SDLRPCFunctionNameOnInteriorVehicleData).to(equal(@"OnInteriorVehicleData"));
@@ -55,7 +61,10 @@ describe(@"Individual Enum Value Tests", ^ {
         expect(SDLRPCFunctionNameOnLanguageChange).to(equal(@"OnLanguageChange"));
         expect(SDLRPCFunctionNameOnPermissionsChange).to(equal(@"OnPermissionsChange"));
         expect(SDLRPCFunctionNameOnRCStatus).to(equal(@"OnRCStatus"));
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         expect(SDLRPCFunctionNameOnSyncPData).to(equal(@"OnSyncPData"));
+#pragma clang diagnostic pop
         expect(SDLRPCFunctionNameOnSystemCapabilityUpdated).to(equal(@"OnSystemCapabilityUpdated"));
         expect(SDLRPCFunctionNameOnSystemRequest).to(equal(@"OnSystemRequest"));
         expect(SDLRPCFunctionNameOnTBTClientState).to(equal(@"OnTBTClientState"));
@@ -86,7 +95,10 @@ describe(@"Individual Enum Value Tests", ^ {
         expect(SDLRPCFunctionNameSubscribeButton).to(equal(@"SubscribeButton"));
         expect(SDLRPCFunctionNameSubscribeVehicleData).to(equal(@"SubscribeVehicleData"));
         expect(SDLRPCFunctionNameSubscribeWayPoints).to(equal(@"SubscribeWayPoints"));
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         expect(SDLRPCFunctionNameSyncPData).to(equal(@"SyncPData"));
+#pragma clang diagnostic pop
         expect(SDLRPCFunctionNameSystemRequest).to(equal(@"SystemRequest"));
         expect(SDLRPCFunctionNameUnpublishAppService).to(equal(@"UnpublishAppService"));
         expect(SDLRPCFunctionNameUnregisterAppInterface).to(equal(@"UnregisterAppInterface"));


### PR DESCRIPTION
Fixes #1599 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Unit tests were updated to account for the deprecations

#### Core Tests
N/A, purely deprecations

Core version / branch / commit hash / module tested against: n/a
HMI name / version / branch / commit hash / module tested against: n/a

### Summary
This PR deprecates removed / deprecated RPCs in the RPC_SPEC. The deprecated RPCs predated the `deprecated=true` attribute and are only deprecated via comment.

### Changelog
##### Bug Fixes
* Deprecated removed / deprecated RPCs relating to `SyncPData`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
