### PR TITLE
Deprecated lockscreen notification and enum

### DIFF
--- a/SmartDeviceLink/SDLLockScreenManager.m
+++ b/SmartDeviceLink/SDLLockScreenManager.m
@@ -197,17 +197,26 @@ NS_ASSUME_NONNULL_BEGIN
         if (self.canPresent) {
             [self.presenter updateLockScreenToShow:YES withCompletionHandler:nil];
         }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     } else if ([self.lastLockNotification.lockScreenStatus isEqualToEnum:SDLLockScreenStatusRequired]) {
+#pragma clang diagnostic pop
         if (self.canPresent && !self.lockScreenDismissedByUser) {
             [self.presenter updateLockScreenToShow:YES withCompletionHandler:nil];
         }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     } else if ([self.lastLockNotification.lockScreenStatus isEqualToEnum:SDLLockScreenStatusOptional]) {
+#pragma clang diagnostic pop
         if (self.config.displayMode == SDLLockScreenConfigurationDisplayModeOptionalOrRequired && self.canPresent && !self.lockScreenDismissedByUser) {
             [self.presenter updateLockScreenToShow:YES withCompletionHandler:nil];
         } else if (self.config.displayMode != SDLLockScreenConfigurationDisplayModeOptionalOrRequired) {
             [self.presenter updateLockScreenToShow:NO withCompletionHandler:nil];
         }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     } else if ([self.lastLockNotification.lockScreenStatus isEqualToEnum:SDLLockScreenStatusOff]) {
+#pragma clang diagnostic pop
         [self.presenter updateLockScreenToShow:NO withCompletionHandler:nil];
     }
 }

--- a/SmartDeviceLink/SDLLockScreenManager.m
+++ b/SmartDeviceLink/SDLLockScreenManager.m
@@ -54,7 +54,10 @@ NS_ASSUME_NONNULL_BEGIN
     _presenter = presenter;
     _lockScreenDismissedByUser = NO;
     
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_lockScreenStatusDidChange:) name:SDLDidChangeLockScreenStatusNotification object:dispatcher];
+#pragma clang diagnostic pop
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_lockScreenIconReceived:) name:SDLDidReceiveLockScreenIcon object:dispatcher];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_appDidBecomeActive:) name:UIApplicationDidBecomeActiveNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_driverDistractionStateDidChange:) name:SDLDidChangeDriverDistractionStateNotification object:dispatcher];

--- a/SmartDeviceLink/SDLLockScreenStatus.h
+++ b/SmartDeviceLink/SDLLockScreenStatus.h
@@ -11,19 +11,19 @@
 
  Used in OnLockScreenStatus
  */
-typedef SDLEnum SDLLockScreenStatus SDL_SWIFT_ENUM;
+typedef SDLEnum SDLLockScreenStatus SDL_SWIFT_ENUM __deprecated;
 
 /**
  * LockScreen is Not Required
  */
-extern SDLLockScreenStatus const SDLLockScreenStatusOff;
+extern SDLLockScreenStatus const SDLLockScreenStatusOff __deprecated;
 
 /**
  * LockScreen is Optional
  */
-extern SDLLockScreenStatus const SDLLockScreenStatusOptional;
+extern SDLLockScreenStatus const SDLLockScreenStatusOptional __deprecated;
 
 /**
  * LockScreen is Required
  */
-extern SDLLockScreenStatus const SDLLockScreenStatusRequired;
+extern SDLLockScreenStatus const SDLLockScreenStatusRequired __deprecated;

--- a/SmartDeviceLink/SDLLockScreenStatusManager.h
+++ b/SmartDeviceLink/SDLLockScreenStatusManager.h
@@ -17,9 +17,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic) BOOL userSelected;
 @property (assign, nonatomic) BOOL driverDistracted;
 @property (nullable, strong, nonatomic) SDLHMILevel hmiLevel;
-@property (strong, nonatomic, readonly) SDLLockScreenStatus lockScreenStatus;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+@property (strong, nonatomic, readonly) SDLLockScreenStatus lockScreenStatus;
 @property (strong, nonatomic, readonly) SDLOnLockScreenStatus *lockScreenStatusNotification;
 #pragma clang diagnostic pop
 

--- a/SmartDeviceLink/SDLLockScreenStatusManager.m
+++ b/SmartDeviceLink/SDLLockScreenStatusManager.m
@@ -68,36 +68,60 @@ NS_ASSUME_NONNULL_BEGIN
     return notification;
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (SDLLockScreenStatus)lockScreenStatus {
+#pragma clang diagnostic pop
     if (self.hmiLevel == nil || [self.hmiLevel isEqualToEnum:SDLHMILevelNone]) {
         // App is not active on the car
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         return SDLLockScreenStatusOff;
+#pragma clang diagnostic pop
     } else if ([self.hmiLevel isEqualToEnum:SDLHMILevelBackground]) {
         // App is in the background on the car
         if (self.userSelected) {
             // It was user selected
             if (self.haveDriverDistractionStatus && !self.driverDistracted) {
                 // We have the distraction status, and the driver is not distracted
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 return SDLLockScreenStatusOptional;
+#pragma clang diagnostic pop
             } else {
                 // We don't have the distraction status, and/or the driver is distracted
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 return SDLLockScreenStatusRequired;
+#pragma clang diagnostic pop
             }
         } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             return SDLLockScreenStatusOff;
+#pragma clang diagnostic pop
         }
     } else if ([self.hmiLevel isEqualToEnum:SDLHMILevelFull] || [self.hmiLevel isEqualToEnum:SDLHMILevelLimited]) {
         // App is in the foreground on the car in some manner
         if (self.haveDriverDistractionStatus && !self.driverDistracted) {
             // We have the distraction status, and the driver is not distracted
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             return SDLLockScreenStatusOptional;
+#pragma clang diagnostic pop
         } else {
             // We don't have the distraction status, and/or the driver is distracted
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             return SDLLockScreenStatusRequired;
+#pragma clang diagnostic pop
         }
     } else {
         // This shouldn't be possible.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         return SDLLockScreenStatusOff;
+#pragma clang diagnostic pop
     }
 }
 

--- a/SmartDeviceLink/SDLNotificationConstants.h
+++ b/SmartDeviceLink/SDLNotificationConstants.h
@@ -560,7 +560,7 @@ extern SDLNotificationName const SDLDidReceiveKeyboardInputNotification;
 extern SDLNotificationName const SDLDidChangeLanguageNotification;
 
 /// Name for a LockScreenStatus notification RPC
-extern SDLNotificationName const SDLDidChangeLockScreenStatusNotification;
+extern SDLNotificationName const SDLDidChangeLockScreenStatusNotification __deprecated;
 
 /// Name for a NewHash notification RPC
 extern SDLNotificationName const SDLDidReceiveNewHashNotification;

--- a/SmartDeviceLink/SDLNotificationDispatcher.m
+++ b/SmartDeviceLink/SDLNotificationDispatcher.m
@@ -673,9 +673,15 @@ NS_ASSUME_NONNULL_BEGIN
     [self postRPCNotificationNotification:SDLDidChangeLanguageNotification notification:notification];
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (void)onOnLockScreenNotification:(SDLOnLockScreenStatus *)notification {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [self postRPCNotificationNotification:SDLDidChangeLockScreenStatusNotification notification:notification];
+#pragma clang diagnostic pop
 }
+#pragma clang diagnostic pop
 
 - (void)onOnPermissionsChange:(SDLOnPermissionsChange *)notification {
     [self postRPCNotificationNotification:SDLDidChangePermissionsNotification notification:notification];

--- a/SmartDeviceLink/SDLProxyListener.h
+++ b/SmartDeviceLink/SDLProxyListener.h
@@ -1178,7 +1178,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-- (void)onOnLockScreenNotification:(SDLOnLockScreenStatus *)notification;
+- (void)onOnLockScreenNotification:(SDLOnLockScreenStatus *)notification __deprecated;
 #pragma clang diagnostic pop
 
 /**

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLLockScreenManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLLockScreenManagerSpec.m
@@ -75,8 +75,10 @@ describe(@"a lock screen manager", ^{
 #pragma clang diagnostic pop
 
                     testRequiredStatus.lockScreenStatus = SDLLockScreenStatusRequired;
-                    
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                     [testNotificationDispatcher postNotificationName:SDLDidChangeLockScreenStatusNotification infoObject:testRequiredStatus];
+#pragma clang diagnostic pop
                 });
                 
                 it(@"should not have presented the lock screen", ^{
@@ -120,8 +122,10 @@ describe(@"a lock screen manager", ^{
                     testRequiredStatus = [[SDLOnLockScreenStatus alloc] init];
 #pragma clang diagnostic pop
                     testRequiredStatus.lockScreenStatus = SDLLockScreenStatusRequired;
-                    
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                     SDLRPCNotificationNotification *testLockStatusNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidChangeLockScreenStatusNotification object:nil rpcNotification:testRequiredStatus];
+#pragma clang diagnostic pop
                     [[NSNotificationCenter defaultCenter] postNotification:testLockStatusNotification];
                 });
                 
@@ -221,8 +225,10 @@ describe(@"a lock screen manager", ^{
                         testOffStatus = [[SDLOnLockScreenStatus alloc] init];
 #pragma clang diagnostic pop
                         testOffStatus.lockScreenStatus = SDLLockScreenStatusOff;
-                        
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                         SDLRPCNotificationNotification *testLockStatusNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidChangeLockScreenStatusNotification object:nil rpcNotification:testOffStatus];
+#pragma clang diagnostic pop
                         [[NSNotificationCenter defaultCenter] postNotification:testLockStatusNotification];
                     });
                     
@@ -377,7 +383,10 @@ describe(@"a lock screen manager", ^{
         context(@"receiving a lock screen status of required", ^{
             beforeEach(^{
                 testStatus.lockScreenStatus = SDLLockScreenStatusRequired;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 testLockStatusNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidChangeLockScreenStatusNotification object:nil rpcNotification:testStatus];
+#pragma clang diagnostic pop
 
                 [[NSNotificationCenter defaultCenter] postNotification:testLockStatusNotification];
             });
@@ -390,7 +399,10 @@ describe(@"a lock screen manager", ^{
         context(@"receiving a lock screen status of off", ^{
             beforeEach(^{
                 testStatus.lockScreenStatus = SDLLockScreenStatusOff;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 testLockStatusNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidChangeLockScreenStatusNotification object:nil rpcNotification:testStatus];
+#pragma clang diagnostic pop
 
                 [[NSNotificationCenter defaultCenter] postNotification:testLockStatusNotification];
             });
@@ -414,7 +426,10 @@ describe(@"a lock screen manager", ^{
             SDLOnLockScreenStatus *testOptionalStatus = [[SDLOnLockScreenStatus alloc] init];
 #pragma clang diagnostic pop
             testOptionalStatus.lockScreenStatus = SDLLockScreenStatusOptional;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             testLockStatusNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidChangeLockScreenStatusNotification object:nil rpcNotification:testOptionalStatus];
+#pragma clang diagnostic pop
             testLockScreenConfig = [SDLLockScreenConfiguration enabledConfiguration];
         });
 

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLLockScreenManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLLockScreenManagerSpec.m
@@ -66,17 +66,10 @@ describe(@"a lock screen manager", ^{
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 __block SDLOnLockScreenStatus *testRequiredStatus = nil;
-#pragma clang diagnostic pop
 
                 beforeEach(^{
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                     testRequiredStatus = [[SDLOnLockScreenStatus alloc] init];
-#pragma clang diagnostic pop
-
                     testRequiredStatus.lockScreenStatus = SDLLockScreenStatusRequired;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                     [testNotificationDispatcher postNotificationName:SDLDidChangeLockScreenStatusNotification infoObject:testRequiredStatus];
 #pragma clang diagnostic pop
                 });
@@ -120,10 +113,7 @@ describe(@"a lock screen manager", ^{
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
                     testRequiredStatus = [[SDLOnLockScreenStatus alloc] init];
-#pragma clang diagnostic pop
                     testRequiredStatus.lockScreenStatus = SDLLockScreenStatusRequired;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                     SDLRPCNotificationNotification *testLockStatusNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidChangeLockScreenStatusNotification object:nil rpcNotification:testRequiredStatus];
 #pragma clang diagnostic pop
                     [[NSNotificationCenter defaultCenter] postNotification:testLockStatusNotification];
@@ -217,16 +207,10 @@ describe(@"a lock screen manager", ^{
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
                     __block SDLOnLockScreenStatus *testOffStatus = nil;
-#pragma clang diagnostic pop
-                    
+
                     beforeEach(^{
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                         testOffStatus = [[SDLOnLockScreenStatus alloc] init];
-#pragma clang diagnostic pop
                         testOffStatus.lockScreenStatus = SDLLockScreenStatusOff;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                         SDLRPCNotificationNotification *testLockStatusNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidChangeLockScreenStatusNotification object:nil rpcNotification:testOffStatus];
 #pragma clang diagnostic pop
                         [[NSNotificationCenter defaultCenter] postNotification:testLockStatusNotification];
@@ -338,8 +322,8 @@ describe(@"a lock screen manager", ^{
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 SDLOnLockScreenStatus *status = [[SDLOnLockScreenStatus alloc] init];
-#pragma clang diagnostic pop
                 status.lockScreenStatus = SDLLockScreenStatusRequired;
+#pragma clang diagnostic pop
                 testManager.lastLockNotification = status;
 
                 SDLOnDriverDistraction *testDriverDistraction = [[SDLOnDriverDistraction alloc] init];
@@ -382,9 +366,9 @@ describe(@"a lock screen manager", ^{
 
         context(@"receiving a lock screen status of required", ^{
             beforeEach(^{
-                testStatus.lockScreenStatus = SDLLockScreenStatusRequired;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+                testStatus.lockScreenStatus = SDLLockScreenStatusRequired;
                 testLockStatusNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidChangeLockScreenStatusNotification object:nil rpcNotification:testStatus];
 #pragma clang diagnostic pop
 
@@ -398,9 +382,9 @@ describe(@"a lock screen manager", ^{
 
         context(@"receiving a lock screen status of off", ^{
             beforeEach(^{
-                testStatus.lockScreenStatus = SDLLockScreenStatusOff;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+                testStatus.lockScreenStatus = SDLLockScreenStatusOff;
                 testLockStatusNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidChangeLockScreenStatusNotification object:nil rpcNotification:testStatus];
 #pragma clang diagnostic pop
 
@@ -424,10 +408,7 @@ describe(@"a lock screen manager", ^{
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
             SDLOnLockScreenStatus *testOptionalStatus = [[SDLOnLockScreenStatus alloc] init];
-#pragma clang diagnostic pop
             testOptionalStatus.lockScreenStatus = SDLLockScreenStatusOptional;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             testLockStatusNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidChangeLockScreenStatusNotification object:nil rpcNotification:testOptionalStatus];
 #pragma clang diagnostic pop
             testLockScreenConfig = [SDLLockScreenConfiguration enabledConfiguration];

--- a/SmartDeviceLinkTests/ProxySpecs/SDLLockScreenStatusManagerSpec.m
+++ b/SmartDeviceLinkTests/ProxySpecs/SDLLockScreenStatusManagerSpec.m
@@ -99,7 +99,10 @@ describe(@"the lockscreen status manager", ^{
             });
             
             it(@"should return lock screen off", ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 expect(lockScreenManager.lockScreenStatus).to(equal(SDLLockScreenStatusOff));
+#pragma clang diagnostic pop
             });
         });
         
@@ -109,7 +112,10 @@ describe(@"the lockscreen status manager", ^{
             });
             
             it(@"should return lock screen off", ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 expect(lockScreenManager.lockScreenStatus).to(equal(SDLLockScreenStatusOff));
+#pragma clang diagnostic pop
             });
         });
         
@@ -125,7 +131,10 @@ describe(@"the lockscreen status manager", ^{
 
                 context(@"if we do not set the driver distraction state", ^{
                     it(@"should return lock screen required", ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                         expect(lockScreenManager.lockScreenStatus).to(equal(SDLLockScreenStatusRequired));
+#pragma clang diagnostic pop
                     });
                 });
 
@@ -135,7 +144,10 @@ describe(@"the lockscreen status manager", ^{
                     });
 
                     it(@"should return lock screen optional", ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                         expect(lockScreenManager.lockScreenStatus).to(equal(SDLLockScreenStatusOptional));
+#pragma clang diagnostic pop
                     });
                 });
 
@@ -145,7 +157,10 @@ describe(@"the lockscreen status manager", ^{
                     });
 
                     it(@"should return lock screen required", ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                         expect(lockScreenManager.lockScreenStatus).to(equal(SDLLockScreenStatusRequired));
+#pragma clang diagnostic pop
                     });
                 });
             });
@@ -156,7 +171,10 @@ describe(@"the lockscreen status manager", ^{
                 });
                 
                 it(@"should return lock screen off", ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                     expect(lockScreenManager.lockScreenStatus).to(equal(SDLLockScreenStatusOff));
+#pragma clang diagnostic pop
                 });
             });
         });
@@ -168,7 +186,10 @@ describe(@"the lockscreen status manager", ^{
             
             context(@"if we do not set the driver distraction state", ^{
                 it(@"should return lock screen required", ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                     expect(lockScreenManager.lockScreenStatus).to(equal(SDLLockScreenStatusRequired));
+#pragma clang diagnostic pop
                 });
             });
             
@@ -178,7 +199,10 @@ describe(@"the lockscreen status manager", ^{
                 });
                 
                 it(@"should return lock screen optional", ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                     expect(lockScreenManager.lockScreenStatus).to(equal(SDLLockScreenStatusOptional));
+#pragma clang diagnostic pop
                 });
             });
             
@@ -188,7 +212,10 @@ describe(@"the lockscreen status manager", ^{
                 });
                 
                 it(@"should return lock screen required", ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                     expect(lockScreenManager.lockScreenStatus).to(equal(SDLLockScreenStatusRequired));
+#pragma clang diagnostic pop
                 });
             });
         });
@@ -200,7 +227,10 @@ describe(@"the lockscreen status manager", ^{
             
             context(@"if we do not set the driver distraction state", ^{
                 it(@"should return lock screen required", ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                     expect(lockScreenManager.lockScreenStatus).to(equal(SDLLockScreenStatusRequired));
+#pragma clang diagnostic pop
                 });
             });
             
@@ -210,7 +240,10 @@ describe(@"the lockscreen status manager", ^{
                 });
                 
                 it(@"should return lock screen optional", ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                     expect(lockScreenManager.lockScreenStatus).to(equal(SDLLockScreenStatusOptional));
+#pragma clang diagnostic pop
                 });
             });
             
@@ -220,7 +253,10 @@ describe(@"the lockscreen status manager", ^{
                 });
                 
                 it(@"should return lock screen required", ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                     expect(lockScreenManager.lockScreenStatus).to(equal(SDLLockScreenStatusRequired));
+#pragma clang diagnostic pop
                 });
             });
         });
@@ -253,7 +289,10 @@ describe(@"the lockscreen status manager", ^{
         });
         
         it(@"should properly return lock screen status", ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             expect(onLockScreenStatusNotification.lockScreenStatus).to(equal(SDLLockScreenStatusOptional));
+#pragma clang diagnostic pop
         });
     });
 });

--- a/SmartDeviceLinkTests/RPCSpecs/EnumSpecs/SDLLockScreenStatusSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/EnumSpecs/SDLLockScreenStatusSpec.m
@@ -14,9 +14,12 @@ QuickSpecBegin(SDLLockScreenStatusSpec)
 
 describe(@"Individual Enum Value Tests", ^ {
     it(@"Should match internal values", ^ {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         expect(SDLLockScreenStatusOff).to(equal(@"OFF"));
         expect(SDLLockScreenStatusOptional).to(equal(@"OPTIONAL"));
         expect(SDLLockScreenStatusRequired).to(equal(@"REQUIRED"));
+#pragma clang diagnostic pop
     });
 });
 

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnLockScreenStatusSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnLockScreenStatusSpec.m
@@ -22,15 +22,20 @@ describe(@"Getter/Setter Tests", ^ {
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnLockScreenStatus* testNotification = [[SDLOnLockScreenStatus alloc] init];
 #pragma clang diagnostic pop
-
         testNotification.driverDistractionStatus = @NO;
         testNotification.userSelected = @3;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         testNotification.lockScreenStatus = SDLLockScreenStatusRequired;
+#pragma clang diagnostic pop
         testNotification.hmiLevel = SDLHMILevelNone;
         
         expect(testNotification.driverDistractionStatus).to(equal(@NO));
         expect(testNotification.userSelected).to(equal(@3));
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         expect(testNotification.lockScreenStatus).to(equal(SDLLockScreenStatusRequired));
+#pragma clang diagnostic pop
         expect(testNotification.hmiLevel).to(equal(SDLHMILevelNone));
     });
     
@@ -39,7 +44,10 @@ describe(@"Getter/Setter Tests", ^ {
                                            @{SDLRPCParameterNameParameters:
                                                  @{@"driverDistractionStatus":@NO,
                                                    @"userSelected":@3,
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                                                    @"OnLockScreenStatus":SDLLockScreenStatusRequired,
+#pragma clang diagnostic pop
                                                    @"hmiLevel":SDLHMILevelNone},
                                              SDLRPCParameterNameOperationName:@"OnLockScreenStatus"}} mutableCopy];
 #pragma clang diagnostic push
@@ -49,7 +57,10 @@ describe(@"Getter/Setter Tests", ^ {
         
         expect(testNotification.driverDistractionStatus).to(equal(@NO));
         expect(testNotification.userSelected).to(equal(@3));
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         expect(testNotification.lockScreenStatus).to(equal(SDLLockScreenStatusRequired));
+#pragma clang diagnostic pop
         expect(testNotification.hmiLevel).to(equal(SDLHMILevelNone));
     });
     


### PR DESCRIPTION
Fixes #1601 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Fixed warnings in unit tests and built and ran existing unit tests.

#### Core Tests
Not needed as only deprecations were added. 

Core version / branch / commit hash / module tested against: n/a
HMI name / version / branch / commit hash / module tested against: n/a

### Summary
Deprecated the `SDLOnLockScreenStatus` notification and its corresponding notification name `SDLDidChangeLockScreenStatusNotification` as well as the `SDLLockScreenStatus` enum.

### Changelog
##### Enhancements
* Deprecated the `SDLOnLockScreenStatus` notification. 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
