### PR TITLE
replaced SDLServiceTypeRPC with service parameter

### DIFF
--- a/SmartDeviceLink/SDLProtocol.m
+++ b/SmartDeviceLink/SDLProtocol.m
@@ -418,7 +418,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     SDLProtocolMessage *message = [SDLProtocolMessage messageWithHeader:header andPayload:data];
 
-    if (message.size < [[SDLGlobals sharedGlobals] mtuSizeForServiceType:SDLServiceTypeRPC]) {
+    if (message.size < [[SDLGlobals sharedGlobals] mtuSizeForServiceType:service]) {
         SDLLogV(@"Sending protocol message: %@", message);
         [self sdl_sendDataToTransport:message.data onService:header.serviceType];
     } else {


### PR DESCRIPTION
Fixes #1577 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Ran tests without failure. No unit tests were added or changed.

#### Core Tests

Core version / branch / commit hash / module tested against: SYNC 3.0 (Build 17276_DEVTEST)
HMI name / version / branch / commit hash / module tested against: sdl_core 6.0.1 (Generic HMI 0.7.2)

Used Trippy app to connect to Core and verified that the correct mtu size was being used.
SYNC 3.0 (Build 17276_DEVTEST):
- mtu size: 131024

sdl_core 6.0.1 (Generic HMI 0.7.2)
- mtu size: 131072

### Summary
Fixed an issue where we were getting the mtu size from `SDLServiceTypeRPC` for RPC, video, and audio services. Instead, we are now using the passed in `service` parameter to get the mtu size.

### Changelog
##### Bug Fixes
* `sdl_sendRawData:onService:encryption:` no longer uses `SDLServiceTypeRPC` to set the mtu size and will now use the mtu size from the `service` passed in.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
