### PR TITLE
Delay shutting down secondary transport when device app is backgrounded

### DIFF
--- a/SmartDeviceLink/SDLBackgroundTaskManager.h
+++ b/SmartDeviceLink/SDLBackgroundTaskManager.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface SDLBackgroundTaskManager : NSObject
 
-/// Handler called when the background task has ended.
+/// Handler called when the background task is about to expire. Use this handler to perform some cleanup before the background task is destroyed. When you have finished cleanup, you must call the `endBackgroundTask` function so the background task can be destroyed. If you do not call `endBackgroundTask`, the system may kill the app.
 @property (copy, nonatomic, nullable) void (^taskEndedHandler)(void);
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -29,17 +29,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (instancetype)initWithBackgroundTaskName:(NSString *)backgroundTaskName;
 
-/**
- *  Starts a background task that allows the app to establish a session while app is backgrounded. If the app is not currently backgrounded, the background task will remain dormant until the app moves to the background.
- */
+/// Starts a background task. If the app is not currently backgrounded, the background task will remain dormant until the app moves to the background.
 - (void)startBackgroundTask;
 
-/**
- *  Cleans up a background task when it is stopped. This should be called when:
- *
- *  1. The app has established a session.
- *  2. The system has called the `expirationHandler` for the background task. The system may kill the app if the background task is not ended when `expirationHandler` is called.
- */
+/// Destroys the background task.
 - (void)endBackgroundTask;
 
 @end

--- a/SmartDeviceLink/SDLBackgroundTaskManager.h
+++ b/SmartDeviceLink/SDLBackgroundTaskManager.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Destroys the background task.
 - (void)endBackgroundTask;
 
-/// Destroys the background task after cleanup has finished. This should only be called if you have subscribed to the `taskExpiringHandler` in order to do some cleanup before the background task is destroyed.
+/// Destroys the background task after cleanup has finished.
 - (void)expiredTaskCleanupFinished;
 
 @end

--- a/SmartDeviceLink/SDLBackgroundTaskManager.h
+++ b/SmartDeviceLink/SDLBackgroundTaskManager.h
@@ -16,6 +16,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface SDLBackgroundTaskManager : NSObject
 
+/// Handler called when the background task has ended.
+@property (copy, nonatomic, nullable) void (^taskEndedHandler)(void);
+
 - (instancetype)init NS_UNAVAILABLE;
 
 /**

--- a/SmartDeviceLink/SDLBackgroundTaskManager.h
+++ b/SmartDeviceLink/SDLBackgroundTaskManager.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SDLBackgroundTaskManager : NSObject
 
 /// Handler called when the background task is about to expire. Use this handler to perform some cleanup before the background task is destroyed. When you have finished cleanup, you must call the `endBackgroundTask` function so the background task can be destroyed. If you do not call `endBackgroundTask`, the system may kill the app.
-@property (copy, nonatomic, nullable) void (^taskEndedHandler)(void);
+@property (copy, nonatomic, nullable) BOOL (^taskExpiringHandler)(void);
 
 - (instancetype)init NS_UNAVAILABLE;
 
@@ -34,6 +34,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Destroys the background task.
 - (void)endBackgroundTask;
+
+/// Destroys the background task after cleanup has finished. This should only be called if you have subscribed to the `taskExpiringHandler` in order to do some cleanup before the background task is destroyed.
+- (void)expiredTaskCleanupFinished;
 
 @end
 

--- a/SmartDeviceLink/SDLBackgroundTaskManager.h
+++ b/SmartDeviceLink/SDLBackgroundTaskManager.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SDLBackgroundTaskManager : NSObject
 
 /// Handler called when the background task is about to expire. Use this handler to perform some cleanup before the background task is destroyed. When you have finished cleanup, you must call the `endBackgroundTask` function so the background task can be destroyed. If you do not call `endBackgroundTask`, the system may kill the app.
-/// @return Whether or to wait for the subscriber to cleanup. If NO, the background task will be killed immediately. If YES, the background task will not be destroyed until the `expiredTaskCleanupFinished` method is called.
+/// @return Whether or to wait for the subscriber to cleanup. If NO, the background task will be killed immediately. If YES, the background task will not be destroyed until the `endBackgroundTask` method is called.
 @property (copy, nonatomic, nullable) BOOL (^taskExpiringHandler)(void);
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -35,9 +35,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Destroys the background task.
 - (void)endBackgroundTask;
-
-/// Destroys the background task after cleanup has finished.
-- (void)expiredTaskCleanupFinished;
 
 @end
 

--- a/SmartDeviceLink/SDLBackgroundTaskManager.h
+++ b/SmartDeviceLink/SDLBackgroundTaskManager.h
@@ -17,6 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SDLBackgroundTaskManager : NSObject
 
 /// Handler called when the background task is about to expire. Use this handler to perform some cleanup before the background task is destroyed. When you have finished cleanup, you must call the `endBackgroundTask` function so the background task can be destroyed. If you do not call `endBackgroundTask`, the system may kill the app.
+/// @return Whether or to wait for the subscriber to cleanup. If NO, the background task will be killed immediately. If YES, the background task will not be destroyed until the `expiredTaskCleanupFinished` method is called.
 @property (copy, nonatomic, nullable) BOOL (^taskExpiringHandler)(void);
 
 - (instancetype)init NS_UNAVAILABLE;

--- a/SmartDeviceLink/SDLBackgroundTaskManager.h
+++ b/SmartDeviceLink/SDLBackgroundTaskManager.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SDLBackgroundTaskManager : NSObject
 
 /// Handler called when the background task is about to expire. Use this handler to perform some cleanup before the background task is destroyed. When you have finished cleanup, you must call the `endBackgroundTask` function so the background task can be destroyed. If you do not call `endBackgroundTask`, the system may kill the app.
-/// @return Whether or to wait for the subscriber to cleanup. If NO, the background task will be killed immediately. If YES, the background task will not be destroyed until the `endBackgroundTask` method is called.
+/// @return Whether or not to wait for the subscriber to cleanup. If NO, the background task will be killed immediately. If YES, the background task will not be destroyed until the `endBackgroundTask` method is called by the subscriber.
 @property (copy, nonatomic, nullable) BOOL (^taskExpiringHandler)(void);
 
 - (instancetype)init NS_UNAVAILABLE;

--- a/SmartDeviceLink/SDLBackgroundTaskManager.m
+++ b/SmartDeviceLink/SDLBackgroundTaskManager.m
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation SDLBackgroundTaskManager
 
 - (instancetype)initWithBackgroundTaskName:(NSString *)backgroundTaskName {
-    SDLLogV(@"Creating manager with name %@", backgroundTaskName);
+    SDLLogV(@"Creating background task manager with name %@", backgroundTaskName);
     self = [super init];
     if (!self) {
         return nil;
@@ -42,7 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
     __weak typeof(self) weakSelf = self;
     self.currentBackgroundTaskId = [[UIApplication sharedApplication] beginBackgroundTaskWithName:self.backgroundTaskName expirationHandler:^{
         __strong typeof(weakSelf) strongSelf = weakSelf;
-        SDLLogD(@"The %@ background task expired", strongSelf.backgroundTaskName);
+        SDLLogD(@"The background task %@ expired", strongSelf.backgroundTaskName);
         [strongSelf endBackgroundTask];
     }];
 

--- a/SmartDeviceLink/SDLBackgroundTaskManager.m
+++ b/SmartDeviceLink/SDLBackgroundTaskManager.m
@@ -64,11 +64,6 @@ NS_ASSUME_NONNULL_BEGIN
     SDLLogD(@"The %@ background task started with id: %lu", self.backgroundTaskName, (unsigned long)self.currentBackgroundTaskId);
 }
 
-- (void)expiredTaskCleanupFinished {
-    SDLLogD(@"Ending background task %@ because clean up has finished.", self.backgroundTaskName);
-    [self endBackgroundTask];
-}
-
 - (void)endBackgroundTask {
     SDLLogV(@"Attempting to end background task %@", self.backgroundTaskName);
     self.taskExpiringHandler = nil;

--- a/SmartDeviceLink/SDLBackgroundTaskManager.m
+++ b/SmartDeviceLink/SDLBackgroundTaskManager.m
@@ -65,7 +65,6 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)expiredTaskCleanupFinished {
-    if (self.taskExpiringHandler == nil) { return; }
     SDLLogD(@"Ending background task %@ because clean up has finished.", self.backgroundTaskName);
     [self endBackgroundTask];
 }

--- a/SmartDeviceLink/SDLSecondaryTransportManager.m
+++ b/SmartDeviceLink/SDLSecondaryTransportManager.m
@@ -716,9 +716,9 @@ struct TransportProtocolUpdated {
     return ^{
         __strong typeof(self) strongSelf = weakSelf;
         if (strongSelf.sdl_getAppState == UIApplicationStateActive) {
-            SDLLogD(@"App has been foregrounded. Ignoring notification that the background task ended.");
+            SDLLogV(@"App has been foregrounded. Ignoring notification that the background task ended.");
         } else if ([strongSelf.stateMachine isCurrentState:SDLSecondaryTransportStateStopped]) {
-            SDLLogD(@"Manager has been stopped. Ignoring notification that the background task ended.");
+            SDLLogV(@"Manager has been stopped. Ignoring notification that the background task ended.");
         } else {
             SDLLogD(@"Disconnecting TCP transport due to the background task ending.");
             [strongSelf.stateMachine transitionToState:SDLSecondaryTransportStateConfigured];

--- a/SmartDeviceLink/SDLSecondaryTransportManager.m
+++ b/SmartDeviceLink/SDLSecondaryTransportManager.m
@@ -722,6 +722,7 @@ struct TransportProtocolUpdated {
             SDLLogV(@"No cleanup needed since manager has been stopped.");
             return NO;
         } else {
+            // `endBackgroundTask` will be called when the secondary transport disconnects.
             SDLLogD(@"Performing cleanup due to the background task expiring: disconnecting the TCP transport.");
             [strongSelf.stateMachine transitionToState:SDLSecondaryTransportStateConfigured];
             return YES;

--- a/SmartDeviceLink/SDLSecondaryTransportManager.m
+++ b/SmartDeviceLink/SDLSecondaryTransportManager.m
@@ -438,7 +438,7 @@ struct TransportProtocolUpdated {
     self.secondaryTransport = nil;
     self.secondaryProtocol = nil;
 
-    [self.backgroundTaskManager expiredTaskCleanupFinished];
+    [self.backgroundTaskManager endBackgroundTask];
 
     return YES;
 }

--- a/SmartDeviceLink/SDLSecondaryTransportManager.m
+++ b/SmartDeviceLink/SDLSecondaryTransportManager.m
@@ -703,7 +703,7 @@ struct TransportProtocolUpdated {
                 [strongSelf.backgroundTaskManager endBackgroundTask];
                 [strongSelf.stateMachine transitionToState:SDLSecondaryTransportStateConnecting];
             } else {
-                SDLLogD(@"TCP transport not ready to start, our current state is: %@, strongSelf.stateMachine.currentState");
+                SDLLogD(@"TCP transport not ready to start, our current state is: %@", strongSelf.stateMachine.currentState);
             }
         }
     });

--- a/SmartDeviceLink/SDLSecondaryTransportManager.m
+++ b/SmartDeviceLink/SDLSecondaryTransportManager.m
@@ -111,7 +111,7 @@ struct TransportProtocolUpdated {
 @property (strong, nonatomic, nullable) SDLHMILevel currentHMILevel;
 
 /// A background task used to close the secondary transport before the app is suspended.
-@property (copy, nonatomic) SDLBackgroundTaskManager *backgroundTaskManager;
+@property (strong, nonatomic) SDLBackgroundTaskManager *backgroundTaskManager;
 
 @end
 

--- a/SmartDeviceLink/SDLSecondaryTransportManager.m
+++ b/SmartDeviceLink/SDLSecondaryTransportManager.m
@@ -688,22 +688,22 @@ struct TransportProtocolUpdated {
                 strongSelf.backgroundTaskManager.taskEndedHandler = [strongSelf sdl_backgroundTaskEndedHandler];
                 [strongSelf.backgroundTaskManager startBackgroundTask];
             } else {
-                SDLLogD(@"TCP transport already disconnected");
+                SDLLogD(@"TCP transport already disconnected, will not start a background task.");
             }
         } else if (notification.name == UIApplicationDidBecomeActiveNotification) {
             SDLLogD(@"App entered the foreground");
             if ([strongSelf.stateMachine isCurrentState:SDLSecondaryTransportStateRegistered]) {
-                SDLLogD(@"TCP transport has not yet been shutdown");
+                SDLLogD(@"In the registered state; TCP transport has not yet been shutdown. Ending the background task.");
                 [strongSelf.backgroundTaskManager endBackgroundTask];
             } else if ([strongSelf.stateMachine isCurrentState:SDLSecondaryTransportStateConfigured]
                 && strongSelf.secondaryTransportType == SDLSecondaryTransportTypeTCP
                 && [strongSelf sdl_isTCPReady]
                 && [strongSelf sdl_isHMILevelNonNone]) {
-                SDLLogD(@"Restarting the TCP transport");
+                SDLLogD(@"In the configured state; restarting the TCP transport. Ending the background task.");
                 [strongSelf.backgroundTaskManager endBackgroundTask];
                 [strongSelf.stateMachine transitionToState:SDLSecondaryTransportStateConnecting];
             } else {
-                SDLLogD(@"TCP transport not ready to start");
+                SDLLogD(@"TCP transport not ready to start, our current state is: %@, strongSelf.stateMachine.currentState");
             }
         }
     });

--- a/SmartDeviceLink/SDLSecondaryTransportManager.m
+++ b/SmartDeviceLink/SDLSecondaryTransportManager.m
@@ -709,20 +709,22 @@ struct TransportProtocolUpdated {
     });
 }
 
-/// Handles a notification that the background task has ended. If the app is still in the background, the TCP transport disconnects. If the app has re-entered the foreground or the manager has shutdown then the notification is ignored.
+/// Handles a notification that the background task is about to expire. If the app is still backgrounded we must close the TCP socket, which can take a few moments to complete. When this manager transitons to the Configured state, the `SDLStreamingMediaManager` is notified that the secondary transport wants to shutdown via the `streamingProtocolDelegate`. The `SDLStreamingMediaManager` sends an end video service control frame and an end audio service control frame and waits for responses to both requests from the module. Once the module has responded to both end service requests, the `SDLStreamingMediaManager` notifies us that the TCP socket can be shutdown by calling the `disconnectSecondaryTransport` method. Finally, once we know the socket has shutdown, we can end the background task. To ensure that all the shutdown steps are performed, we must delay shutting down the background task, otherwise some of the steps might not complete due to the app being suspended. Improper shutdown can cause trouble when establishing a new streaming session as either the new TCP connection will fail (due to the TCP socket's I/O streams not shutting down) or restarting the video and audio streams can fail (due to Core not receiving the end service requests). On the other hand, we can end the background task immediately if the app has re-entered the foreground or the manager has shutdown as no cleanup needs to be performed.
 /// @return A background task ended handler
 - (nullable BOOL (^)(void))sdl_backgroundTaskEndedHandler {
     __weak typeof(self) weakSelf = self;
     return ^{
         __strong typeof(self) strongSelf = weakSelf;
         if (strongSelf.sdl_getAppState == UIApplicationStateActive || [strongSelf.stateMachine isCurrentState:SDLSecondaryTransportStateStopped]) {
+            // Return NO as we do not need to perform any cleanup and can end the background task immediately
             SDLLogV(@"No cleanup needed since app has been foregrounded.");
             return NO;
         } else if ([strongSelf.stateMachine isCurrentState:SDLSecondaryTransportStateStopped]) {
+            // Return NO as we do not need to perform any cleanup and can end the background task immediately
             SDLLogV(@"No cleanup needed since manager has been stopped.");
             return NO;
         } else {
-            // `endBackgroundTask` will be called when the secondary transport disconnects.
+            //  Return YES as we want to delay ending the background task until shutdown of the secondary transport has finished. Transitoning to the Configured state starts the process of shutting down the streaming services and the TCP socket which can take a few moments to complete. Once the streaming services have shutdown, the `SDLStreamingMediaManager` calls the `disconnectSecondaryTransport` method. The `disconnectSecondaryTransport` takes care of destroying the background task after disconnecting the TCP transport.
             SDLLogD(@"Performing cleanup due to the background task expiring: disconnecting the TCP transport.");
             [strongSelf.stateMachine transitionToState:SDLSecondaryTransportStateConfigured];
             return YES;

--- a/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
@@ -155,6 +155,11 @@ NS_ASSUME_NONNULL_BEGIN
     _audioEncrypted = NO;
 
     [[NSNotificationCenter defaultCenter] postNotificationName:SDLAudioStreamDidStopNotification object:nil];
+
+    if (self.audioServiceEndedCompletionHandler != nil) {
+        self.audioServiceEndedCompletionHandler();
+        self.audioServiceEndedCompletionHandler = nil;
+    }
 }
 
 - (void)didEnterStateAudioStreamStarting {
@@ -210,12 +215,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)handleProtocolEndServiceACKMessage:(SDLProtocolMessage *)endServiceACK {
     if (endServiceACK.header.serviceType != SDLServiceTypeAudio) { return; }
-
     SDLLogD(@"Request to end audio service ACKed");
-    if (self.audioServiceEndedCompletionHandler != nil) {
-        self.audioServiceEndedCompletionHandler();
-        self.audioServiceEndedCompletionHandler = nil;
-    }
 
     [self.audioStreamStateMachine transitionToState:SDLAudioStreamManagerStateStopped];
 }
@@ -225,10 +225,6 @@ NS_ASSUME_NONNULL_BEGIN
 
     SDLControlFramePayloadNak *nakPayload = [[SDLControlFramePayloadNak alloc] initWithData:endServiceNAK.payload];
     SDLLogE(@"Request to end audio service NAKed with playlod: %@", nakPayload);
-    if (self.audioServiceEndedCompletionHandler != nil) {
-        self.audioServiceEndedCompletionHandler();
-        self.audioServiceEndedCompletionHandler = nil;
-    }
 
     /// Core will NAK the audio end service control frame if audio is not streaming or if video is streaming but the HMI does not recognize that audio is streaming.
     [self.audioStreamStateMachine transitionToState:SDLAudioStreamManagerStateStopped];

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -364,6 +364,11 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
     [self sdl_disposeDisplayLink];
 
     [[NSNotificationCenter defaultCenter] postNotificationName:SDLVideoStreamDidStopNotification object:nil];
+
+    if (self.videoServiceEndedCompletionHandler != nil) {
+        self.videoServiceEndedCompletionHandler();
+        self.videoServiceEndedCompletionHandler = nil;
+    }
 }
 
 - (void)didEnterStateVideoStreamStarting {
@@ -560,12 +565,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
 
 - (void)handleProtocolEndServiceACKMessage:(SDLProtocolMessage *)endServiceACK {
     if (endServiceACK.header.serviceType != SDLServiceTypeVideo) { return; }
-
     SDLLogD(@"Request to end video service ACKed");
-    if (self.videoServiceEndedCompletionHandler != nil) {
-        self.videoServiceEndedCompletionHandler();
-        self.videoServiceEndedCompletionHandler = nil;
-    }
 
     [self.videoStreamStateMachine transitionToState:SDLVideoStreamManagerStateStopped];
 }
@@ -575,10 +575,6 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
 
     SDLControlFramePayloadNak *nakPayload = [[SDLControlFramePayloadNak alloc] initWithData:endServiceNAK.payload];
     SDLLogE(@"Request to end video service NAKed with payload: %@", nakPayload);
-    if (self.videoServiceEndedCompletionHandler != nil) {
-        self.videoServiceEndedCompletionHandler();
-        self.videoServiceEndedCompletionHandler = nil;
-    }
 
     /// Core will NAK the video end service control frame if video is not streaming or if video is streaming but the HMI does not recognize that video is streaming.
     [self.videoStreamStateMachine transitionToState:SDLVideoStreamManagerStateStopped];


### PR DESCRIPTION
Fixes #1560 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Unit tests were added to the **SecondaryTransportManagerSpec**. 

#### Core Tests
Tests were performed with a video streaming app using a TCP secondary transport. Tests were considered successful:
1. If the background task did not expire before the app was foregrounded then video resumed and audio continued without interruption.
1. If the the background task expired while the app was backgrounded, then when the app was brought back to the foreground video and audio resumed.

##### Tests Performed
1. Put app on device in the background and brought app on device back to foreground before background task expired. 
1. Put app on device in the background and brought app on device back to foreground after the background task expired.
1. Put app on device in the background and then locked the device. Unlocked the device before the background task expired and foregrounded the app. 
1. Put app on device in the background and then locked the device. Waited for the background task to expire. Unlocked the device and foregrounded the app. 
1. Put app on device in the background and then locked the device. Waited for the background task to expire. Attempted to launch the SDL app while the device was still locked, the attempting to connect alert shows up. Unlocked the device and foregrounded the app. 
1. Locked the device while the app on the device was still in foreground. Unlocked the device.
1. Put app on device in background, opened another SDL video streaming app, then switched back to the app and brought it back to the foreground.

Core version / branch / commit hash / module tested against: SYNC 4 (20016_DEVTEST)
HMI name / version / branch / commit hash / module tested against: SYNC 4 (20016_DEVTEST)

### Summary
When the app on the device is backgrounded the secondary transport is now closed when the background task expires instead of immediately. This improves user experience by:

1. Avoiding a reconnect delay if the user backgrounds the app and then foregrounds the app within the time the background task is kept alive (~1 minute).
1. Showing the `videoStreamBackgroundString` when the app on the device is backgrounded. Previously the warning message was either flashed for a moment or not shown all.

In order to ensure that the video, audio and tcp transports are all shutdown before the background task is ended, I moved calling the `videoServiceEndedCompletionHandler` and the `audioServiceEndedCompletionHandler` from the stop service ACK and NAK handler methods to the stopped state of the `SDLStreamingVideoLifecycleManager` and `SDLStreamingAudioLifecycleManager` to ensure that both managers' properties get reset before the background task ends when the app is backgrounded. This also reduced duplicate code since both the ACK/NAK handlers transition to the stopped state anyways. 

### Changelog
##### Enhancements
* When the app on the device is backgrounded the secondary transport is now closed when the background task expires instead of immediately.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
