### PR TITLE
Fix PreloadChoicesOperation uploading images when WindowCapability properties are nil

### DIFF
--- a/SmartDeviceLink/SDLPreloadChoicesOperation.m
+++ b/SmartDeviceLink/SDLPreloadChoicesOperation.m
@@ -183,6 +183,7 @@ NS_ASSUME_NONNULL_BEGIN
     return [[SDLCreateInteractionChoiceSet alloc] initWithId:(UInt32)choice.choiceID.unsignedIntValue choiceSet:@[choice]];
 }
 
+/// Determine if we should send primary text. If textFields is nil, we don't know the capabilities and we will send everything.
 - (BOOL)sdl_shouldSendChoiceText {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -194,18 +195,22 @@ NS_ASSUME_NONNULL_BEGIN
     return (self.windowCapability.textFields != nil) ? [self.windowCapability hasTextFieldOfName:SDLTextFieldNameMenuName] : YES;
 }
 
+/// Determine if we should send secondary text. If textFields is nil, we don't know the capabilities and we will send everything.
 - (BOOL)sdl_shouldSendChoiceSecondaryText {
     return (self.windowCapability.textFields != nil) ? [self.windowCapability hasTextFieldOfName:SDLTextFieldNameSecondaryText] : YES;
 }
 
+/// Determine if we should send teriary text. If textFields is nil, we don't know the capabilities and we will send everything.
 - (BOOL)sdl_shouldSendChoiceTertiaryText {
     return (self.windowCapability.textFields != nil) ? [self.windowCapability hasTextFieldOfName:SDLTextFieldNameTertiaryText] : YES;
 }
 
+/// Determine if we should send the primary image. If imageFields is nil, we don't know the capabilities and we will send everything.
 - (BOOL)sdl_shouldSendChoicePrimaryImage {
     return (self.windowCapability.imageFields != nil) ? [self.windowCapability hasImageFieldOfName:SDLImageFieldNameChoiceImage] : YES;
 }
 
+/// Determine if we should send the secondary image. If imageFields is nil, we don't know the capabilities and we will send everything.
 - (BOOL)sdl_shouldSendChoiceSecondaryImage {
     return (self.windowCapability.imageFields != nil) ? [self.windowCapability hasImageFieldOfName:SDLImageFieldNameChoiceSecondaryImage] : YES;
 }

--- a/SmartDeviceLink/SDLPreloadChoicesOperation.m
+++ b/SmartDeviceLink/SDLPreloadChoicesOperation.m
@@ -87,12 +87,10 @@ NS_ASSUME_NONNULL_BEGIN
 
     NSMutableArray<SDLArtwork *> *artworksToUpload = [NSMutableArray arrayWithCapacity:self.cellsToUpload.count];
     for (SDLChoiceCell *cell in self.cellsToUpload) {
-        if ([self.windowCapability hasImageFieldOfName:SDLImageFieldNameChoiceImage]
-            && [self sdl_artworkNeedsUpload:cell.artwork]) {
+        if ([self sdl_shouldSendChoicePrimaryImage] && [self sdl_artworkNeedsUpload:cell.artwork]) {
             [artworksToUpload addObject:cell.artwork];
         }
-        if ([self.windowCapability hasImageFieldOfName:SDLImageFieldNameChoiceSecondaryImage]
-            && [self sdl_artworkNeedsUpload:cell.secondaryArtwork]) {
+        if ([self sdl_shouldSendChoiceSecondaryImage] && [self sdl_artworkNeedsUpload:cell.secondaryArtwork]) {
             [artworksToUpload addObject:cell.secondaryArtwork];
         }
     }


### PR DESCRIPTION
Fixes #1618

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Unit tests were run but not updated

#### Core Tests
This was tested against Core for basic choice set functionality.

Core version / branch / commit hash / module tested against: Ford Sync 3.4 19353_DEVTEST
HMI name / version / branch / commit hash / module tested against: Ford Sync 3.4 19353_DEVTEST

### Summary
This updates the check for uploading choice images during a choice set operation to check for the window capability like it does elsewhere in the operation.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
