### PR TITLE
Fix SDLImageField nullability of initializer parameter

### DIFF
--- a/SmartDeviceLink/SDLImageField.h
+++ b/SmartDeviceLink/SDLImageField.h
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param name The name identifying this image field
 /// @param imageTypeSupported The image data types this field supports
 /// @param imageResolution The native resolution of this image field
-- (instancetype)initWithName:(SDLImageFieldName)name imageTypeSupported:(NSArray<SDLFileType> *)imageTypeSupported imageResolution:(SDLImageResolution *)imageResolution;
+- (instancetype)initWithName:(SDLImageFieldName)name imageTypeSupported:(NSArray<SDLFileType> *)imageTypeSupported imageResolution:(nullable SDLImageResolution *)imageResolution;
 
 @end
 

--- a/SmartDeviceLink/SDLImageField.m
+++ b/SmartDeviceLink/SDLImageField.m
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
     return [self.store sdl_objectForName:SDLRPCParameterNameImageResolution ofClass:SDLImageResolution.class error:nil];
 }
 
-- (instancetype)initWithName:(SDLImageFieldName)name imageTypeSupported:(NSArray<SDLFileType> *)imageTypeSupported imageResolution:(SDLImageResolution *)imageResolution {
+- (instancetype)initWithName:(SDLImageFieldName)name imageTypeSupported:(NSArray<SDLFileType> *)imageTypeSupported imageResolution:(nullable SDLImageResolution *)imageResolution {
     self = [self init];
     if (!self) { return nil; }
 


### PR DESCRIPTION
Fixes #1625 

This PR is **ready** for review.

### Risk
This PR makes **major** API changes. These changes are internal to the next release

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
N/A

#### Core Tests
This only changed nullability of a parameter, so tests were not performed.

Core version / branch / commit hash / module tested against: n/a
HMI name / version / branch / commit hash / module tested against: n/a

### Summary
Update `SDLImageField initWithName:imageTypeSupported:imageResolution:` to make the `imageResolution` parameter `nullable` like the property itself.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
