### PR TITLE
Fix SDLStreamingMediaManager private classes should not be public properties / methods

### DIFF
--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -75,7 +75,15 @@ SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
 
 NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask";
 
-#pragma mark - SDLManager Private Interface
+#pragma mark - Protected Class Interfaces
+@interface SDLStreamingMediaManager ()
+
+@property (strong, nonatomic, nullable) SDLSecondaryTransportManager *secondaryTransportManager;
+- (void)startSecondaryTransportWithProtocol:(SDLProtocol *)protocol;
+
+@end
+
+#pragma mark - SDLLifecycleManager Private Interface
 
 @interface SDLLifecycleManager () <SDLConnectionManagerType>
 

--- a/SmartDeviceLink/SDLStreamingMediaManager.h
+++ b/SmartDeviceLink/SDLStreamingMediaManager.h
@@ -117,8 +117,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (assign, nonatomic) BOOL showVideoBackgroundDisplay;
 
-/// The manager for handling streaming over a secondary transport
-@property (strong, nonatomic, nullable) SDLSecondaryTransportManager *secondaryTransportManager;
 
 #pragma mark - Lifecycle
 
@@ -184,12 +182,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)sendAudioData:(NSData *)audioData;
 
 #pragma mark - Secondary Transport Specific
-
-/**
- *  Starts the video/audio services on the passed protocol. This method is used internally.
- *  @param protocol The protocol to use for the audio/video services
- */
-- (void)startSecondaryTransportWithProtocol:(SDLProtocol *)protocol;
 
 /**
  *  Start the manager. This is used internally. To use an SDLStreamingMediaManager, you should use the manager found on `SDLManager`.

--- a/SmartDeviceLink/SDLStreamingMediaManager.m
+++ b/SmartDeviceLink/SDLStreamingMediaManager.m
@@ -33,6 +33,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic, nullable) SDLProtocol *audioProtocol;
 @property (strong, nonatomic, nullable) SDLProtocol *videoProtocol;
 
+@property (strong, nonatomic, nullable) SDLSecondaryTransportManager *secondaryTransportManager;
+
 @end
 
 

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleManagerSpec.m
@@ -47,6 +47,13 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 
+@interface SDLStreamingMediaManager ()
+
+@property (strong, nonatomic, nullable) SDLSecondaryTransportManager *secondaryTransportManager;
+- (void)startSecondaryTransportWithProtocol:(SDLProtocol *)protocol;
+
+@end
+
 @interface SDLLifecycleManager ()
 // this private property is used for testing
 @property (copy, nonatomic) dispatch_queue_t lifecycleQueue;

--- a/SmartDeviceLinkTests/SDLStreamingMediaManagerSpec.m
+++ b/SmartDeviceLinkTests/SDLStreamingMediaManagerSpec.m
@@ -25,6 +25,9 @@
 @property (strong, nonatomic, nullable) SDLProtocol *audioProtocol;
 @property (strong, nonatomic, nullable) SDLProtocol *videoProtocol;
 
+@property (strong, nonatomic, nullable) SDLSecondaryTransportManager *secondaryTransportManager;
+
+- (void)startSecondaryTransportWithProtocol:(SDLProtocol *)protocol;
 - (void)didUpdateFromOldVideoProtocol:(nullable SDLProtocol *)oldVideoProtocol toNewVideoProtocol:(nullable SDLProtocol *)newVideoProtocol fromOldAudioProtocol:(nullable SDLProtocol *)oldAudioProtocol toNewAudioProtocol:(nullable SDLProtocol *)newAudioProtocol;
 
 @end


### PR DESCRIPTION
Fixes #1627 

This PR is **ready** for review.

### Risk
This PR makes **major** API changes. These changes are internal to this release

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Unit tests were run and fixed

#### Core Tests
No core tests were done because no logic was changed.

Core version / branch / commit hash / module tested against: n/a
HMI name / version / branch / commit hash / module tested against: n/a

### Summary
This PR fixes private classes being exposed through public properties on `SDLStreamingMediaManager`.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
