### PR TITLE
WIP: Lockscreen does not dismiss on transport disconnect

### DIFF
--- a/SmartDeviceLink/SDLLockScreenManager.m
+++ b/SmartDeviceLink/SDLLockScreenManager.m
@@ -173,12 +173,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)sdl_appDidBecomeActive:(NSNotification *)notification {
     // Restart, and potentially dismiss the lock screen if the app was disconnected in the background
-    if (!self.canPresent) {
-        [self start];
-    }
+    __weak typeof(self) weakSelf = self;
+    [self sdl_runOnMainQueue:^{
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf.canPresent) {
+            [strongSelf start];
+        }
 
-    // Notifications are always sent on the main thread so we do not need to dispatch tasks to the concurrent queue.
-    [self sdl_checkLockScreen];
+        [strongSelf sdl_checkLockScreen];
+    }];
 }
 
 - (void)sdl_driverDistractionStateDidChange:(SDLRPCNotificationNotification *)notification {

--- a/SmartDeviceLink/SDLLockScreenManager.m
+++ b/SmartDeviceLink/SDLLockScreenManager.m
@@ -172,10 +172,10 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)sdl_appDidBecomeActive:(NSNotification *)notification {
-    // Restart, and potentially dismiss the lock screen if the app was disconnected in the background
     __weak typeof(self) weakSelf = self;
-    [self sdl_runOnMainQueue:^{
+    [self sdl_runAsyncOnConcurrentQueue:^{
         __strong typeof(weakSelf) strongSelf = weakSelf;
+        // Restart, and potentially dismiss the lock screen if the app was disconnected in the background
         if (!strongSelf.canPresent) {
             [strongSelf start];
         }

--- a/SmartDeviceLink/SDLLockScreenManager.m
+++ b/SmartDeviceLink/SDLLockScreenManager.m
@@ -9,6 +9,7 @@
 #import "SDLLockScreenManager.h"
 
 #import "NSBundle+SDLBundle.h"
+#import "SDLGlobals.h"
 #import "SDLLogMacros.h"
 #import "SDLLockScreenConfiguration.h"
 #import "SDLLockScreenStatus.h"
@@ -23,6 +24,9 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface SDLLockScreenManager ()
+
+/// Concurrent queue for executing the lockscreen tasks. When updates to the lockscreen UI are performed, the current thread is blocked until the main thread finishes executing the block. This can cause deadlock if the lockscreen UI updates are preformed from a serial queue because another class can perform a blocking dispatch to the same serial queue from the main thread.
+@property (copy, nonatomic) dispatch_queue_t lockscreenQueue;
 
 @property (assign, nonatomic) BOOL canPresent;
 @property (strong, nonatomic, readwrite) SDLLockScreenConfiguration *config;
@@ -48,6 +52,12 @@ NS_ASSUME_NONNULL_BEGIN
         return nil;
     }
 
+    if (@available(iOS 10.0, *)) {
+        _lockscreenQueue = dispatch_queue_create_with_target("com.sdl.lockscreen.manager", DISPATCH_QUEUE_CONCURRENT, [SDLGlobals sharedGlobals].sdlConcurrentQueue);
+    } else {
+        _lockscreenQueue = [SDLGlobals sharedGlobals].sdlConcurrentQueue;
+    }
+
     _canPresent = NO;
     _lockScreenDismissable = NO;
     _config = config;
@@ -69,13 +79,8 @@ NS_ASSUME_NONNULL_BEGIN
     self.canPresent = NO;
 
     __weak typeof(self) weakSelf = self;
-    [self sdl_runOnMainQueue:^{
+   [self sdl_runAsyncOnConcurrentQueue:^{
         __strong typeof(weakSelf) strongSelf = weakSelf;
-
-        if (UIApplication.sharedApplication.applicationState != UIApplicationStateActive) {
-            SDLLogW(@"Attempted to start lock screen manager, but we are in the background. We will attempt to start again when we are in the foreground.");
-            return;
-        }
 
         // This usually means that we disconnected and connected with the device in the background. We will need to check and dismiss the view controller if it's presented before setting up a new one.
         if (strongSelf.presenter.lockViewController != nil) {
@@ -117,11 +122,16 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)stop {
-    // Don't allow the lockscreen to present again until we start
     self.canPresent = NO;
-    self.lastLockNotification = nil;
-    self.lastDriverDistractionNotification = nil;
-    [self.presenter stopWithCompletionHandler:nil];
+
+    // Don't allow the lockscreen to present again until we start
+    __weak typeof(self) weakSelf = self;
+    [self sdl_runAsyncOnConcurrentQueue:^{
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        strongSelf.lastLockNotification = nil;
+        strongSelf.lastDriverDistractionNotification = nil;
+        [strongSelf.presenter stopWithCompletionHandler:nil];
+    }];
 }
 
 - (nullable UIViewController *)lockScreenViewController {
@@ -140,7 +150,12 @@ NS_ASSUME_NONNULL_BEGIN
 
     self.lastLockNotification = notification.notification;
 
-    [self sdl_checkLockScreen];
+    // Don't allow the lockscreen to present again until we start
+    __weak typeof(self) weakSelf = self;
+    [self sdl_runAsyncOnConcurrentQueue:^{
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        [strongSelf sdl_checkLockScreen];
+    }];
 }
 
 - (void)sdl_lockScreenIconReceived:(NSNotification *)notification {
@@ -158,16 +173,13 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)sdl_appDidBecomeActive:(NSNotification *)notification {
-    __weak typeof(self) weakSelf = self;
-    [self sdl_runOnMainQueue:^{
-        __strong typeof(weakSelf) strongSelf = weakSelf;
-        // Restart, and potentially dismiss the lock screen if the app was disconnected in the background
-        if (!strongSelf.canPresent) {
-            [strongSelf start];
-        }
+    // Restart, and potentially dismiss the lock screen if the app was disconnected in the background
+    if (!self.canPresent) {
+        [self start];
+    }
 
-        [strongSelf sdl_checkLockScreen];
-    }];
+    // Notifications are always sent on the main thread so we do not need to dispatch tasks to the concurrent queue.
+    [self sdl_checkLockScreen];
 }
 
 - (void)sdl_driverDistractionStateDidChange:(SDLRPCNotificationNotification *)notification {
@@ -176,7 +188,12 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     self.lastDriverDistractionNotification = notification.notification;
-    [self sdl_updateLockScreenDismissable];
+
+    __weak typeof(self) weakSelf = self;
+    [self sdl_runAsyncOnConcurrentQueue:^{
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        [strongSelf sdl_updateLockScreenDismissable];
+    }];
 }
 
 #pragma mark - Private Helpers
@@ -266,11 +283,25 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Threading Utilities
 
+/// Checks if we are already on the main queue. If so, the block is added to the queue; if not, the block is dispatched to the main queue.
+/// @discussion Used to ensure that updates to the lock screen UI are done on the main thread.
+/// @param block The block to be executed.
 - (void)sdl_runOnMainQueue:(void (^)(void))block {
     if ([NSThread isMainThread]) {
         block();
     } else {
         dispatch_sync(dispatch_get_main_queue(), block);
+    }
+}
+
+/// Checks if we are already on a concurrent queue. If so, the block is added to the queue; if not, the block is dispatched to the concurrent `processing` queue.
+/// @discussion Used to ensure that the lock screen updates are not done on a serial queue (other than the main queue). Otherwise deadlock may occur if another class tries to  `dispatch_sync` to a serial queue from the main thread while this class attempts to `dispatch_sync` to the main queue from the same serial queue.
+/// @param block The block to be executed.
+- (void)sdl_runAsyncOnConcurrentQueue:(void (^)(void))block {
+    if (dispatch_get_specific(SDLConcurrentQueueName) != nil) {
+        block();
+    } else {
+        dispatch_async(self.lockscreenQueue, block);
     }
 }
 

--- a/SmartDeviceLink/SDLLockScreenManager.m
+++ b/SmartDeviceLink/SDLLockScreenManager.m
@@ -150,7 +150,6 @@ NS_ASSUME_NONNULL_BEGIN
 
     self.lastLockNotification = notification.notification;
 
-    // Don't allow the lockscreen to present again until we start
     __weak typeof(self) weakSelf = self;
     [self sdl_runAsyncOnConcurrentQueue:^{
         __strong typeof(weakSelf) strongSelf = weakSelf;

--- a/SmartDeviceLink/SDLLockScreenPresenter.m
+++ b/SmartDeviceLink/SDLLockScreenPresenter.m
@@ -210,7 +210,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Threading Utilities
 
-/// Checks if we are already on the main queue. If so, the block is added to the queue; if not, the block is dispatched to the `main` queue.
+/// Checks if we are already on the main queue. If so, the block is added to the queue; if not, the block is dispatched to the main queue.
 /// @discussion Used to ensure that updates to the lock screen UI are done on the main thread.
 /// @param block The block to be executed.
 - (void)sdl_runOnMainQueue:(void (^)(void))block {

--- a/SmartDeviceLink/SDLLockScreenPresenter.m
+++ b/SmartDeviceLink/SDLLockScreenPresenter.m
@@ -210,6 +210,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Threading Utilities
 
+/// Checks if we are already on the main queue. If so, the block is added to the queue; if not, the block is dispatched to the `main` queue.
+/// @discussion Used to ensure that updates to the lock screen UI are done on the main thread.
+/// @param block The block to be executed.
 - (void)sdl_runOnMainQueue:(void (^)(void))block {
     if ([NSThread isMainThread]) {
         block();

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLLockScreenManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLLockScreenManagerSpec.m
@@ -94,6 +94,9 @@ describe(@"a lock screen manager", ^{
         describe(@"after it's started", ^{
             beforeEach(^{
                 [testManager start];
+
+                // Wait a little bit to allow blocks dispatched to another queue to finish
+                [NSThread sleepForTimeInterval:0.1];
             });
             
             it(@"should set up the view controller correctly", ^{
@@ -133,6 +136,9 @@ describe(@"a lock screen manager", ^{
                     beforeEach(^{
                         testIcon = [UIImage imageNamed:@"testImagePNG" inBundle:[NSBundle bundleForClass:self.class] compatibleWithTraitCollection:nil];
                         [[NSNotificationCenter defaultCenter] postNotificationName:SDLDidReceiveLockScreenIcon object:nil userInfo:@{ SDLNotificationUserInfoObject: testIcon }];
+
+                        // Wait a little bit to allow the notification to propagate
+                        [NSThread sleepForTimeInterval:0.1];
                     });
                     
                     it(@"should have a vehicle icon", ^{
@@ -267,6 +273,9 @@ describe(@"a lock screen manager", ^{
         describe(@"after it's started", ^{
             beforeEach(^{
                 [testManager start];
+
+                // Wait a little bit to allow blocks dispatched to another queue to finish
+                [NSThread sleepForTimeInterval:0.1];
             });
             
             it(@"should set up the view controller correctly", ^{
@@ -424,6 +433,9 @@ describe(@"a lock screen manager", ^{
                 testLockScreenManager = [[SDLLockScreenManager alloc] initWithConfiguration:testLockScreenConfig notificationDispatcher:nil presenter:mockViewControllerPresenter];
 
                 [testLockScreenManager start]; // Sets `canPresent` to `true`
+
+                // Wait a little bit to allow blocks dispatched to another queue to finish
+                [NSThread sleepForTimeInterval:0.1];
             });
 
             it(@"should present the lock screen if not already presented", ^{

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLSoftButtonManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLSoftButtonManagerSpec.m
@@ -167,6 +167,9 @@ describe(@"a soft button manager", ^{
             testObject2 = [[SDLSoftButtonObject alloc] initWithName:object2Name state:object2State1 handler:nil];
 
             testManager.softButtonObjects = @[testObject1, testObject2];
+
+            // Wait a little bit to allow blocks dispatched to another queue to finish
+            [NSThread sleepForTimeInterval:0.1];
         });
 
         it(@"should set soft buttons correctly", ^{


### PR DESCRIPTION
Fixes #1629 

This PR is **not ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Fixed failing test cases. 

#### Core Tests
Performed smoke tests with SYNC 3.0 and sdl_core + sdl_hmi. 
* Tested using a Swift app using  the `SceneDelegate` class
* Tested using an Obj-C app using the `UIWindow` class
* Tested using a video streaming app on iOS 13 (iPhone 11) and iOS 12 (iPhone 12)

Core version / branch / commit hash / module tested against: sdl_core (branch `release/6.1`, commit: a85ef58358c456f69fee93addb7066dc02ecae48)
HMI name / version / branch / commit hash / module tested against: sdl_hmi (branch `develop`, commit: eda948d6c65b57f16616420ae14f526a84a7de05)

### Summary
The lockscreen was sometimes not being dismissed when the transport disconnected due to deadlock caused by the `SDLLifecycleManager` `dispatch_sync`ing to the `lifecycleQueue` from the main thread and the `SDLLockScreenPresenter` `dispatch_sync`ing to the main thread from the `lifecycleQueue`. This meant that both threads were blocked waiting for each other. 

* The fix implemented was to ensure that the `SDLockScreenManager` tasks run on a concurrent queue so when the lock screen UI is updated via a blocking dispatch to the main thread, we don't have to worry about deadlock. 
* Invalidating the `displayLink` from the `stop` method on the `SDLStreamingVideoLifecycleManager` sometime hanged so the `displayLink` is now invalidated on the same thread that it was created. 

### Changelog
##### Bug Fixes
* Fixed the lockscreen not dismissing due to deadlock

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
