### PR TITLE
Fix SDLAudioStreamManager doesn't have human readable error messages

### DIFF
--- a/SmartDeviceLink/SDLAudioStreamManager.h
+++ b/SmartDeviceLink/SDLAudioStreamManager.h
@@ -16,18 +16,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/// Error relates to AudioStreamManager
-extern NSString *const SDLErrorDomainAudioStreamManager;
-
-/// AudioStreamManager errors
-typedef NS_ENUM(NSInteger, SDLAudioStreamManagerError) {
-    /// The audio stream is not currently connected
-    SDLAudioStreamManagerErrorNotConnected = -1,
-
-    /// Attempted to play but there's no audio in the queue
-    SDLAudioStreamManagerErrorNoQueuedAudio = -2
-};
-
 /**
  The manager to control the audio stream
  */

--- a/SmartDeviceLink/SDLAudioStreamManager.m
+++ b/SmartDeviceLink/SDLAudioStreamManager.m
@@ -9,17 +9,16 @@
 #import "SDLAudioStreamManager.h"
 
 #import "SDLAudioFile.h"
+#import "SDLAudioStreamManagerDelegate.h"
+#import "SDLError.h"
 #import "SDLFile.h"
 #import "SDLGlobals.h"
 #import "SDLLogMacros.h"
 #import "SDLManager.h"
 #import "SDLPCMAudioConverter.h"
-#import "SDLAudioStreamManagerDelegate.h"
 #import "SDLStreamingAudioManagerType.h"
 
 NS_ASSUME_NONNULL_BEGIN
-
-NSString *const SDLErrorDomainAudioStreamManager = @"com.sdl.extension.pcmAudioStreamManager";
 
 @interface SDLAudioStreamManager ()
 
@@ -126,7 +125,7 @@ NSString *const SDLErrorDomainAudioStreamManager = @"com.sdl.extension.pcmAudioS
 
     if (!self.streamManager.isAudioConnected) {
         if (self.delegate != nil) {
-            NSError *error = [NSError errorWithDomain:SDLErrorDomainAudioStreamManager code:SDLAudioStreamManagerErrorNotConnected userInfo:nil];
+            NSError *error = [NSError sdl_audioStreamManager_notConnected];
             [self.delegate audioStreamManager:self errorDidOccurForFile:self.mutableQueue.firstObject.inputFileURL error:error];
         }
         return;

--- a/SmartDeviceLink/SDLError.h
+++ b/SmartDeviceLink/SDLError.h
@@ -39,14 +39,14 @@ extern SDLErrorDomain *const SDLErrorDomainAudioStreamManager;
 
 #pragma mark SDLManager
 
-+ (NSError *)sdl_lifecycle_rpcErrorWithDescription:(NSString *)description andReason:(NSString *)reason;
++ (NSError *)sdl_lifecycle_rpcErrorWithDescription:(nullable NSString *)description andReason:(nullable NSString *)reason;
 + (NSError *)sdl_lifecycle_notConnectedError;
 + (NSError *)sdl_lifecycle_notReadyError;
-+ (NSError *)sdl_lifecycle_unknownRemoteErrorWithDescription:(NSString *)description andReason:(NSString *)reason;
++ (NSError *)sdl_lifecycle_unknownRemoteErrorWithDescription:(nullable NSString *)description andReason:(nullable NSString *)reason;
 + (NSError *)sdl_lifecycle_managersFailedToStart;
-+ (NSError *)sdl_lifecycle_startedWithBadResult:(SDLResult)result info:(NSString *)info;
-+ (NSError *)sdl_lifecycle_startedWithWarning:(SDLResult)result info:(NSString *)info;
-+ (NSError *)sdl_lifecycle_failedWithBadResult:(SDLResult)result info:(NSString *)info;
++ (NSError *)sdl_lifecycle_startedWithBadResult:(nullable SDLResult)result info:(nullable NSString *)info;
++ (NSError *)sdl_lifecycle_startedWithWarning:(nullable SDLResult)result info:(nullable NSString *)info;
++ (NSError *)sdl_lifecycle_failedWithBadResult:(nullable SDLResult)result info:(nullable NSString *)info;
 + (NSError *)sdl_lifecycle_multipleRequestsCancelled;
 
 #pragma mark SDLFileManager

--- a/SmartDeviceLink/SDLError.h
+++ b/SmartDeviceLink/SDLError.h
@@ -27,6 +27,8 @@ extern SDLErrorDomain *const SDLErrorDomainSystemCapabilityManager;
 extern SDLErrorDomain *const SDLErrorDomainTransport;
 extern SDLErrorDomain *const SDLErrorDomainRPCStore;
 extern SDLErrorDomain *const SDLErrorDomainCacheFileManager;
+extern SDLErrorDomain *const SDLErrorDomainAudioStreamManager;
+
 
 @interface NSError (SDLErrors)
 
@@ -98,6 +100,10 @@ extern SDLErrorDomain *const SDLErrorDomainCacheFileManager;
 #pragma mark Cache File Manager
 
 + (NSError *)sdl_cacheFileManager_updateIconArchiveFileFailed;
+
+#pragma mark Audio Stream Manager
+
++ (NSError *)sdl_audioStreamManager_notConnected;
 
 @end
 

--- a/SmartDeviceLink/SDLError.m
+++ b/SmartDeviceLink/SDLError.m
@@ -25,15 +25,16 @@ SDLErrorDomain *const SDLErrorDomainSystemCapabilityManager = @"com.sdl.systemca
 SDLErrorDomain *const SDLErrorDomainTransport = @"com.sdl.transport.error";
 SDLErrorDomain *const SDLErrorDomainRPCStore = @"com.sdl.rpcStore.error";
 SDLErrorDomain *const SDLErrorDomainCacheFileManager = @"com.sdl.cachefilemanager.error";
+SDLErrorDomain *const SDLErrorDomainAudioStreamManager = @"com.sdl.extension.pcmAudioStreamManager";
 
 @implementation NSError (SDLErrors)
 
 #pragma mark - SDLEncryptionLifecycleManager
 + (NSError *)sdl_encryption_lifecycle_notReadyError {
     NSDictionary<NSString *, NSString *> *userInfo = @{
-                                                       NSLocalizedDescriptionKey: NSLocalizedString(@"Encryption Lifecycle manager not ready", nil),
-                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"The SDL library is not finished setting up the connection, please wait until the encryption lifecycleState is SDLEncryptionLifecycleStateReady", nil),
-                                                       NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"Make sure HMI is not NONE and at least one RPC requires encryption in permissions?", nil)
+                                                       NSLocalizedDescriptionKey: @"Encryption Lifecycle manager not ready",
+                                                       NSLocalizedFailureReasonErrorKey: @"The SDL library is not finished setting up the connection, please wait until the encryption lifecycleState is SDLEncryptionLifecycleStateReady",
+                                                       NSLocalizedRecoverySuggestionErrorKey: @"Make sure HMI is not NONE and at least one RPC requires encryption in permissions?"
                                                        };
     
     return [NSError errorWithDomain:SDLErrorDomainEncryptionLifecycleManager
@@ -43,9 +44,9 @@ SDLErrorDomain *const SDLErrorDomainCacheFileManager = @"com.sdl.cachefilemanage
 
 + (NSError *)sdl_encryption_lifecycle_encryption_off {
     NSDictionary<NSString *, NSString *> *userInfo = @{
-                                                       NSLocalizedDescriptionKey: NSLocalizedString(@"Encryption Lifecycle received a ACK with encryption bit = 0", nil),
-                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"The SDL library received ACK with encryption = OFF.", nil),
-                                                       NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"Make sure you are on a supported remote head unit with proper policies and your app id is approved.", nil)
+                                                       NSLocalizedDescriptionKey: @"Encryption Lifecycle received a ACK with encryption bit = 0",
+                                                       NSLocalizedFailureReasonErrorKey: @"The SDL library received ACK with encryption = OFF.",
+                                                       NSLocalizedRecoverySuggestionErrorKey: @"Make sure you are on a supported remote head unit with proper policies and your app id is approved."
                                                        };
     
     return [NSError errorWithDomain:SDLErrorDomainEncryptionLifecycleManager
@@ -55,9 +56,9 @@ SDLErrorDomain *const SDLErrorDomainCacheFileManager = @"com.sdl.cachefilemanage
 
 + (NSError *)sdl_encryption_lifecycle_nak {
     NSDictionary<NSString *, NSString *> *userInfo = @{
-                                                       NSLocalizedDescriptionKey: NSLocalizedString(@"Encryption Lifecycle received a negative acknowledgement", nil),
-                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"The remote head unit sent a NAK.  Encryption service failed to start due to NAK.", nil),
-                                                       NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"Make sure your certificates are valid.", nil)
+                                                       NSLocalizedDescriptionKey: @"Encryption Lifecycle received a negative acknowledgement",
+                                                       NSLocalizedFailureReasonErrorKey: @"The remote head unit sent a NAK.  Encryption service failed to start due to NAK.",
+                                                       NSLocalizedRecoverySuggestionErrorKey: @"Make sure your certificates are valid."
                                                        };
     
     return [NSError errorWithDomain:SDLErrorDomainEncryptionLifecycleManager
@@ -70,8 +71,8 @@ SDLErrorDomain *const SDLErrorDomainCacheFileManager = @"com.sdl.cachefilemanage
 
 + (NSError *)sdl_lifecycle_rpcErrorWithDescription:(NSString *)description andReason:(NSString *)reason {
     NSDictionary<NSString *, NSString *> *userInfo = @{
-                                                       NSLocalizedDescriptionKey: NSLocalizedString(description, nil),
-                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(reason, nil)
+                                                       NSLocalizedDescriptionKey: description,
+                                                       NSLocalizedFailureReasonErrorKey: reason
                                                        };
     return [NSError errorWithDomain:SDLErrorDomainLifecycleManager
                                code:SDLManagerErrorRPCRequestFailed
@@ -80,8 +81,8 @@ SDLErrorDomain *const SDLErrorDomainCacheFileManager = @"com.sdl.cachefilemanage
 
 + (NSError *)sdl_lifecycle_notConnectedError {
     NSDictionary<NSString *, NSString *> *userInfo = @{
-                                                       NSLocalizedDescriptionKey: NSLocalizedString(@"Could not find a connection", nil),
-                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"The SDL library could not find a current connection to an SDL hardware device", nil)
+                                                       NSLocalizedDescriptionKey: @"Could not find a connection",
+                                                       NSLocalizedFailureReasonErrorKey: @"The SDL library could not find a current connection to an SDL hardware device"
                                                        };
 
     return [NSError errorWithDomain:SDLErrorDomainLifecycleManager
@@ -91,8 +92,8 @@ SDLErrorDomain *const SDLErrorDomainCacheFileManager = @"com.sdl.cachefilemanage
 
 + (NSError *)sdl_lifecycle_notReadyError {
     NSDictionary<NSString *, NSString *> *userInfo = @{
-                                                       NSLocalizedDescriptionKey: NSLocalizedString(@"Lifecycle manager not ready", nil),
-                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"The SDL library is not finished setting up the connection, please wait until the lifecycleState is SDLLifecycleStateReady", nil)
+                                                       NSLocalizedDescriptionKey: @"Lifecycle manager not ready",
+                                                       NSLocalizedFailureReasonErrorKey: @"The SDL library is not finished setting up the connection, please wait until the lifecycleState is SDLLifecycleStateReady"
                                                        };
 
     return [NSError errorWithDomain:SDLErrorDomainLifecycleManager
@@ -102,8 +103,8 @@ SDLErrorDomain *const SDLErrorDomainCacheFileManager = @"com.sdl.cachefilemanage
 
 + (NSError *)sdl_lifecycle_unknownRemoteErrorWithDescription:(NSString *)description andReason:(NSString *)reason {
     NSDictionary<NSString *, NSString *> *userInfo = @{
-                                                       NSLocalizedDescriptionKey: NSLocalizedString(description, nil),
-                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(reason, nil)
+                                                       NSLocalizedDescriptionKey: description,
+                                                       NSLocalizedFailureReasonErrorKey: reason
                                                        };
     return [NSError errorWithDomain:SDLErrorDomainLifecycleManager
                                code:SDLManagerErrorUnknownRemoteError
@@ -118,8 +119,8 @@ SDLErrorDomain *const SDLErrorDomainCacheFileManager = @"com.sdl.cachefilemanage
 
 + (NSError *)sdl_lifecycle_startedWithBadResult:(SDLResult)result info:(NSString *)info {
     NSDictionary<NSString *, NSString *> *userInfo = @{
-                                                       NSLocalizedDescriptionKey: NSLocalizedString(result, nil),
-                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(info, nil)
+                                                       NSLocalizedDescriptionKey: result,
+                                                       NSLocalizedFailureReasonErrorKey: info
                                                        };
     return [NSError errorWithDomain:SDLErrorDomainLifecycleManager
                                code:SDLManagerErrorRegistrationFailed
@@ -128,8 +129,8 @@ SDLErrorDomain *const SDLErrorDomainCacheFileManager = @"com.sdl.cachefilemanage
 
 + (NSError *)sdl_lifecycle_startedWithWarning:(SDLResult)result info:(NSString *)info {
     NSDictionary<NSString *, NSString *> *userInfo = @{
-                                                       NSLocalizedDescriptionKey: NSLocalizedString(result, nil),
-                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(info, nil)
+                                                       NSLocalizedDescriptionKey: result,
+                                                       NSLocalizedFailureReasonErrorKey: info
                                                        };
     return [NSError errorWithDomain:SDLErrorDomainLifecycleManager
                                code:SDLManagerErrorRegistrationSuccessWithWarning
@@ -138,8 +139,8 @@ SDLErrorDomain *const SDLErrorDomainCacheFileManager = @"com.sdl.cachefilemanage
 
 + (NSError *)sdl_lifecycle_failedWithBadResult:(SDLResult)result info:(NSString *)info {
     NSDictionary<NSString *, NSString *> *userInfo = @{
-                                                       NSLocalizedDescriptionKey: NSLocalizedString(result, nil),
-                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(info, nil)
+                                                       NSLocalizedDescriptionKey: result,
+                                                       NSLocalizedFailureReasonErrorKey: info
                                                        };
     return [NSError errorWithDomain:SDLErrorDomainLifecycleManager
                                code:SDLManagerErrorRegistrationFailed
@@ -157,36 +158,36 @@ SDLErrorDomain *const SDLErrorDomainCacheFileManager = @"com.sdl.cachefilemanage
 
 + (NSError *)sdl_fileManager_cannotOverwriteError {
     NSDictionary<NSString *, NSString *> *userInfo = @{
-                                                       NSLocalizedDescriptionKey: NSLocalizedString(@"Cannot overwrite remote file", nil),
-                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"The remote file system already has a file of this name, and the file manager is set to not automatically overwrite files", nil),
-                                                       NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"Set SDLFileManager autoOverwrite to YES, or call forceUploadFile:completion:", nil)
+                                                       NSLocalizedDescriptionKey: @"Cannot overwrite remote file",
+                                                       NSLocalizedFailureReasonErrorKey: @"The remote file system already has a file of this name, and the file manager is set to not automatically overwrite files",
+                                                       NSLocalizedRecoverySuggestionErrorKey: @"Set SDLFileManager autoOverwrite to YES, or call forceUploadFile:completion:"
                                                        };
     return [NSError errorWithDomain:SDLErrorDomainFileManager code:SDLFileManagerErrorCannotOverwrite userInfo:userInfo];
 }
 
 + (NSError *)sdl_fileManager_noKnownFileError {
     NSDictionary<NSString *, NSString *> *userInfo = @{
-                                                       NSLocalizedDescriptionKey: NSLocalizedString(@"No such remote file is currently known", nil),
-                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"The remote file is not currently known by the file manager. It could be that this file does not exist on the remote system or that the file manager has not completed its initialization and received a list of files from the remote system.", nil),
-                                                       NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"Make sure a file with this name is present on the remote system and that the file manager has finished its initialization.", nil)
+                                                       NSLocalizedDescriptionKey: @"No such remote file is currently known",
+                                                       NSLocalizedFailureReasonErrorKey: @"The remote file is not currently known by the file manager. It could be that this file does not exist on the remote system or that the file manager has not completed its initialization and received a list of files from the remote system.",
+                                                       NSLocalizedRecoverySuggestionErrorKey: @"Make sure a file with this name is present on the remote system and that the file manager has finished its initialization."
                                                        };
     return [NSError errorWithDomain:SDLErrorDomainFileManager code:SDLFileManagerErrorNoKnownFile userInfo:userInfo];
 }
 
 + (NSError *)sdl_fileManager_unableToStartError {
     NSDictionary<NSString *, NSString *> *userInfo = @{
-                                                       NSLocalizedDescriptionKey: NSLocalizedString(@"The file manager was unable to start", nil),
-                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"This may be because files are not supported on this unit and / or LISTFILES returned an error", nil),
-                                                       NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"Make sure that the system is sending back a proper LIST FILES response", nil)
+                                                       NSLocalizedDescriptionKey: @"The file manager was unable to start",
+                                                       NSLocalizedFailureReasonErrorKey: @"This may be because files are not supported on this unit and / or LISTFILES returned an error",
+                                                       NSLocalizedRecoverySuggestionErrorKey: @"Make sure that the system is sending back a proper LIST FILES response"
                                                        };
     return [NSError errorWithDomain:SDLErrorDomainFileManager code:SDLFileManagerErrorUnableToStart userInfo:userInfo];
 }
 
 + (NSError *)sdl_fileManager_unableToUploadError {
     NSDictionary<NSString *, NSString *> *userInfo = @{
-                                                       NSLocalizedDescriptionKey: NSLocalizedString(@"The file manager was unable to send this file", nil),
-                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"This could be because the file manager has not started, or the head unit does not support files", nil),
-                                                       NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"Make sure that the system is sending back a proper LIST FILES response and check the file manager's state", nil)
+                                                       NSLocalizedDescriptionKey: @"The file manager was unable to send this file",
+                                                       NSLocalizedFailureReasonErrorKey: @"This could be because the file manager has not started, or the head unit does not support files",
+                                                       NSLocalizedRecoverySuggestionErrorKey: @"Make sure that the system is sending back a proper LIST FILES response and check the file manager's state"
                                                        };
     return [NSError errorWithDomain:SDLErrorDomainFileManager code:SDLFileManagerErrorUnableToUpload userInfo:userInfo];
 }
@@ -201,27 +202,27 @@ SDLErrorDomain *const SDLErrorDomainCacheFileManager = @"com.sdl.cachefilemanage
 
 + (NSError *)sdl_fileManager_fileUploadCanceled {
     NSDictionary<NSString *, NSString *> *userInfo = @{
-                                                       NSLocalizedDescriptionKey: NSLocalizedString(@"The file upload was canceled", nil),
-                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"The file upload transaction was canceled before it could be completed", nil),
-                                                       NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"The file upload was canceled", nil)
+                                                       NSLocalizedDescriptionKey: @"The file upload was canceled",
+                                                       NSLocalizedFailureReasonErrorKey: @"The file upload transaction was canceled before it could be completed",
+                                                       NSLocalizedRecoverySuggestionErrorKey: @"The file upload was canceled"
                                                        };
     return [NSError errorWithDomain:SDLErrorDomainFileManager code:SDLFileManagerUploadCanceled userInfo:userInfo];
 }
 
 + (NSError *)sdl_fileManager_dataMissingError {
     NSDictionary<NSString *, NSString *> *userInfo = @{
-                                                       NSLocalizedDescriptionKey: NSLocalizedString(@"The file upload was canceled", nil),
-                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"The data for the file is missing", nil),
-                                                       NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"Make sure the data used to create the file is valid", nil)
+                                                       NSLocalizedDescriptionKey: @"The file upload was canceled",
+                                                       NSLocalizedFailureReasonErrorKey: @"The data for the file is missing",
+                                                       NSLocalizedRecoverySuggestionErrorKey: @"Make sure the data used to create the file is valid"
                                                        };
     return [NSError errorWithDomain:SDLErrorDomainFileManager code:SDLFileManagerErrorFileDataMissing userInfo:userInfo];
 }
 
 + (NSError *)sdl_fileManager_staticIconError {
     NSDictionary<NSString *, NSString *> *userInfo = @{
-                                                       NSLocalizedDescriptionKey: NSLocalizedString(@"The file upload was canceled", nil),
-                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"The file is a static icon, which cannot be uploaded", nil),
-                                                       NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"Stop trying to upload a static icon, set it via the screen manager or create an SDLImage instead", nil)
+                                                       NSLocalizedDescriptionKey: @"The file upload was canceled",
+                                                       NSLocalizedFailureReasonErrorKey: @"The file is a static icon, which cannot be uploaded",
+                                                       NSLocalizedRecoverySuggestionErrorKey: @"Stop trying to upload a static icon, set it via the screen manager or create an SDLImage instead"
                                                        };
     return [NSError errorWithDomain:SDLErrorDomainFileManager code:SDLFileManagerErrorStaticIcon userInfo:userInfo];
 }
@@ -230,9 +231,9 @@ SDLErrorDomain *const SDLErrorDomainCacheFileManager = @"com.sdl.cachefilemanage
 
 + (NSError *)sdl_fileManager_fileDoesNotExistError {
     NSDictionary<NSString *, NSString *> *userInfo = @{
-                                                       NSLocalizedDescriptionKey: NSLocalizedString(@"The file manager was unable to send the file", nil),
-                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"This could be because the file does not exist at the specified file path or that passed data is invalid", nil),
-                                                       NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"Make sure that the the correct file path is being set and that the passed data is valid", nil)
+                                                       NSLocalizedDescriptionKey: @"The file manager was unable to send the file",
+                                                       NSLocalizedFailureReasonErrorKey: @"This could be because the file does not exist at the specified file path or that passed data is invalid",
+                                                       NSLocalizedRecoverySuggestionErrorKey: @"Make sure that the the correct file path is being set and that the passed data is valid"
                                                        };
     return [NSError errorWithDomain:SDLErrorDomainFileManager code:SDLFileManagerErrorFileDoesNotExist userInfo:userInfo];
 }
@@ -269,9 +270,9 @@ SDLErrorDomain *const SDLErrorDomainCacheFileManager = @"com.sdl.cachefilemanage
 
 + (NSError *)sdl_choiceSetManager_failedToCreateMenuItems {
     NSDictionary<NSString *, NSString *> *userInfo = @{
-                                                       NSLocalizedDescriptionKey: NSLocalizedString(@"Choice Set Manager error", nil),
-                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"Choice set manager failed to create menu items due to menuName being empty.", nil),
-                                                       NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"If you are setting the menuName, it is possible that the head unit is sending incorrect displayCapabilities.", nil)
+                                                       NSLocalizedDescriptionKey: @"Choice Set Manager error",
+                                                       NSLocalizedFailureReasonErrorKey: @"Choice set manager failed to create menu items due to menuName being empty.",
+                                                       NSLocalizedRecoverySuggestionErrorKey: @"If you are setting the menuName, it is possible that the head unit is sending incorrect displayCapabilities."
                                                        };
     return [NSError errorWithDomain:SDLErrorDomainChoiceSetManager code:SDLChoiceSetManagerErrorFailedToCreateMenuItems userInfo:userInfo];
 }
@@ -280,8 +281,8 @@ SDLErrorDomain *const SDLErrorDomainCacheFileManager = @"com.sdl.cachefilemanage
     NSString *errorString = [NSString stringWithFormat:@"Choice Set Manager error invalid state: %@", state];
     NSDictionary<NSString *, NSString *> *userInfo = @{
                                                        NSLocalizedDescriptionKey: errorString,
-                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"The choice set manager could be in an invalid state because the head unit doesn't support choice sets or the manager failed to set up correctly.", nil),
-                                                       NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"If you are setting the menuName, it is possible that the head unit is sending incorrect displayCapabilities.", nil)
+                                                       NSLocalizedFailureReasonErrorKey: @"The choice set manager could be in an invalid state because the head unit doesn't support choice sets or the manager failed to set up correctly.",
+                                                       NSLocalizedRecoverySuggestionErrorKey: @"If you are setting the menuName, it is possible that the head unit is sending incorrect displayCapabilities."
                                                        };
     return [NSError errorWithDomain:SDLErrorDomainChoiceSetManager code:SDLChoiceSetManagerErrorInvalidState userInfo:userInfo];
 }
@@ -290,27 +291,27 @@ SDLErrorDomain *const SDLErrorDomainCacheFileManager = @"com.sdl.cachefilemanage
 
 + (NSError *)sdl_systemCapabilityManager_moduleDoesNotSupportSystemCapabilities {
     NSDictionary<NSString *, NSString *> *userInfo = @{
-                                                       NSLocalizedDescriptionKey: NSLocalizedString(@"Module does not understand system capabilities", nil),
-                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"The connected module does not support system capabilities", nil),
-                                                       NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"Use isCapabilitySupported to find out if the feature is supported on the head unit, but no more information about the feature is available on this module", nil)
+                                                       NSLocalizedDescriptionKey: @"Module does not understand system capabilities",
+                                                       NSLocalizedFailureReasonErrorKey: @"The connected module does not support system capabilities",
+                                                       NSLocalizedRecoverySuggestionErrorKey: @"Use isCapabilitySupported to find out if the feature is supported on the head unit, but no more information about the feature is available on this module"
                                                        };
     return [NSError errorWithDomain:SDLErrorDomainSystemCapabilityManager code:SDLSystemCapabilityManagerErrorModuleDoesNotSupportSystemCapabilities userInfo:userInfo];
 }
 
 + (NSError *)sdl_systemCapabilityManager_cannotUpdateInHMINONE {
     NSDictionary<NSString *, NSString *> *userInfo = @{
-                                                       NSLocalizedDescriptionKey: NSLocalizedString(@"System capabilities cannot be updated in HMI NONE.", nil),
-                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"The system capability manager attempted to subscribe or update a system capability in HMI NONE, which is not allowed.", nil),
-                                                       NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"Wait until you are in HMI BACKGROUND, LIMITED, OR FULL before subscribing or updating a capability.", nil)
+                                                       NSLocalizedDescriptionKey: @"System capabilities cannot be updated in HMI NONE.",
+                                                       NSLocalizedFailureReasonErrorKey: @"The system capability manager attempted to subscribe or update a system capability in HMI NONE, which is not allowed.",
+                                                       NSLocalizedRecoverySuggestionErrorKey: @"Wait until you are in HMI BACKGROUND, LIMITED, OR FULL before subscribing or updating a capability."
                                                        };
     return [NSError errorWithDomain:SDLErrorDomainSystemCapabilityManager code:SDLSystemCapabilityManagerErrorHMINone userInfo:userInfo];
 }
 
 + (NSError *)sdl_systemCapabilityManager_cannotUpdateTypeDISPLAYS {
     NSDictionary<NSString *, NSString *> *userInfo = @{
-                                                       NSLocalizedDescriptionKey: NSLocalizedString(@"System capability type DISPLAYS cannot be updated.", nil),
-                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"The system capability manager attempted to update system capability type DISPLAYS, which is not allowed.", nil),
-                                                       NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"Subscribe to DISPLAYS to automatically receive updates or retrieve a cached display capability value directly from the SystemCapabilityManager.", nil)
+                                                       NSLocalizedDescriptionKey: @"System capability type DISPLAYS cannot be updated.",
+                                                       NSLocalizedFailureReasonErrorKey: @"The system capability manager attempted to update system capability type DISPLAYS, which is not allowed.",
+                                                       NSLocalizedRecoverySuggestionErrorKey: @"Subscribe to DISPLAYS to automatically receive updates or retrieve a cached display capability value directly from the SystemCapabilityManager."
                                                        };
     return [NSError errorWithDomain:SDLErrorDomainSystemCapabilityManager code:SDLSystemCapabilityManagerErrorCannotUpdateTypeDisplays userInfo:userInfo];
 }
@@ -319,36 +320,36 @@ SDLErrorDomain *const SDLErrorDomainCacheFileManager = @"com.sdl.cachefilemanage
 
 + (NSError *)sdl_transport_unknownError {
     NSDictionary<NSString *, NSString *> *userInfo = @{
-                                                       NSLocalizedDescriptionKey: NSLocalizedString(@"TCP connection error", nil),
-                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"TCP connection cannot be established due to unknown error.", nil),
-                                                       NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"Make sure that correct IP address and TCP port number are specified, and the phone is connected to the correct Wi-Fi network.", nil)
+                                                       NSLocalizedDescriptionKey: @"TCP connection error",
+                                                       NSLocalizedFailureReasonErrorKey: @"TCP connection cannot be established due to unknown error.",
+                                                       NSLocalizedRecoverySuggestionErrorKey: @"Make sure that correct IP address and TCP port number are specified, and the phone is connected to the correct Wi-Fi network."
                                                        };
     return [NSError errorWithDomain:SDLErrorDomainTransport code:SDLTransportErrorUnknown userInfo:userInfo];
 }
 
 + (NSError *)sdl_transport_connectionRefusedError {
     NSDictionary<NSString *, NSString *> *userInfo = @{
-                                                       NSLocalizedDescriptionKey: NSLocalizedString(@"TCP connection cannot be established", nil),
-                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"The TCP connection is refused by head unit. Possible causes are that the specified TCP port number is not correct, or SDL Core is not running properly on the head unit.", nil),
-                                                       NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"Make sure that correct IP address and TCP port number are specified. Also, make sure that SDL Core on the head unit enables TCP transport.", nil)
+                                                       NSLocalizedDescriptionKey: @"TCP connection cannot be established",
+                                                       NSLocalizedFailureReasonErrorKey: @"The TCP connection is refused by head unit. Possible causes are that the specified TCP port number is not correct, or SDL Core is not running properly on the head unit.",
+                                                       NSLocalizedRecoverySuggestionErrorKey: @"Make sure that correct IP address and TCP port number are specified. Also, make sure that SDL Core on the head unit enables TCP transport."
                                                        };
     return [NSError errorWithDomain:SDLErrorDomainTransport code:SDLTransportErrorConnectionRefused userInfo:userInfo];
 }
 
 + (NSError *)sdl_transport_connectionTimedOutError {
     NSDictionary<NSString *, NSString *> *userInfo = @{
-                                                       NSLocalizedDescriptionKey: NSLocalizedString(@"TCP connection timed out", nil),
-                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"The TCP connection cannot be established within a given time. Possible causes are that the specified IP address is not correct, or the connection is blocked by a firewall.", nil),
-                                                       NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"Make sure that correct IP address and TCP port number are specified. Also, make sure that the head unit's system configuration accepts TCP connections.", nil)
+                                                       NSLocalizedDescriptionKey: @"TCP connection timed out",
+                                                       NSLocalizedFailureReasonErrorKey: @"The TCP connection cannot be established within a given time. Possible causes are that the specified IP address is not correct, or the connection is blocked by a firewall.",
+                                                       NSLocalizedRecoverySuggestionErrorKey: @"Make sure that correct IP address and TCP port number are specified. Also, make sure that the head unit's system configuration accepts TCP connections."
                                                        };
     return [NSError errorWithDomain:SDLErrorDomainTransport code:SDLTransportErrorConnectionTimedOut userInfo:userInfo];
 }
 
 + (NSError *)sdl_transport_networkDownError {
     NSDictionary<NSString *, NSString *> *userInfo = @{
-                                                       NSLocalizedDescriptionKey: NSLocalizedString(@"Network is not available", nil),
-                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"TCP connection cannot be established because the phone is not connected to the network. Possible causes are: Wi-Fi being disabled on the phone or the phone is connected to a wrong Wi-Fi network.", nil),
-                                                       NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"Make sure that the phone is connected to the Wi-Fi network that has the head unit on it. Also, make sure that correct IP address and TCP port number are specified.", nil)
+                                                       NSLocalizedDescriptionKey: @"Network is not available",
+                                                       NSLocalizedFailureReasonErrorKey: @"TCP connection cannot be established because the phone is not connected to the network. Possible causes are: Wi-Fi being disabled on the phone or the phone is connected to a wrong Wi-Fi network.",
+                                                       NSLocalizedRecoverySuggestionErrorKey: @"Make sure that the phone is connected to the Wi-Fi network that has the head unit on it. Also, make sure that correct IP address and TCP port number are specified."
                                                        };
     return [NSError errorWithDomain:SDLErrorDomainTransport code:SDLTransportErrorNetworkDown userInfo:userInfo];
 }
@@ -357,9 +358,9 @@ SDLErrorDomain *const SDLErrorDomainCacheFileManager = @"com.sdl.cachefilemanage
 
 + (NSError *)sdl_rpcStore_invalidObjectErrorWithObject:(id)wrongObject expectedType:(Class)type {
     NSDictionary<NSString *, NSString *> *userInfo = @{
-                                                       NSLocalizedDescriptionKey: NSLocalizedString(@"Type of stored value doesn't match with requested", nil),
+                                                       NSLocalizedDescriptionKey: @"Type of stored value doesn't match with requested",
                                                        NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:@"Requested %@ but returned %@", NSStringFromClass(type), NSStringFromClass([wrongObject class])],
-                                                       NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"Check the object type returned from the head unit system", nil)
+                                                       NSLocalizedRecoverySuggestionErrorKey: @"Check the object type returned from the head unit system"
                                                        };
     return [NSError errorWithDomain:SDLErrorDomainRPCStore code:SDLRPCStoreErrorGetInvalidObject userInfo:userInfo];
 }
@@ -368,11 +369,22 @@ SDLErrorDomain *const SDLErrorDomainCacheFileManager = @"com.sdl.cachefilemanage
 
 + (NSError *)sdl_cacheFileManager_updateIconArchiveFileFailed {
     NSDictionary<NSString *, NSString *> *userInfo = @{
-                                                       NSLocalizedDescriptionKey: NSLocalizedString(@"Cache File Manager error", nil),
-                                                       NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"Unable to archive icon archive file to file path", nil),
-                                                       NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(@"Make sure that file path is valid", nil)
+                                                       NSLocalizedDescriptionKey: @"Failed to update the icon archive file",
+                                                       NSLocalizedFailureReasonErrorKey: @"Unable to archive icon archive file to file path",
+                                                       NSLocalizedRecoverySuggestionErrorKey: @"Make sure that file path is valid"
                                                        };
     return [NSError errorWithDomain:SDLErrorDomainCacheFileManager code:SDLCacheManagerErrorUpdateIconArchiveFileFailure userInfo:userInfo];
+}
+
+#pragma mark Audio Stream Manager
++ (NSError *)sdl_audioStreamManager_notConnected {
+    NSDictionary<NSString *, NSString *> *userInfo = @{
+        NSLocalizedDescriptionKey: @"Couldn't send audio data, the audio service is not connected",
+        NSLocalizedFailureReasonErrorKey: @"The audio service must be connected before sending audio data",
+        NSLocalizedRecoverySuggestionErrorKey: @"Make sure that a connection has been established, you are a NAVIGATION app and have the NAVIGATION app type in your configuration, and you are the active NAVIGATION app"
+    };
+
+    return [NSError errorWithDomain:SDLErrorDomainAudioStreamManager code:SDLAudioStreamManagerErrorNotConnected userInfo:userInfo];
 }
 
 @end

--- a/SmartDeviceLink/SDLError.m
+++ b/SmartDeviceLink/SDLError.m
@@ -69,10 +69,12 @@ SDLErrorDomain *const SDLErrorDomainAudioStreamManager = @"com.sdl.extension.pcm
 
 #pragma mark - SDLManager
 
-+ (NSError *)sdl_lifecycle_rpcErrorWithDescription:(NSString *)description andReason:(NSString *)reason {
++ (NSError *)sdl_lifecycle_rpcErrorWithDescription:(nullable NSString *)description andReason:(nullable NSString *)reason {
+    NSString *descriptionString = description ?: @"";
+    NSString *reasonString = reason ?: @"";
     NSDictionary<NSString *, NSString *> *userInfo = @{
-                                                       NSLocalizedDescriptionKey: description,
-                                                       NSLocalizedFailureReasonErrorKey: reason
+                                                       NSLocalizedDescriptionKey: descriptionString,
+                                                       NSLocalizedFailureReasonErrorKey: reasonString
                                                        };
     return [NSError errorWithDomain:SDLErrorDomainLifecycleManager
                                code:SDLManagerErrorRPCRequestFailed
@@ -101,10 +103,12 @@ SDLErrorDomain *const SDLErrorDomainAudioStreamManager = @"com.sdl.extension.pcm
                            userInfo:userInfo];
 }
 
-+ (NSError *)sdl_lifecycle_unknownRemoteErrorWithDescription:(NSString *)description andReason:(NSString *)reason {
++ (NSError *)sdl_lifecycle_unknownRemoteErrorWithDescription:(nullable NSString *)description andReason:(nullable NSString *)reason {
+    NSString *descriptionString = description ?: @"";
+    NSString *reasonString = reason ?: @"";
     NSDictionary<NSString *, NSString *> *userInfo = @{
-                                                       NSLocalizedDescriptionKey: description,
-                                                       NSLocalizedFailureReasonErrorKey: reason
+                                                       NSLocalizedDescriptionKey: descriptionString,
+                                                       NSLocalizedFailureReasonErrorKey: reasonString
                                                        };
     return [NSError errorWithDomain:SDLErrorDomainLifecycleManager
                                code:SDLManagerErrorUnknownRemoteError
@@ -117,30 +121,36 @@ SDLErrorDomain *const SDLErrorDomainAudioStreamManager = @"com.sdl.extension.pcm
                            userInfo:nil];
 }
 
-+ (NSError *)sdl_lifecycle_startedWithBadResult:(SDLResult)result info:(NSString *)info {
++ (NSError *)sdl_lifecycle_startedWithBadResult:(nullable SDLResult)result info:(nullable NSString *)info {
+    NSString *resultString = result ?: @"";
+    NSString *infoString = info ?: @"";
     NSDictionary<NSString *, NSString *> *userInfo = @{
-                                                       NSLocalizedDescriptionKey: result,
-                                                       NSLocalizedFailureReasonErrorKey: info
+                                                       NSLocalizedDescriptionKey: resultString,
+                                                       NSLocalizedFailureReasonErrorKey: infoString
                                                        };
     return [NSError errorWithDomain:SDLErrorDomainLifecycleManager
                                code:SDLManagerErrorRegistrationFailed
                            userInfo:userInfo];
 }
 
-+ (NSError *)sdl_lifecycle_startedWithWarning:(SDLResult)result info:(NSString *)info {
++ (NSError *)sdl_lifecycle_startedWithWarning:(nullable SDLResult)result info:(nullable NSString *)info {
+    NSString *resultString = result ?: @"";
+    NSString *infoString = info ?: @"";
     NSDictionary<NSString *, NSString *> *userInfo = @{
-                                                       NSLocalizedDescriptionKey: result,
-                                                       NSLocalizedFailureReasonErrorKey: info
+                                                       NSLocalizedDescriptionKey: resultString,
+                                                       NSLocalizedFailureReasonErrorKey: infoString
                                                        };
     return [NSError errorWithDomain:SDLErrorDomainLifecycleManager
                                code:SDLManagerErrorRegistrationSuccessWithWarning
                            userInfo:userInfo];
 }
 
-+ (NSError *)sdl_lifecycle_failedWithBadResult:(SDLResult)result info:(NSString *)info {
++ (NSError *)sdl_lifecycle_failedWithBadResult:(nullable SDLResult)result info:(nullable NSString *)info {
+    NSString *resultString = result ?: @"";
+    NSString *infoString = info ?: @"";
     NSDictionary<NSString *, NSString *> *userInfo = @{
-                                                       NSLocalizedDescriptionKey: result,
-                                                       NSLocalizedFailureReasonErrorKey: info
+                                                       NSLocalizedDescriptionKey: resultString,
+                                                       NSLocalizedFailureReasonErrorKey: infoString
                                                        };
     return [NSError errorWithDomain:SDLErrorDomainLifecycleManager
                                code:SDLManagerErrorRegistrationFailed

--- a/SmartDeviceLink/SDLErrorConstants.h
+++ b/SmartDeviceLink/SDLErrorConstants.h
@@ -199,3 +199,11 @@ typedef NS_ENUM(NSInteger, SDLCacheFileManagerError) {
      */
     SDLCacheManagerErrorUpdateIconArchiveFileFailure = -1,
 };
+
+typedef NS_ENUM(NSInteger, SDLAudioStreamManagerError) {
+    /// The audio stream is not currently connected
+    SDLAudioStreamManagerErrorNotConnected = -1,
+
+    /// Attempted to play but there's no audio in the queue
+    SDLAudioStreamManagerErrorNoQueuedAudio = -2
+};

--- a/SmartDeviceLink/SDLPCMAudioConverter.m
+++ b/SmartDeviceLink/SDLPCMAudioConverter.m
@@ -132,7 +132,7 @@ NSString *const SDLErrorDomainPCMAudioStreamConverter = @"com.sdl.extension.pcmA
         err = ExtAudioFileRead(infile, &numFrames, &fillBufList);
         if (err != noErr) {
             if (*error != nil) {
-                *error = [NSError errorWithDomain:SDLErrorDomainPCMAudioStreamConverter code:err userInfo:nil];
+                *error = [NSError errorWithDomain:SDLErrorDomainPCMAudioStreamConverter code:err userInfo:@{@"type": @"ExtAudioFileRead"}];
             }
             return nil;
         }
@@ -143,7 +143,7 @@ NSString *const SDLErrorDomainPCMAudioStreamConverter = @"com.sdl.extension.pcmA
         err = ExtAudioFileWrite(outfile, numFrames, &fillBufList);
         if (err != noErr) {
             if (*error != nil) {
-                *error = [NSError errorWithDomain:SDLErrorDomainPCMAudioStreamConverter code:err userInfo:nil];
+                *error = [NSError errorWithDomain:SDLErrorDomainPCMAudioStreamConverter code:err userInfo:@{@"type": @"ExtAudioFileWrite"}];
             }
             return nil;
         }

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLAudioStreamManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLAudioStreamManagerSpec.m
@@ -2,6 +2,7 @@
 #import <Nimble/Nimble.h>
 
 #import "SDLAudioStreamManager.h"
+#import "SDLError.h"
 #import "SDLStreamingAudioManagerMock.h"
 
 QuickSpecBegin(SDLAudioStreamManagerSpec)


### PR DESCRIPTION
Fixes #1622

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Tests were run, fixed an import error

#### Core Tests
N/A, error string updates only

Core version / branch / commit hash / module tested against: n/a
HMI name / version / branch / commit hash / module tested against: n/a

### Summary
Updated the `SDLAudioStreamManager` to move its error domain and code to `SDLError`. This is just declarations of an enum and constant, so moving them isn't a major change. Also updated the human-readable string values on an error, and a few other code cleanup items.

### Changelog
##### Bug Fixes
* Updated an SDLAudioStreamManager error to have a human-readable message.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
