### PR TITLE
Replace uses of NSTimer with SDLTimer

### DIFF
--- a/SmartDeviceLink/SDLTCPTransport.m
+++ b/SmartDeviceLink/SDLTCPTransport.m
@@ -132,7 +132,7 @@ NSTimeInterval ConnectionTimeoutSecs = 30.0;
         self.connectionTimer.elapsedBlock = ^{
             [weakSelf sdl_onConnectionTimedOut];
         };
-        [self.connectionTimer start];
+        [self.connectionTimer startOnRunLoop:[NSRunLoop currentRunLoop]];
 
         // these will initiate a connection to remote server
         SDLLogD(@"Connecting to %@:%@ ...", self.hostName, self.portNumber);

--- a/SmartDeviceLink/SDLTimer.h
+++ b/SmartDeviceLink/SDLTimer.h
@@ -16,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDuration:(NSTimeInterval)duration;
 - (instancetype)initWithDuration:(NSTimeInterval)duration repeat:(BOOL)repeat;
 - (void)start;
+- (void)startOnRunLoop:(NSRunLoop *)runLoop;
 - (void)cancel;
 
 @end

--- a/SmartDeviceLink/SDLTimer.h
+++ b/SmartDeviceLink/SDLTimer.h
@@ -8,15 +8,34 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SDLTimer : NSObject
 
+/// A block called when the timer elapses
 @property (copy, nonatomic, nullable) void (^elapsedBlock)(void);
+
+/// A block called when the timer is cancelled
 @property (copy, nonatomic, nullable) void (^canceledBlock)(void);
+
+/// The time between calling `start` and when the elapsed block will be called
 @property (assign, nonatomic) NSTimeInterval duration;
 
-- (instancetype)init;
+- (instancetype)init NS_UNAVAILABLE;
+
+/// Initialize a timer with a specified duration on the main run loop without repeating
+/// @param duration The duration of the timer. Must not be 0.
 - (instancetype)initWithDuration:(NSTimeInterval)duration;
+
+/// Initialize a timer with a specified duration on the passed run loop and optionally repeating
+/// @param duration The duration of the timer
+/// @param repeat Whether or not the timer should autorepeat
 - (instancetype)initWithDuration:(NSTimeInterval)duration repeat:(BOOL)repeat;
+
+/// Starts the timer on the main run loop. When the timer has elapsed, the elapsed block will be called.
 - (void)start;
+
+/// Starts the timer on the specified run loop. When the timer has elapsed, the elapsed block will be called.
+/// @param runLoop The run loop to start the timer on
 - (void)startOnRunLoop:(NSRunLoop *)runLoop;
+
+/// Cancels and invalidates the timer. The canceled block will be called.
 - (void)cancel;
 
 @end

--- a/SmartDeviceLink/SDLTimer.h
+++ b/SmartDeviceLink/SDLTimer.h
@@ -10,11 +10,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (copy, nonatomic, nullable) void (^elapsedBlock)(void);
 @property (copy, nonatomic, nullable) void (^canceledBlock)(void);
-@property (assign, nonatomic) float duration;
+@property (assign, nonatomic) NSTimeInterval duration;
 
 - (instancetype)init;
-- (instancetype)initWithDuration:(float)duration;
-- (instancetype)initWithDuration:(float)duration repeat:(BOOL)repeat;
+- (instancetype)initWithDuration:(NSTimeInterval)duration;
+- (instancetype)initWithDuration:(NSTimeInterval)duration repeat:(BOOL)repeat;
 - (void)start;
 - (void)cancel;
 

--- a/SmartDeviceLink/SDLTimer.m
+++ b/SmartDeviceLink/SDLTimer.m
@@ -74,12 +74,16 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)start {
+    [self startOnRunLoop:[NSRunLoop mainRunLoop]];
+}
+
+- (void)startOnRunLoop:(NSRunLoop *)runLoop {
     if (self.duration > 0) {
         [self stopAndDestroyTimer];
-        
+
         SDLTimerTarget *timerTarget = [[SDLTimerTarget alloc] initWithDelegate:self];
         self.timer = [NSTimer timerWithTimeInterval:self.duration target:timerTarget selector:@selector(timerElapsed) userInfo:nil repeats:_repeat];
-        [[NSRunLoop mainRunLoop] addTimer:self.timer forMode:NSRunLoopCommonModes];
+        [runLoop addTimer:self.timer forMode:NSRunLoopCommonModes];
         self.timerRunning = YES;
     }
 }

--- a/SmartDeviceLink/SDLTimer.m
+++ b/SmartDeviceLink/SDLTimer.m
@@ -2,6 +2,7 @@
 //  SDLTimer.m
 //
 
+#import "SDLLogMacros.h"
 #import "SDLTimer.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -42,18 +43,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic, nullable) NSTimer *timer;
 @property (assign, nonatomic) BOOL timerRunning;
 @property (assign, nonatomic) BOOL repeat;
+
 @end
 
 
 @implementation SDLTimer
-
-- (instancetype)init {
-    if (self = [super init]) {
-        _duration = 0;
-        _timerRunning = NO;
-    }
-    return self;
-}
 
 - (instancetype)initWithDuration:(NSTimeInterval)duration {
     return [self initWithDuration:duration repeat:NO];
@@ -61,11 +55,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithDuration:(NSTimeInterval)duration repeat:(BOOL)repeat {
     self = [super init];
-    if (self) {
-        _duration = duration;
-        _repeat = repeat;
-        _timerRunning = NO;
-    }
+    if (!self) { return nil; }
+
+    NSAssert(duration > 0, @"Cannot create a timer with a 0 duration");
+
+    _duration = duration;
+    _repeat = repeat;
+    _timerRunning = NO;
+
     return self;
 }
 

--- a/SmartDeviceLink/SDLTimer.m
+++ b/SmartDeviceLink/SDLTimer.m
@@ -55,11 +55,11 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (instancetype)initWithDuration:(float)duration {
+- (instancetype)initWithDuration:(NSTimeInterval)duration {
     return [self initWithDuration:duration repeat:NO];
 }
 
-- (instancetype)initWithDuration:(float)duration repeat:(BOOL)repeat {
+- (instancetype)initWithDuration:(NSTimeInterval)duration repeat:(BOOL)repeat {
     self = [super init];
     if (self) {
         _duration = duration;
@@ -78,7 +78,7 @@ NS_ASSUME_NONNULL_BEGIN
         [self stopAndDestroyTimer];
         
         SDLTimerTarget *timerTarget = [[SDLTimerTarget alloc] initWithDelegate:self];
-        self.timer = [NSTimer timerWithTimeInterval:_duration target:timerTarget selector:@selector(timerElapsed) userInfo:nil repeats:_repeat];
+        self.timer = [NSTimer timerWithTimeInterval:self.duration target:timerTarget selector:@selector(timerElapsed) userInfo:nil repeats:_repeat];
         [[NSRunLoop mainRunLoop] addTimer:self.timer forMode:NSRunLoopCommonModes];
         self.timerRunning = YES;
     }

--- a/SmartDeviceLink/SDLTouchManager.h
+++ b/SmartDeviceLink/SDLTouchManager.h
@@ -33,39 +33,35 @@ typedef void(^SDLTouchEventHandler)(SDLTouch *touch, SDLTouchType type);
 @property (nonatomic, weak, nullable) id<SDLTouchManagerDelegate> touchEventDelegate;
 
 /**
- *  @abstract
- *      Returns all OnTouchEvent notifications as SDLTouch and SDLTouchType objects.
+ Returns all OnTouchEvent notifications as SDLTouch and SDLTouchType objects.
  */
 @property (copy, nonatomic, nullable) SDLTouchEventHandler touchEventHandler;
 
 /**
  Distance between two taps on the screen, in the head unit's coordinate system, used for registering double-tap callbacks.
 
- @note Defaults to 50 px.
+ Defaults to 50 px.
  */
 @property (nonatomic, assign) CGFloat tapDistanceThreshold;
 
 /**
  Minimum distance for a pan gesture in the head unit's coordinate system, used for registering pan callbacks.
  
- @note Defaults to 8 px.
+ Defaults to 8 px.
  */
 @property (nonatomic, assign) CGFloat panDistanceThreshold;
 
 /**
- *  @abstract
- *      Time (in seconds) between tap events to register a double-tap callback.
- *  @remark
- *      Default is 0.4 seconds.
+ Time (in seconds) between tap events to register a double-tap callback. This must be greater than 0.0.
+
+ Default is 0.4 seconds.
  */
 @property (nonatomic, assign) CGFloat tapTimeThreshold;
 
 /**
- *  @abstract
- *      Time (in seconds) between movement events to register panning or pinching 
- *      callbacks.
- *  @remark
- *      Default is 0.05 seconds.
+ Time (in seconds) between movement events to register panning or pinching callbacks.
+
+ Default is 0.05 seconds.
  */
 @property (nonatomic, assign) CGFloat movementTimeThreshold __deprecated_msg("This is now unused, the movement time threshold is now synced to the framerate automatically");
 
@@ -75,19 +71,16 @@ typedef void(^SDLTouchEventHandler)(SDLTouch *touch, SDLTouchType type);
 @property (assign, nonatomic) BOOL enableSyncedPanning;
 
 /**
- *  @abstract
- *      Boolean denoting whether or not the touch manager should deliver touch event
- *      callbacks.
- *  @remark
- *      Default is true.
+ Boolean denoting whether or not the touch manager should deliver touch event callbacks.
+
+ Default is true.
  */
 @property (nonatomic, assign, getter=isTouchEnabled) BOOL touchEnabled;
 
 /**
- *  @abstract
- *      Cancels pending touch event timers that may be in progress.
- *  @remark
- *      Currently only impacts the timer used to register single taps.
+ Cancels pending touch event timers that may be in progress.
+
+ Currently only impacts the timer used to register single taps.
  */
 - (void)cancelPendingTouches;
 


### PR DESCRIPTION
Fixes #1611 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Unit tests were run, no changes were needed

#### Core Tests
Run against Manticore to test `TCPTransport` changes.

Core version / branch / commit hash / module tested against: v6.0.1 (Manticore)
HMI name / version / branch / commit hash / module tested against: Generic HMI v0.7.2 (Manticore)

### Summary
This PR removes all uses of `NSTimer` and uses the `SDLTimer` wrapper instead.

### Changelog
n/a - all internal best practice, no known bugs fixed.

### Tasks Remaining:
n/a

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
