### PR TITLE
Remove NSNumber specifiers in certain cases

### DIFF
--- a/SmartDeviceLink/SDLAppServiceManifest.h
+++ b/SmartDeviceLink/SDLAppServiceManifest.h
@@ -191,7 +191,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  Array of Integers, See `SDLFunctionID`, Optional
  */
-@property (nullable, strong, nonatomic) NSArray<NSNumber<SDLInt> *> *handledRPCs;
+@property (nullable, strong, nonatomic) NSArray<NSNumber *> *handledRPCs;
 
 /**
  *  A media service manifest.

--- a/SmartDeviceLink/SDLAppServiceManifest.m
+++ b/SmartDeviceLink/SDLAppServiceManifest.m
@@ -168,11 +168,11 @@ NS_ASSUME_NONNULL_BEGIN
   return [self.store sdl_objectForName:SDLRPCParameterNameRPCSpecVersion ofClass:SDLMsgVersion.class error:nil];
 }
 
-- (void)setHandledRPCs:(nullable NSArray<NSNumber<SDLInt> *> *)handledRPCs {
+- (void)setHandledRPCs:(nullable NSArray<NSNumber *> *)handledRPCs {
     [self.store sdl_setObject:handledRPCs forName:SDLRPCParameterNameHandledRPCs];
 }
 
-- (nullable NSArray<NSNumber<SDLInt> *> *)handledRPCs {
+- (nullable NSArray<NSNumber *> *)handledRPCs {
     return [self.store sdl_objectsForName:SDLRPCParameterNameHandledRPCs ofClass:NSNumber.class error:nil];
 }
 

--- a/SmartDeviceLink/SDLDiagnosticMessage.h
+++ b/SmartDeviceLink/SDLDiagnosticMessage.h
@@ -41,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  Required, Array of NSNumber (Integers), Array size 1 - 65535, Integer Size 0 - 255
  */
-@property (strong, nonatomic) NSArray<NSNumber<SDLInt> *> *messageData;
+@property (strong, nonatomic) NSArray<NSNumber *> *messageData;
 
 @end
 

--- a/SmartDeviceLink/SDLDiagnosticMessage.m
+++ b/SmartDeviceLink/SDLDiagnosticMessage.m
@@ -52,11 +52,11 @@ NS_ASSUME_NONNULL_BEGIN
     return [self.parameters sdl_objectForName:SDLRPCParameterNameMessageLength ofClass:NSNumber.class error:&error];
 }
 
-- (void)setMessageData:(NSArray<NSNumber<SDLInt> *> *)messageData {
+- (void)setMessageData:(NSArray<NSNumber *> *)messageData {
     [self.parameters sdl_setObject:messageData forName:SDLRPCParameterNameMessageData];
 }
 
-- (NSArray<NSNumber<SDLInt> *> *)messageData {
+- (NSArray<NSNumber *> *)messageData {
     NSError *error = nil;
     return [self.parameters sdl_objectsForName:SDLRPCParameterNameMessageData ofClass:NSNumber.class error:&error];
 }

--- a/SmartDeviceLink/SDLDiagnosticMessageResponse.h
+++ b/SmartDeviceLink/SDLDiagnosticMessageResponse.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  Optional
  */
-@property (nullable, strong, nonatomic) NSArray<NSNumber<SDLInt> *> *messageDataResult;
+@property (nullable, strong, nonatomic) NSArray<NSNumber *> *messageDataResult;
 
 @end
 

--- a/SmartDeviceLink/SDLDiagnosticMessageResponse.m
+++ b/SmartDeviceLink/SDLDiagnosticMessageResponse.m
@@ -20,11 +20,11 @@ NS_ASSUME_NONNULL_BEGIN
 }
 #pragma clang diagnostic pop
 
-- (void)setMessageDataResult:(nullable NSArray<NSNumber<SDLInt> *> *)messageDataResult {
+- (void)setMessageDataResult:(nullable NSArray<NSNumber *> *)messageDataResult {
     [self.parameters sdl_setObject:messageDataResult forName:SDLRPCParameterNameMessageDataResult];
 }
 
-- (nullable NSArray<NSNumber<SDLInt> *> *)messageDataResult {
+- (nullable NSArray<NSNumber *> *)messageDataResult {
     NSError *error = nil;
     return [self.parameters sdl_objectsForName:SDLRPCParameterNameMessageDataResult ofClass:NSNumber.class error:&error];
 }

--- a/SmartDeviceLink/SDLGetInteriorVehicleDataConsentResponse.h
+++ b/SmartDeviceLink/SDLGetInteriorVehicleDataConsentResponse.h
@@ -20,9 +20,9 @@ NS_ASSUME_NONNULL_BEGIN
  "true" - if SDL grants the permission for the requested module
  "false" - SDL denies the permission for the requested module.
  
- Optional
+ Optional, contains a boolean
  */
-@property (strong, nonatomic, nullable) NSArray<NSNumber<SDLBool> *> *allowed;
+@property (strong, nonatomic, nullable) NSArray<NSNumber *> *allowed;
 
 @end
 

--- a/SmartDeviceLink/SDLGetInteriorVehicleDataConsentResponse.m
+++ b/SmartDeviceLink/SDLGetInteriorVehicleDataConsentResponse.m
@@ -22,11 +22,11 @@
 }
 #pragma clang diagnostic pop
 
-- (void)setAllowed:(nullable NSArray<NSNumber<SDLBool> *> *)allowed {
+- (void)setAllowed:(nullable NSArray<NSNumber *> *)allowed {
     [self.parameters sdl_setObject:allowed forName:SDLRPCParameterNameAllowed];
 }
 
-- (nullable NSArray<NSNumber<SDLBool> *> *)allowed {
+- (nullable NSArray<NSNumber *> *)allowed {
     NSError *error = nil;
     return [self.parameters sdl_objectsForName:SDLRPCParameterNameAllowed ofClass:NSNumber.class error:&error];
 }

--- a/SmartDeviceLink/SDLPerformInteraction.h
+++ b/SmartDeviceLink/SDLPerformInteraction.h
@@ -189,7 +189,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @since SDL 1.0
  */
-@property (strong, nonatomic) NSArray<NSNumber<SDLInt> *> *interactionChoiceSetIDList;
+@property (strong, nonatomic) NSArray<NSNumber *> *interactionChoiceSetIDList;
 
 /**
  Help text. This is the spoken text when a user speaks "help" while the interaction is occurring.

--- a/SmartDeviceLink/SDLPerformInteraction.m
+++ b/SmartDeviceLink/SDLPerformInteraction.m
@@ -135,11 +135,11 @@ NS_ASSUME_NONNULL_BEGIN
     return [self.parameters sdl_enumForName:SDLRPCParameterNameInteractionMode error:&error];
 }
 
-- (void)setInteractionChoiceSetIDList:(NSArray<NSNumber<SDLInt> *> *)interactionChoiceSetIDList {
+- (void)setInteractionChoiceSetIDList:(NSArray<NSNumber *> *)interactionChoiceSetIDList {
     [self.parameters sdl_setObject:interactionChoiceSetIDList forName:SDLRPCParameterNameInteractionChoiceSetIdList];
 }
 
-- (NSArray<NSNumber<SDLInt> *> *)interactionChoiceSetIDList {
+- (NSArray<NSNumber *> *)interactionChoiceSetIDList {
     NSError *error = nil;
     return [self.parameters sdl_objectsForName:SDLRPCParameterNameInteractionChoiceSetIdList ofClass:NSNumber.class error:&error];
 }

--- a/SmartDeviceLink/SDLReadDID.h
+++ b/SmartDeviceLink/SDLReadDID.h
@@ -44,8 +44,10 @@ NS_ASSUME_NONNULL_BEGIN
  *            <li>Minvalue:0; Maxvalue:65535</li>
  *            <li>ArrayMin:0; ArrayMax:1000</li>
  *            </ul>
+ *
+ * Mandatory, contains an integer
  */
-@property (strong, nonatomic) NSArray<NSNumber<SDLInt> *> *didLocation;
+@property (strong, nonatomic) NSArray<NSNumber *> *didLocation;
 
 @end
 

--- a/SmartDeviceLink/SDLReadDID.m
+++ b/SmartDeviceLink/SDLReadDID.m
@@ -42,11 +42,11 @@ NS_ASSUME_NONNULL_BEGIN
     return [self.parameters sdl_objectForName:SDLRPCParameterNameECUName ofClass:NSNumber.class error:&error];
 }
 
-- (void)setDidLocation:(NSArray<NSNumber<SDLInt> *> *)didLocation {
+- (void)setDidLocation:(NSArray<NSNumber *> *)didLocation {
     [self.parameters sdl_setObject:didLocation forName:SDLRPCParameterNameDIDLocation];
 }
 
-- (NSArray<NSNumber<SDLInt> *> *)didLocation {
+- (NSArray<NSNumber *> *)didLocation {
     NSError *error = nil;
     return [self.parameters sdl_objectsForName:SDLRPCParameterNameDIDLocation ofClass:NSNumber.class error:&error];
 }

--- a/SmartDeviceLink/SDLRegisterAppInterfaceResponse.h
+++ b/SmartDeviceLink/SDLRegisterAppInterfaceResponse.h
@@ -172,7 +172,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @since SDL 3.0
  */
-@property (nullable, strong, nonatomic) NSArray<NSNumber<SDLInt> *> *supportedDiagModes;
+@property (nullable, strong, nonatomic) NSArray<NSNumber *> *supportedDiagModes;
 
 /**
  * Specifies the HMI capabilities.

--- a/SmartDeviceLink/SDLRegisterAppInterfaceResponse.m
+++ b/SmartDeviceLink/SDLRegisterAppInterfaceResponse.m
@@ -163,11 +163,11 @@ NS_ASSUME_NONNULL_BEGIN
     return [self.parameters sdl_objectForName:SDLRPCParameterNameVehicleType ofClass:SDLVehicleType.class error:nil];
 }
 
-- (void)setSupportedDiagModes:(nullable NSArray<NSNumber<SDLInt> *> *)supportedDiagModes {
+- (void)setSupportedDiagModes:(nullable NSArray<NSNumber *> *)supportedDiagModes {
     [self.parameters sdl_setObject:supportedDiagModes forName:SDLRPCParameterNameSupportedDiagnosticModes];
 }
 
-- (nullable NSArray<NSNumber<SDLInt> *> *)supportedDiagModes {
+- (nullable NSArray<NSNumber *> *)supportedDiagModes {
     return [self.parameters sdl_objectsForName:SDLRPCParameterNameSupportedDiagnosticModes ofClass:NSNumber.class error:nil];
 }
 

--- a/SmartDeviceLink/SDLTouchEvent.h
+++ b/SmartDeviceLink/SDLTouchEvent.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  Required, array size 1-1000, contains integer value 0-2000000000
  */
-@property (strong, nonatomic) NSArray<NSNumber<SDLInt> *> *timeStamp;
+@property (strong, nonatomic) NSArray<NSNumber *> *timeStamp;
 
 /**
  The touch's coordinate

--- a/SmartDeviceLink/SDLTouchEvent.m
+++ b/SmartDeviceLink/SDLTouchEvent.m
@@ -21,11 +21,11 @@ NS_ASSUME_NONNULL_BEGIN
     return [self.store sdl_objectForName:SDLRPCParameterNameId ofClass:NSNumber.class error:&error];
 }
 
-- (void)setTimeStamp:(NSArray<NSNumber<SDLInt> *> *)timeStamp {
+- (void)setTimeStamp:(NSArray<NSNumber *> *)timeStamp {
     [self.store sdl_setObject:timeStamp forName:SDLRPCParameterNameTS];
 }
 
-- (NSArray<NSNumber<SDLInt> *> *)timeStamp {
+- (NSArray<NSNumber *> *)timeStamp {
     NSError *error = nil;
     return [self.store sdl_objectsForName:SDLRPCParameterNameTS ofClass:NSNumber.class error:&error];
 }

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetInteriorVehicleDataConsentResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetInteriorVehicleDataConsentResponseSpec.m
@@ -19,7 +19,7 @@
 QuickSpecBegin(SDLGetInteriorVehicleDataConsentResponseSpec)
 
 describe(@"Getter/Setter Tests", ^ {
-    __block NSArray<NSNumber<SDLBool> *> *allowed = nil;
+    __block NSArray<NSNumber *> *allowed = nil;
     
     beforeEach(^{
         allowed = @[@YES, @NO];


### PR DESCRIPTION
Fixes #1636 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

The API changes here have no specifiers, so there should be no breakage.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Only very minor change needed

#### Core Tests
Connected to Core with Swift app.
  - [x] Constructed a broken RPC and attempted pull data from it.

Core version / branch / commit hash / module tested against: v6.0.1 (Manticore)
HMI name / version / branch / commit hash / module tested against: v0.7.2 (Manticore)

### Summary
When specifying an `NSArray` containing an `NSNumber` with a `SDLBool` (and similar) specifier, it would crash in Swift.

### Changelog
##### Bug Fixes
* Fixed potential crashes in Swift apps when pulling data from arrays containing `NSNumbers` with SDL specifiers.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
