### PR TITLE
Fixed SDLButtonPress initializer missing mandatory parameter

### DIFF
--- a/SmartDeviceLink/SDLButtonPress.h
+++ b/SmartDeviceLink/SDLButtonPress.h
@@ -24,7 +24,7 @@ Constructs a newly allocated SDLButtonPress object with the given parameters
 
 @return An instance of the SDLButtonPress class.
 */
-- (instancetype)initWithButtonName:(SDLButtonName)buttonName moduleType:(SDLModuleType)moduleType __deprecated_msg(("Use initWithButtonName:moduleType:moduleId: instead"));;
+- (instancetype)initWithButtonName:(SDLButtonName)buttonName moduleType:(SDLModuleType)moduleType __deprecated_msg(("Use initWithButtonName:moduleType:moduleId:buttonPressMode: instead"));;
 
 /**
 Constructs a newly allocated SDLButtonPress object with the given parameters
@@ -32,10 +32,11 @@ Constructs a newly allocated SDLButtonPress object with the given parameters
 @param buttonName the name of the button
 @param moduleType the module where the button should be pressed
 @param moduleId the id of the module
+@param buttonPressMode indicates LONG or SHORT button press event
 
 @return An instance of the SDLButtonPress class.
 */
-- (instancetype)initWithButtonName:(SDLButtonName)buttonName moduleType:(SDLModuleType)moduleType moduleId:(nullable NSString *)moduleId;
+- (instancetype)initWithButtonName:(SDLButtonName)buttonName moduleType:(SDLModuleType)moduleType moduleId:(nullable NSString *)moduleId buttonPressMode:(SDLButtonPressMode)buttonPressMode;
 
 /**
  * The module where the button should be pressed.

--- a/SmartDeviceLink/SDLButtonPress.h
+++ b/SmartDeviceLink/SDLButtonPress.h
@@ -32,6 +32,17 @@ Constructs a newly allocated SDLButtonPress object with the given parameters
 @param buttonName the name of the button
 @param moduleType the module where the button should be pressed
 @param moduleId the id of the module
+
+@return An instance of the SDLButtonPress class.
+*/
+- (instancetype)initWithButtonName:(SDLButtonName)buttonName moduleType:(SDLModuleType)moduleType moduleId:(nullable NSString *)moduleId __deprecated_msg(("Use initWithButtonName:moduleType:moduleId:buttonPressMode: instead"));;
+
+/**
+Constructs a newly allocated SDLButtonPress object with the given parameters
+
+@param buttonName the name of the button
+@param moduleType the module where the button should be pressed
+@param moduleId the id of the module
 @param buttonPressMode indicates LONG or SHORT button press event
 
 @return An instance of the SDLButtonPress class.

--- a/SmartDeviceLink/SDLButtonPress.m
+++ b/SmartDeviceLink/SDLButtonPress.m
@@ -32,6 +32,19 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (instancetype)initWithButtonName:(SDLButtonName)buttonName moduleType:(SDLModuleType)moduleType moduleId:(nullable NSString *)moduleId {
+    self = [self init];
+    if (!self) {
+        return nil;
+    }
+
+    self.buttonName = buttonName;
+    self.moduleType = moduleType;
+    self.moduleId = moduleId;
+
+    return self;
+}
+
 - (instancetype)initWithButtonName:(SDLButtonName)buttonName moduleType:(SDLModuleType)moduleType moduleId:(nullable NSString *)moduleId buttonPressMode:(SDLButtonPressMode)buttonPressMode {
     self = [self init];
     if (!self) {

--- a/SmartDeviceLink/SDLButtonPress.m
+++ b/SmartDeviceLink/SDLButtonPress.m
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (instancetype)initWithButtonName:(SDLButtonName)buttonName moduleType:(SDLModuleType)moduleType moduleId:(nullable NSString *)moduleId {
+- (instancetype)initWithButtonName:(SDLButtonName)buttonName moduleType:(SDLModuleType)moduleType moduleId:(nullable NSString *)moduleId buttonPressMode:(SDLButtonPressMode)buttonPressMode {
     self = [self init];
     if (!self) {
         return nil;
@@ -41,6 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
     self.buttonName = buttonName;
     self.moduleType = moduleType;
     self.moduleId = moduleId;
+    self.buttonPressMode = buttonPressMode;
     
     return self;
 }

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLButtonPressSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLButtonPressSpec.m
@@ -53,7 +53,25 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testRequest.buttonPressMode).to(equal(SDLButtonPressModeShort));
     });
 
-    it(@"Should get correctly using initializer", ^ {
+    it(@"Should get correctly when initialized with initWithButtonName:moduleType:", ^ {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        SDLButtonPress *testRequest = [[SDLButtonPress alloc] initWithButtonName:SDLButtonNameAC moduleType:SDLModuleTypeClimate];
+#pragma clang diagnostic pop
+        expect(testRequest.buttonName).to(equal(SDLButtonNameAC));
+        expect(testRequest.moduleType).to(equal(SDLModuleTypeClimate));
+    });
+
+    it(@"Should get correctly when initialized with initWithButtonName:moduleType:moduleId:", ^ {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        SDLButtonPress *testRequest = [[SDLButtonPress alloc] initWithButtonName:SDLButtonNameAC moduleType:SDLModuleTypeClimate moduleId:@"123"];
+#pragma clang diagnostic pop
+        expect(testRequest.buttonName).to(equal(SDLButtonNameAC));
+        expect(testRequest.moduleType).to(equal(SDLModuleTypeClimate));
+    });
+
+    it(@"Should get correctly when initialized with initWithButtonName:moduleType:moduleId:buttonPressMode:", ^ {
         SDLButtonPress *testRequest = [[SDLButtonPress alloc] initWithButtonName:SDLButtonNameAC moduleType:SDLModuleTypeClimate moduleId:@"123" buttonPressMode:SDLButtonPressModeShort];
 
         expect(testRequest.buttonName).to(equal(SDLButtonNameAC));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLButtonPressSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLButtonPressSpec.m
@@ -69,6 +69,7 @@ describe(@"Getter/Setter Tests", ^ {
 #pragma clang diagnostic pop
         expect(testRequest.buttonName).to(equal(SDLButtonNameAC));
         expect(testRequest.moduleType).to(equal(SDLModuleTypeClimate));
+        expect(testRequest.moduleId).to(equal(@"123"));
     });
 
     it(@"Should get correctly when initialized with initWithButtonName:moduleType:moduleId:buttonPressMode:", ^ {

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLButtonPressSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLButtonPressSpec.m
@@ -54,11 +54,12 @@ describe(@"Getter/Setter Tests", ^ {
     });
 
     it(@"Should get correctly using initializer", ^ {
-        SDLButtonPress *testRequest = [[SDLButtonPress alloc] initWithButtonName:SDLButtonNameAC moduleType:SDLModuleTypeClimate moduleId:@"123"];
+        SDLButtonPress *testRequest = [[SDLButtonPress alloc] initWithButtonName:SDLButtonNameAC moduleType:SDLModuleTypeClimate moduleId:@"123" buttonPressMode:SDLButtonPressModeShort];
 
         expect(testRequest.buttonName).to(equal(SDLButtonNameAC));
         expect(testRequest.moduleType).to(equal(SDLModuleTypeClimate));
         expect(testRequest.moduleId).to(equal(@"123"));
+        expect(testRequest.buttonPressMode).to(equal(SDLButtonPressModeShort));
     });
 
     it(@"Should return nil if not set", ^ {


### PR DESCRIPTION
Fixes #1635 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Updated `SDLButtonPressSpec` tests to include new parameter in initializer to set the `SDLButtonPressMode`.

#### Core Tests
n/a unit tests confirm that `SDLButtonPressMode` is being properly set.

### Summary
Created a new initializer for `SDLButtonPress` to include the mandatory `SDLButtonPressMode` parameter. Deprecated the old initializer.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)