### PR TITLE
Stop / Start FocusableItemLocator when VideoStreamingLifecycleManager starts / stops

### DIFF
--- a/SmartDeviceLink/SDLFocusableItemLocator.m
+++ b/SmartDeviceLink/SDLFocusableItemLocator.m
@@ -52,10 +52,12 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)start {
+    SDLLogD(@"Starting");
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_projectionViewUpdated:) name:SDLDidUpdateProjectionView object:nil];
 }
 
 - (void)stop {
+    SDLLogD(@"Stopping");
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     [self.focusableViews removeAllObjects];
 }
@@ -71,7 +73,11 @@ NS_ASSUME_NONNULL_BEGIN
             [self.focusableViews exchangeObjectAtIndex:preferredViewIndex withObjectAtIndex:0];
         }
 
+        SDLLogD(@"Updated VC layout, sending new haptic rects");
+        SDLLogV(@"For focusable views: %@", self.focusableViews);
         [self sdl_sendHapticRPC];
+    } else {
+        SDLLogE(@"Attempted to update user interface layout, but it only works on iOS 9.0+");
     }
 }
 
@@ -86,10 +92,14 @@ NS_ASSUME_NONNULL_BEGIN
         return;
     }
 
+    SDLLogD(@"Parsing UIView heirarchy");
+    SDLLogV(@"UIView: %@", currentView);
     if (@available(iOS 9.0, *)) {
+        // Finding focusable subviews
         NSArray *focusableSubviews = [currentView.subviews filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(UIView *  _Nullable evaluatedObject, NSDictionary<NSString *,id> * _Nullable bindings) {
             return (evaluatedObject.canBecomeFocused || [evaluatedObject isKindOfClass:[UIButton class]]);
         }]];
+        SDLLogV(@"Found focusable subviews: %@", focusableSubviews);
 
         BOOL isButton = [currentView isKindOfClass:[UIButton class]];
         if ((currentView.canBecomeFocused || isButton) && focusableSubviews.count == 0) {
@@ -137,7 +147,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     SDLLogV(@"Sending haptic data: %@", hapticRects);
-    SDLSendHapticData* hapticRPC = [[SDLSendHapticData alloc] initWithHapticRectData:hapticRects];
+    SDLSendHapticData *hapticRPC = [[SDLSendHapticData alloc] initWithHapticRectData:hapticRects];
     [self.connectionManager sendConnectionManagerRequest:hapticRPC withResponseHandler:nil];
 }
 
@@ -159,6 +169,7 @@ NS_ASSUME_NONNULL_BEGIN
         }
     }
 
+    SDLLogD(@"Found a focusable view: %@, for point: %@", selectedView, NSStringFromCGPoint(point));
     return selectedView;
 }
 

--- a/SmartDeviceLink/SDLFocusableItemLocator.m
+++ b/SmartDeviceLink/SDLFocusableItemLocator.m
@@ -47,9 +47,17 @@ NS_ASSUME_NONNULL_BEGIN
     _focusableViews = [NSMutableArray array];
 
     _enableHapticDataRequests = NO;
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_projectionViewUpdated:) name:SDLDidUpdateProjectionView object:nil];
 
     return self;
+}
+
+- (void)start {
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_projectionViewUpdated:) name:SDLDidUpdateProjectionView object:nil];
+}
+
+- (void)stop {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    [self.focusableViews removeAllObjects];
 }
 
 - (void)updateInterfaceLayout {

--- a/SmartDeviceLink/SDLFocusableItemLocatorType.h
+++ b/SmartDeviceLink/SDLFocusableItemLocatorType.h
@@ -36,6 +36,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (instancetype)initWithViewController:(UIViewController *)viewController connectionManager:(id<SDLConnectionManagerType>)connectionManager videoScaleManager:(SDLStreamingVideoScaleManager *)videoScaleManager;
 
+/// Start observing updates
+- (void)start;
+
+/// Stop observing updates and clear data
+- (void)stop;
+
 /**
  updateInterfaceLayout crawls through the view hierarchy, updates and keep tracks of views to be reported through Haptic RPC. This function is automatically called when SDLDidUpdateProjectionView notification is sent by the application.
  */

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -189,6 +189,8 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
         }
     }
 
+    [self.focusableItemManager start];
+
     // attempt to start streaming since we may already have necessary conditions met
     [self sdl_startVideoSession];
 }
@@ -204,6 +206,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
     _videoStreamingState = SDLVideoStreamingStateNotStreamable;
     _protocol = nil;
     [self.videoScaleManager stop];
+    [self.focusableItemManager stop];
     _connectedVehicleMake = nil;
 
     [self.videoStreamStateMachine transitionToState:SDLVideoStreamManagerStateStopped];

--- a/SmartDeviceLinkTests/ProxySpecs/SDLHapticManagerSpec.m
+++ b/SmartDeviceLinkTests/ProxySpecs/SDLHapticManagerSpec.m
@@ -367,27 +367,64 @@ describe(@"the haptic manager", ^{
             [hapticManager updateInterfaceLayout];
 
             viewRect2 = CGRectMake(201, 201, 50, 50);
-            UITextField *textField2 = [[UITextField alloc]  initWithFrame:viewRect2];
+            UITextField *textField2 = [[UITextField alloc] initWithFrame:viewRect2];
             [uiViewController.view addSubview:textField2];
-
-            [[NSNotificationCenter defaultCenter] postNotificationName:SDLDidUpdateProjectionView object:nil];
         });
 
-        it(@"should have two views", ^{
-            int expectedCount = 2;
-            expect(sentHapticRequest.hapticRectData.count).toEventually(equal(expectedCount));
+        context(@"when not started", ^{
+            beforeEach(^{
+                [[NSNotificationCenter defaultCenter] postNotificationName:SDLDidUpdateProjectionView object:nil];
+            });
 
-            if(sentHapticRequest.hapticRectData.count == expectedCount) {
-                NSArray<SDLHapticRect *> *hapticRectData = sentHapticRequest.hapticRectData;
-                SDLHapticRect *sdlhapticRect1 = hapticRectData[0];
-                SDLRectangle *sdlRect1 = sdlhapticRect1.rect;
+            it(@"should have one view", ^{
+                int expectedCount = 1;
+                expect(sentHapticRequest.hapticRectData.count).toEventually(equal(expectedCount));
 
-                SDLHapticRect *sdlhapticRect2 = hapticRectData[1];
-                SDLRectangle *sdlRect2 = sdlhapticRect2.rect;
+                if(sentHapticRequest.hapticRectData.count == expectedCount) {
+                    NSArray<SDLHapticRect *> *hapticRectData = sentHapticRequest.hapticRectData;
+                    SDLHapticRect *sdlhapticRect1 = hapticRectData[0];
+                    SDLRectangle *sdlRect1 = sdlhapticRect1.rect;
 
-                compareRectangle(sdlRect1, viewRect2);
-                compareRectangle(sdlRect2, viewRect1);
-            }
+                    compareRectangle(sdlRect1, viewRect1);
+                }
+            });
+        });
+
+        context(@"when started", ^{
+            beforeEach(^{
+                [hapticManager start];
+                [[NSNotificationCenter defaultCenter] postNotificationName:SDLDidUpdateProjectionView object:nil];
+            });
+
+            it(@"should have two views", ^{
+                int expectedCount = 2;
+                expect(sentHapticRequest.hapticRectData.count).toEventually(equal(expectedCount));
+
+                if(sentHapticRequest.hapticRectData.count == expectedCount) {
+                    NSArray<SDLHapticRect *> *hapticRectData = sentHapticRequest.hapticRectData;
+                    SDLHapticRect *sdlhapticRect1 = hapticRectData[0];
+                    SDLRectangle *sdlRect1 = sdlhapticRect1.rect;
+
+                    SDLHapticRect *sdlhapticRect2 = hapticRectData[1];
+                    SDLRectangle *sdlRect2 = sdlhapticRect2.rect;
+
+                    compareRectangle(sdlRect1, viewRect2);
+                    compareRectangle(sdlRect2, viewRect1);
+                }
+            });
+
+            context(@"when stopped", ^{
+                beforeEach(^{
+                    [hapticManager stop];
+                    for (UIView *subview in uiViewController.view.subviews) { [subview removeFromSuperview]; }
+                    [[NSNotificationCenter defaultCenter] postNotificationName:SDLDidUpdateProjectionView object:nil];
+                });
+
+                it(@"should have two views", ^{
+                    int expectedCount = 2;
+                    expect(sentHapticRequest.hapticRectData.count).toEventually(equal(expectedCount));
+                });
+            });
         });
     });
 


### PR DESCRIPTION
Fixes #1631 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Unit tests were updated

#### Core Tests
Tested starting stopping the video stream several times and in a few ways to ensure that when the lifecycle manager starts / stops that the focus manager does as well.

Core version / branch / commit hash / module tested against: Sync Gen 3.4 (19353_DEVTEST)
HMI name / version / branch / commit hash / module tested against: Sync Gen 3.4 (19353_DEVTEST)

### Summary
This PR updates the `SDLFocusableItemLocator` class to start and stop when the `SDLStreamingVideoLifecycleManager` is started and stopped. This prevents the focusable item locator from continuing to run when there's no possibility of the streaming video to run.

### Changelog
##### Bug Fixes
* The `FocusableItemLocator` will no longer run after the app disconnects.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
