### PR TITLE
Fix video streaming state when streaming app fails to resume

### DIFF
--- a/SmartDeviceLink/SDLProtocol.m
+++ b/SmartDeviceLink/SDLProtocol.m
@@ -728,7 +728,7 @@ NS_ASSUME_NONNULL_BEGIN
     // If the handshake went bad and the security library ain't happy, send over the failure to the module. This should result in an ACK with encryption off.
     SDLProtocolMessage *serverSecurityMessage = nil;
     if (serverHandshakeData == nil) {
-        SDLLogE(@"Error running TLS handshake procedure. Sending error to module. Error: %@", handshakeError);
+        SDLLogE(@"Error running TLS handshake procedure. Sending error to module. Error: %@, %@", handshakeError, [[NSString alloc] initWithData:clientHandshakeData encoding:NSUTF8StringEncoding]);
 
         serverSecurityMessage = [self.class sdl_serverSecurityFailedMessageWithClientMessageHeader:clientHandshakeMessage.header messageId:++_messageID];
     } else {

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -707,7 +707,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
     } else if ([self.videoStreamStateMachine.currentState isEqualToEnum: SDLVideoStreamManagerStateStarting]) {
         [self.videoStreamStateMachine transitionToState:SDLVideoStreamManagerStateStopped];
     } else {
-        SDLLogV(@"No video currently streaming. Will not send an end video service request");
+        SDLLogW(@"No video is currently streaming. Will not send an end video service request.");
     }
 }
 

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -704,7 +704,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
 
     if (self.isVideoConnected || self.isVideoSuspended) {
         [self.videoStreamStateMachine transitionToState:SDLVideoStreamManagerStateShuttingDown];
-    } else if ([self.videoStreamingState isEqualToEnum: SDLVideoStreamManagerStateStarting]) {
+    } else if ([self.videoStreamStateMachine.currentState isEqualToEnum: SDLVideoStreamManagerStateStarting]) {
         [self.videoStreamStateMachine transitionToState:SDLVideoStreamManagerStateStopped];
     } else {
         SDLLogV(@"No video currently streaming. Will not send an end video service request");

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -704,9 +704,10 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
 
     if (self.isVideoConnected || self.isVideoSuspended) {
         [self.videoStreamStateMachine transitionToState:SDLVideoStreamManagerStateShuttingDown];
-    } else {
-        SDLLogW(@"No video is currently streaming. Will not send an end video service request.");
+    } else if ([self.videoStreamingState isEqualToEnum: SDLVideoStreamManagerStateStarting]) {
         [self.videoStreamStateMachine transitionToState:SDLVideoStreamManagerStateStopped];
+    } else {
+        SDLLogV(@"No video currently streaming. Will not send an end video service request");
     }
 }
 

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -706,6 +706,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
         [self.videoStreamStateMachine transitionToState:SDLVideoStreamManagerStateShuttingDown];
     } else {
         SDLLogW(@"No video is currently streaming. Will not send an end video service request.");
+        [self.videoStreamStateMachine transitionToState:SDLVideoStreamManagerStateStopped];
     }
 }
 


### PR DESCRIPTION
Fixes #1527 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
-

Core version / branch / commit hash / module tested against: SYNC 3.2v2 R4
HMI name / version / branch / commit hash / module tested against: SYNC 3.2v2 R4

### Summary
Fix video streaming state when streaming app fails to resume

### Changelog
##### Breaking Changes
* None

##### Bug Fixes
* Fix video streaming state when streaming app fails to resume

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)