### PR TITLE
Add secondary transport security manager unit tests

### DIFF
--- a/SmartDeviceLinkTests/ProxySpecs/SDLSecondaryTransportManagerSpec.m
+++ b/SmartDeviceLinkTests/ProxySpecs/SDLSecondaryTransportManagerSpec.m
@@ -521,6 +521,7 @@ describe(@"the secondary transport manager ", ^{
                 testPrimaryProtocol = [[SDLProtocol alloc] init];
                 testPrimaryTransport = [[SDLTCPTransport alloc] init];
                 testPrimaryProtocol.transport = testPrimaryTransport;
+                testPrimaryProtocol.securityManager = OCMClassMock([SDLFakeSecurityManager class]);
 
                 dispatch_sync(testStateMachineQueue, ^{
                     [manager startWithPrimaryProtocol:testPrimaryProtocol];
@@ -537,6 +538,7 @@ describe(@"the secondary transport manager ", ^{
                 it(@"should stay in state Configured", ^{
                     expect(manager.stateMachine.currentState).to(equal(SDLSecondaryTransportStateConfigured));
                     expect(manager.currentHMILevel).to(beNil());
+                    expect(manager.secondaryProtocol.securityManager).to(beNil());
 
                     OCMVerifyAll(testStreamingProtocolDelegate);
                 });
@@ -550,6 +552,7 @@ describe(@"the secondary transport manager ", ^{
                 it(@"should transition to Connecting state", ^{
                     expect(manager.stateMachine.currentState).to(equal(SDLSecondaryTransportStateConnecting));
                     expect(manager.currentHMILevel).to(equal(SDLHMILevelFull));
+                    expect(manager.secondaryProtocol.securityManager).to(equal(testPrimaryProtocol.securityManager));
 
                     OCMVerifyAll(testStreamingProtocolDelegate);
                 });
@@ -601,6 +604,7 @@ describe(@"the secondary transport manager ", ^{
                     testTransportEventUpdatePayload = [[SDLControlFramePayloadTransportEventUpdate alloc] initWithTcpIpAddress:testTcpIpAddress tcpPort:testTcpPort];
                     testTransportEventUpdateMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testTransportEventUpdateHeader andPayload:testTransportEventUpdatePayload.data];
 
+                    testPrimaryProtocol.securityManager = OCMClassMock([SDLFakeSecurityManager class]);
                     [testPrimaryProtocol handleBytesFromTransport:testTransportEventUpdateMessage.data];
                     [NSThread sleepForTimeInterval:0.1];
 
@@ -610,6 +614,7 @@ describe(@"the secondary transport manager ", ^{
                     it(@"should stay in Configured state", ^{
                         expect(manager.stateMachine.currentState).to(equal(SDLSecondaryTransportStateConfigured));
                         expect(manager.currentHMILevel).to(beNil());
+                        expect(manager.secondaryProtocol.securityManager).to(beNil());
 
                         OCMVerifyAll(testStreamingProtocolDelegate);
                     });
@@ -623,6 +628,7 @@ describe(@"the secondary transport manager ", ^{
                     it(@"should transition to Connecting", ^{
                         expect(manager.stateMachine.currentState).to(equal(SDLSecondaryTransportStateConnecting));
                         expect(manager.currentHMILevel).to(equal(SDLHMILevelFull));
+                        expect(manager.secondaryProtocol.securityManager).to(equal(testPrimaryProtocol.securityManager));
 
                         OCMVerifyAll(testStreamingProtocolDelegate);
                     });


### PR DESCRIPTION
Fixes #1653 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Added tests to the **SDLSecondaryTransportManagerSpec** that check if the security manager was set correctly on the secondary transport. 

#### Core Tests
N/A as this PR only adds unit tests.

Core version / branch / commit hash / module tested against: n/a
HMI name / version / branch / commit hash / module tested against: n/a

### Summary
Added unit tests to the **SDLSecondaryTransportManagerSpec**. 

### Changelog
##### Enhancements
* Added tests to the **SDLSecondaryTransportManagerSpec** that check if the security manager was set correctly on the secondary transport. 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
