### PR TITLE
Update example apps with icons for vehicle data menu items

### DIFF
--- a/Example Apps/Example ObjC/MenuManager.m
+++ b/Example Apps/Example ObjC/MenuManager.m
@@ -52,7 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSMutableArray *submenuItems = [[NSMutableArray alloc] init];
     NSArray<NSString *> *allVehicleDataTypes = [self sdlex_allVehicleDataTypes];
     for (NSString *vehicleDataType in allVehicleDataTypes) {
-        SDLMenuCell *cell = [[SDLMenuCell alloc] initWithTitle:vehicleDataType icon:nil voiceCommands:nil handler:^(SDLTriggerSource  _Nonnull triggerSource) {
+        SDLMenuCell *cell = [[SDLMenuCell alloc] initWithTitle:vehicleDataType icon:[SDLArtwork artworkWithStaticIcon:SDLStaticIconNameSettings] voiceCommands:nil handler:^(SDLTriggerSource  _Nonnull triggerSource) {
             [VehicleDataManager getAllVehicleDataWithManager:manager triggerSource:triggerSource vehicleDataType:vehicleDataType];
         }];
         [submenuItems addObject:cell];

--- a/Example Apps/Example Swift/MenuManager.swift
+++ b/Example Apps/Example Swift/MenuManager.swift
@@ -62,7 +62,7 @@ private extension MenuManager {
     /// - Returns: A SDLMenuCell object
     class func menuCellGetAllVehicleData(with manager: SDLManager) -> SDLMenuCell {
         let submenuItems = allVehicleDataTypes.map { submenuName in
-            SDLMenuCell(title: submenuName, icon: nil, voiceCommands: nil, handler: { triggerSource in
+            SDLMenuCell(title: submenuName, icon: SDLArtwork(staticIcon: .settings), voiceCommands: nil, handler: { triggerSource in
                 VehicleDataManager.getAllVehicleData(with: manager, triggerSource: triggerSource, vehicleDataType: submenuName)
             })
         }


### PR DESCRIPTION
Fixes #1580

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [ ] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
No unit tests because this does not affect library code

#### Core Tests
Tested the swift example app with Manticore to see what the vehicle data menu looks like.

Core version / branch / commit hash / module tested against: v6.0.1
HMI name / version / branch / commit hash / module tested against: Generic HMI v0.7.2

### Summary
Update the example app's vehicle data submenu with static icons to make the menu look better in Generic HMI.

### Changelog
##### Example Apps
* Update example app vehicle data menu items to use a static icon to make it look better on generic_hmi (or any TILE layout)

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
