### PR TITLE
fix to call sdl_handleSystemRequestLaunchApp only in main thread

### DIFF
--- a/SmartDeviceLink/SDLProxy.m
+++ b/SmartDeviceLink/SDLProxy.m
@@ -585,7 +585,9 @@ static float DefaultConnectionTimeout = 45.0;
     } else if ([requestType isEqualToEnum:SDLRequestTypeHTTP]) {
         [self sdl_handleSystemRequestHTTP:systemRequest];
     } else if ([requestType isEqualToEnum:SDLRequestTypeLaunchApp]) {
-        [self sdl_handleSystemRequestLaunchApp:systemRequest];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self sdl_handleSystemRequestLaunchApp:systemRequest];
+        });
     }
 }
 


### PR DESCRIPTION
Fixes #1662 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [ ] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
none

#### Core Tests
We have tested with our internal devboard

Core version / branch / commit hash / module tested against: 4.5.1
HMI name / version / branch / commit hash / module tested against: our intenal HMI

### Summary
fix to call sdl_handleSystemRequestLaunchApp only in main thread to avoid main thread checker warning

### Changelog
##### Bug Fixes
* fix to call sdl_handleSystemRequestLaunchApp only in main thread to avoid main thread checker warning

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
