### PR TITLE
Handle nil displayCapabilities better in SCM

### DIFF
--- a/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
+++ b/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
@@ -409,13 +409,17 @@
 		1FF7DABA1F75B2A800B46C30 /* SDLFocusableItemLocator.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FF7DAB91F75B2A800B46C30 /* SDLFocusableItemLocator.h */; };
 		1FF7DABC1F75B2BF00B46C30 /* SDLFocusableItemLocator.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FF7DABB1F75B2BF00B46C30 /* SDLFocusableItemLocator.m */; };
 		1FF7DAC01F75CF6C00B46C30 /* SDLHapticManagerSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FF7DABF1F75CF6C00B46C30 /* SDLHapticManagerSpec.m */; };
-		2B233530232BD8A5002118E5 /* SDLWindowCapability+ShowManagerExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B23352E232BD8A5002118E5 /* SDLWindowCapability+ShowManagerExtensions.h */; };
-		2B233531232BD8A5002118E5 /* SDLWindowCapability+ShowManagerExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B23352F232BD8A5002118E5 /* SDLWindowCapability+ShowManagerExtensions.m */; };
+		2B233530232BD8A5002118E5 /* SDLWindowCapability+ScreenManagerExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B23352E232BD8A5002118E5 /* SDLWindowCapability+ScreenManagerExtensions.h */; };
+		2B233531232BD8A5002118E5 /* SDLWindowCapability+ScreenManagerExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B23352F232BD8A5002118E5 /* SDLWindowCapability+ScreenManagerExtensions.m */; };
 		2BF2F84F20ED004000A26EF2 /* SDLAudioStreamingIndicator.h in Headers */ = {isa = PBXBuildFile; fileRef = 2BF2F84D20ED004000A26EF2 /* SDLAudioStreamingIndicator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2BF2F85020ED004000A26EF2 /* SDLAudioStreamingIndicator.m in Sources */ = {isa = PBXBuildFile; fileRef = 2BF2F84E20ED004000A26EF2 /* SDLAudioStreamingIndicator.m */; };
 		2BF2F85220ED068200A26EF2 /* SDLAudioStreamingIndicatorSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 2BF2F85120ED068200A26EF2 /* SDLAudioStreamingIndicatorSpec.m */; };
 		332A914F1CED9CC60043824C /* SDLAppInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 332A913D1CED87F80043824C /* SDLAppInfo.m */; };
 		332A91501CED9CF10043824C /* SDLAppInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 332A913C1CED87F80043824C /* SDLAppInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4A99D00E247576B7009B43E6 /* SDLTextField+ScreenManagerExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A99D00C247576B7009B43E6 /* SDLTextField+ScreenManagerExtensions.h */; };
+		4A99D00F247576B7009B43E6 /* SDLTextField+ScreenManagerExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A99D00D247576B7009B43E6 /* SDLTextField+ScreenManagerExtensions.m */; };
+		4A99D0122475773C009B43E6 /* SDLImageField+ScreenManagerExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A99D0102475773C009B43E6 /* SDLImageField+ScreenManagerExtensions.h */; };
+		4A99D0132475773C009B43E6 /* SDLImageField+ScreenManagerExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A99D0112475773C009B43E6 /* SDLImageField+ScreenManagerExtensions.m */; };
 		5D00AC671F140F0A004000D9 /* SDLSystemCapabilityType.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D00AC651F140F0A004000D9 /* SDLSystemCapabilityType.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5D00AC681F140F0A004000D9 /* SDLSystemCapabilityType.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D00AC661F140F0A004000D9 /* SDLSystemCapabilityType.m */; };
 		5D00AC6B1F141339004000D9 /* SDLSystemCapability.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D00AC691F141339004000D9 /* SDLSystemCapability.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -2120,13 +2124,17 @@
 		1FF7DAB91F75B2A800B46C30 /* SDLFocusableItemLocator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDLFocusableItemLocator.h; sourceTree = "<group>"; };
 		1FF7DABB1F75B2BF00B46C30 /* SDLFocusableItemLocator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLFocusableItemLocator.m; sourceTree = "<group>"; };
 		1FF7DABF1F75CF6C00B46C30 /* SDLHapticManagerSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SDLHapticManagerSpec.m; path = ProxySpecs/SDLHapticManagerSpec.m; sourceTree = "<group>"; };
-		2B23352E232BD8A5002118E5 /* SDLWindowCapability+ShowManagerExtensions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SDLWindowCapability+ShowManagerExtensions.h"; sourceTree = "<group>"; };
-		2B23352F232BD8A5002118E5 /* SDLWindowCapability+ShowManagerExtensions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "SDLWindowCapability+ShowManagerExtensions.m"; sourceTree = "<group>"; };
+		2B23352E232BD8A5002118E5 /* SDLWindowCapability+ScreenManagerExtensions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SDLWindowCapability+ScreenManagerExtensions.h"; sourceTree = "<group>"; };
+		2B23352F232BD8A5002118E5 /* SDLWindowCapability+ScreenManagerExtensions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "SDLWindowCapability+ScreenManagerExtensions.m"; sourceTree = "<group>"; };
 		2BF2F84D20ED004000A26EF2 /* SDLAudioStreamingIndicator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDLAudioStreamingIndicator.h; sourceTree = "<group>"; };
 		2BF2F84E20ED004000A26EF2 /* SDLAudioStreamingIndicator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLAudioStreamingIndicator.m; sourceTree = "<group>"; };
 		2BF2F85120ED068200A26EF2 /* SDLAudioStreamingIndicatorSpec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLAudioStreamingIndicatorSpec.m; sourceTree = "<group>"; };
 		332A913C1CED87F80043824C /* SDLAppInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDLAppInfo.h; sourceTree = "<group>"; };
 		332A913D1CED87F80043824C /* SDLAppInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLAppInfo.m; sourceTree = "<group>"; };
+		4A99D00C247576B7009B43E6 /* SDLTextField+ScreenManagerExtensions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SDLTextField+ScreenManagerExtensions.h"; sourceTree = "<group>"; };
+		4A99D00D247576B7009B43E6 /* SDLTextField+ScreenManagerExtensions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "SDLTextField+ScreenManagerExtensions.m"; sourceTree = "<group>"; };
+		4A99D0102475773C009B43E6 /* SDLImageField+ScreenManagerExtensions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SDLImageField+ScreenManagerExtensions.h"; sourceTree = "<group>"; };
+		4A99D0112475773C009B43E6 /* SDLImageField+ScreenManagerExtensions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "SDLImageField+ScreenManagerExtensions.m"; sourceTree = "<group>"; };
 		5D00AC651F140F0A004000D9 /* SDLSystemCapabilityType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDLSystemCapabilityType.h; sourceTree = "<group>"; };
 		5D00AC661F140F0A004000D9 /* SDLSystemCapabilityType.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLSystemCapabilityType.m; sourceTree = "<group>"; };
 		5D00AC691F141339004000D9 /* SDLSystemCapability.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDLSystemCapability.h; sourceTree = "<group>"; };
@@ -4021,6 +4029,7 @@
 				5D339CE5207C0651000CC364 /* Menu */,
 				5D0A737F203F23D10001595D /* Soft Button */,
 				5D0A737D203F23B30001595D /* Text and Graphic */,
+				5D1BF6AA2047429C00D36881 /* Utilities */,
 				5DAD5F7D204DEDEB0025624C /* SDLScreenManager.h */,
 				5DAD5F7E204DEDEB0025624C /* SDLScreenManager.m */,
 			);
@@ -4059,7 +4068,6 @@
 		5D0A737D203F23B30001595D /* Text and Graphic */ = {
 			isa = PBXGroup;
 			children = (
-				5D1BF6AA2047429C00D36881 /* Utilities */,
 				5D0A7372203F0C730001595D /* SDLTextAndGraphicManager.h */,
 				5D0A7373203F0C730001595D /* SDLTextAndGraphicManager.m */,
 			);
@@ -4103,8 +4111,12 @@
 		5D1BF6AA2047429C00D36881 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
-				2B23352E232BD8A5002118E5 /* SDLWindowCapability+ShowManagerExtensions.h */,
-				2B23352F232BD8A5002118E5 /* SDLWindowCapability+ShowManagerExtensions.m */,
+				4A99D0102475773C009B43E6 /* SDLImageField+ScreenManagerExtensions.h */,
+				4A99D0112475773C009B43E6 /* SDLImageField+ScreenManagerExtensions.m */,
+				4A99D00C247576B7009B43E6 /* SDLTextField+ScreenManagerExtensions.h */,
+				4A99D00D247576B7009B43E6 /* SDLTextField+ScreenManagerExtensions.m */,
+				2B23352E232BD8A5002118E5 /* SDLWindowCapability+ScreenManagerExtensions.h */,
+				2B23352F232BD8A5002118E5 /* SDLWindowCapability+ScreenManagerExtensions.m */,
 			);
 			name = Utilities;
 			sourceTree = "<group>";
@@ -5978,11 +5990,6 @@
 			isa = PBXGroup;
 			children = (
 				00E22CE822C2F19700BC6B08 /* Encryption */,
-				5DA3F36E1BC4489A0026F2D0 /* SDLManager.h */,
-				5DA3F36F1BC4489A0026F2D0 /* SDLManager.m */,
-				5D82041C1BCD8E6100D0A41B /* SDLConfiguration.h */,
-				5D82041D1BCD8E6100D0A41B /* SDLConfiguration.m */,
-				5D2F58071D0717D5001085CE /* SDLManagerDelegate.h */,
 				5D82042A1BCEA91E00D0A41B /* Files */,
 				5D1654571D3E79CA00554D93 /* Lifecycle */,
 				5DBAE0A51D355EE700CE00BF /* Lock Screen */,
@@ -5990,6 +5997,11 @@
 				DA8966E71E56937100413EAB /* Streaming */,
 				5D0A736F203F0C450001595D /* Screen */,
 				880E35B12088F73400181259 /* System Capabilities */,
+				5DA3F36E1BC4489A0026F2D0 /* SDLManager.h */,
+				5DA3F36F1BC4489A0026F2D0 /* SDLManager.m */,
+				5D82041C1BCD8E6100D0A41B /* SDLConfiguration.h */,
+				5D82041D1BCD8E6100D0A41B /* SDLConfiguration.m */,
+				5D2F58071D0717D5001085CE /* SDLManagerDelegate.h */,
 			);
 			name = Managers;
 			sourceTree = "<group>";
@@ -6899,6 +6911,7 @@
 				5D61FD2D1A84238C00846EE7 /* SDLPermissionItem.h in Headers */,
 				5D61FCD11A84238C00846EE7 /* SDLImageFieldName.h in Headers */,
 				88B3BF9820DA859800943565 /* SDLFuelType.h in Headers */,
+				4A99D00E247576B7009B43E6 /* SDLTextField+ScreenManagerExtensions.h in Headers */,
 				5DBF062D1E64A93A00A5CF03 /* SDLLogFilter.h in Headers */,
 				5DCF76F91ACDD7CD00BB647B /* SDLSendLocationResponse.h in Headers */,
 				5D61FD391A84238C00846EE7 /* SDLPrerecordedSpeech.h in Headers */,
@@ -6933,6 +6946,7 @@
 				5D61FD0B1A84238C00846EE7 /* SDLOnEncodedSyncPData.h in Headers */,
 				5D61FC631A84238C00846EE7 /* SDLClusterModeStatus.h in Headers */,
 				5D61FD371A84238C00846EE7 /* SDLPredefinedLayout.h in Headers */,
+				4A99D0122475773C009B43E6 /* SDLImageField+ScreenManagerExtensions.h in Headers */,
 				008DB36D22EA83E4003F458C /* SDLReleaseInteriorVehicleDataModuleResponse.h in Headers */,
 				5D61FDE31A84238C00846EE7 /* SDLUnregisterAppInterface.h in Headers */,
 				5D61FD331A84238C00846EE7 /* SDLPowerModeQualificationStatus.h in Headers */,
@@ -7018,7 +7032,7 @@
 				5D61FD951A84238C00846EE7 /* SDLShowResponse.h in Headers */,
 				5D61FCA31A84238C00846EE7 /* SDLEndAudioPassThru.h in Headers */,
 				88A795D22106787400056542 /* SDLStaticIconName.h in Headers */,
-				2B233530232BD8A5002118E5 /* SDLWindowCapability+ShowManagerExtensions.h in Headers */,
+				2B233530232BD8A5002118E5 /* SDLWindowCapability+ScreenManagerExtensions.h in Headers */,
 				5D61FCB11A84238C00846EE7 /* SDLGetDTCs.h in Headers */,
 				5D61FDFF1A84238C00846EE7 /* SDLVehicleDataEventStatus.h in Headers */,
 				5D61FC5B1A84238C00846EE7 /* SDLChangeRegistration.h in Headers */,
@@ -7465,6 +7479,7 @@
 				5D61FDC81A84238C00846EE7 /* SDLTextAlignment.m in Sources */,
 				5D4631091F21261B0092EFDC /* SDLControlFramePayloadRPCStartServiceAck.m in Sources */,
 				5D82042E1BCEC32F00D0A41B /* SDLFile.m in Sources */,
+				4A99D00F247576B7009B43E6 /* SDLTextField+ScreenManagerExtensions.m in Sources */,
 				5DA3F3601BC448590026F2D0 /* SDLNotificationConstants.m in Sources */,
 				5D61FD5A1A84238C00846EE7 /* SDLReadDID.m in Sources */,
 				1EAA472E20344108000FE74B /* SDLLightStatus.m in Sources */,
@@ -7586,13 +7601,14 @@
 				5DCF76FA1ACDD7CD00BB647B /* SDLSendLocationResponse.m in Sources */,
 				5D9FDA8F1F2A7D3400A495C8 /* bson_array.c in Sources */,
 				5D61FD661A84238C00846EE7 /* SDLResetGlobalPropertiesResponse.m in Sources */,
+				4A99D0132475773C009B43E6 /* SDLImageField+ScreenManagerExtensions.m in Sources */,
 				5D61FCFE1A84238C00846EE7 /* SDLObjectWithPriority.m in Sources */,
 				5D92937D20B70A3E00FCC775 /* SDLPresentKeyboardOperation.m in Sources */,
 				9FD334E122DC6E7500F62736 /* SDLCreateWindow.m in Sources */,
 				5DBF06241E64A83F00A5CF03 /* SDLLogManager.m in Sources */,
 				5D61FC401A84238C00846EE7 /* SDLAmbientLightStatus.m in Sources */,
 				9F425ADB22DD983500BE3245 /* SDLDisplayCapability.m in Sources */,
-				2B233531232BD8A5002118E5 /* SDLWindowCapability+ShowManagerExtensions.m in Sources */,
+				2B233531232BD8A5002118E5 /* SDLWindowCapability+ScreenManagerExtensions.m in Sources */,
 				88EEC5BC220A327B005AA2F9 /* SDLPublishAppServiceResponse.m in Sources */,
 				5D61FC951A84238C00846EE7 /* SDLDriverDistractionState.m in Sources */,
 				5DB996611F28C6ED002D8795 /* SDLControlFramePayloadVideoStartServiceAck.m in Sources */,

--- a/SmartDeviceLink/Assets/Base.lproj/SDLLockScreen.storyboard
+++ b/SmartDeviceLink/Assets/Base.lproj/SDLLockScreen.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="sao-xX-Ugl">
-    <device id="retina5_5" orientation="landscape" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="sao-xX-Ugl">
+    <device id="retina5_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -16,18 +16,18 @@
                         <viewControllerLayoutGuide type="bottom" id="wh4-r5-yql"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="daa-1b-9se">
-                        <rect key="frame" x="0.0" y="0.0" width="736" height="414"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="fyC-E0-YKF">
-                                <rect key="frame" x="308" y="341" width="120" height="36"/>
+                                <rect key="frame" x="147" y="663" width="120" height="36"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="120" id="Pm5-yr-PT3"/>
                                     <constraint firstAttribute="height" constant="36" id="yVy-ww-yMp"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Locked for your safety" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2GC-iG-Bjq">
-                                <rect key="frame" x="20" y="389" width="696" height="17"/>
+                                <rect key="frame" x="20" y="711" width="374" height="17"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
@@ -47,14 +47,14 @@
                                 </constraints>
                             </imageView>
                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="b2o-8D-i9T">
-                                <rect key="frame" x="275.66666666666669" y="169" width="185" height="76"/>
+                                <rect key="frame" x="114.66666666666669" y="330" width="185" height="76"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="185" id="CE6-0z-Lmn"/>
                                     <constraint firstAttribute="height" constant="76" id="emS-mJ-Ryy"/>
                                 </constraints>
                             </imageView>
                             <view opaque="NO" alpha="0.0" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yyo-mJ-82g" userLabel="Center Spacer View">
-                                <rect key="frame" x="367" y="206" width="2" height="2"/>
+                                <rect key="frame" x="206" y="367" width="2" height="2"/>
                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="2" id="1D8-iN-cG4"/>
@@ -62,7 +62,7 @@
                                 </constraints>
                             </view>
                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="M7Q-8D-weT">
-                                <rect key="frame" x="532" y="143" width="184" height="128"/>
+                                <rect key="frame" x="87" y="418" width="240" height="128"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="128" id="1Px-le-yzw"/>
                                     <constraint firstAttribute="width" constant="240" id="eVl-bJ-3TM"/>
@@ -79,7 +79,7 @@
                                 </variation>
                             </imageView>
                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="qlE-SZ-K9i">
-                                <rect key="frame" x="20" y="143" width="184" height="128"/>
+                                <rect key="frame" x="87" y="190" width="240" height="128"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="240" id="Bk8-YV-DHy"/>
                                     <constraint firstAttribute="height" constant="128" id="boE-Tt-Ols"/>
@@ -168,14 +168,14 @@
                                 <include reference="MKF-hz-tMZ"/>
                             </mask>
                             <mask key="constraints">
-                                <exclude reference="3M5-ke-rxH"/>
-                                <exclude reference="gwo-mS-ib9"/>
-                                <exclude reference="Bda-7E-hB1"/>
-                                <exclude reference="d7Z-Gl-Q0P"/>
                                 <include reference="PAm-2N-EDL"/>
                                 <include reference="WXE-1r-KaS"/>
                                 <exclude reference="a80-NE-fUz"/>
                                 <include reference="euB-xP-ET0"/>
+                                <exclude reference="3M5-ke-rxH"/>
+                                <exclude reference="gwo-mS-ib9"/>
+                                <exclude reference="Bda-7E-hB1"/>
+                                <exclude reference="d7Z-Gl-Q0P"/>
                                 <include reference="6A2-Sa-iGG"/>
                                 <include reference="SM4-aR-RUB"/>
                                 <include reference="5Z9-0c-ZVz"/>
@@ -196,14 +196,14 @@
                                 <include reference="MKF-hz-tMZ"/>
                             </mask>
                             <mask key="constraints">
-                                <exclude reference="3M5-ke-rxH"/>
-                                <exclude reference="gwo-mS-ib9"/>
-                                <exclude reference="Bda-7E-hB1"/>
-                                <exclude reference="d7Z-Gl-Q0P"/>
                                 <include reference="PAm-2N-EDL"/>
                                 <include reference="WXE-1r-KaS"/>
                                 <exclude reference="a80-NE-fUz"/>
                                 <include reference="euB-xP-ET0"/>
+                                <exclude reference="3M5-ke-rxH"/>
+                                <exclude reference="gwo-mS-ib9"/>
+                                <exclude reference="Bda-7E-hB1"/>
+                                <exclude reference="d7Z-Gl-Q0P"/>
                                 <include reference="6A2-Sa-iGG"/>
                                 <include reference="SM4-aR-RUB"/>
                                 <include reference="5Z9-0c-ZVz"/>
@@ -231,7 +231,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Wfa-ZV-GKT" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="878.804347826087" y="886.95652173913049"/>
+            <point key="canvasLocation" x="501" y="885"/>
         </scene>
     </scenes>
     <resources>

--- a/SmartDeviceLink/SDLChoiceSetManager.m
+++ b/SmartDeviceLink/SDLChoiceSetManager.m
@@ -39,7 +39,7 @@
 #import "SDLSystemCapability.h"
 #import "SDLSystemCapabilityManager.h"
 #import "SDLWindowCapability.h"
-#import "SDLWindowCapability+ShowManagerExtensions.h"
+#import "SDLWindowCapability+ScreenManagerExtensions.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/SmartDeviceLink/SDLImageField+ScreenManagerExtensions.h
+++ b/SmartDeviceLink/SDLImageField+ScreenManagerExtensions.h
@@ -1,0 +1,19 @@
+//
+//  SDLImageField+ScreenManagerExtensions.h
+//  SmartDeviceLink
+//
+//  Created by Joel Fischer on 5/20/20.
+//  Copyright © 2020 smartdevicelink. All rights reserved.
+//
+
+#import <SmartDeviceLink/SmartDeviceLink.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SDLImageField (ScreenManagerExtensions)
+
++ (NSArray<SDLImageField *> *)allImageFields;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLImageField+ScreenManagerExtensions.m
+++ b/SmartDeviceLink/SDLImageField+ScreenManagerExtensions.m
@@ -1,0 +1,30 @@
+//
+//  SDLImageField+ScreenManagerExtensions.m
+//  SmartDeviceLink
+//
+//  Created by Joel Fischer on 5/20/20.
+//  Copyright © 2020 smartdevicelink. All rights reserved.
+//
+
+#import "SDLImageField+ScreenManagerExtensions.h"
+
+@implementation SDLImageField (ScreenManagerExtensions)
+
++ (NSArray<SDLImageFieldName> *)sdl_allImageFieldNames {
+    return @[SDLImageFieldNameAppIcon, SDLImageFieldNameGraphic, SDLImageFieldNameMenuIcon, SDLImageFieldNameTurnIcon, SDLImageFieldNameAlertIcon, SDLImageFieldNameChoiceImage, SDLImageFieldNameCommandIcon, SDLImageFieldNameLocationImage, SDLImageFieldNameSoftButtonImage, SDLImageFieldNameSecondaryGraphic, SDLImageFieldNameShowConstantTBTIcon, SDLImageFieldNameChoiceSecondaryImage, SDLImageFieldNameVoiceRecognitionHelpItem, SDLImageFieldNameShowConstantTBTNextTurnIcon];
+}
+
++ (NSArray<SDLFileType> *)sdl_allImageFileTypes {
+    return @[SDLFileTypeBMP, SDLFileTypePNG, SDLFileTypeJPEG];
+}
+
++ (NSArray<SDLImageField *> *)allImageFields {
+    NSMutableArray<SDLImageField *> *tempImageFields = [NSMutableArray array];
+    for (SDLImageFieldName fieldName in [self sdl_allImageFieldNames]) {
+        [tempImageFields addObject:[[SDLImageField alloc] initWithName:fieldName imageTypeSupported:[self sdl_allImageFileTypes] imageResolution:nil]];
+    }
+
+    return tempImageFields;
+}
+
+@end

--- a/SmartDeviceLink/SDLMenuManager.h
+++ b/SmartDeviceLink/SDLMenuManager.h
@@ -30,9 +30,10 @@ typedef void(^SDLMenuUpdateCompletionHandler)(NSError *__nullable error);
 
 - (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager fileManager:(SDLFileManager *)fileManager systemCapabilityManager:(SDLSystemCapabilityManager *)systemCapabilityManager;
 
-/**
- *  Stops the manager. This method is used internally.
- */
+/// Starts the manager. This method is used internally.
+- (void)start;
+
+/// Stops the manager. This method is used internally.
 - (void)stop;
 
 @property (strong, nonatomic) SDLMenuConfiguration *menuConfiguration;

--- a/SmartDeviceLink/SDLMenuManager.m
+++ b/SmartDeviceLink/SDLMenuManager.m
@@ -104,6 +104,10 @@ UInt32 const MenuCellIdMin = 1;
     return self;
 }
 
+- (void)start {
+    [self.systemCapabilityManager subscribeToCapabilityType:SDLSystemCapabilityTypeDisplays withObserver:self selector:@selector(sdl_displayCapabilityDidUpdate:)];
+}
+
 - (void)stop {
     _lastMenuId = MenuCellIdMin;
     _menuCells = @[];

--- a/SmartDeviceLink/SDLMenuManager.m
+++ b/SmartDeviceLink/SDLMenuManager.m
@@ -159,6 +159,7 @@ UInt32 const MenuCellIdMin = 1;
     if (self.currentHMILevel == nil
         || [self.currentHMILevel isEqualToEnum:SDLHMILevelNone]
         || [self.currentSystemContext isEqualToEnum:SDLSystemContextMenu]) {
+        SDLLogD(@"Waiting for HMI update to send menu cells");
         self.waitingOnHMIUpdate = YES;
         self.waitingUpdateMenuCells = menuCells;
         return;

--- a/SmartDeviceLink/SDLPreloadChoicesOperation.m
+++ b/SmartDeviceLink/SDLPreloadChoicesOperation.m
@@ -19,7 +19,7 @@
 #import "SDLImage.h"
 #import "SDLLogMacros.h"
 #import "SDLWindowCapability.h"
-#import "SDLWindowCapability+ShowManagerExtensions.h"
+#import "SDLWindowCapability+ScreenManagerExtensions.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -192,27 +192,27 @@ NS_ASSUME_NONNULL_BEGIN
     }
 #pragma clang diagnostic pop
 
-    return (self.windowCapability.textFields != nil) ? [self.windowCapability hasTextFieldOfName:SDLTextFieldNameMenuName] : YES;
+    return [self.windowCapability hasTextFieldOfName:SDLTextFieldNameMenuName];
 }
 
 /// Determine if we should send secondary text. If textFields is nil, we don't know the capabilities and we will send everything.
 - (BOOL)sdl_shouldSendChoiceSecondaryText {
-    return (self.windowCapability.textFields != nil) ? [self.windowCapability hasTextFieldOfName:SDLTextFieldNameSecondaryText] : YES;
+    return [self.windowCapability hasTextFieldOfName:SDLTextFieldNameSecondaryText];
 }
 
 /// Determine if we should send teriary text. If textFields is nil, we don't know the capabilities and we will send everything.
 - (BOOL)sdl_shouldSendChoiceTertiaryText {
-    return (self.windowCapability.textFields != nil) ? [self.windowCapability hasTextFieldOfName:SDLTextFieldNameTertiaryText] : YES;
+    return [self.windowCapability hasTextFieldOfName:SDLTextFieldNameTertiaryText];
 }
 
 /// Determine if we should send the primary image. If imageFields is nil, we don't know the capabilities and we will send everything.
 - (BOOL)sdl_shouldSendChoicePrimaryImage {
-    return (self.windowCapability.imageFields != nil) ? [self.windowCapability hasImageFieldOfName:SDLImageFieldNameChoiceImage] : YES;
+    return [self.windowCapability hasImageFieldOfName:SDLImageFieldNameChoiceImage];
 }
 
 /// Determine if we should send the secondary image. If imageFields is nil, we don't know the capabilities and we will send everything.
 - (BOOL)sdl_shouldSendChoiceSecondaryImage {
-    return (self.windowCapability.imageFields != nil) ? [self.windowCapability hasImageFieldOfName:SDLImageFieldNameChoiceSecondaryImage] : YES;
+    return [self.windowCapability hasImageFieldOfName:SDLImageFieldNameChoiceSecondaryImage];
 }
 
 #pragma mark - Property Overrides

--- a/SmartDeviceLink/SDLScreenManager.m
+++ b/SmartDeviceLink/SDLScreenManager.m
@@ -52,6 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)startWithCompletionHandler:(void (^)(NSError * _Nullable))handler {
     [self.textAndGraphicManager start];
     [self.softButtonManager start];
+    [self.menuManager start];
     [self.choiceSetManager start];
 
     handler(nil);

--- a/SmartDeviceLink/SDLSoftButtonReplaceOperation.m
+++ b/SmartDeviceLink/SDLSoftButtonReplaceOperation.m
@@ -248,7 +248,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Images
 
 - (BOOL)sdl_artworkNeedsUpload:(SDLArtwork *)artwork {
-    return (artwork != nil && ![self.fileManager hasUploadedFile:artwork] && !artwork.isStaticIcon);
+    return (artwork != nil && ![self.fileManager hasUploadedFile:artwork] && self.softButtonCapabilities.imageSupported.boolValue && !artwork.isStaticIcon);
 }
 
 - (BOOL)sdl_currentStateHasImages {

--- a/SmartDeviceLink/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.m
@@ -20,6 +20,7 @@
 #import "SDLGetSystemCapabilityResponse.h"
 #import "SDLGlobals.h"
 #import "SDLHMICapabilities.h"
+#import "SDLImageField+ScreenManagerExtensions.h"
 #import "SDLLogMacros.h"
 #import "SDLNavigationCapability.h"
 #import "SDLNotificationConstants.h"
@@ -35,6 +36,8 @@
 #import "SDLSetDisplayLayoutResponse.h"
 #import "SDLSystemCapability.h"
 #import "SDLSystemCapabilityObserver.h"
+#import "SDLTextField+ScreenManagerExtensions.h"
+#import "SDLTextFieldName.h"
 #import "SDLVersion.h"
 #import "SDLVideoStreamingCapability.h"
 #import "SDLWindowCapability.h"
@@ -208,6 +211,8 @@ typedef NSString * SDLServiceID;
 
     // return if display capabilities don't exist.
     if (display == nil) {
+        defaultWindowCapability.textFields = [SDLTextField allTextFields];
+        defaultWindowCapability.imageFields = [SDLImageField allImageFields];
         displayCapability.windowCapabilities = @[defaultWindowCapability];
         return @[displayCapability];
     }

--- a/SmartDeviceLink/SDLTextAndGraphicManager.m
+++ b/SmartDeviceLink/SDLTextAndGraphicManager.m
@@ -312,7 +312,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSArray *nonNilFields = [self sdl_findNonNilTextFields];
     if (nonNilFields.count == 0) { return show; }
 
-    NSUInteger numberOfLines = (self.windowCapability.textFields != nil) ? self.windowCapability.maxNumberOfMainFieldLines : 4;
+    NSUInteger numberOfLines = self.windowCapability.maxNumberOfMainFieldLines;
     if (numberOfLines == 1) {
         show = [self sdl_assembleOneLineShowText:show withShowFields:nonNilFields];
     } else if (numberOfLines == 2) {

--- a/SmartDeviceLink/SDLTextAndGraphicManager.m
+++ b/SmartDeviceLink/SDLTextAndGraphicManager.m
@@ -27,7 +27,7 @@
 #import "SDLSystemCapabilityManager.h"
 #import "SDLTextField.h"
 #import "SDLWindowCapability.h"
-#import "SDLWindowCapability+ShowManagerExtensions.h"
+#import "SDLWindowCapability+ScreenManagerExtensions.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -523,46 +523,46 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (BOOL)sdl_shouldUpdatePrimaryImage {
-    BOOL templateSupportsPrimaryArtwork = (self.windowCapability.imageFields != nil) ? [self.windowCapability hasImageFieldOfName:SDLImageFieldNameGraphic] : YES;
+    BOOL templateSupportsPrimaryArtwork = [self.windowCapability hasImageFieldOfName:SDLImageFieldNameGraphic];
+    BOOL graphicMatchesExisting = [self.currentScreenData.graphic.value isEqualToString:self.primaryGraphic.name];
+    BOOL graphicExists = (self.primaryGraphic != nil);
 
-    return (templateSupportsPrimaryArtwork
-            && ![self.currentScreenData.graphic.value isEqualToString:self.primaryGraphic.name]
-            && self.primaryGraphic != nil);
+    return (templateSupportsPrimaryArtwork && !graphicMatchesExisting && graphicExists);
 }
 
 - (BOOL)sdl_shouldUpdateSecondaryImage {
-    BOOL templateSupportsSecondaryArtwork = (self.windowCapability.imageFields != nil) ? ([self.windowCapability hasImageFieldOfName:SDLImageFieldNameGraphic] || [self.windowCapability hasImageFieldOfName:SDLImageFieldNameSecondaryGraphic]) : YES;
+    BOOL templateSupportsSecondaryArtwork = [self.windowCapability hasImageFieldOfName:SDLImageFieldNameSecondaryGraphic];
+    BOOL graphicMatchesExisting = [self.currentScreenData.secondaryGraphic.value isEqualToString:self.secondaryGraphic.name];
+    BOOL graphicExists = (self.secondaryGraphic != nil);
 
     // Cannot detect if there is a secondary image, so we'll just try to detect if there's a primary image and allow it if there is.
-    return (templateSupportsSecondaryArtwork
-            && ![self.currentScreenData.secondaryGraphic.value isEqualToString:self.secondaryGraphic.name]
-            && self.secondaryGraphic != nil);
+    return (templateSupportsSecondaryArtwork && !graphicMatchesExisting && graphicExists);
 }
 
 - (BOOL)sdl_shouldUpdateMediaTextField {
-    return (self.windowCapability.textFields != nil) ? [self.windowCapability hasTextFieldOfName:SDLTextFieldNameMediaTrack] : YES;
+    return [self.windowCapability hasTextFieldOfName:SDLTextFieldNameMediaTrack];
 }
 
 - (BOOL)sdl_shouldUpdateTitleField {
-    return (self.windowCapability.textFields != nil) ? [self.windowCapability hasTextFieldOfName:SDLTextFieldNameTemplateTitle] : YES;
+    return [self.windowCapability hasTextFieldOfName:SDLTextFieldNameTemplateTitle];
 }
 
 - (NSArray<NSString *> *)sdl_findNonNilTextFields {
     NSMutableArray *array = [NSMutableArray array];
-    self.textField1.length > 0 ? [array addObject:self.textField1] : nil;
-    self.textField2.length > 0 ? [array addObject:self.textField2] : nil;
-    self.textField3.length > 0 ? [array addObject:self.textField3] : nil;
-    self.textField4.length > 0 ? [array addObject:self.textField4] : nil;
+    (self.textField1.length > 0) ? [array addObject:self.textField1] : nil;
+    (self.textField2.length > 0) ? [array addObject:self.textField2] : nil;
+    (self.textField3.length > 0) ? [array addObject:self.textField3] : nil;
+    (self.textField4.length > 0) ? [array addObject:self.textField4] : nil;
 
     return [array copy];
 }
 
 - (NSArray<SDLMetadataType> *)sdl_findNonNilMetadataFields {
     NSMutableArray *array = [NSMutableArray array];
-    self.textField1Type.length > 0 ? [array addObject:self.textField1Type] : nil;
-    self.textField2Type.length > 0 ? [array addObject:self.textField2Type] : nil;
-    self.textField3Type.length > 0 ? [array addObject:self.textField3Type] : nil;
-    self.textField4Type.length > 0 ? [array addObject:self.textField4Type] : nil;
+    (self.textField1Type.length) > 0 ? [array addObject:self.textField1Type] : nil;
+    (self.textField2Type.length) > 0 ? [array addObject:self.textField2Type] : nil;
+    (self.textField3Type.length) > 0 ? [array addObject:self.textField3Type] : nil;
+    (self.textField4Type.length) > 0 ? [array addObject:self.textField4Type] : nil;
 
     return [array copy];
 }

--- a/SmartDeviceLink/SDLTextField+ScreenManagerExtensions.h
+++ b/SmartDeviceLink/SDLTextField+ScreenManagerExtensions.h
@@ -1,0 +1,19 @@
+//
+//  SDLTextField+ScreenManagerExtensions.h
+//  SmartDeviceLink
+//
+//  Created by Joel Fischer on 5/20/20.
+//  Copyright © 2020 smartdevicelink. All rights reserved.
+//
+
+#import "SDLTextField.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SDLTextField (ScreenManagerExtensions)
+
++ (NSArray<SDLTextField *> *)allTextFields;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLTextField+ScreenManagerExtensions.m
+++ b/SmartDeviceLink/SDLTextField+ScreenManagerExtensions.m
@@ -1,0 +1,26 @@
+//
+//  SDLTextField+ScreenManagerExtensions.m
+//  SmartDeviceLink
+//
+//  Created by Joel Fischer on 5/20/20.
+//  Copyright © 2020 smartdevicelink. All rights reserved.
+//
+
+#import "SDLTextField+ScreenManagerExtensions.h"
+
+@implementation SDLTextField (ScreenManagerExtensions)
+
++ (NSArray<SDLTextFieldName> *)sdl_allTextFieldNames {
+    return @[SDLTextFieldNameETA, SDLTextFieldNameMenuName, SDLTextFieldNameMenuTitle, SDLTextFieldNameStatusBar, SDLTextFieldNameAlertText1, SDLTextFieldNameAlertText2, SDLTextFieldNameAlertText3, SDLTextFieldNameMainField1, SDLTextFieldNameMainField2, SDLTextFieldNameMainField3, SDLTextFieldNameMainField4, SDLTextFieldNameMediaClock, SDLTextFieldNameMediaTrack, SDLTextFieldNamePhoneNumber, SDLTextFieldNameAddressLines, SDLTextFieldNameLocationName, SDLTextFieldNameSliderFooter, SDLTextFieldNameSliderHeader, SDLTextFieldNameTertiaryText, SDLTextFieldNameSecondaryText, SDLTextFieldNameTemplateTitle, SDLTextFieldNameTotalDistance, SDLTextFieldNameNavigationText1, SDLTextFieldNameNavigationText2, SDLTextFieldNameLocationDescription, SDLTextFieldNameScrollableMessageBody, SDLTextFieldNameInitialInteractionText, SDLTextFieldNameAudioPassThruDisplayText1, SDLTextFieldNameAudioPassThruDisplayText2];
+}
+
++ (NSArray<SDLTextField *> *)allTextFields {
+    NSMutableArray<SDLTextField *> *tempTextFields = [NSMutableArray array];
+    for (SDLTextFieldName fieldName in [self sdl_allTextFieldNames]) {
+        [tempTextFields addObject:[[SDLTextField alloc] initWithName:fieldName characterSet:SDLCharacterSetCID1 width:500 rows:500]];
+    }
+
+    return tempTextFields;
+}
+
+@end

--- a/SmartDeviceLink/SDLTextField+ScreenManagerExtensions.m
+++ b/SmartDeviceLink/SDLTextField+ScreenManagerExtensions.m
@@ -17,7 +17,7 @@
 + (NSArray<SDLTextField *> *)allTextFields {
     NSMutableArray<SDLTextField *> *tempTextFields = [NSMutableArray array];
     for (SDLTextFieldName fieldName in [self sdl_allTextFieldNames]) {
-        [tempTextFields addObject:[[SDLTextField alloc] initWithName:fieldName characterSet:SDLCharacterSetCID1 width:500 rows:500]];
+        [tempTextFields addObject:[[SDLTextField alloc] initWithName:fieldName characterSet:SDLCharacterSetCID1 width:500 rows:8]];
     }
 
     return tempTextFields;

--- a/SmartDeviceLink/SDLWindowCapability+ScreenManagerExtensions.h
+++ b/SmartDeviceLink/SDLWindowCapability+ScreenManagerExtensions.h
@@ -14,7 +14,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SDLWindowCapability (ShowManagerExtensions)
+@interface SDLWindowCapability (ScreenManagerExtensions)
 
 @property (assign, nonatomic, readonly) NSUInteger maxNumberOfMainFieldLines;
 

--- a/SmartDeviceLink/SDLWindowCapability+ScreenManagerExtensions.m
+++ b/SmartDeviceLink/SDLWindowCapability+ScreenManagerExtensions.m
@@ -8,11 +8,11 @@
 //  Copyright © 2019 smartdevicelink. All rights reserved.
 //
 
-#import "SDLWindowCapability+ShowManagerExtensions.h"
+#import "SDLWindowCapability+ScreenManagerExtensions.h"
 #import "SDLImageField.h"
 #import "SDLTextField.h"
 
-@implementation SDLWindowCapability (ShowManagerExtension)
+@implementation SDLWindowCapability (ScreenManagerExtensions)
 
 - (BOOL)hasTextFieldOfName:(SDLTextFieldName)name {
     for (SDLTextField *textField in self.textFields) {

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLMenuManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLMenuManagerSpec.m
@@ -30,11 +30,10 @@
 @property (assign, nonatomic) BOOL hasQueuedUpdate;
 @property (assign, nonatomic) BOOL waitingOnHMIUpdate;
 @property (copy, nonatomic) NSArray<SDLMenuCell *> *waitingUpdateMenuCells;
+@property (strong, nonatomic, nullable) SDLWindowCapability *windowCapability;
 
 @property (assign, nonatomic) UInt32 lastMenuId;
 @property (copy, nonatomic) NSArray<SDLMenuCell *> *oldMenuCells;
-
-- (void)sdl_displayCapabilityDidUpdate:(SDLSystemCapability *)systemCapability;
 
 @end
 
@@ -81,13 +80,7 @@ describe(@"menu manager", ^{
         windowCapability.imageFields = @[commandIconField];
         windowCapability.imageTypeSupported = @[SDLImageTypeDynamic, SDLImageTypeStatic];
         windowCapability.menuLayoutsAvailable = @[SDLMenuLayoutList, SDLMenuLayoutTiles];
-
-        SDLDisplayCapability *displayCapability = [[SDLDisplayCapability alloc] initWithDisplayName:SDLDisplayTypeGeneric];
-        displayCapability.windowCapabilities = @[windowCapability];
-
-        OCMStub(mockSystemCapabilityManager.defaultMainWindowCapability).andReturn(windowCapability);
-        OCMStub(mockSystemCapabilityManager.displays).andReturn(@[displayCapability]);
-        [testManager sdl_displayCapabilityDidUpdate:nil];
+        testManager.windowCapability = windowCapability;
     });
 
     it(@"should instantiate correctly", ^{

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLMenuManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLMenuManagerSpec.m
@@ -34,6 +34,8 @@
 @property (assign, nonatomic) UInt32 lastMenuId;
 @property (copy, nonatomic) NSArray<SDLMenuCell *> *oldMenuCells;
 
+- (void)sdl_displayCapabilityDidUpdate:(SDLSystemCapability *)systemCapability;
+
 @end
 
 QuickSpecBegin(SDLMenuManagerSpec)
@@ -85,6 +87,7 @@ describe(@"menu manager", ^{
 
         OCMStub(mockSystemCapabilityManager.defaultMainWindowCapability).andReturn(windowCapability);
         OCMStub(mockSystemCapabilityManager.displays).andReturn(@[displayCapability]);
+        [testManager sdl_displayCapabilityDidUpdate:nil];
     });
 
     it(@"should instantiate correctly", ^{

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicManagerSpec.m
@@ -375,7 +375,7 @@ describe(@"text and graphic manager", ^{
                 testManager.windowCapability = [[SDLWindowCapability alloc] init];
             });
 
-            fit(@"should send nothing", ^{
+            it(@"should send nothing", ^{
                 testManager.mediaTrackTextField = textMediaTrack;
                 testManager.title = textTitle;
                 testManager.textField1 = textLine1;

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicManagerSpec.m
@@ -6,6 +6,7 @@
 #import "SDLFileManager.h"
 #import "SDLHMILevel.h"
 #import "SDLImage.h"
+#import "SDLImageField.h"
 #import "SDLMetadataTags.h"
 #import "SDLPutFileResponse.h"
 #import "SDLShow.h"
@@ -36,6 +37,8 @@
 @property (strong, nonatomic) SDLArtwork *blankArtwork;
 
 @property (assign, nonatomic) BOOL isDirty;
+
+- (void)sdl_displayCapabilityDidUpdate:(SDLSystemCapability *)systemCapability;
 
 @end
 
@@ -859,10 +862,21 @@ describe(@"text and graphic manager", ^{
             });
         });
 
-        context(@"updating images", ^{
+        fcontext(@"updating images", ^{
             __block NSString *testTextFieldText = @"mainFieldText";
 
             beforeEach(^{
+                testManager.windowCapability = [[SDLWindowCapability alloc] init];
+                SDLImageField *primaryImageField = [[SDLImageField alloc] init];
+                primaryImageField.name = SDLImageFieldNameGraphic;
+                SDLImageField *secondaryImageField = [[SDLImageField alloc] init];
+                secondaryImageField.name = SDLImageFieldNameSecondaryGraphic;
+                testManager.windowCapability.imageFields = @[primaryImageField, secondaryImageField];
+
+                SDLTextField *lineOneField = [[SDLTextField alloc] init];
+                lineOneField.name = SDLTextFieldNameMainField1;
+                testManager.windowCapability.textFields = @[lineOneField];
+
                 testManager.batchUpdates = YES;
                 testManager.textField1 = testTextFieldText;
             });
@@ -888,7 +902,7 @@ describe(@"text and graphic manager", ^{
                         testManager.windowCapability = [[SDLWindowCapability alloc] init];
                     });
 
-                    it(@"should send everything", ^{
+                    it(@"should send nothing", ^{
                         testManager.primaryGraphic = testArtwork;
                         testManager.secondaryGraphic = testArtwork;
                         testManager.batchUpdates = NO;

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicManagerSpec.m
@@ -862,7 +862,7 @@ describe(@"text and graphic manager", ^{
             });
         });
 
-        fcontext(@"updating images", ^{
+        context(@"updating images", ^{
             __block NSString *testTextFieldText = @"mainFieldText";
 
             beforeEach(^{
@@ -881,6 +881,23 @@ describe(@"text and graphic manager", ^{
                 testManager.textField1 = testTextFieldText;
             });
 
+            context(@"when imageFields are nil", ^{
+                beforeEach(^{
+                    testManager.windowCapability.imageFields = nil;
+                });
+
+                it(@"should send nothing", ^{
+                    testManager.primaryGraphic = testArtwork;
+                    testManager.secondaryGraphic = testArtwork;
+                    testManager.batchUpdates = NO;
+                    [testManager updateWithCompletionHandler:nil];
+
+                    expect(testManager.inProgressUpdate.graphic).to(beNil());
+                    expect(testManager.inProgressUpdate.secondaryGraphic).to(beNil());
+                    expect(testManager.inProgressUpdate.mainField1).to(equal(testTextFieldText));
+                });
+            });
+
             context(@"when the image is already on the head unit", ^{
                 beforeEach(^{
                     OCMStub([mockFileManager hasUploadedFile:[OCMArg isNotNil]]).andReturn(YES);
@@ -895,23 +912,6 @@ describe(@"text and graphic manager", ^{
                     expect(testManager.inProgressUpdate.graphic.value).to(equal(testArtworkName));
                     expect(testManager.inProgressUpdate.secondaryGraphic.value).to(equal(testArtworkName));
                     expect(testManager.inProgressUpdate.mainField1).to(equal(testTextFieldText));
-                });
-
-                context(@"when imageFields are nil", ^{
-                    beforeEach(^{
-                        testManager.windowCapability = [[SDLWindowCapability alloc] init];
-                    });
-
-                    it(@"should send nothing", ^{
-                        testManager.primaryGraphic = testArtwork;
-                        testManager.secondaryGraphic = testArtwork;
-                        testManager.batchUpdates = NO;
-                        [testManager updateWithCompletionHandler:nil];
-
-                        expect(testManager.inProgressUpdate.graphic.value).to(equal(testArtworkName));
-                        expect(testManager.inProgressUpdate.secondaryGraphic.value).to(equal(testArtworkName));
-                        expect(testManager.inProgressUpdate.mainField1).to(equal(testTextFieldText));
-                    });
                 });
             });
 

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicManagerSpec.m
@@ -375,7 +375,7 @@ describe(@"text and graphic manager", ^{
                 testManager.windowCapability = [[SDLWindowCapability alloc] init];
             });
 
-            it(@"should send everything", ^{
+            fit(@"should send nothing", ^{
                 testManager.mediaTrackTextField = textMediaTrack;
                 testManager.title = textTitle;
                 testManager.textField1 = textLine1;
@@ -386,12 +386,12 @@ describe(@"text and graphic manager", ^{
                 testManager.batchUpdates = NO;
                 [testManager updateWithCompletionHandler:nil];
 
-                expect(testManager.inProgressUpdate.mediaTrack).to(equal(textMediaTrack));
-                expect(testManager.inProgressUpdate.templateTitle).to(equal(textTitle));
-                expect(testManager.inProgressUpdate.mainField1).to(equal(textLine1));
-                expect(testManager.inProgressUpdate.mainField2).to(equal(textLine2));
-                expect(testManager.inProgressUpdate.mainField3).to(equal(textLine3));
-                expect(testManager.inProgressUpdate.mainField4).to(equal(textLine4));
+                expect(testManager.inProgressUpdate.mediaTrack).toNot(equal(textMediaTrack));
+                expect(testManager.inProgressUpdate.templateTitle).toNot(equal(textTitle));
+                expect(testManager.inProgressUpdate.mainField1).toNot(equal(textLine1));
+                expect(testManager.inProgressUpdate.mainField2).toNot(equal(textLine2));
+                expect(testManager.inProgressUpdate.mainField3).toNot(equal(textLine3));
+                expect(testManager.inProgressUpdate.mainField4).toNot(equal(textLine4));
             });
         });
 

--- a/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
+++ b/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
@@ -390,6 +390,12 @@ describe(@"System capability manager", ^{
                 expect(testSystemCapabilityManager.vrCapability).to(beFalse());
                 expect(testSystemCapabilityManager.audioPassThruCapabilities).to(beNil());
                 expect(testSystemCapabilityManager.pcmStreamCapability).to(beNil());
+
+                expect(testSystemCapabilityManager.phoneCapability).to(beNil());
+                expect(testSystemCapabilityManager.navigationCapability).to(beNil());
+                expect(testSystemCapabilityManager.videoStreamingCapability).to(beNil());
+                expect(testSystemCapabilityManager.remoteControlCapability).to(beNil());
+                expect(testSystemCapabilityManager.appServicesCapabilities).to(beNil());
             });
         });
 
@@ -416,16 +422,13 @@ describe(@"System capability manager", ^{
                 expect(testSystemCapabilityManager.vrCapability).to(beTrue());
                 expect(testSystemCapabilityManager.audioPassThruCapabilities).to(equal(testAudioPassThruCapabilities));
                 expect(testSystemCapabilityManager.pcmStreamCapability).to(equal(testPCMStreamCapability));
-            });
-        });
 
-        afterEach(^{
-            // Make sure the system capabilities properties were not inadverdently set
-            expect(testSystemCapabilityManager.phoneCapability).to(beNil());
-            expect(testSystemCapabilityManager.navigationCapability).to(beNil());
-            expect(testSystemCapabilityManager.videoStreamingCapability).to(beNil());
-            expect(testSystemCapabilityManager.remoteControlCapability).to(beNil());
-            expect(testSystemCapabilityManager.appServicesCapabilities).to(beNil());
+                expect(testSystemCapabilityManager.phoneCapability).to(beNil());
+                expect(testSystemCapabilityManager.navigationCapability).to(beNil());
+                expect(testSystemCapabilityManager.videoStreamingCapability).to(beNil());
+                expect(testSystemCapabilityManager.remoteControlCapability).to(beNil());
+                expect(testSystemCapabilityManager.appServicesCapabilities).to(beNil());
+            });
         });
     });
 
@@ -456,6 +459,19 @@ describe(@"System capability manager", ^{
                 expect(testSystemCapabilityManager.buttonCapabilities).to(beNil());
                 expect(testSystemCapabilityManager.presetBankCapabilities).to(beNil());
 #pragma clang diagnostic pop
+
+                expect(testSystemCapabilityManager.hmiCapabilities).to(beNil());
+                expect(testSystemCapabilityManager.hmiZoneCapabilities).to(beNil());
+                expect(testSystemCapabilityManager.speechCapabilities).to(beNil());
+                expect(testSystemCapabilityManager.prerecordedSpeechCapabilities).to(beNil());
+                expect(testSystemCapabilityManager.vrCapability).to(beFalse());
+                expect(testSystemCapabilityManager.audioPassThruCapabilities).to(beNil());
+                expect(testSystemCapabilityManager.pcmStreamCapability).to(beNil());
+                expect(testSystemCapabilityManager.phoneCapability).to(beNil());
+                expect(testSystemCapabilityManager.navigationCapability).to(beNil());
+                expect(testSystemCapabilityManager.videoStreamingCapability).to(beNil());
+                expect(testSystemCapabilityManager.remoteControlCapability).to(beNil());
+                expect(testSystemCapabilityManager.appServicesCapabilities).to(beNil());
             });
         });
 
@@ -475,23 +491,35 @@ describe(@"System capability manager", ^{
                 expect(testSystemCapabilityManager.buttonCapabilities).to(equal(testButtonCapabilities));
                 expect(testSystemCapabilityManager.presetBankCapabilities).to(equal(testPresetBankCapabilities));
 #pragma clang diagnostic pop
+
+                expect(testSystemCapabilityManager.hmiCapabilities).to(beNil());
+                expect(testSystemCapabilityManager.hmiZoneCapabilities).to(beNil());
+                expect(testSystemCapabilityManager.speechCapabilities).to(beNil());
+                expect(testSystemCapabilityManager.prerecordedSpeechCapabilities).to(beNil());
+                expect(testSystemCapabilityManager.vrCapability).to(beFalse());
+                expect(testSystemCapabilityManager.audioPassThruCapabilities).to(beNil());
+                expect(testSystemCapabilityManager.pcmStreamCapability).to(beNil());
+                expect(testSystemCapabilityManager.phoneCapability).to(beNil());
+                expect(testSystemCapabilityManager.navigationCapability).to(beNil());
+                expect(testSystemCapabilityManager.videoStreamingCapability).to(beNil());
+                expect(testSystemCapabilityManager.remoteControlCapability).to(beNil());
+                expect(testSystemCapabilityManager.appServicesCapabilities).to(beNil());
             });
         });
 
-        afterEach(^{
-            // Make sure the other RAIR properties and system capabilities were not inadverdently set
-            expect(testSystemCapabilityManager.hmiCapabilities).to(beNil());
-            expect(testSystemCapabilityManager.hmiZoneCapabilities).to(beNil());
-            expect(testSystemCapabilityManager.speechCapabilities).to(beNil());
-            expect(testSystemCapabilityManager.prerecordedSpeechCapabilities).to(beNil());
-            expect(testSystemCapabilityManager.vrCapability).to(beFalse());
-            expect(testSystemCapabilityManager.audioPassThruCapabilities).to(beNil());
-            expect(testSystemCapabilityManager.pcmStreamCapability).to(beNil());
-            expect(testSystemCapabilityManager.phoneCapability).to(beNil());
-            expect(testSystemCapabilityManager.navigationCapability).to(beNil());
-            expect(testSystemCapabilityManager.videoStreamingCapability).to(beNil());
-            expect(testSystemCapabilityManager.remoteControlCapability).to(beNil());
-            expect(testSystemCapabilityManager.appServicesCapabilities).to(beNil());
+        describe(@"if the setdisplaylayout has nil displaycapabilities", ^{
+            beforeEach(^{
+                testSetDisplayLayoutResponse.success = @YES;
+                testSetDisplayLayoutResponse.displayCapabilities = nil;
+                SDLRPCResponseNotification *notification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveSetDisplayLayoutResponse object:self rpcResponse:testSetDisplayLayoutResponse];
+                [[NSNotificationCenter defaultCenter] postNotification:notification];
+            });
+
+            it(@"should should save the capabilities", ^{
+                // All the text fields and image fields should be available
+                expect(testSystemCapabilityManager.defaultMainWindowCapability.textFields).to(haveCount(29));
+                expect(testSystemCapabilityManager.defaultMainWindowCapability.imageFields).to(haveCount(14));
+            });
         });
     });
     


### PR DESCRIPTION
Fixes #1623 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
- Unit tests were updated to account for the changes to the screen manager sub-managers.
- Unit test was added to the SCM manager to ensure that all the text / image fields are available in the particular case.

#### Core Tests
- [x] Test that SetDisplayLayout works on Sync3
- [x] Test that Show works on Manticore

Core version / branch / commit hash / module tested against:
1. Sync 3, v3.4 19353_DEVTEST
2. Manticore (Core v6.0.1)

HMI name / version / branch / commit hash / module tested against:
1. Sync 3, v3.4 19353_DEVTEST
2. Manticore (Generic_HMI v0.7.2)

### Summary
This PR updates the SCM and screen sub-managers to better handle when `displayCapabilities == nil` to construct the `imageFields` and `textFields` to be fully capable. Then when `displayCapabilities.imageFields == nil` and `displayCapabilities.textFields == nil` while the `displayCapabilities` struct itself is not `nil`, then all `imageFields` and `textFields` are assumed to be unsupported.

### Changelog
##### Bug Fixes
* Fixed a case where when `displayCapabilities.imageFields` or `displayCapabilities.textFields` is `nil` intentionally, the head unit believes that everything is supported.

### Tasks Remaining:
- [x] Run and update unit tests
- [x] Add SCM unit tests
- [x] Test with Core

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
