### PR TITLE
Added empty check for menu cell voice commands array

### DIFF
--- a/SmartDeviceLink/SDLMenuCell.m
+++ b/SmartDeviceLink/SDLMenuCell.m
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     _title = title;
     _icon = icon;
-    _voiceCommands = voiceCommands;
+    _voiceCommands = ([voiceCommands count] == 0) ? nil : voiceCommands;
     _handler = handler;
 
     _cellId = UINT32_MAX;

--- a/SmartDeviceLink/SDLMenuCell.m
+++ b/SmartDeviceLink/SDLMenuCell.m
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     _title = title;
     _icon = icon;
-    _voiceCommands = ([voiceCommands count] == 0) ? nil : voiceCommands;
+    _voiceCommands = voiceCommands;
     _handler = handler;
 
     _cellId = UINT32_MAX;

--- a/SmartDeviceLink/SDLMenuManager.m
+++ b/SmartDeviceLink/SDLMenuManager.m
@@ -642,7 +642,7 @@ UInt32 const MenuCellIdMin = 1;
     params.position = @(position);
 
     command.menuParams = params;
-    command.vrCommands = cell.voiceCommands.count == 0 ? nil : cell.voiceCommands;
+    command.vrCommands = (cell.voiceCommands.count == 0) ? nil : cell.voiceCommands;
     command.cmdIcon = (cell.icon && shouldHaveArtwork) ? cell.icon.imageRPC : nil;
     command.cmdID = @(cell.cellId);
 

--- a/SmartDeviceLink/SDLMenuManager.m
+++ b/SmartDeviceLink/SDLMenuManager.m
@@ -642,7 +642,7 @@ UInt32 const MenuCellIdMin = 1;
     params.position = @(position);
 
     command.menuParams = params;
-    command.vrCommands = cell.voiceCommands;
+    command.vrCommands = cell.voiceCommands.count == 0 ? nil : cell.voiceCommands;
     command.cmdIcon = (cell.icon && shouldHaveArtwork) ? cell.icon.imageRPC : nil;
     command.cmdID = @(cell.cellId);
 


### PR DESCRIPTION
Fixes #1648 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests
1. Set the first `SDLMenuCell` in the SmartDeviceLink-Example-Swift app to have an empty `voiceCommands` array. 
2. Connect app to Core/Manticore
3. Observe that the `SDLMenuCell` appears in menu

Core version / branch / commit hash / module tested against: SYNC 3.0 Build 17276_DEVTEST
HMI name / version / branch / commit hash / module tested against: Manticore v0.7.2

### Summary
Added empty check to `SDLMenuCell.m` for the `voiceCommands` being passed in. If the array is empty, the `voiceCommands` will be set to nil.

### Changelog
##### Bug Fixes
* Fixes `SDLMenuCell` being rejected due to empty `voiceCommands` array.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
