### PR TITLE
Bugfix/issue 1667 permission manager method alignment

### DIFF
--- a/Example Apps/Example ObjC/RPCPermissionsManager.m
+++ b/Example Apps/Example ObjC/RPCPermissionsManager.m
@@ -61,7 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @return         True if the RPC can be sent to Core right now, false if not
  */
 + (BOOL)sdlex_checkCurrentPermissionWithManager:(SDLManager *)manager rpcName:(SDLRPCFunctionName)rpcName {
-    BOOL isRPCAllowed = [manager.permissionManager isRPCPermitted:rpcName];
+    BOOL isRPCAllowed = [manager.permissionManager isRPCNameAllowed:rpcName];
     [self sdlex_logRPCPermission:rpcName isRPCAllowed:isRPCAllowed];
     return isRPCAllowed;
 }
@@ -75,7 +75,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (SDLPermissionGroupStatus)sdlex_checkCurrentGroupPermissionsWithManager:(SDLManager *)manager rpcNames:(NSArray<SDLRPCFunctionName> *)rpcNames {
     SDLPermissionGroupStatus groupPermissionStatus = [manager.permissionManager groupStatusOfRPCNames:rpcNames];
-    NSDictionary<NSString *, NSNumber *> *individualPermissionStatuses = [manager.permissionManager statusOfRPCNames:rpcNames];
+    NSDictionary<NSString *, NSNumber *> *individualPermissionStatuses = [manager.permissionManager statusesOfRPCNames:rpcNames];
     [self sdlex_logRPCGroupPermissions:rpcNames groupPermissionStatus:groupPermissionStatus individualPermissionStatuses:individualPermissionStatuses];
     return groupPermissionStatus;
 }
@@ -91,7 +91,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @return             A unique identifier for the subscription. This can be used to later to unsubscribe from the notifications.
  */
 + (SDLPermissionObserverIdentifier)sdlex_subscribeGroupPermissionsWithManager:(SDLManager *)manager rpcNames:(NSArray<SDLRPCFunctionName> *)rpcNames groupType:(SDLPermissionGroupType)groupType {
-    SDLPermissionObserverIdentifier observerId = [manager.permissionManager subscribeToRPCs:rpcNames groupType:groupType withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber<SDLBool> *> * _Nonnull change, SDLPermissionGroupStatus status) {
+    SDLPermissionObserverIdentifier observerId = [manager.permissionManager subscribeToRPCNames:rpcNames groupType:groupType withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber<SDLBool> *> * _Nonnull change, SDLPermissionGroupStatus status) {
         [self sdlex_logRPCGroupPermissions:rpcNames groupPermissionStatus:status individualPermissionStatuses:change];
     }];
     return observerId;

--- a/Example Apps/Example ObjC/RPCPermissionsManager.m
+++ b/Example Apps/Example ObjC/RPCPermissionsManager.m
@@ -24,11 +24,11 @@ NS_ASSUME_NONNULL_BEGIN
     [self sdlex_checkCurrentPermissionWithManager:manager rpcName:showRPCName];
 
     // Checks if all the RPCs need to create menus are allowed right at this moment
-    NSArray<NSString *> *menuRPCNames = @[@"AddCommand", @"CreateInteractionChoiceSet", @"PerformInteraction"];
+    NSArray<SDLRPCFunctionName> *menuRPCNames = @[SDLRPCFunctionNameAddCommand, SDLRPCFunctionNameCreateInteractionChoiceSet, SDLRPCFunctionNamePerformInteraction];
     [self sdlex_checkCurrentGroupPermissionsWithManager:manager rpcNames:menuRPCNames];
 
     // Set up an observer for permissions changes to media template releated RPCs. Since the `groupType` is set to all allowed, this block is called when the group permissions changes from all allowed. This block is called immediately when created.
-    NSArray<NSString *> *mediaTemplateRPCs = @[@"SetMediaClockTimer", @"SubscribeButton"];
+    NSArray<SDLRPCFunctionName> *mediaTemplateRPCs = @[SDLRPCFunctionNameSetMediaClockTimer, SDLRPCFunctionNameSubscribeButton];
     SDLPermissionObserverIdentifier allAllowedObserverId = [self sdlex_subscribeGroupPermissionsWithManager:manager rpcNames:mediaTemplateRPCs groupType:SDLPermissionGroupTypeAllAllowed];
 
     // Stop observing permissions changes for the media template releated RPCs
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (BOOL)isDialNumberRPCAllowedWithManager:(SDLManager *)manager {
     SDLLogD(@"Checking if app has permission to dial a number");
-    return [self sdlex_checkCurrentPermissionWithManager:manager rpcName:@"DialNumber"];
+    return [self sdlex_checkCurrentPermissionWithManager:manager rpcName:SDLRPCFunctionNameDialNumber];
 }
 
 #pragma mark - Check Permissions
@@ -60,8 +60,8 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param rpcName  The name of the RPC
  *  @return         True if the RPC can be sent to Core right now, false if not
  */
-+ (BOOL)sdlex_checkCurrentPermissionWithManager:(SDLManager *)manager rpcName:(NSString *)rpcName {
-    BOOL isRPCAllowed = [manager.permissionManager isRPCAllowed:rpcName];
++ (BOOL)sdlex_checkCurrentPermissionWithManager:(SDLManager *)manager rpcName:(SDLRPCFunctionName)rpcName {
+    BOOL isRPCAllowed = [manager.permissionManager isRPCPermitted:rpcName];
     [self sdlex_logRPCPermission:rpcName isRPCAllowed:isRPCAllowed];
     return isRPCAllowed;
 }
@@ -73,9 +73,9 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param rpcNames The names of the RPCs
  *  @return         The current permission status for all the RPCs in the group
  */
-+ (SDLPermissionGroupStatus)sdlex_checkCurrentGroupPermissionsWithManager:(SDLManager *)manager rpcNames:(NSArray<NSString *> *)rpcNames {
-    SDLPermissionGroupStatus groupPermissionStatus = [manager.permissionManager groupStatusOfRPCs:rpcNames];
-    NSDictionary<NSString *, NSNumber *> *individualPermissionStatuses = [manager.permissionManager statusOfRPCs:rpcNames];
++ (SDLPermissionGroupStatus)sdlex_checkCurrentGroupPermissionsWithManager:(SDLManager *)manager rpcNames:(NSArray<SDLRPCFunctionName> *)rpcNames {
+    SDLPermissionGroupStatus groupPermissionStatus = [manager.permissionManager groupStatusOfRPCNames:rpcNames];
+    NSDictionary<NSString *, NSNumber *> *individualPermissionStatuses = [manager.permissionManager statusOfRPCNames:rpcNames];
     [self sdlex_logRPCGroupPermissions:rpcNames groupPermissionStatus:groupPermissionStatus individualPermissionStatuses:individualPermissionStatuses];
     return groupPermissionStatus;
 }
@@ -90,8 +90,8 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param groupType    The type of changes you want to be notified about for the group
  *  @return             A unique identifier for the subscription. This can be used to later to unsubscribe from the notifications.
  */
-+ (SDLPermissionObserverIdentifier)sdlex_subscribeGroupPermissionsWithManager:(SDLManager *)manager rpcNames:(NSArray<NSString *> *)rpcNames groupType:(SDLPermissionGroupType)groupType {
-    SDLPermissionObserverIdentifier observerId = [manager.permissionManager addObserverForRPCs:rpcNames groupType:groupType withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber<SDLBool> *> * _Nonnull change, SDLPermissionGroupStatus status) {
++ (SDLPermissionObserverIdentifier)sdlex_subscribeGroupPermissionsWithManager:(SDLManager *)manager rpcNames:(NSArray<SDLRPCFunctionName> *)rpcNames groupType:(SDLPermissionGroupType)groupType {
+    SDLPermissionObserverIdentifier observerId = [manager.permissionManager subscribeToRPCs:rpcNames groupType:groupType withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber<SDLBool> *> * _Nonnull change, SDLPermissionGroupStatus status) {
         [self sdlex_logRPCGroupPermissions:rpcNames groupPermissionStatus:status individualPermissionStatuses:change];
     }];
     return observerId;

--- a/Example Apps/Example ObjC/VehicleDataManager.m
+++ b/Example Apps/Example ObjC/VehicleDataManager.m
@@ -137,7 +137,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (void)getAllVehicleDataWithManager:(SDLManager *)manager triggerSource:(SDLTriggerSource)triggerSource vehicleDataType:(NSString *)vehicleDataType {
     SDLLogD(@"Checking if app has permission to access vehicle data...");
-    if (![manager.permissionManager isRPCPermitted:SDLRPCFunctionNameGetVehicleData]) {
+    if (![manager.permissionManager isRPCNameAllowed:SDLRPCFunctionNameGetVehicleData]) {
         [manager sendRequest:[AlertManager alertWithMessageAndCloseButton:@"This app does not have the required permissions to access vehicle data" textField2:nil iconName:nil]];
         return;
     }

--- a/Example Apps/Example ObjC/VehicleDataManager.m
+++ b/Example Apps/Example ObjC/VehicleDataManager.m
@@ -8,6 +8,7 @@
 
 #import "AlertManager.h"
 #import "AppConstants.h"
+#import "SDLRPCFunctionNames.h"
 #import "SmartDeviceLink.h"
 #import "TextValidator.h"
 #import "VehicleDataManager.h"
@@ -136,7 +137,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (void)getAllVehicleDataWithManager:(SDLManager *)manager triggerSource:(SDLTriggerSource)triggerSource vehicleDataType:(NSString *)vehicleDataType {
     SDLLogD(@"Checking if app has permission to access vehicle data...");
-    if (![manager.permissionManager isRPCAllowed:@"GetVehicleData"]) {
+    if (![manager.permissionManager isRPCPermitted:SDLRPCFunctionNameGetVehicleData]) {
         [manager sendRequest:[AlertManager alertWithMessageAndCloseButton:@"This app does not have the required permissions to access vehicle data" textField2:nil iconName:nil]];
         return;
     }

--- a/Example Apps/Example Swift/ProxyManager.swift
+++ b/Example Apps/Example Swift/ProxyManager.swift
@@ -139,16 +139,7 @@ private extension ProxyManager {
             self.vehicleDataManager = VehicleDataManager(sdlManager: self.sdlManager, refreshUIHandler: self.refreshUIHandler)
             self.performInteractionManager = PerformInteractionManager(sdlManager: self.sdlManager)
 
-//            RPCPermissionsManager.setupPermissionsCallbacks(with: self.sdlManager)
-            let permissionsManager = self.sdlManager.permissionManager
-//            permissionsManager.subscribe(toRPCs: [SDLRPCFunctionName.addCommand], groupType: .allAllowed) { (dict, status) in
-//                print("SUBSCRIBE TO RPCS CALLED")
-//            }
-
-            permissionsManager.addObserver(forRPCs: ["PerformInteraction"], groupType: .allAllowed) { (dict, status) in
-                print("AddOBSERVER TO RPCS CALLED")
-                print("STATUS IS \(dict["PerformInteraction"])")
-            }
+            RPCPermissionsManager.setupPermissionsCallbacks(with: self.sdlManager)
 
             SDLLog.d("SDL file manager storage: \(self.sdlManager.fileManager.bytesAvailable / 1024 / 1024) mb")
         })

--- a/Example Apps/Example Swift/ProxyManager.swift
+++ b/Example Apps/Example Swift/ProxyManager.swift
@@ -139,7 +139,16 @@ private extension ProxyManager {
             self.vehicleDataManager = VehicleDataManager(sdlManager: self.sdlManager, refreshUIHandler: self.refreshUIHandler)
             self.performInteractionManager = PerformInteractionManager(sdlManager: self.sdlManager)
 
-            RPCPermissionsManager.setupPermissionsCallbacks(with: self.sdlManager)
+//            RPCPermissionsManager.setupPermissionsCallbacks(with: self.sdlManager)
+            let permissionsManager = self.sdlManager.permissionManager
+//            permissionsManager.subscribe(toRPCs: [SDLRPCFunctionName.addCommand], groupType: .allAllowed) { (dict, status) in
+//                print("SUBSCRIBE TO RPCS CALLED")
+//            }
+
+            permissionsManager.addObserver(forRPCs: ["PerformInteraction"], groupType: .allAllowed) { (dict, status) in
+                print("AddOBSERVER TO RPCS CALLED")
+                print("STATUS IS \(dict["PerformInteraction"])")
+            }
 
             SDLLog.d("SDL file manager storage: \(self.sdlManager.fileManager.bytesAvailable / 1024 / 1024) mb")
         })

--- a/Example Apps/Example Swift/RPCPermissionsManager.swift
+++ b/Example Apps/Example Swift/RPCPermissionsManager.swift
@@ -16,15 +16,15 @@ class RPCPermissionsManager {
     /// - Parameter manager: The SDL Manager
     class func setupPermissionsCallbacks(with manager: SDLManager) {
         // Checks if the `SDLShow` RPC is allowed right at this moment
-        let showRPCName = "Show"
+        let showRPCName = SDLRPCFunctionName.show
         _ = checkCurrentPermission(with: manager, rpcName: showRPCName)
 
         // Checks if all the RPCs need to create menus are allowed right at this moment
-        let menuRPCNames = ["AddCommand", "CreateInteractionChoiceSet", "PerformInteraction"]
+        let menuRPCNames = [SDLRPCFunctionName.addCommand, SDLRPCFunctionName.createInteractionChoiceSet, SDLRPCFunctionName.performInteraction]
         _ = checkCurrentGroupPermissions(with: manager, rpcNames: menuRPCNames)
 
         // Set up an observer for permissions changes to media template releated RPCs. Since the `groupType` is set to all allowed, this block is called when the group permissions changes from all allowed. This block is called immediately when created.
-        let mediaTemplateRPCs = ["SetMediaClockTimer", "SubscribeButton"]
+        let mediaTemplateRPCs = [SDLRPCFunctionName.setMediaClockTimer, SDLRPCFunctionName.subscribeButton]
         let allAllowedObserverId = subscribeGroupPermissions(with: manager, rpcNames: mediaTemplateRPCs, groupType: .allAllowed)
 
         // Stop observing permissions changes for the media template releated RPCs
@@ -40,7 +40,7 @@ class RPCPermissionsManager {
     /// - Returns: True if allowed, false if not
     class func isDialNumberRPCAllowed(with manager: SDLManager) -> Bool {
         SDLLog.d("Checking if app has permission to dial a number")
-        return checkCurrentPermission(with: manager, rpcName: "DialNumber")
+        return checkCurrentPermission(with: manager, rpcName: SDLRPCFunctionName.dialNumber)
     }
 }
 
@@ -51,8 +51,8 @@ private extension RPCPermissionsManager {
     ///
     /// - Parameter manager: The SDL Manager
     /// - Returns: true if allowed, false if not
-    class func checkCurrentPermission(with manager: SDLManager, rpcName: String) -> Bool {
-        let isRPCAllowed = manager.permissionManager.isRPCAllowed(rpcName)
+    class func checkCurrentPermission(with manager: SDLManager, rpcName: SDLRPCFunctionName) -> Bool {
+        let isRPCAllowed = manager.permissionManager.isRPCPermitted(rpcName)
         logRPCPermission(rpcName: rpcName, isRPCAllowed: isRPCAllowed)
         return isRPCAllowed
     }
@@ -61,9 +61,9 @@ private extension RPCPermissionsManager {
     ///
     /// - Parameter manager: The SDL Manager
     /// - Returns: The rpc names, the group permission status and the permission status for each rpc in the group
-    class func checkCurrentGroupPermissions(with manager: SDLManager, rpcNames: [String]) -> SDLPermissionGroupStatus {
-        let groupPermissionStatus = manager.permissionManager.groupStatus(ofRPCs: rpcNames)
-        let individualPermissionStatuses = manager.permissionManager.status(ofRPCs: rpcNames)
+    class func checkCurrentGroupPermissions(with manager: SDLManager, rpcNames: [SDLRPCFunctionName]) -> SDLPermissionGroupStatus {
+        let groupPermissionStatus = manager.permissionManager.groupStatus(ofRPCNames: rpcNames)
+        let individualPermissionStatuses = manager.permissionManager.status(ofRPCNames: rpcNames)
         logRPCGroupPermissions(rpcNames: rpcNames, groupPermissionStatus: groupPermissionStatus, individualPermissionStatuses: individualPermissionStatuses)
         return groupPermissionStatus
     }
@@ -74,8 +74,8 @@ private extension RPCPermissionsManager {
     ///   - manager: The SDL Manager
     ///   - groupType: The type of changes to get notified about
     /// - Returns: A unique id assigned to observer. Use the id to unsubscribe to notifications
-    class func subscribeGroupPermissions(with manager: SDLManager, rpcNames: [String], groupType: SDLPermissionGroupType) -> UUID {
-        let permissionAllAllowedObserverId = manager.permissionManager.addObserver(forRPCs: rpcNames, groupType: groupType, withHandler: { (individualStatuses, groupStatus) in
+    class func subscribeGroupPermissions(with manager: SDLManager, rpcNames: [SDLRPCFunctionName], groupType: SDLPermissionGroupType) -> UUID {
+        let permissionAllAllowedObserverId = manager.permissionManager.subscribe(toRPCs: rpcNames, groupType: groupType, withHandler: { (individualStatuses, groupStatus) in
             self.logRPCGroupPermissions(rpcNames: rpcNames, groupPermissionStatus: groupStatus, individualPermissionStatuses: individualStatuses)
         })
 
@@ -100,7 +100,7 @@ private extension RPCPermissionsManager {
     /// - Parameters:
     ///   - rpcName: The name of the RPC
     ///   - isRPCAllowed: The permission status for the RPC
-    class func logRPCPermission(rpcName: String, isRPCAllowed: Bool) {
+    class func logRPCPermission(rpcName: SDLRPCFunctionName, isRPCAllowed: Bool) {
         SDLLog.d("\(rpcName) RPC can be sent to SDL Core? \(isRPCAllowed ? "yes" : "no")")
     }
 
@@ -110,10 +110,10 @@ private extension RPCPermissionsManager {
     ///   - rpcNames: The names of the RPCs
     ///   - groupPermissionStatus: The permission status for all RPCs in the group
     ///   - individualPermissionStatuses: The permission status for each of the RPCs in the group
-    class func logRPCGroupPermissions(rpcNames: [String], groupPermissionStatus: SDLPermissionGroupStatus, individualPermissionStatuses: [String:NSNumber]) {
+    class func logRPCGroupPermissions(rpcNames: [SDLRPCFunctionName], groupPermissionStatus: SDLPermissionGroupStatus, individualPermissionStatuses: [SDLRPCFunctionName:NSNumber]) {
         SDLLog.d("The group status for \(rpcNames) has changed to: \(groupPermissionStatus)")
         for (rpcName, rpcAllowed) in individualPermissionStatuses {
-            logRPCPermission(rpcName: rpcName as String, isRPCAllowed: rpcAllowed.boolValue)
+            logRPCPermission(rpcName: rpcName, isRPCAllowed: rpcAllowed.boolValue)
         }
     }
 }

--- a/Example Apps/Example Swift/RPCPermissionsManager.swift
+++ b/Example Apps/Example Swift/RPCPermissionsManager.swift
@@ -101,7 +101,7 @@ private extension RPCPermissionsManager {
     ///   - rpcName: The name of the RPC
     ///   - isRPCAllowed: The permission status for the RPC
     class func logRPCPermission(rpcName: SDLRPCFunctionName, isRPCAllowed: Bool) {
-        SDLLog.d("\(rpcName) RPC can be sent to SDL Core? \(isRPCAllowed ? "yes" : "no")")
+        SDLLog.d("\(rpcName.rawValue.rawValue) RPC can be sent to SDL Core? \(isRPCAllowed ? "yes" : "no")")
     }
 
     /// Logs permissions for a group of RPCs
@@ -111,7 +111,7 @@ private extension RPCPermissionsManager {
     ///   - groupPermissionStatus: The permission status for all RPCs in the group
     ///   - individualPermissionStatuses: The permission status for each of the RPCs in the group
     class func logRPCGroupPermissions(rpcNames: [SDLRPCFunctionName], groupPermissionStatus: SDLPermissionGroupStatus, individualPermissionStatuses: [SDLRPCFunctionName:NSNumber]) {
-        SDLLog.d("The group status for \(rpcNames) has changed to: \(groupPermissionStatus)")
+        SDLLog.d("The group status for \(rpcNames.map { $0.rawValue.rawValue } ) has changed to: \(groupPermissionStatus.rawValue)")
         for (rpcName, rpcAllowed) in individualPermissionStatuses {
             logRPCPermission(rpcName: rpcName, isRPCAllowed: rpcAllowed.boolValue)
         }

--- a/Example Apps/Example Swift/RPCPermissionsManager.swift
+++ b/Example Apps/Example Swift/RPCPermissionsManager.swift
@@ -52,7 +52,7 @@ private extension RPCPermissionsManager {
     /// - Parameter manager: The SDL Manager
     /// - Returns: true if allowed, false if not
     class func checkCurrentPermission(with manager: SDLManager, rpcName: SDLRPCFunctionName) -> Bool {
-        let isRPCAllowed = manager.permissionManager.isRPCPermitted(rpcName)
+        let isRPCAllowed = manager.permissionManager.isRPCNameAllowed(rpcName)
         logRPCPermission(rpcName: rpcName, isRPCAllowed: isRPCAllowed)
         return isRPCAllowed
     }
@@ -63,7 +63,7 @@ private extension RPCPermissionsManager {
     /// - Returns: The rpc names, the group permission status and the permission status for each rpc in the group
     class func checkCurrentGroupPermissions(with manager: SDLManager, rpcNames: [SDLRPCFunctionName]) -> SDLPermissionGroupStatus {
         let groupPermissionStatus = manager.permissionManager.groupStatus(ofRPCNames: rpcNames)
-        let individualPermissionStatuses = manager.permissionManager.status(ofRPCNames: rpcNames)
+        let individualPermissionStatuses = manager.permissionManager.statuses(ofRPCNames: rpcNames)
         logRPCGroupPermissions(rpcNames: rpcNames, groupPermissionStatus: groupPermissionStatus, individualPermissionStatuses: individualPermissionStatuses)
         return groupPermissionStatus
     }
@@ -75,7 +75,7 @@ private extension RPCPermissionsManager {
     ///   - groupType: The type of changes to get notified about
     /// - Returns: A unique id assigned to observer. Use the id to unsubscribe to notifications
     class func subscribeGroupPermissions(with manager: SDLManager, rpcNames: [SDLRPCFunctionName], groupType: SDLPermissionGroupType) -> UUID {
-        let permissionAllAllowedObserverId = manager.permissionManager.subscribe(toRPCs: rpcNames, groupType: groupType, withHandler: { (individualStatuses, groupStatus) in
+        let permissionAllAllowedObserverId = manager.permissionManager.subscribe(toRPCNames: rpcNames, groupType: groupType, withHandler: { (individualStatuses, groupStatus) in
             self.logRPCGroupPermissions(rpcNames: rpcNames, groupPermissionStatus: groupStatus, individualPermissionStatuses: individualStatuses)
         })
 

--- a/Example Apps/Example Swift/VehicleDataManager.swift
+++ b/Example Apps/Example Swift/VehicleDataManager.swift
@@ -232,7 +232,7 @@ extension VehicleDataManager {
     class func hasPermissionToAccessVehicleData(with manager: SDLManager) -> Bool {
         SDLLog.d("Checking if app has permission to access vehicle data...")
 
-        guard manager.permissionManager.isRPCPermitted(SDLRPCFunctionName.getVehicleData) else {
+        guard manager.permissionManager.isRPCNameAllowed(SDLRPCFunctionName.getVehicleData) else {
             let alert = AlertManager.alertWithMessageAndCloseButton("This app does not have the required permissions to access vehicle data")
             manager.send(request: alert)
             return false

--- a/Example Apps/Example Swift/VehicleDataManager.swift
+++ b/Example Apps/Example Swift/VehicleDataManager.swift
@@ -232,7 +232,7 @@ extension VehicleDataManager {
     class func hasPermissionToAccessVehicleData(with manager: SDLManager) -> Bool {
         SDLLog.d("Checking if app has permission to access vehicle data...")
 
-        guard manager.permissionManager.isRPCAllowed("GetVehicleData") else {
+        guard manager.permissionManager.isRPCPermitted(SDLRPCFunctionName.getVehicleData) else {
             let alert = AlertManager.alertWithMessageAndCloseButton("This app does not have the required permissions to access vehicle data")
             manager.send(request: alert)
             return false

--- a/SmartDeviceLink/SDLPermissionConstants.h
+++ b/SmartDeviceLink/SDLPermissionConstants.h
@@ -70,9 +70,9 @@ typedef void (^SDLPermissionsChangedHandler)(NSDictionary<SDLPermissionRPCName, 
 /**
 *  The SDLObservedPermissionsChangedHandler is a block that is passed in to subscribeToRPCs:groupType:withHandler: that will be stored and called when specified permissions change.
 *
-*  @param change  A dictionary of permission changes containing <key(SDLRPCFunctionName): RPC Name, object(BOOL): YES if the RPC is allowed, NO if it is not allowed>
-*  @param status       The change made to all of the RPCs in the changedDict. Allowed, if all RPCs are now allowed, Disallowed if all RPCs are now disallowed, or Mixed if some are allowed, and some are disallowed
+*  @param change A dictionary of permission changes containing <key(SDLRPCFunctionName): RPC Name, object(BOOL): YES if the RPC is allowed, NO if it is not allowed>
+*  @param status The change made to all of the RPCs in the changedDict. Allowed, if all RPCs are now allowed, Disallowed if all RPCs are now disallowed, or Mixed if some are allowed, and some are disallowed
 */
-typedef void (^SDLObservedPermissionsChangedHandler)(NSDictionary<SDLRPCFunctionName, NSNumber *> *_Nonnull change, SDLPermissionGroupStatus status);
+typedef void (^SDLSubscribedPermissionsChangedHandler)(NSDictionary<SDLRPCFunctionName, NSNumber *> *_Nonnull change, SDLPermissionGroupStatus status);
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLPermissionConstants.h
+++ b/SmartDeviceLink/SDLPermissionConstants.h
@@ -68,11 +68,11 @@ typedef NS_ENUM(NSUInteger, SDLPermissionGroupStatus) {
 typedef void (^SDLPermissionsChangedHandler)(NSDictionary<SDLPermissionRPCName, NSNumber *> *_Nonnull change, SDLPermissionGroupStatus status);
 
 /**
-*  The SDLObeservedPermissionsChangedHandler is a block that is passed in to subscribeToRPCs:groupType:withHandler: that will be stored and called when specified permissions change.
+*  The SDLObservedPermissionsChangedHandler is a block that is passed in to subscribeToRPCs:groupType:withHandler: that will be stored and called when specified permissions change.
 *
 *  @param change  A dictionary of permission changes containing <key(SDLRPCFunctionName): RPC Name, object(BOOL): YES if the RPC is allowed, NO if it is not allowed>
 *  @param status       The change made to all of the RPCs in the changedDict. Allowed, if all RPCs are now allowed, Disallowed if all RPCs are now disallowed, or Mixed if some are allowed, and some are disallowed
 */
-typedef void (^SDLObeservedPermissionsChangedHandler)(NSDictionary<SDLRPCFunctionName, NSNumber *> *_Nonnull change, SDLPermissionGroupStatus status);
+typedef void (^SDLObservedPermissionsChangedHandler)(NSDictionary<SDLRPCFunctionName, NSNumber *> *_Nonnull change, SDLPermissionGroupStatus status);
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLPermissionConstants.h
+++ b/SmartDeviceLink/SDLPermissionConstants.h
@@ -68,11 +68,11 @@ typedef NS_ENUM(NSUInteger, SDLPermissionGroupStatus) {
 typedef void (^SDLPermissionsChangedHandler)(NSDictionary<SDLPermissionRPCName, NSNumber *> *_Nonnull change, SDLPermissionGroupStatus status);
 
 /**
-*  The SDLObservedPermissionsChangedHandler is a block that is passed in to subscribeToRPCNames:groupType:withHandler: that will be stored and called when specified permissions change.
-*
-*  @param change A dictionary of permission changes containing <key(SDLRPCFunctionName): RPC Name, object(BOOL): YES if the RPC is allowed, NO if it is not allowed>
-*  @param status The change made to all of the RPCs in the changedDict. Allowed, if all RPCs are now allowed, Disallowed if all RPCs are now disallowed, or Mixed if some are allowed, and some are disallowed
-*/
+ *  The SDLObservedPermissionsChangedHandler is a block that is passed in to subscribeToRPCNames:groupType:withHandler: that will be stored and called when specified permissions change.
+ *
+ *  @param change A dictionary of permission changes containing <key(SDLRPCFunctionName): RPC Name, object(BOOL): YES if the RPC is allowed, NO if it is not allowed>
+ *  @param status The change made to all of the RPCs in the changedDict. Allowed, if all RPCs are now allowed, Disallowed if all RPCs are now disallowed, or Mixed if some are allowed, and some are disallowed
+ */
 typedef void (^SDLSubscribedPermissionsChangedHandler)(NSDictionary<SDLRPCFunctionName, NSNumber *> *_Nonnull change, SDLPermissionGroupStatus status);
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLPermissionConstants.h
+++ b/SmartDeviceLink/SDLPermissionConstants.h
@@ -68,7 +68,7 @@ typedef NS_ENUM(NSUInteger, SDLPermissionGroupStatus) {
 typedef void (^SDLPermissionsChangedHandler)(NSDictionary<SDLPermissionRPCName, NSNumber *> *_Nonnull change, SDLPermissionGroupStatus status);
 
 /**
-*  The SDLObservedPermissionsChangedHandler is a block that is passed in to subscribeToRPCs:groupType:withHandler: that will be stored and called when specified permissions change.
+*  The SDLObservedPermissionsChangedHandler is a block that is passed in to subscribeToRPCNames:groupType:withHandler: that will be stored and called when specified permissions change.
 *
 *  @param change A dictionary of permission changes containing <key(SDLRPCFunctionName): RPC Name, object(BOOL): YES if the RPC is allowed, NO if it is not allowed>
 *  @param status The change made to all of the RPCs in the changedDict. Allowed, if all RPCs are now allowed, Disallowed if all RPCs are now disallowed, or Mixed if some are allowed, and some are disallowed

--- a/SmartDeviceLink/SDLPermissionConstants.h
+++ b/SmartDeviceLink/SDLPermissionConstants.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 
 #import "NSNumber+NumberType.h"
+#import "SDLRPCFunctionNames.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -65,5 +66,13 @@ typedef NS_ENUM(NSUInteger, SDLPermissionGroupStatus) {
  *  @param status       The change made to all of the RPCs in the changedDict. Allowed, if all RPCs are now allowed, Disallowed if all RPCs are now disallowed, or Mixed if some are allowed, and some are disallowed
  */
 typedef void (^SDLPermissionsChangedHandler)(NSDictionary<SDLPermissionRPCName, NSNumber *> *_Nonnull change, SDLPermissionGroupStatus status);
+
+/**
+*  The SDLObeservedPermissionsChangedHandler is a block that is passed in to subscribeToRPCs:groupType:withHandler: that will be stored and called when specified permissions change.
+*
+*  @param change  A dictionary of permission changes containing <key(SDLRPCFunctionName): RPC Name, object(BOOL): YES if the RPC is allowed, NO if it is not allowed>
+*  @param status       The change made to all of the RPCs in the changedDict. Allowed, if all RPCs are now allowed, Disallowed if all RPCs are now disallowed, or Mixed if some are allowed, and some are disallowed
+*/
+typedef void (^SDLObeservedPermissionsChangedHandler)(NSDictionary<SDLRPCFunctionName, NSNumber *> *_Nonnull change, SDLPermissionGroupStatus status);
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLPermissionManager.h
+++ b/SmartDeviceLink/SDLPermissionManager.h
@@ -49,11 +49,11 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Determine if an individual RPC is allowed for the current HMI level
  *
- * @param rpcName  The name of the RPC to be tested, for example, SDLRPCFunctionNameShow
+ * @param rpcName The name of the RPC to be tested, for example, SDLRPCFunctionNameShow
  *
  * @return YES if the RPC is allowed at the current HMI level, NO if not
  */
-- (BOOL)isRPCPermitted:(SDLRPCFunctionName)rpcName;
+- (BOOL)isRPCNameAllowed:(SDLRPCFunctionName)rpcName;
 
 /**
  *  Determine if all RPCs are allowed for the current HMI level
@@ -89,7 +89,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A dictionary specifying if the passed in RPC names are currently allowed or not
 */
-- (NSDictionary<SDLRPCFunctionName, NSNumber *> *)statusOfRPCNames:(NSArray<SDLRPCFunctionName> *)rpcNames;
+- (NSDictionary<SDLRPCFunctionName, NSNumber *> *)statusesOfRPCNames:(NSArray<SDLRPCFunctionName> *)rpcNames;
 
 /**
  *  Add an observer for specified RPC names, with a callback that will be called whenever the value changes, as well as immediately with the current status.
@@ -109,8 +109,6 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Subscribe to specified RPC names, with a callback that will be called whenever the value changes. Unlike addObserverForRPCs:groupType:withHandler:, the callback will not return immediately with the current status and will wait for the permissions changes specified in the groupType param.
  *
- *  @warning This block will be captured by the SDLPermissionsManager, be sure to use [weakself/strongself](http://www.logicsector.com/ios/avoiding-objc-retain-cycles-with-weakself-and-strongself-the-easy-way/) if you are referencing self within your observer block.
- *
  *  @warning The observer may be called before this method returns, do not attempt to remove the observer from within the observer. That could send `nil` to removeObserverForIdentifier:. If you want functionality like that, call groupStatusOfRPCs: instead.
  *
  *  @param rpcNames The RPCs to be observed
@@ -119,7 +117,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @return An identifier that can be passed to removeObserverForIdentifer: to remove the observer
  */
-- (SDLPermissionObserverIdentifier)subscribeToRPCs:(NSArray<SDLRPCFunctionName> *)rpcNames groupType:(SDLPermissionGroupType)groupType withHandler:(SDLObservedPermissionsChangedHandler)handler;
+- (SDLPermissionObserverIdentifier)subscribeToRPCNames:(NSArray<SDLRPCFunctionName> *)rpcNames groupType:(SDLPermissionGroupType)groupType withHandler:(SDLObservedPermissionsChangedHandler)handler;
 
 /**
  *  Remove every current observer

--- a/SmartDeviceLink/SDLPermissionManager.h
+++ b/SmartDeviceLink/SDLPermissionManager.h
@@ -119,7 +119,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @return An identifier that can be passed to removeObserverForIdentifer: to remove the observer
  */
-- (SDLPermissionObserverIdentifier)subscribeToRPCs:(NSArray<SDLRPCFunctionName> *)rpcNames groupType:(SDLPermissionGroupType)groupType withHandler:(SDLObeservedPermissionsChangedHandler)handler;
+- (SDLPermissionObserverIdentifier)subscribeToRPCs:(NSArray<SDLRPCFunctionName> *)rpcNames groupType:(SDLPermissionGroupType)groupType withHandler:(SDLObservedPermissionsChangedHandler)handler;
 
 /**
  *  Remove every current observer

--- a/SmartDeviceLink/SDLPermissionManager.h
+++ b/SmartDeviceLink/SDLPermissionManager.h
@@ -53,7 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
 *
 *  @return YES if the RPC is allowed at the current HMI level, NO if not
 */
-- (BOOL)isRPCNameAllowed:(SDLRPCFunctionName)rpcName;
+- (BOOL)isRPCPermitted:(SDLRPCFunctionName)rpcName;
 
 /**
  *  Determine if all RPCs are allowed for the current HMI level

--- a/SmartDeviceLink/SDLPermissionManager.h
+++ b/SmartDeviceLink/SDLPermissionManager.h
@@ -10,6 +10,7 @@
 
 #import "SDLHMILevel.h"
 #import "SDLPermissionConstants.h"
+#import "SDLRPCFunctionNames.h"
 
 @class SDLPermissionItem;
 @class SDLRPCMessage;
@@ -43,7 +44,16 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @return YES if the RPC is allowed at the current HMI level, NO if not
  */
-- (BOOL)isRPCAllowed:(SDLPermissionRPCName)rpcName;
+- (BOOL)isRPCAllowed:(SDLPermissionRPCName)rpcName __deprecated_msg(("Use isRPCNameAllowed: instead"));
+
+/**
+*  Determine if an individual RPC is allowed for the current HMI level
+*
+*  @param rpcName  The name of the RPC to be tested, for example, SDLShow
+*
+*  @return YES if the RPC is allowed at the current HMI level, NO if not
+*/
+- (BOOL)isRPCNameAllowed:(SDLRPCFunctionName)rpcName;
 
 /**
  *  Determine if all RPCs are allowed for the current HMI level
@@ -52,7 +62,16 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @return AllAllowed if all of the permissions are allowed, AllDisallowed if all the permissions are disallowed, Any if some are allowed, and some are disallowed
  */
-- (SDLPermissionGroupStatus)groupStatusOfRPCs:(NSArray<SDLPermissionRPCName> *)rpcNames;
+- (SDLPermissionGroupStatus)groupStatusOfRPCs:(NSArray<SDLPermissionRPCName> *)rpcNames __deprecated_msg(("Use groupStatusOfRPCNames: instead"));
+
+/**
+*  Determine if all RPCs are allowed for the current HMI level
+*
+*  @param rpcNames The RPCs to check
+*
+*  @return AllAllowed if all of the permissions are allowed, AllDisallowed if all the permissions are disallowed, Any if some are allowed, and some are disallowed
+*/
+- (SDLPermissionGroupStatus)groupStatusOfRPCNames:(NSArray<SDLRPCFunctionName> *)rpcNames;
 
 /**
  *  Retrieve a dictionary with keys that are the passed in RPC names, and objects of an NSNumber<BOOL> specifying if that RPC is currently allowed
@@ -61,7 +80,16 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @return A dictionary specifying if the passed in RPC names are currently allowed or not
  */
-- (NSDictionary<SDLPermissionRPCName, NSNumber *> *)statusOfRPCs:(NSArray<SDLPermissionRPCName> *)rpcNames;
+- (NSDictionary<SDLPermissionRPCName, NSNumber *> *)statusOfRPCs:(NSArray<SDLPermissionRPCName> *)rpcNames __deprecated_msg(("Use statusOfRPCNames: instead"));
+
+/**
+*  Retrieve a dictionary with keys that are the passed in RPC names, and objects of an NSNumber<BOOL> specifying if that RPC is currently allowed
+*
+*  @param rpcNames An array of RPC names to check
+*
+*  @return A dictionary specifying if the passed in RPC names are currently allowed or not
+*/
+- (NSDictionary<SDLPermissionRPCName, NSNumber *> *)statusOfRPCNames:(NSArray<SDLRPCFunctionName> *)rpcNames;
 
 /**
  *  Add an observer for specified RPC names, with a callback that will be called whenever the value changes, as well as immediately with the current status.
@@ -76,7 +104,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @return An identifier that can be passed to removeObserverForIdentifer: to remove the observer
  */
-- (SDLPermissionObserverIdentifier)addObserverForRPCs:(NSArray<SDLPermissionRPCName> *)rpcNames groupType:(SDLPermissionGroupType)groupType withHandler:(SDLPermissionsChangedHandler)handler;
+- (SDLPermissionObserverIdentifier)addObserverForRPCs:(NSArray<SDLPermissionRPCName> *)rpcNames groupType:(SDLPermissionGroupType)groupType withHandler:(SDLPermissionsChangedHandler)handler __deprecated_msg(("Use subscribeToRPCs:groupType:withHandler: instead"));
 
 /**
 *  Add an observer for specified RPC names, with a callback that will be called whenever the value changes. Unlike addObserverForRPCs:groupType:withHandler:, the callback will not return immediately with the current status and will wait for the permissions changes specified in the groupType param.
@@ -91,7 +119,7 @@ NS_ASSUME_NONNULL_BEGIN
 *
 *  @return An identifier that can be passed to removeObserverForIdentifer: to remove the observer
 */
-- (SDLPermissionObserverIdentifier)addStrictObserverForRPCs:(NSArray<SDLPermissionRPCName> *)rpcNames groupType:(SDLPermissionGroupType)groupType withHandler:(SDLPermissionsChangedHandler)handler;
+- (SDLPermissionObserverIdentifier)subscribeToRPCs:(NSArray<SDLPermissionRPCName> *)rpcNames groupType:(SDLPermissionGroupType)groupType withHandler:(SDLPermissionsChangedHandler)handler;
 
 /**
  *  Remove every current observer
@@ -109,7 +137,12 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Check whether or not an RPC needs encryption.
  */
-- (BOOL)rpcRequiresEncryption:(SDLPermissionRPCName)rpcName;
+- (BOOL)rpcRequiresEncryption:(SDLPermissionRPCName)rpcName __deprecated_msg(("Use rpcNameRequiresEncryption: instead"));
+
+/**
+ *  Check whether or not an RPC needs encryption.
+ */
+- (BOOL)rpcNameRequiresEncryption:(SDLRPCFunctionName)rpcName;
 
 @end
 

--- a/SmartDeviceLink/SDLPermissionManager.h
+++ b/SmartDeviceLink/SDLPermissionManager.h
@@ -44,7 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @return YES if the RPC is allowed at the current HMI level, NO if not
  */
-- (BOOL)isRPCAllowed:(SDLPermissionRPCName)rpcName __deprecated_msg(("Use isRPCPermitted: instead"));
+- (BOOL)isRPCAllowed:(SDLPermissionRPCName)rpcName __deprecated_msg(("Use isRPCNameAllowed: instead"));
 
 /**
  * Determine if an individual RPC is allowed for the current HMI level
@@ -80,7 +80,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @return A dictionary specifying if the passed in RPC names are currently allowed or not
  */
-- (NSDictionary<SDLPermissionRPCName, NSNumber *> *)statusOfRPCs:(NSArray<SDLPermissionRPCName> *)rpcNames __deprecated_msg(("Use statusOfRPCNames: instead"));
+- (NSDictionary<SDLPermissionRPCName, NSNumber *> *)statusOfRPCs:(NSArray<SDLPermissionRPCName> *)rpcNames __deprecated_msg(("Use statusesOfRPCNames: instead"));
 
 /**
  * Retrieve a dictionary with keys that are the passed in RPC names, and objects of an NSNumber<BOOL> specifying if that RPC is currently allowed
@@ -104,10 +104,10 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @return An identifier that can be passed to removeObserverForIdentifer: to remove the observer
  */
-- (SDLPermissionObserverIdentifier)addObserverForRPCs:(NSArray<SDLPermissionRPCName> *)rpcNames groupType:(SDLPermissionGroupType)groupType withHandler:(SDLPermissionsChangedHandler)handler __deprecated_msg(("Use subscribeToRPCs:groupType:withHandler: instead"));
+- (SDLPermissionObserverIdentifier)addObserverForRPCs:(NSArray<SDLPermissionRPCName> *)rpcNames groupType:(SDLPermissionGroupType)groupType withHandler:(SDLPermissionsChangedHandler)handler __deprecated_msg(("Use subscribeToRPCNames:groupType:withHandler: instead"));
 
 /**
- *  Subscribe to specified RPC names, with a callback that will be called whenever the value changes. Unlike addObserverForRPCs:groupType:withHandler:, the callback will not return immediately with the current status and will wait for the permissions changes specified in the groupType param.
+ *  Subscribe to specified RPC names, with a callback that will be called whenever the value changes. Unlike addObserverForRPCs:groupType:withHandler:, the callback will only return immediately if the groupType is set to SDLPermissionGroupTypeAny or if the groupType is set to SDLPermissionGroupTypeAllAllowed and all RPCs in the rpcNames parameter are allowed.
  *
  *  @warning The observer may be called before this method returns, do not attempt to remove the observer from within the observer. That could send `nil` to removeObserverForIdentifier:. If you want functionality like that, call groupStatusOfRPCs: instead.
  *
@@ -117,7 +117,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @return An identifier that can be passed to removeObserverForIdentifer: to remove the observer
  */
-- (SDLPermissionObserverIdentifier)subscribeToRPCNames:(NSArray<SDLRPCFunctionName> *)rpcNames groupType:(SDLPermissionGroupType)groupType withHandler:(SDLObservedPermissionsChangedHandler)handler;
+- (SDLPermissionObserverIdentifier)subscribeToRPCNames:(NSArray<SDLRPCFunctionName> *)rpcNames groupType:(SDLPermissionGroupType)groupType withHandler:(SDLSubscribedPermissionsChangedHandler)handler;
 
 /**
  *  Remove every current observer

--- a/SmartDeviceLink/SDLPermissionManager.h
+++ b/SmartDeviceLink/SDLPermissionManager.h
@@ -79,6 +79,21 @@ NS_ASSUME_NONNULL_BEGIN
 - (SDLPermissionObserverIdentifier)addObserverForRPCs:(NSArray<SDLPermissionRPCName> *)rpcNames groupType:(SDLPermissionGroupType)groupType withHandler:(SDLPermissionsChangedHandler)handler;
 
 /**
+*  Add an observer for specified RPC names, with a callback that will be called whenever the value changes. Unlike addObserverForRPCs:groupType:withHandler:, the callback will not return immediately with the current status and will wait for the permissions changes specified in the groupType param.
+*
+*  @warning This block will be captured by the SDLPermissionsManager, be sure to use [weakself/strongself](http://www.logicsector.com/ios/avoiding-objc-retain-cycles-with-weakself-and-strongself-the-easy-way/) if you are referencing self within your observer block.
+*
+*  @warning The observer may be called before this method returns, do not attempt to remove the observer from within the observer. That could send `nil` to removeObserverForIdentifier:. If you want functionality like that, call groupStatusOfRPCs: instead.
+*
+*  @param rpcNames The RPCs to be observed
+*  @param groupType Affects the times that the observer block will be called. If Any, any change to any RPC in rpcNames will cause the observer block to be called. If AllAllowed, the block will be called when: 1. Every RPC in rpcNames becomes allowed 2. The group of rpcNames goes from all being allowed to some or all being disallowed.
+*  @param handler The block that will be called whenever permissions change.
+*
+*  @return An identifier that can be passed to removeObserverForIdentifer: to remove the observer
+*/
+- (SDLPermissionObserverIdentifier)addStrictObserverForRPCs:(NSArray<SDLPermissionRPCName> *)rpcNames groupType:(SDLPermissionGroupType)groupType withHandler:(SDLPermissionsChangedHandler)handler;
+
+/**
  *  Remove every current observer
  */
 - (void)removeAllObservers;

--- a/SmartDeviceLink/SDLPermissionManager.h
+++ b/SmartDeviceLink/SDLPermissionManager.h
@@ -44,15 +44,15 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @return YES if the RPC is allowed at the current HMI level, NO if not
  */
-- (BOOL)isRPCAllowed:(SDLPermissionRPCName)rpcName __deprecated_msg(("Use isRPCNameAllowed: instead"));
+- (BOOL)isRPCAllowed:(SDLPermissionRPCName)rpcName __deprecated_msg(("Use isRPCPermitted: instead"));
 
 /**
-*  Determine if an individual RPC is allowed for the current HMI level
-*
-*  @param rpcName  The name of the RPC to be tested, for example, SDLShow
-*
-*  @return YES if the RPC is allowed at the current HMI level, NO if not
-*/
+ * Determine if an individual RPC is allowed for the current HMI level
+ *
+ * @param rpcName  The name of the RPC to be tested, for example, SDLRPCFunctionNameShow
+ *
+ * @return YES if the RPC is allowed at the current HMI level, NO if not
+ */
 - (BOOL)isRPCPermitted:(SDLRPCFunctionName)rpcName;
 
 /**
@@ -65,11 +65,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (SDLPermissionGroupStatus)groupStatusOfRPCs:(NSArray<SDLPermissionRPCName> *)rpcNames __deprecated_msg(("Use groupStatusOfRPCNames: instead"));
 
 /**
-*  Determine if all RPCs are allowed for the current HMI level
-*
-*  @param rpcNames The RPCs to check
-*
-*  @return AllAllowed if all of the permissions are allowed, AllDisallowed if all the permissions are disallowed, Any if some are allowed, and some are disallowed
+ * Determine if all RPCs are allowed for the current HMI level
+ *
+ * @param rpcNames The RPCs to check
+ *
+ * @return AllAllowed if all of the permissions are allowed, AllDisallowed if all the permissions are disallowed, Any if some are allowed, and some are disallowed
 */
 - (SDLPermissionGroupStatus)groupStatusOfRPCNames:(NSArray<SDLRPCFunctionName> *)rpcNames;
 
@@ -83,13 +83,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSDictionary<SDLPermissionRPCName, NSNumber *> *)statusOfRPCs:(NSArray<SDLPermissionRPCName> *)rpcNames __deprecated_msg(("Use statusOfRPCNames: instead"));
 
 /**
-*  Retrieve a dictionary with keys that are the passed in RPC names, and objects of an NSNumber<BOOL> specifying if that RPC is currently allowed
-*
-*  @param rpcNames An array of RPC names to check
-*
-*  @return A dictionary specifying if the passed in RPC names are currently allowed or not
+ * Retrieve a dictionary with keys that are the passed in RPC names, and objects of an NSNumber<BOOL> specifying if that RPC is currently allowed
+ *
+ * @param rpcNames An array of RPC names to check
+ *
+ * @return A dictionary specifying if the passed in RPC names are currently allowed or not
 */
-- (NSDictionary<SDLPermissionRPCName, NSNumber *> *)statusOfRPCNames:(NSArray<SDLRPCFunctionName> *)rpcNames;
+- (NSDictionary<SDLRPCFunctionName, NSNumber *> *)statusOfRPCNames:(NSArray<SDLRPCFunctionName> *)rpcNames;
 
 /**
  *  Add an observer for specified RPC names, with a callback that will be called whenever the value changes, as well as immediately with the current status.
@@ -107,19 +107,19 @@ NS_ASSUME_NONNULL_BEGIN
 - (SDLPermissionObserverIdentifier)addObserverForRPCs:(NSArray<SDLPermissionRPCName> *)rpcNames groupType:(SDLPermissionGroupType)groupType withHandler:(SDLPermissionsChangedHandler)handler __deprecated_msg(("Use subscribeToRPCs:groupType:withHandler: instead"));
 
 /**
-*  Add an observer for specified RPC names, with a callback that will be called whenever the value changes. Unlike addObserverForRPCs:groupType:withHandler:, the callback will not return immediately with the current status and will wait for the permissions changes specified in the groupType param.
-*
-*  @warning This block will be captured by the SDLPermissionsManager, be sure to use [weakself/strongself](http://www.logicsector.com/ios/avoiding-objc-retain-cycles-with-weakself-and-strongself-the-easy-way/) if you are referencing self within your observer block.
-*
-*  @warning The observer may be called before this method returns, do not attempt to remove the observer from within the observer. That could send `nil` to removeObserverForIdentifier:. If you want functionality like that, call groupStatusOfRPCs: instead.
-*
-*  @param rpcNames The RPCs to be observed
-*  @param groupType Affects the times that the observer block will be called. If Any, any change to any RPC in rpcNames will cause the observer block to be called. If AllAllowed, the block will be called when: 1. Every RPC in rpcNames becomes allowed 2. The group of rpcNames goes from all being allowed to some or all being disallowed.
-*  @param handler The block that will be called whenever permissions change.
-*
-*  @return An identifier that can be passed to removeObserverForIdentifer: to remove the observer
-*/
-- (SDLPermissionObserverIdentifier)subscribeToRPCs:(NSArray<SDLRPCFunctionName> *)rpcNames groupType:(SDLPermissionGroupType)groupType withHandler:(SDLPermissionsChangedHandler)handler;
+ *  Subscribe to specified RPC names, with a callback that will be called whenever the value changes. Unlike addObserverForRPCs:groupType:withHandler:, the callback will not return immediately with the current status and will wait for the permissions changes specified in the groupType param.
+ *
+ *  @warning This block will be captured by the SDLPermissionsManager, be sure to use [weakself/strongself](http://www.logicsector.com/ios/avoiding-objc-retain-cycles-with-weakself-and-strongself-the-easy-way/) if you are referencing self within your observer block.
+ *
+ *  @warning The observer may be called before this method returns, do not attempt to remove the observer from within the observer. That could send `nil` to removeObserverForIdentifier:. If you want functionality like that, call groupStatusOfRPCs: instead.
+ *
+ *  @param rpcNames The RPCs to be observed
+ *  @param groupType Affects the times that the observer block will be called. If Any, any change to any RPC in rpcNames will cause the observer block to be called. If AllAllowed, the block will be called when: 1. Every RPC in rpcNames becomes allowed 2. The group of rpcNames goes from all being allowed to some or all being disallowed.
+ *  @param handler The block that will be called whenever permissions change.
+ *
+ *  @return An identifier that can be passed to removeObserverForIdentifer: to remove the observer
+ */
+- (SDLPermissionObserverIdentifier)subscribeToRPCs:(NSArray<SDLRPCFunctionName> *)rpcNames groupType:(SDLPermissionGroupType)groupType withHandler:(SDLObeservedPermissionsChangedHandler)handler;
 
 /**
  *  Remove every current observer

--- a/SmartDeviceLink/SDLPermissionManager.h
+++ b/SmartDeviceLink/SDLPermissionManager.h
@@ -119,7 +119,7 @@ NS_ASSUME_NONNULL_BEGIN
 *
 *  @return An identifier that can be passed to removeObserverForIdentifer: to remove the observer
 */
-- (SDLPermissionObserverIdentifier)subscribeToRPCs:(NSArray<SDLPermissionRPCName> *)rpcNames groupType:(SDLPermissionGroupType)groupType withHandler:(SDLPermissionsChangedHandler)handler;
+- (SDLPermissionObserverIdentifier)subscribeToRPCs:(NSArray<SDLRPCFunctionName> *)rpcNames groupType:(SDLPermissionGroupType)groupType withHandler:(SDLPermissionsChangedHandler)handler;
 
 /**
  *  Remove every current observer

--- a/SmartDeviceLink/SDLPermissionManager.m
+++ b/SmartDeviceLink/SDLPermissionManager.m
@@ -74,7 +74,7 @@ NS_ASSUME_NONNULL_BEGIN
     return [item.hmiPermissions.allowed containsObject:self.currentHMILevel];
 }
 
-- (BOOL)isRPCNameAllowed:(SDLRPCFunctionName)rpcName {
+- (BOOL)isRPCPermitted:(SDLRPCFunctionName)rpcName {
     if (self.permissions[rpcName] == nil || self.currentHMILevel == nil) {
         return NO;
     }
@@ -155,7 +155,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSMutableDictionary<SDLPermissionRPCName, NSNumber *> *permissionAllowedDict = [NSMutableDictionary dictionary];
     // to do
     for (NSString *rpcName in rpcNames) {
-        BOOL allowed = [self isRPCNameAllowed:rpcName];
+        BOOL allowed = [self isRPCPermitted:rpcName];
         permissionAllowedDict[rpcName] = @(allowed);
     }
 

--- a/SmartDeviceLink/SDLPermissionManager.m
+++ b/SmartDeviceLink/SDLPermissionManager.m
@@ -149,7 +149,7 @@ NS_ASSUME_NONNULL_BEGIN
     return filter.identifier;
 }
 
-- (SDLPermissionObserverIdentifier)addStrictObserverForRPCs:(NSArray<SDLPermissionRPCName> *)rpcNames groupType:(SDLPermissionGroupType)groupType withHandler:(SDLPermissionsChangedHandler)handler {
+- (SDLPermissionObserverIdentifier)subscribeToRPCs:(NSArray<SDLPermissionRPCName> *)rpcNames groupType:(SDLPermissionGroupType)groupType withHandler:(SDLPermissionsChangedHandler)handler {
     SDLPermissionFilter *filter = [SDLPermissionFilter filterWithRPCNames:rpcNames groupType:groupType observer:handler];
 
     // Store the filter for later use

--- a/SmartDeviceLink/SDLPermissionManager.m
+++ b/SmartDeviceLink/SDLPermissionManager.m
@@ -79,7 +79,6 @@ NS_ASSUME_NONNULL_BEGIN
         return NO;
     }
 
-    // to do
     SDLPermissionItem *item = self.permissions[rpcName];
     return [item.hmiPermissions.allowed containsObject:self.currentHMILevel];
 }
@@ -97,7 +96,6 @@ NS_ASSUME_NONNULL_BEGIN
         return SDLPermissionGroupStatusUnknown;
     }
 
-    // to do double check this
     return [self.class sdl_groupStatusOfRPCs:rpcNames withPermissions:[self.permissions copy] hmiLevel:self.currentHMILevel];
 }
 
@@ -151,10 +149,10 @@ NS_ASSUME_NONNULL_BEGIN
     return [permissionAllowedDict copy];
 }
 
-- (NSDictionary<SDLPermissionRPCName,NSNumber *> *)statusOfRPCNames:(NSArray<SDLRPCFunctionName> *)rpcNames {
-    NSMutableDictionary<SDLPermissionRPCName, NSNumber *> *permissionAllowedDict = [NSMutableDictionary dictionary];
-    // to do
-    for (NSString *rpcName in rpcNames) {
+- (NSDictionary<SDLRPCFunctionName,NSNumber *> *)statusOfRPCNames:(NSArray<SDLRPCFunctionName> *)rpcNames {
+    NSMutableDictionary<SDLRPCFunctionName, NSNumber *> *permissionAllowedDict = [NSMutableDictionary dictionary];
+    
+    for (SDLRPCFunctionName rpcName in rpcNames) {
         BOOL allowed = [self isRPCPermitted:rpcName];
         permissionAllowedDict[rpcName] = @(allowed);
     }
@@ -414,7 +412,6 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (BOOL)rpcNameRequiresEncryption:(SDLRPCFunctionName)rpcName {
-    // to do
     if (self.permissions[rpcName].requireEncryption != nil) {
         return self.permissions[rpcName].requireEncryption.boolValue;
     }

--- a/SmartDeviceLink/SDLPermissionManager.m
+++ b/SmartDeviceLink/SDLPermissionManager.m
@@ -149,6 +149,15 @@ NS_ASSUME_NONNULL_BEGIN
     return filter.identifier;
 }
 
+- (SDLPermissionObserverIdentifier)addStrictObserverForRPCs:(NSArray<SDLPermissionRPCName> *)rpcNames groupType:(SDLPermissionGroupType)groupType withHandler:(SDLPermissionsChangedHandler)handler {
+    SDLPermissionFilter *filter = [SDLPermissionFilter filterWithRPCNames:rpcNames groupType:groupType observer:handler];
+
+    // Store the filter for later use
+    [self.filters addObject:filter];
+
+    return filter.identifier;
+}
+
 - (void)sdl_callFilterObserver:(SDLPermissionFilter *)filter {
     SDLPermissionGroupStatus permissionStatus = [self groupStatusOfRPCs:filter.rpcNames];
     NSDictionary<SDLPermissionRPCName, NSNumber *> *allowedDict = [self statusOfRPCs:filter.rpcNames];

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLPermissionsManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLPermissionsManagerSpec.m
@@ -294,7 +294,7 @@ describe(@"SDLPermissionsManager", ^{
                     #pragma clang diagnostic pop
                 });
 
-                it(@"should return mixed", ^{
+                it(@"should return allowed", ^{
                     expect(@(testResultStatus)).to(equal(@(SDLPermissionGroupStatusAllowed)));
                 });
             });
@@ -307,7 +307,7 @@ describe(@"SDLPermissionsManager", ^{
                     testResultStatus = [testPermissionsManager groupStatusOfRPCNames:@[testRPCNameAllAllowed, testRPCNameFullLimitedAllowed]];
                 });
 
-                it(@"should return mixed", ^{
+                it(@"should return allowed", ^{
                     expect(@(testResultStatus)).to(equal(@(SDLPermissionGroupStatusAllowed)));
                 });
             });
@@ -324,7 +324,7 @@ describe(@"SDLPermissionsManager", ^{
                     #pragma clang diagnostic pop
                 });
 
-                it(@"should return mixed", ^{
+                it(@"should return disallowed", ^{
                     expect(@(testResultStatus)).to(equal(@(SDLPermissionGroupStatusDisallowed)));
                 });
             });
@@ -337,7 +337,7 @@ describe(@"SDLPermissionsManager", ^{
                     testResultStatus = [testPermissionsManager groupStatusOfRPCNames:@[testRPCNameFullLimitedAllowed, testRPCNameAllDisallowed]];
                 });
 
-                it(@"should return mixed", ^{
+                it(@"should return disallowed", ^{
                     expect(@(testResultStatus)).to(equal(@(SDLPermissionGroupStatusDisallowed)));
                 });
             });

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLPermissionsManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLPermissionsManagerSpec.m
@@ -11,6 +11,7 @@
 #import "SDLPermissionFilter.h"
 #import "SDLPermissionItem.h"
 #import "SDLPermissionManager.h"
+#import "SDLRPCFunctionNames.h"
 #import "SDLRPCNotificationNotification.h"
 #import "SDLRPCResponseNotification.h"
 
@@ -133,65 +134,122 @@ describe(@"SDLPermissionsManager", ^{
     
     describe(@"checking if a permission is allowed", ^{
         __block NSString *someRPCName = nil;
+        __block SDLRPCFunctionName someRPCFunctionName = nil;
         __block BOOL testResultBOOL = NO;
-        
-        context(@"when no permissions exist", ^{
-            beforeEach(^{
-                someRPCName = @"some rpc name";
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-                testResultBOOL = [testPermissionsManager isRPCAllowed:someRPCName];
-#pragma clang diagnostic pop
+        context(@"when no permissions exist", ^{
+            context(@"deprecated isRPCAllowed: method", ^{
+                beforeEach(^{
+                    someRPCName = @"some rpc name";
+
+                    #pragma clang diagnostic push
+                    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+                    testResultBOOL = [testPermissionsManager isRPCAllowed:someRPCName];
+                    #pragma clang diagnostic pop
+                });
+
+                it(@"should not be allowed", ^{
+                    expect(@(testResultBOOL)).to(equal(@NO));
+                });
             });
-            
-            it(@"should not be allowed", ^{
-                expect(@(testResultBOOL)).to(equal(@NO));
+
+            context(@"isRPCPermitted: method", ^{
+                beforeEach(^{
+                    someRPCFunctionName = @"SomeRPCFunctionName";
+                    testResultBOOL = [testPermissionsManager isRPCPermitted:someRPCName];
+                });
+
+                it(@"should not be allowed", ^{
+                    expect(@(testResultBOOL)).to(equal(@NO));
+                });
             });
         });
         
         context(@"when permissions exist but no HMI level", ^{
-            beforeEach(^{
-                [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-                testResultBOOL = [testPermissionsManager isRPCAllowed:testRPCNameAllAllowed];
-#pragma clang diagnostic pop
+            context(@"deprecated isRPCAllowed: method", ^{
+                beforeEach(^{
+                    [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
+                    #pragma clang diagnostic push
+                    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+                    testResultBOOL = [testPermissionsManager isRPCAllowed:testRPCNameAllAllowed];
+                    #pragma clang diagnostic pop
+                });
+
+                it(@"should not be allowed", ^{
+                    expect(@(testResultBOOL)).to(equal(@NO));
+                });
             });
-            
-            it(@"should not be allowed", ^{
-                expect(@(testResultBOOL)).to(equal(@NO));
+
+            context(@"isRPCPermitted: method", ^{
+                beforeEach(^{
+                    [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
+                    testResultBOOL = [testPermissionsManager isRPCPermitted:someRPCName];
+                });
+
+                it(@"should not be allowed", ^{
+                    expect(@(testResultBOOL)).to(equal(@NO));
+                });
             });
         });
         
         context(@"when permissions exist", ^{
-            context(@"and the permission is allowed", ^{
-                beforeEach(^{
-                    [[NSNotificationCenter defaultCenter] postNotification:limitedHMINotification];
-                    [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-                    testResultBOOL = [testPermissionsManager isRPCAllowed:testRPCNameAllAllowed];
-#pragma clang diagnostic pop
+            context(@"deprecated isRPCAllowed: method", ^{
+                context(@"and the permission is allowed", ^{
+                    beforeEach(^{
+                        [[NSNotificationCenter defaultCenter] postNotification:limitedHMINotification];
+                        [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
+                        #pragma clang diagnostic push
+                        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+                        testResultBOOL = [testPermissionsManager isRPCAllowed:testRPCNameAllAllowed];
+                        #pragma clang diagnostic pop
+                    });
+
+                    it(@"should be allowed", ^{
+                        expect(@(testResultBOOL)).to(equal(@YES));
+                    });
                 });
-                
-                it(@"should be allowed", ^{
-                    expect(@(testResultBOOL)).to(equal(@YES));
+
+                context(@"and the permission is denied", ^{
+                    beforeEach(^{
+                        [[NSNotificationCenter defaultCenter] postNotification:limitedHMINotification];
+                        [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
+                        #pragma clang diagnostic push
+                        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+                        testResultBOOL = [testPermissionsManager isRPCAllowed:testRPCNameAllDisallowed];
+                        #pragma clang diagnostic pop
+                    });
+
+                    it(@"should be denied", ^{
+                        expect(@(testResultBOOL)).to(equal(@NO));
+                    });
                 });
             });
-            
-            context(@"and the permission is denied", ^{
-                beforeEach(^{
-                    [[NSNotificationCenter defaultCenter] postNotification:limitedHMINotification];
-                    [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-                    testResultBOOL = [testPermissionsManager isRPCAllowed:testRPCNameAllDisallowed];
-#pragma clang diagnostic pop
+
+            context(@"isRPCPermitted: method", ^{
+                context(@"and the permission is allowed", ^{
+                    beforeEach(^{
+                        [[NSNotificationCenter defaultCenter] postNotification:limitedHMINotification];
+                        [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
+
+                        testResultBOOL = [testPermissionsManager isRPCPermitted:testRPCNameAllAllowed];
+                    });
+
+                    it(@"should be allowed", ^{
+                        expect(@(testResultBOOL)).to(equal(@YES));
+                    });
                 });
-                
-                it(@"should be denied", ^{
-                    expect(@(testResultBOOL)).to(equal(@NO));
+
+                context(@"and the permission is denied", ^{
+                    beforeEach(^{
+                        [[NSNotificationCenter defaultCenter] postNotification:limitedHMINotification];
+                        [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
+
+                        testResultBOOL = [testPermissionsManager isRPCPermitted:testRPCNameAllDisallowed];
+                    });
+
+                    it(@"should be denied", ^{
+                        expect(@(testResultBOOL)).to(equal(@NO));
+                    });
                 });
             });
         });
@@ -201,94 +259,179 @@ describe(@"SDLPermissionsManager", ^{
         __block SDLPermissionGroupStatus testResultStatus = SDLPermissionGroupStatusUnknown;
         
         context(@"with no permissions data", ^{
-            beforeEach(^{
+            context(@"deprecated groupStatusOfRPCs: method", ^{
+                beforeEach(^{
                 #pragma clang diagnostic push
                 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-                testResultStatus = [testPermissionsManager groupStatusOfRPCs:@[testRPCNameAllAllowed, testRPCNameAllDisallowed]];
+                    testResultStatus = [testPermissionsManager groupStatusOfRPCs:@[testRPCNameAllAllowed, testRPCNameAllDisallowed]];
                 #pragma clang diagnostic pop
+                });
+
+                it(@"should return unknown", ^{
+                    expect(@(testResultStatus)).to(equal(@(SDLPermissionGroupStatusUnknown)));
+                });
             });
-            
-            it(@"should return unknown", ^{
-                expect(@(testResultStatus)).to(equal(@(SDLPermissionGroupStatusUnknown)));
+
+            context(@"groupStatusOfRPCNames: method", ^{
+                beforeEach(^{
+                    testResultStatus = [testPermissionsManager groupStatusOfRPCNames:@[testRPCNameAllAllowed, testRPCNameAllDisallowed]];
+                });
+
+                it(@"should return unknown", ^{
+                    expect(@(testResultStatus)).to(equal(@(SDLPermissionGroupStatusUnknown)));
+                });
             });
         });
         
         context(@"for an all allowed group", ^{
-            beforeEach(^{
-                [[NSNotificationCenter defaultCenter] postNotification:limitedHMINotification];
-                [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
-                #pragma clang diagnostic push
-                #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-                testResultStatus = [testPermissionsManager groupStatusOfRPCs:@[testRPCNameAllAllowed, testRPCNameFullLimitedAllowed]];
-                #pragma clang diagnostic pop
+            context(@"deprecated groupStatusOfRPCs: method", ^{
+                beforeEach(^{
+                    [[NSNotificationCenter defaultCenter] postNotification:limitedHMINotification];
+                    [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
+                    #pragma clang diagnostic push
+                    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+                    testResultStatus = [testPermissionsManager groupStatusOfRPCs:@[testRPCNameAllAllowed, testRPCNameFullLimitedAllowed]];
+                    #pragma clang diagnostic pop
+                });
+
+                it(@"should return mixed", ^{
+                    expect(@(testResultStatus)).to(equal(@(SDLPermissionGroupStatusAllowed)));
+                });
             });
-            
-            it(@"should return mixed", ^{
-                expect(@(testResultStatus)).to(equal(@(SDLPermissionGroupStatusAllowed)));
+
+            context(@"groupStatusOfRPCNames: method", ^{
+                beforeEach(^{
+                    [[NSNotificationCenter defaultCenter] postNotification:limitedHMINotification];
+                    [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
+
+                    testResultStatus = [testPermissionsManager groupStatusOfRPCNames:@[testRPCNameAllAllowed, testRPCNameFullLimitedAllowed]];
+                });
+
+                it(@"should return mixed", ^{
+                    expect(@(testResultStatus)).to(equal(@(SDLPermissionGroupStatusAllowed)));
+                });
             });
         });
         
         context(@"for an all disallowed group", ^{
-            beforeEach(^{
-                [[NSNotificationCenter defaultCenter] postNotification:backgroundHMINotification];
-                [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
-                #pragma clang diagnostic push
-                #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-                testResultStatus = [testPermissionsManager groupStatusOfRPCs:@[testRPCNameFullLimitedAllowed, testRPCNameAllDisallowed]];
-                #pragma clang diagnostic pop
+            context(@"deprecated groupStatusOfRPCs: method", ^{
+                beforeEach(^{
+                    [[NSNotificationCenter defaultCenter] postNotification:backgroundHMINotification];
+                    [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
+                    #pragma clang diagnostic push
+                    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+                    testResultStatus = [testPermissionsManager groupStatusOfRPCs:@[testRPCNameFullLimitedAllowed, testRPCNameAllDisallowed]];
+                    #pragma clang diagnostic pop
+                });
+
+                it(@"should return mixed", ^{
+                    expect(@(testResultStatus)).to(equal(@(SDLPermissionGroupStatusDisallowed)));
+                });
             });
-            
-            it(@"should return mixed", ^{
-                expect(@(testResultStatus)).to(equal(@(SDLPermissionGroupStatusDisallowed)));
+
+            context(@"groupStatusOfRPCNames: method", ^{
+                beforeEach(^{
+                    [[NSNotificationCenter defaultCenter] postNotification:backgroundHMINotification];
+                    [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
+
+                    testResultStatus = [testPermissionsManager groupStatusOfRPCNames:@[testRPCNameFullLimitedAllowed, testRPCNameAllDisallowed]];
+                });
+
+                it(@"should return mixed", ^{
+                    expect(@(testResultStatus)).to(equal(@(SDLPermissionGroupStatusDisallowed)));
+                });
             });
         });
         
         context(@"for a mixed group", ^{
-            beforeEach(^{
-                [[NSNotificationCenter defaultCenter] postNotification:limitedHMINotification];
-                [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
-                #pragma clang diagnostic push
-                #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-                testResultStatus = [testPermissionsManager groupStatusOfRPCs:@[testRPCNameAllAllowed, testRPCNameAllDisallowed]];
-                #pragma clang diagnostic pop
+            context(@"deprecated groupStatusOfRPCs: method", ^{
+                beforeEach(^{
+                    [[NSNotificationCenter defaultCenter] postNotification:limitedHMINotification];
+                    [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
+                    #pragma clang diagnostic push
+                    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+                    testResultStatus = [testPermissionsManager groupStatusOfRPCs:@[testRPCNameAllAllowed, testRPCNameAllDisallowed]];
+                    #pragma clang diagnostic pop
+                });
+
+                it(@"should return mixed", ^{
+                    expect(@(testResultStatus)).to(equal(@(SDLPermissionGroupStatusMixed)));
+                });
             });
-            
-            it(@"should return mixed", ^{
-                expect(@(testResultStatus)).to(equal(@(SDLPermissionGroupStatusMixed)));
+
+            context(@"groupStatusOfRPCNames: method", ^{
+                beforeEach(^{
+                    [[NSNotificationCenter defaultCenter] postNotification:limitedHMINotification];
+                    [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
+
+                    testResultStatus = [testPermissionsManager groupStatusOfRPCNames:@[testRPCNameAllAllowed, testRPCNameAllDisallowed]];
+                });
+
+                it(@"should return mixed", ^{
+                    expect(@(testResultStatus)).to(equal(@(SDLPermissionGroupStatusMixed)));
+                });
             });
         });
     });
     
     describe(@"checking the status of RPCs", ^{
         __block NSDictionary<SDLPermissionRPCName, NSNumber *> *testResultPermissionStatusDict = nil;
-        
         context(@"with no permissions data", ^{
-            beforeEach(^{
-                #pragma clang diagnostic push
-                #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-                testResultPermissionStatusDict = [testPermissionsManager statusOfRPCs:@[testRPCNameAllAllowed, testRPCNameAllDisallowed]];
-                #pragma clang diagnostic pop
+            context(@"deprecated statusOfRPCs: method", ^{
+                beforeEach(^{
+                    #pragma clang diagnostic push
+                    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+                    testResultPermissionStatusDict = [testPermissionsManager statusOfRPCs:@[testRPCNameAllAllowed, testRPCNameAllDisallowed]];
+                    #pragma clang diagnostic pop
+                });
+
+                it(@"should return correct permission statuses", ^{
+                    expect(testResultPermissionStatusDict[testRPCNameAllAllowed]).to(equal(@NO));
+                    expect(testResultPermissionStatusDict[testRPCNameAllDisallowed]).to(equal(@NO));
+                });
             });
-            
-            it(@"should return correct permission statuses", ^{
-                expect(testResultPermissionStatusDict[testRPCNameAllAllowed]).to(equal(@NO));
-                expect(testResultPermissionStatusDict[testRPCNameAllDisallowed]).to(equal(@NO));
+
+            context(@"statusOfRPCNames: method", ^{
+                beforeEach(^{
+                    testResultPermissionStatusDict = [testPermissionsManager statusOfRPCNames:@[testRPCNameAllAllowed, testRPCNameAllDisallowed]];
+                });
+
+                it(@"should return correct permission statuses", ^{
+                    expect(testResultPermissionStatusDict[testRPCNameAllAllowed]).to(equal(@NO));
+                    expect(testResultPermissionStatusDict[testRPCNameAllDisallowed]).to(equal(@NO));
+                });
             });
         });
         
         context(@"with permissions data", ^{
-            beforeEach(^{
-                [[NSNotificationCenter defaultCenter] postNotification:limitedHMINotification];
-                [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
-                #pragma clang diagnostic push
-                #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-                testResultPermissionStatusDict = [testPermissionsManager statusOfRPCs:@[testRPCNameAllAllowed, testRPCNameAllDisallowed]];
-                #pragma clang diagnostic pop
+            context(@"deprecated statusOfRPCs: method", ^{
+                beforeEach(^{
+                    [[NSNotificationCenter defaultCenter] postNotification:limitedHMINotification];
+                    [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
+                    #pragma clang diagnostic push
+                    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+                    testResultPermissionStatusDict = [testPermissionsManager statusOfRPCs:@[testRPCNameAllAllowed, testRPCNameAllDisallowed]];
+                    #pragma clang diagnostic pop
+                });
+
+                it(@"should return correct permission statuses", ^{
+                    expect(testResultPermissionStatusDict[testRPCNameAllAllowed]).to(equal(@YES));
+                    expect(testResultPermissionStatusDict[testRPCNameAllDisallowed]).to(equal(@NO));
+                });
             });
-            
-            it(@"should return correct permission statuses", ^{
-                expect(testResultPermissionStatusDict[testRPCNameAllAllowed]).to(equal(@YES));
-                expect(testResultPermissionStatusDict[testRPCNameAllDisallowed]).to(equal(@NO));
+
+            context(@"statusOfRPCNames: method", ^{
+                beforeEach(^{
+                    [[NSNotificationCenter defaultCenter] postNotification:limitedHMINotification];
+                    [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
+
+                    testResultPermissionStatusDict = [testPermissionsManager statusOfRPCNames:@[testRPCNameAllAllowed, testRPCNameAllDisallowed]];
+                });
+
+                it(@"should return correct permission statuses", ^{
+                    expect(testResultPermissionStatusDict[testRPCNameAllAllowed]).to(equal(@YES));
+                    expect(testResultPermissionStatusDict[testRPCNameAllDisallowed]).to(equal(@NO));
+                });
             });
         });
     });

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLPermissionsManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLPermissionsManagerSpec.m
@@ -149,7 +149,7 @@ describe(@"SDLPermissionsManager", ^{
                 });
 
                 it(@"should not be allowed", ^{
-                    expect(@(testResultBOOL)).to(equal(@NO));
+                    expect(testResultBOOL).to(beFalse());
                 });
             });
 
@@ -160,7 +160,7 @@ describe(@"SDLPermissionsManager", ^{
                 });
 
                 it(@"should not be allowed", ^{
-                    expect(@(testResultBOOL)).to(equal(@NO));
+                    expect(testResultBOOL).to(beFalse());
                 });
             });
         });
@@ -176,7 +176,7 @@ describe(@"SDLPermissionsManager", ^{
                 });
 
                 it(@"should not be allowed", ^{
-                    expect(@(testResultBOOL)).to(equal(@NO));
+                    expect(testResultBOOL).to(beFalse());
                 });
             });
 
@@ -187,7 +187,7 @@ describe(@"SDLPermissionsManager", ^{
                 });
 
                 it(@"should not be allowed", ^{
-                    expect(@(testResultBOOL)).to(equal(@NO));
+                    expect(testResultBOOL).to(beFalse());
                 });
             });
         });
@@ -205,7 +205,7 @@ describe(@"SDLPermissionsManager", ^{
                     });
 
                     it(@"should be allowed", ^{
-                        expect(@(testResultBOOL)).to(equal(@YES));
+                        expect(testResultBOOL).to(beTrue());
                     });
                 });
 
@@ -220,7 +220,7 @@ describe(@"SDLPermissionsManager", ^{
                     });
 
                     it(@"should be denied", ^{
-                        expect(@(testResultBOOL)).to(equal(@NO));
+                        expect(testResultBOOL).to(beFalse());
                     });
                 });
             });
@@ -235,7 +235,7 @@ describe(@"SDLPermissionsManager", ^{
                     });
 
                     it(@"should be allowed", ^{
-                        expect(@(testResultBOOL)).to(equal(@YES));
+                        expect(testResultBOOL).to(beTrue());
                     });
                 });
 
@@ -248,7 +248,7 @@ describe(@"SDLPermissionsManager", ^{
                     });
 
                     it(@"should be denied", ^{
-                        expect(@(testResultBOOL)).to(equal(@NO));
+                        expect(testResultBOOL).to(beFalse());
                     });
                 });
             });
@@ -570,7 +570,7 @@ describe(@"SDLPermissionsManager", ^{
                 });
 
                 it(@"should not be called", ^{
-                    expect(@(testObserverCalled)).to(equal(@NO));
+                    expect(testObserverCalled).to(beFalse());
                 });
             });
 

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLPermissionsManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLPermissionsManagerSpec.m
@@ -282,7 +282,7 @@ describe(@"SDLPermissionsManager", ^{
                     testObserverStatus = SDLPermissionGroupStatusUnknown;
                     testObserverChangeDict = nil;
 
-                    [testPermissionsManager addStrictObserverForRPCs:@[testRPCNameAllAllowed, testRPCNameAllDisallowed] groupType:SDLPermissionGroupTypeAny withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull change, SDLPermissionGroupStatus status) {
+                    [testPermissionsManager subscribeToRPCs:@[testRPCNameAllAllowed, testRPCNameAllDisallowed] groupType:SDLPermissionGroupTypeAny withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull change, SDLPermissionGroupStatus status) {
                         testObserverChangeDict = change;
                         testObserverStatus = status;
                         testObserverCalled = YES;
@@ -313,7 +313,7 @@ describe(@"SDLPermissionsManager", ^{
                         [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
 
                         // This should be called twice, once for each RPC being observed. It should be called immediately since data should already be present
-                        [testPermissionsManager addStrictObserverForRPCs:@[testRPCNameAllAllowed, testRPCNameAllDisallowed] groupType:SDLPermissionGroupTypeAny withHandler:^(NSDictionary<SDLPermissionRPCName, NSNumber *> * _Nonnull changedDict, SDLPermissionGroupStatus status) {
+                        [testPermissionsManager subscribeToRPCs:@[testRPCNameAllAllowed, testRPCNameAllDisallowed] groupType:SDLPermissionGroupTypeAny withHandler:^(NSDictionary<SDLPermissionRPCName, NSNumber *> * _Nonnull changedDict, SDLPermissionGroupStatus status) {
                             numberOfTimesObserverCalled++;
                             testObserverBlockChangedDict = changedDict;
                             testObserverReturnStatus = status;
@@ -340,7 +340,7 @@ describe(@"SDLPermissionsManager", ^{
                         [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
 
                         // This should be called twice, once for each RPC being observed. It should be called immediately since data should already be present
-                        [testPermissionsManager addStrictObserverForRPCs:@[testRPCNameAllAllowed, testRPCNameFullLimitedAllowed] groupType:SDLPermissionGroupTypeAllAllowed withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull change, SDLPermissionGroupStatus status) {
+                        [testPermissionsManager subscribeToRPCs:@[testRPCNameAllAllowed, testRPCNameFullLimitedAllowed] groupType:SDLPermissionGroupTypeAllAllowed withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull change, SDLPermissionGroupStatus status) {
                             numberOfTimesObserverCalled++;
                             testObserverBlockChangedDict = change;
                             testObserverReturnStatus = status;
@@ -367,7 +367,7 @@ describe(@"SDLPermissionsManager", ^{
                         [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
 
                         // This should be called twice, once for each RPC being observed. It should be called immediately since data should already be present
-                        [testPermissionsManager addStrictObserverForRPCs:@[testRPCNameAllDisallowed, testRPCNameFullLimitedAllowed] groupType:SDLPermissionGroupTypeAllAllowed withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull change, SDLPermissionGroupStatus status) {
+                        [testPermissionsManager subscribeToRPCs:@[testRPCNameAllDisallowed, testRPCNameFullLimitedAllowed] groupType:SDLPermissionGroupTypeAllAllowed withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull change, SDLPermissionGroupStatus status) {
                             numberOfTimesObserverCalled++;
                             testObserverReturnStatus = status;
                         }];
@@ -402,7 +402,7 @@ describe(@"SDLPermissionsManager", ^{
                         [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
 
                         // Set an observer that should be called when new data is sent
-                        [testPermissionsManager addStrictObserverForRPCs:@[testRPCNameAllAllowed, testRPCNameAllDisallowed] groupType:SDLPermissionGroupTypeAny withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull changedDict, SDLPermissionGroupStatus status) {
+                        [testPermissionsManager subscribeToRPCs:@[testRPCNameAllAllowed, testRPCNameAllDisallowed] groupType:SDLPermissionGroupTypeAny withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull changedDict, SDLPermissionGroupStatus status) {
                             numberOfTimesObserverCalled++;
                             [changeDicts addObject:changedDict];
                         }];
@@ -502,7 +502,7 @@ describe(@"SDLPermissionsManager", ^{
                     context(@"so that it becomes All Allowed", ^{
                         beforeEach(^{
                             // Set an observer that should be called immediately for the preexisting data, then called again when new data is sent
-                            [testPermissionsManager addStrictObserverForRPCs:@[testRPCNameAllDisallowed, testRPCNameFullLimitedBackgroundAllowed] groupType:SDLPermissionGroupTypeAllAllowed withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull change, SDLPermissionGroupStatus status) {
+                            [testPermissionsManager subscribeToRPCs:@[testRPCNameAllDisallowed, testRPCNameFullLimitedBackgroundAllowed] groupType:SDLPermissionGroupTypeAllAllowed withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull change, SDLPermissionGroupStatus status) {
                                 numberOfTimesObserverCalled++;
                                 [changeDicts addObject:change];
                                 [testStatuses addObject:@(status)];
@@ -545,7 +545,7 @@ describe(@"SDLPermissionsManager", ^{
                     context(@"so that it goes from All Allowed to mixed", ^{
                         beforeEach(^{
                             // Set an observer that should be called immediately for the preexisting data, then called again when new data is sent
-                            [testPermissionsManager addStrictObserverForRPCs:@[testRPCNameAllAllowed] groupType:SDLPermissionGroupTypeAllAllowed withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull change, SDLPermissionGroupStatus status) {
+                            [testPermissionsManager subscribeToRPCs:@[testRPCNameAllAllowed] groupType:SDLPermissionGroupTypeAllAllowed withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull change, SDLPermissionGroupStatus status) {
                                 numberOfTimesObserverCalled++;
                                 [changeDicts addObject:change];
                                 [testStatuses addObject:@(status)];
@@ -608,7 +608,7 @@ describe(@"SDLPermissionsManager", ^{
                     context(@"from mixed to disallowed", ^{
                         beforeEach(^{
                             // Set an observer that should be called immediately for the preexisting data, then called again when new data is sent
-                            [testPermissionsManager addStrictObserverForRPCs:@[testRPCNameAllAllowed, testRPCNameAllDisallowed] groupType:SDLPermissionGroupTypeAllAllowed withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull change, SDLPermissionGroupStatus status) {
+                            [testPermissionsManager subscribeToRPCs:@[testRPCNameAllAllowed, testRPCNameAllDisallowed] groupType:SDLPermissionGroupTypeAllAllowed withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull change, SDLPermissionGroupStatus status) {
                                 numberOfTimesObserverCalled++;
                                 [changeDicts addObject:change];
                                 [testStatuses addObject:@(status)];
@@ -642,7 +642,7 @@ describe(@"SDLPermissionsManager", ^{
                     context(@"from disallowed to mixed", ^{
                         beforeEach(^{
                             // Set an observer that should be called immediately for the preexisting data, then called again when new data is sent
-                            [testPermissionsManager addStrictObserverForRPCs:@[testRPCNameFullLimitedAllowed, testRPCNameAllDisallowed] groupType:SDLPermissionGroupTypeAllAllowed withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull change, SDLPermissionGroupStatus status) {
+                            [testPermissionsManager subscribeToRPCs:@[testRPCNameFullLimitedAllowed, testRPCNameAllDisallowed] groupType:SDLPermissionGroupTypeAllAllowed withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull change, SDLPermissionGroupStatus status) {
                                 numberOfTimesObserverCalled++;
                                 [changeDicts addObject:change];
                                 [testStatuses addObject:@(status)];

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLPermissionsManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLPermissionsManagerSpec.m
@@ -270,7 +270,424 @@ describe(@"SDLPermissionsManager", ^{
         });
     });
     
-    describe(@"adding and using observers", ^{
+    fdescribe(@"adding and using observers", ^{
+        describe(@"adding new observers with struct method", ^{
+            context(@"when no data is present", ^{
+                __block BOOL testObserverCalled = NO;
+                __block SDLPermissionGroupStatus testObserverStatus = SDLPermissionGroupStatusUnknown;
+                __block NSDictionary<SDLPermissionRPCName,NSNumber *> *testObserverChangeDict = nil;
+
+                beforeEach(^{
+                    testObserverCalled = NO;
+                    testObserverStatus = SDLPermissionGroupStatusUnknown;
+                    testObserverChangeDict = nil;
+
+                    [testPermissionsManager addStrictObserverForRPCs:@[testRPCNameAllAllowed, testRPCNameAllDisallowed] groupType:SDLPermissionGroupTypeAny withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull change, SDLPermissionGroupStatus status) {
+                        testObserverChangeDict = change;
+                        testObserverStatus = status;
+                        testObserverCalled = YES;
+                    }];
+                });
+
+                it(@"should not return permission statuses", ^{
+                    expect(@(testObserverCalled)).to(equal(@NO));
+                    expect(@(testObserverStatus)).to(equal(@(SDLPermissionGroupStatusUnknown)));
+                    expect(testObserverChangeDict[testRPCNameAllAllowed]).to(beNil());
+                    expect(testObserverChangeDict[testRPCNameAllDisallowed]).to(beNil());
+                });
+            });
+
+            context(@"when data is already present", ^{
+                __block NSInteger numberOfTimesObserverCalled = 0;
+                __block NSDictionary<SDLPermissionRPCName,NSNumber *> *testObserverBlockChangedDict = nil;
+                __block SDLPermissionGroupStatus testObserverReturnStatus = SDLPermissionGroupStatusUnknown;
+
+                context(@"to match an ANY observer", ^{
+                    beforeEach(^{
+                        // Reset vars
+                        numberOfTimesObserverCalled = 0;
+
+                        // Post the notification before setting the observer to make sure data is already present
+                        // HMI Full & Limited allowed
+                        [[NSNotificationCenter defaultCenter] postNotification:limitedHMINotification];
+                        [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
+
+                        // This should be called twice, once for each RPC being observed. It should be called immediately since data should already be present
+                        [testPermissionsManager addStrictObserverForRPCs:@[testRPCNameAllAllowed, testRPCNameAllDisallowed] groupType:SDLPermissionGroupTypeAny withHandler:^(NSDictionary<SDLPermissionRPCName, NSNumber *> * _Nonnull changedDict, SDLPermissionGroupStatus status) {
+                            numberOfTimesObserverCalled++;
+                            testObserverBlockChangedDict = changedDict;
+                            testObserverReturnStatus = status;
+                        }];
+                    });
+
+                    it(@"should call the observer with proper status", ^{
+                        expect(@(numberOfTimesObserverCalled)).to(equal(0));
+                        expect(testObserverBlockChangedDict[testRPCNameAllAllowed]).to(beNil());
+                        expect(testObserverBlockChangedDict[testRPCNameAllDisallowed]).to(beNil());
+                        expect(testObserverBlockChangedDict.allKeys).to(beNil());
+                        expect(@(testObserverReturnStatus)).to(equal(@(SDLPermissionGroupStatusUnknown)));
+                    });
+                });
+
+                context(@"to match an all allowed observer", ^{
+                    beforeEach(^{
+                        // Reset vars
+                        numberOfTimesObserverCalled = 0;
+
+                        // Post the notification before setting the observer to make sure data is already present
+                        // HMI Full & Limited allowed, hmi level LIMITED
+                        [[NSNotificationCenter defaultCenter] postNotification:limitedHMINotification];
+                        [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
+
+                        // This should be called twice, once for each RPC being observed. It should be called immediately since data should already be present
+                        [testPermissionsManager addStrictObserverForRPCs:@[testRPCNameAllAllowed, testRPCNameFullLimitedAllowed] groupType:SDLPermissionGroupTypeAllAllowed withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull change, SDLPermissionGroupStatus status) {
+                            numberOfTimesObserverCalled++;
+                            testObserverBlockChangedDict = change;
+                            testObserverReturnStatus = status;
+                        }];
+                    });
+
+                    it(@"should call the observer with proper status", ^{
+                        expect(@(numberOfTimesObserverCalled)).to(equal(@0));
+                        expect(testObserverBlockChangedDict[testRPCNameAllAllowed]).to(beNil());
+                        expect(testObserverBlockChangedDict[testRPCNameFullLimitedAllowed]).to(beNil());
+                        expect(testObserverBlockChangedDict.allKeys).to(beNil());
+                        expect(@(testObserverReturnStatus)).to(equal(@(SDLPermissionGroupStatusUnknown)));
+                    });
+                });
+
+                context(@"that does not match an all allowed observer", ^{
+                    beforeEach(^{
+                        // Reset vars
+                        numberOfTimesObserverCalled = 0;
+
+                        // Post the notification before setting the observer to make sure data is already present
+                        // HMI Full & Limited allowed, hmi level NONE
+                        [[NSNotificationCenter defaultCenter] postNotification:noneHMINotification];
+                        [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
+
+                        // This should be called twice, once for each RPC being observed. It should be called immediately since data should already be present
+                        [testPermissionsManager addStrictObserverForRPCs:@[testRPCNameAllDisallowed, testRPCNameFullLimitedAllowed] groupType:SDLPermissionGroupTypeAllAllowed withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull change, SDLPermissionGroupStatus status) {
+                            numberOfTimesObserverCalled++;
+                            testObserverReturnStatus = status;
+                        }];
+                    });
+
+                    it(@"should call the observer with status Disallowed", ^{
+                        expect(@(numberOfTimesObserverCalled)).to(equal(@0));
+                        expect(@(testObserverReturnStatus)).to(equal(@(SDLPermissionGroupStatusUnknown)));
+                    });
+                });
+            });
+
+
+            context(@"updating an observer with new permission data", ^{
+                __block NSInteger numberOfTimesObserverCalled = 0;
+
+                __block SDLOnPermissionsChange *testPermissionChangeUpdate = nil;
+                __block SDLPermissionItem *testPermissionUpdated = nil;
+                __block NSMutableArray<NSDictionary<SDLPermissionRPCName,NSNumber*> *> *changeDicts = nil;
+                __block NSMutableArray<NSNumber<SDLUInt> *> *testStatuses = nil;
+
+                context(@"to match an ANY observer", ^{
+                    beforeEach(^{
+                        // Reset vars
+                        numberOfTimesObserverCalled = 0;
+                        changeDicts = [NSMutableArray array];
+                        testStatuses = [NSMutableArray array];
+
+                        // Post the notification before setting the observer to make sure data is already present
+                        // HMI Full & Limited allowed, hmi level LIMITED
+                        [[NSNotificationCenter defaultCenter] postNotification:limitedHMINotification];
+                        [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
+
+                        // Set an observer that should be called when new data is sent
+                        [testPermissionsManager addStrictObserverForRPCs:@[testRPCNameAllAllowed, testRPCNameAllDisallowed] groupType:SDLPermissionGroupTypeAny withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull changedDict, SDLPermissionGroupStatus status) {
+                            numberOfTimesObserverCalled++;
+                            [changeDicts addObject:changedDict];
+                        }];
+
+                        // Create a permission update disallowing our current HMI level for the observed permission
+                        SDLParameterPermissions *testParameterPermissions = [[SDLParameterPermissions alloc] init];
+                        SDLHMIPermissions *testHMIPermissionsUpdated = [[SDLHMIPermissions alloc] init];
+                        testHMIPermissionsUpdated.allowed = @[SDLHMILevelBackground, SDLHMILevelFull];
+                        testHMIPermissionsUpdated.userDisallowed = @[SDLHMILevelLimited, SDLHMILevelNone];
+
+                        testPermissionUpdated = [[SDLPermissionItem alloc] init];
+                        testPermissionUpdated.rpcName = testRPCNameAllAllowed;
+                        testPermissionUpdated.hmiPermissions = testHMIPermissionsUpdated;
+                        testPermissionUpdated.parameterPermissions = testParameterPermissions;
+
+                        testPermissionChangeUpdate = [[SDLOnPermissionsChange alloc] init];
+                        testPermissionChangeUpdate.permissionItem = [NSArray arrayWithObject:testPermissionUpdated];
+
+                        // Send the permission update
+                        SDLRPCNotificationNotification *updatedNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidChangePermissionsNotification object:nil rpcNotification:testPermissionChangeUpdate];
+                        [[NSNotificationCenter defaultCenter] postNotification:updatedNotification];
+                    });
+
+                    it(@"should call the observer once", ^{
+                        expect(@(numberOfTimesObserverCalled)).to(equal(@1));
+                    });
+
+                    // Since we are not sending the immediate callback, there will only be one change dict
+                    // values in the change dict will be no, since we are disallowing the RPC
+//                    it(@"should have proper data in the first change dict", ^{
+//                        expect(changeDicts[0].allKeys).to(contain(testRPCNameAllAllowed));
+//                        expect(changeDicts[0].allKeys).to(contain(testRPCNameAllDisallowed));
+//
+//                        NSNumber<SDLBool> *allAllowed = changeDicts[0][testRPCNameAllAllowed];
+//                        expect(allAllowed).to(equal(@NO));
+//
+//                        NSNumber<SDLBool> *allDisallowed = changeDicts[0][testRPCNameAllDisallowed];
+//                        expect(allDisallowed).to(equal(@NO));
+//                    });
+
+                    it(@"should have the proper data in the first change dict", ^{
+                        expect(changeDicts[0].allKeys).to(contain(testRPCNameAllAllowed));
+                        expect(changeDicts[0].allKeys).to(contain(testRPCNameAllDisallowed));
+
+                        NSNumber<SDLBool> *allAllowed = changeDicts[1][testRPCNameAllAllowed];
+                        expect(allAllowed).to(equal(@NO));
+
+                        NSNumber<SDLBool> *allDisallowed = changeDicts[1][testRPCNameAllDisallowed];
+                        expect(allDisallowed).to(equal(@NO));
+                    });
+
+                    describe(@"when the permission has not changed", ^{
+                        __block SDLOnPermissionsChange *testPermissionChangeUpdateNoChange = nil;
+                        __block SDLPermissionItem *testPermissionUpdatedNoChange = nil;
+
+                        beforeEach(^{
+                            numberOfTimesObserverCalled = 0;
+
+                            // Create a permission update disallowing our current HMI level for the observed permission
+                            SDLParameterPermissions *testParameterPermissions = [[SDLParameterPermissions alloc] init];
+                            SDLHMIPermissions *testHMIPermissionsUpdated = [[SDLHMIPermissions alloc] init];
+                            testHMIPermissionsUpdated.allowed = @[SDLHMILevelBackground, SDLHMILevelFull];
+                            testHMIPermissionsUpdated.userDisallowed = @[SDLHMILevelLimited, SDLHMILevelNone];
+
+                            testPermissionUpdatedNoChange = [[SDLPermissionItem alloc] init];
+                            testPermissionUpdatedNoChange.rpcName = testRPCNameAllAllowed;
+                            testPermissionUpdatedNoChange.hmiPermissions = testHMIPermissionsUpdated;
+                            testPermissionUpdatedNoChange.parameterPermissions = testParameterPermissions;
+
+                            testPermissionChangeUpdateNoChange = [[SDLOnPermissionsChange alloc] init];
+                            testPermissionChangeUpdateNoChange.permissionItem = [NSArray arrayWithObject:testPermissionUpdated];
+
+                            // Send the permission update
+                            SDLRPCNotificationNotification *updatedNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidChangePermissionsNotification object:nil rpcNotification:testPermissionChangeUpdate];
+                            [[NSNotificationCenter defaultCenter] postNotification:updatedNotification];
+                        });
+
+                        it(@"should not call the filter observer again", ^{
+                            expect(numberOfTimesObserverCalled).to(equal(0));
+                        });
+                    });
+                });
+
+                context(@"to match an all allowed observer", ^{
+                    beforeEach(^{
+                        // Reset vars
+                        numberOfTimesObserverCalled = 0;
+                        changeDicts = [NSMutableArray array];
+                        testStatuses = [NSMutableArray array];
+
+                        // Post the notification before setting the observer to make sure data is already present
+                        // HMI Full & Limited allowed, hmi level BACKGROUND
+                        [[NSNotificationCenter defaultCenter] postNotification:backgroundHMINotification];
+                        [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
+                    });
+
+                    context(@"so that it becomes All Allowed", ^{
+                        beforeEach(^{
+                            // Set an observer that should be called immediately for the preexisting data, then called again when new data is sent
+                            [testPermissionsManager addStrictObserverForRPCs:@[testRPCNameAllDisallowed, testRPCNameFullLimitedBackgroundAllowed] groupType:SDLPermissionGroupTypeAllAllowed withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull change, SDLPermissionGroupStatus status) {
+                                numberOfTimesObserverCalled++;
+                                [changeDicts addObject:change];
+                                [testStatuses addObject:@(status)];
+                            }];
+
+                            // Create a permission update allowing our current HMI level for the observed permission
+                            SDLParameterPermissions *testParameterPermissions = [[SDLParameterPermissions alloc] init];
+                            SDLHMIPermissions *testHMIPermissionsUpdated = [[SDLHMIPermissions alloc] init];
+                            testHMIPermissionsUpdated.allowed = @[SDLHMILevelLimited, SDLHMILevelNone, SDLHMILevelBackground, SDLHMILevelFull];
+                            testHMIPermissionsUpdated.userDisallowed = @[];
+
+                            testPermissionUpdated = [[SDLPermissionItem alloc] init];
+                            testPermissionUpdated.rpcName = testRPCNameAllDisallowed;
+                            testPermissionUpdated.hmiPermissions = testHMIPermissionsUpdated;
+                            testPermissionUpdated.parameterPermissions = testParameterPermissions;
+
+                            testPermissionChangeUpdate = [[SDLOnPermissionsChange alloc] init];
+                            testPermissionChangeUpdate.permissionItem = [NSArray arrayWithObject:testPermissionUpdated];
+
+                            // Send the permission update
+                            SDLRPCNotificationNotification *updatedNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidChangePermissionsNotification object:nil rpcNotification:testPermissionChangeUpdate];
+                            [[NSNotificationCenter defaultCenter] postNotification:updatedNotification];
+                        });
+
+                        it(@"should call the observer twice", ^{
+                            expect(@(numberOfTimesObserverCalled)).to(equal(@1));
+                        });
+
+                        it(@"should have proper data in the first change dict", ^{
+                            expect(changeDicts[0].allKeys).to(haveCount(@2));
+                            expect(testStatuses[0]).to(equal(@(SDLPermissionGroupStatusMixed)));
+                        });
+
+                        it(@"should have the proper data in the second change dict", ^{
+                            expect(changeDicts[1].allKeys).to(haveCount(@2));
+                            expect(testStatuses[1]).to(equal(@(SDLPermissionGroupStatusAllowed)));
+                        });
+                    });
+
+                    context(@"so that it goes from All Allowed to mixed", ^{
+                        beforeEach(^{
+                            // Set an observer that should be called immediately for the preexisting data, then called again when new data is sent
+                            [testPermissionsManager addStrictObserverForRPCs:@[testRPCNameAllAllowed] groupType:SDLPermissionGroupTypeAllAllowed withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull change, SDLPermissionGroupStatus status) {
+                                numberOfTimesObserverCalled++;
+                                [changeDicts addObject:change];
+                                [testStatuses addObject:@(status)];
+                            }];
+
+                            // Create a permission update disallowing our current HMI level for the observed permission
+                            SDLParameterPermissions *testParameterPermissions = [[SDLParameterPermissions alloc] init];
+                            SDLHMIPermissions *testHMIPermissionsUpdated = [[SDLHMIPermissions alloc] init];
+                            testHMIPermissionsUpdated.allowed = @[];
+                            testHMIPermissionsUpdated.userDisallowed = @[SDLHMILevelBackground, SDLHMILevelFull, SDLHMILevelLimited, SDLHMILevelNone];
+
+                            testPermissionUpdated = [[SDLPermissionItem alloc] init];
+                            testPermissionUpdated.rpcName = testRPCNameAllAllowed;
+                            testPermissionUpdated.hmiPermissions = testHMIPermissionsUpdated;
+                            testPermissionUpdated.parameterPermissions = testParameterPermissions;
+
+                            testPermissionChangeUpdate = [[SDLOnPermissionsChange alloc] init];
+                            testPermissionChangeUpdate.permissionItem = [NSArray arrayWithObject:testPermissionUpdated];
+
+                            // Send the permission update
+                            SDLRPCNotificationNotification *updatedNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidChangePermissionsNotification object:nil rpcNotification:testPermissionChangeUpdate];
+                            [[NSNotificationCenter defaultCenter] postNotification:updatedNotification];
+                        });
+
+                        it(@"should call the observer twice", ^{
+                            expect(@(numberOfTimesObserverCalled)).to(equal(@2));
+                        });
+
+                        it(@"should have proper data in the first change dict", ^{
+                            expect(testStatuses[0]).to(equal(@(SDLPermissionGroupStatusAllowed)));
+                            expect(changeDicts[0].allKeys).to(contain(testRPCNameAllAllowed));
+
+                            NSNumber<SDLBool> *isAllowed = changeDicts[0][testRPCNameAllAllowed];
+                            expect(isAllowed).to(equal(@YES));
+                        });
+
+                        it(@"should have the proper data in the second change dict", ^{
+                            expect(testStatuses[1]).to(equal(@(SDLPermissionGroupStatusDisallowed)));
+                            expect(changeDicts[1].allKeys).to(contain(testRPCNameAllAllowed));
+
+                            NSNumber<SDLBool> *isAllowed = changeDicts[1][testRPCNameAllAllowed];
+                            expect(isAllowed).to(equal(@NO));
+                        });
+                    });
+                });
+
+                context(@"to not match an all allowed observer", ^{
+                    beforeEach(^{
+                        // Reset vars
+                        numberOfTimesObserverCalled = 0;
+                        changeDicts = [NSMutableArray array];
+                        testStatuses = [NSMutableArray array];
+
+                        // Post the notification before setting the observer to make sure data is already present
+                        // HMI Full & Limited allowed, hmi level BACKGROUND
+                        [[NSNotificationCenter defaultCenter] postNotification:backgroundHMINotification];
+                        [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
+                    });
+
+                    context(@"from mixed to disallowed", ^{
+                        beforeEach(^{
+                            // Set an observer that should be called immediately for the preexisting data, then called again when new data is sent
+                            [testPermissionsManager addStrictObserverForRPCs:@[testRPCNameAllAllowed, testRPCNameAllDisallowed] groupType:SDLPermissionGroupTypeAllAllowed withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull change, SDLPermissionGroupStatus status) {
+                                numberOfTimesObserverCalled++;
+                                [changeDicts addObject:change];
+                                [testStatuses addObject:@(status)];
+                            }];
+
+                            // Create a permission update disallowing our current HMI level for the observed permission
+                            SDLParameterPermissions *testParameterPermissions = [[SDLParameterPermissions alloc] init];
+                            SDLHMIPermissions *testHMIPermissionsUpdated = [[SDLHMIPermissions alloc] init];
+                            testHMIPermissionsUpdated.allowed = @[];
+                            testHMIPermissionsUpdated.userDisallowed = @[SDLHMILevelBackground, SDLHMILevelFull, SDLHMILevelLimited, SDLHMILevelNone];
+
+                            testPermissionUpdated = [[SDLPermissionItem alloc] init];
+                            testPermissionUpdated.rpcName = testRPCNameAllAllowed;
+                            testPermissionUpdated.hmiPermissions = testHMIPermissionsUpdated;
+                            testPermissionUpdated.parameterPermissions = testParameterPermissions;
+
+                            testPermissionChangeUpdate = [[SDLOnPermissionsChange alloc] init];
+                            testPermissionChangeUpdate.permissionItem = [NSArray arrayWithObject:testPermissionUpdated];
+
+                            // Send the permission update
+                            SDLRPCNotificationNotification *updatedNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidChangePermissionsNotification object:nil rpcNotification:testPermissionChangeUpdate];
+                            [[NSNotificationCenter defaultCenter] postNotification:updatedNotification];
+                        });
+
+                        it(@"should call the observer with a mixed status", ^{
+                            expect(@(numberOfTimesObserverCalled)).to(equal(@1));
+                            expect(testStatuses[0]).to(equal(@(SDLPermissionGroupStatusMixed)));
+                        });
+                    });
+
+                    context(@"from disallowed to mixed", ^{
+                        beforeEach(^{
+                            // Set an observer that should be called immediately for the preexisting data, then called again when new data is sent
+                            [testPermissionsManager addStrictObserverForRPCs:@[testRPCNameFullLimitedAllowed, testRPCNameAllDisallowed] groupType:SDLPermissionGroupTypeAllAllowed withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull change, SDLPermissionGroupStatus status) {
+                                numberOfTimesObserverCalled++;
+                                [changeDicts addObject:change];
+                                [testStatuses addObject:@(status)];
+                            }];
+
+                            // Create a permission update disallowing our current HMI level for the observed permission
+                            SDLParameterPermissions *testParameterPermissions = [[SDLParameterPermissions alloc] init];
+                            SDLHMIPermissions *testHMIPermissionsUpdated = [[SDLHMIPermissions alloc] init];
+                            testHMIPermissionsUpdated.allowed = @[SDLHMILevelLimited, SDLHMILevelBackground];
+                            testHMIPermissionsUpdated.userDisallowed = @[SDLHMILevelFull, SDLHMILevelNone];
+
+                            testPermissionUpdated = [[SDLPermissionItem alloc] init];
+                            testPermissionUpdated.rpcName = testRPCNameAllAllowed;
+                            testPermissionUpdated.hmiPermissions = testHMIPermissionsUpdated;
+                            testPermissionUpdated.parameterPermissions = testParameterPermissions;
+
+                            testPermissionChangeUpdate = [[SDLOnPermissionsChange alloc] init];
+                            testPermissionChangeUpdate.permissionItem = [NSArray arrayWithObject:testPermissionUpdated];
+
+                            // Send the permission update
+                            SDLRPCNotificationNotification *updatedNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidChangePermissionsNotification object:nil rpcNotification:testPermissionChangeUpdate];
+                            [[NSNotificationCenter defaultCenter] postNotification:updatedNotification];
+                        });
+
+                        it(@"should call the observer", ^{
+                            expect(@(numberOfTimesObserverCalled)).to(equal(@1));
+                            expect(testStatuses[0]).to(equal(@(SDLPermissionGroupStatusDisallowed)));
+                        });
+                    });
+                });
+            });
+        });
+
+
+
+
+
+
+
+
+
+
+
+
+
         describe(@"adding new observers", ^{
             context(@"when no data is present", ^{
                 __block BOOL testObserverCalled = NO;

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLPermissionsManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLPermissionsManagerSpec.m
@@ -558,6 +558,45 @@ describe(@"SDLPermissionsManager", ^{
             });
         });
 
+        describe(@"adding a new observer with subscribeToRPC:", ^{
+            context(@"when no data is present", ^{
+                __block BOOL testObserverCalled = NO;
+
+                beforeEach(^{
+                    testObserverCalled = NO;
+                    [testPermissionsManager subscribeToRPCs:@[testRPCNameAllAllowed, testRPCNameAllDisallowed] groupType:SDLPermissionGroupTypeAny withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull change, SDLPermissionGroupStatus status) {
+                        testObserverCalled = YES;
+                    }];
+                });
+
+                it(@"should not be called", ^{
+                    expect(@(testObserverCalled)).to(equal(@NO));
+                });
+            });
+
+            context(@"when data is present", ^{
+                __block BOOL testObserverCalled = NO;
+
+                beforeEach(^{
+                    testObserverCalled = NO;
+
+                    // Post the notification before setting the observer to make sure data is already present
+                    // HMI Full & Limited allowed
+                    [[NSNotificationCenter defaultCenter] postNotification:limitedHMINotification];
+                    [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
+
+                    // This should not be called even with data currently present, the handler will only be called when an permissions update occurs after the RPC is subscribed to
+                    [testPermissionsManager subscribeToRPCs:@[testRPCNameAllAllowed, testRPCNameAllDisallowed] groupType:SDLPermissionGroupTypeAny withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull change, SDLPermissionGroupStatus status) {
+                        testObserverCalled = YES;
+                    }];
+                });
+
+                it(@"should not be called", ^{
+                    expect(@(testObserverCalled)).to(equal(@NO));
+                });
+            });
+        });
+
         context(@"updating an observer with new permission data", ^{
             __block NSInteger numberOfTimesObserverCalled = 0;
 

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLPermissionsManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLPermissionsManagerSpec.m
@@ -153,10 +153,10 @@ describe(@"SDLPermissionsManager", ^{
                 });
             });
 
-            context(@"isRPCPermitted: method", ^{
+            context(@"isRPCNameAllowed: method", ^{
                 beforeEach(^{
                     someRPCFunctionName = @"SomeRPCFunctionName";
-                    testResultBOOL = [testPermissionsManager isRPCPermitted:someRPCName];
+                    testResultBOOL = [testPermissionsManager isRPCNameAllowed:someRPCName];
                 });
 
                 it(@"should not be allowed", ^{
@@ -180,10 +180,10 @@ describe(@"SDLPermissionsManager", ^{
                 });
             });
 
-            context(@"isRPCPermitted: method", ^{
+            context(@"isRPCNameAllowed: method", ^{
                 beforeEach(^{
                     [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
-                    testResultBOOL = [testPermissionsManager isRPCPermitted:someRPCName];
+                    testResultBOOL = [testPermissionsManager isRPCNameAllowed:someRPCName];
                 });
 
                 it(@"should not be allowed", ^{
@@ -225,13 +225,13 @@ describe(@"SDLPermissionsManager", ^{
                 });
             });
 
-            context(@"isRPCPermitted: method", ^{
+            context(@"isRPCNameAllowed: method", ^{
                 context(@"and the permission is allowed", ^{
                     beforeEach(^{
                         [[NSNotificationCenter defaultCenter] postNotification:limitedHMINotification];
                         [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
 
-                        testResultBOOL = [testPermissionsManager isRPCPermitted:testRPCNameAllAllowed];
+                        testResultBOOL = [testPermissionsManager isRPCNameAllowed:testRPCNameAllAllowed];
                     });
 
                     it(@"should be allowed", ^{
@@ -244,7 +244,7 @@ describe(@"SDLPermissionsManager", ^{
                         [[NSNotificationCenter defaultCenter] postNotification:limitedHMINotification];
                         [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
 
-                        testResultBOOL = [testPermissionsManager isRPCPermitted:testRPCNameAllDisallowed];
+                        testResultBOOL = [testPermissionsManager isRPCNameAllowed:testRPCNameAllDisallowed];
                     });
 
                     it(@"should be denied", ^{
@@ -391,9 +391,9 @@ describe(@"SDLPermissionsManager", ^{
                 });
             });
 
-            context(@"statusOfRPCNames: method", ^{
+            context(@"statusesOfRPCNames: method", ^{
                 beforeEach(^{
-                    testResultPermissionStatusDict = [testPermissionsManager statusOfRPCNames:@[testRPCNameAllAllowed, testRPCNameAllDisallowed]];
+                    testResultPermissionStatusDict = [testPermissionsManager statusesOfRPCNames:@[testRPCNameAllAllowed, testRPCNameAllDisallowed]];
                 });
 
                 it(@"should return correct permission statuses", ^{
@@ -420,12 +420,12 @@ describe(@"SDLPermissionsManager", ^{
                 });
             });
 
-            context(@"statusOfRPCNames: method", ^{
+            context(@"statusesOfRPCNames: method", ^{
                 beforeEach(^{
                     [[NSNotificationCenter defaultCenter] postNotification:limitedHMINotification];
                     [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
 
-                    testResultPermissionStatusDict = [testPermissionsManager statusOfRPCNames:@[testRPCNameAllAllowed, testRPCNameAllDisallowed]];
+                    testResultPermissionStatusDict = [testPermissionsManager statusesOfRPCNames:@[testRPCNameAllAllowed, testRPCNameAllDisallowed]];
                 });
 
                 it(@"should return correct permission statuses", ^{
@@ -558,19 +558,19 @@ describe(@"SDLPermissionsManager", ^{
             });
         });
 
-        describe(@"adding a new observer with subscribeToRPC:", ^{
+        describe(@"adding a new observer with subscribeToRPCNames:groupType:Handler", ^{
             context(@"when no data is present", ^{
                 __block BOOL testObserverCalled = NO;
 
                 beforeEach(^{
                     testObserverCalled = NO;
-                    [testPermissionsManager subscribeToRPCs:@[testRPCNameAllAllowed, testRPCNameAllDisallowed] groupType:SDLPermissionGroupTypeAny withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull change, SDLPermissionGroupStatus status) {
+                    [testPermissionsManager subscribeToRPCNames:@[testRPCNameAllAllowed, testRPCNameAllDisallowed] groupType:SDLPermissionGroupTypeAny withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull change, SDLPermissionGroupStatus status) {
                         testObserverCalled = YES;
                     }];
                 });
 
-                it(@"should not be called", ^{
-                    expect(testObserverCalled).to(beFalse());
+                it(@"should be called", ^{
+                    expect(testObserverCalled).to(beTrue());
                 });
             });
 
@@ -586,13 +586,13 @@ describe(@"SDLPermissionsManager", ^{
                     [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
 
                     // This should not be called even with data currently present, the handler will only be called when an permissions update occurs after the RPC is subscribed to
-                    [testPermissionsManager subscribeToRPCs:@[testRPCNameAllAllowed, testRPCNameAllDisallowed] groupType:SDLPermissionGroupTypeAny withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull change, SDLPermissionGroupStatus status) {
+                    [testPermissionsManager subscribeToRPCNames:@[testRPCNameAllAllowed, testRPCNameAllDisallowed] groupType:SDLPermissionGroupTypeAny withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull change, SDLPermissionGroupStatus status) {
                         testObserverCalled = YES;
                     }];
                 });
 
-                it(@"should not be called", ^{
-                    expect(@(testObserverCalled)).to(equal(@NO));
+                it(@"should be called", ^{
+                    expect(@(testObserverCalled)).to(beTrue());
                 });
             });
         });

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLPermissionsManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLPermissionsManagerSpec.m
@@ -138,8 +138,11 @@ describe(@"SDLPermissionsManager", ^{
         context(@"when no permissions exist", ^{
             beforeEach(^{
                 someRPCName = @"some rpc name";
-                
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 testResultBOOL = [testPermissionsManager isRPCAllowed:someRPCName];
+#pragma clang diagnostic pop
             });
             
             it(@"should not be allowed", ^{
@@ -150,8 +153,10 @@ describe(@"SDLPermissionsManager", ^{
         context(@"when permissions exist but no HMI level", ^{
             beforeEach(^{
                 [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
-                
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 testResultBOOL = [testPermissionsManager isRPCAllowed:testRPCNameAllAllowed];
+#pragma clang diagnostic pop
             });
             
             it(@"should not be allowed", ^{
@@ -164,8 +169,10 @@ describe(@"SDLPermissionsManager", ^{
                 beforeEach(^{
                     [[NSNotificationCenter defaultCenter] postNotification:limitedHMINotification];
                     [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
-                    
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                     testResultBOOL = [testPermissionsManager isRPCAllowed:testRPCNameAllAllowed];
+#pragma clang diagnostic pop
                 });
                 
                 it(@"should be allowed", ^{
@@ -177,8 +184,10 @@ describe(@"SDLPermissionsManager", ^{
                 beforeEach(^{
                     [[NSNotificationCenter defaultCenter] postNotification:limitedHMINotification];
                     [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
-                    
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                     testResultBOOL = [testPermissionsManager isRPCAllowed:testRPCNameAllDisallowed];
+#pragma clang diagnostic pop
                 });
                 
                 it(@"should be denied", ^{
@@ -193,7 +202,10 @@ describe(@"SDLPermissionsManager", ^{
         
         context(@"with no permissions data", ^{
             beforeEach(^{
+                #pragma clang diagnostic push
+                #pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 testResultStatus = [testPermissionsManager groupStatusOfRPCs:@[testRPCNameAllAllowed, testRPCNameAllDisallowed]];
+                #pragma clang diagnostic pop
             });
             
             it(@"should return unknown", ^{
@@ -205,8 +217,10 @@ describe(@"SDLPermissionsManager", ^{
             beforeEach(^{
                 [[NSNotificationCenter defaultCenter] postNotification:limitedHMINotification];
                 [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
-                
+                #pragma clang diagnostic push
+                #pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 testResultStatus = [testPermissionsManager groupStatusOfRPCs:@[testRPCNameAllAllowed, testRPCNameFullLimitedAllowed]];
+                #pragma clang diagnostic pop
             });
             
             it(@"should return mixed", ^{
@@ -218,8 +232,10 @@ describe(@"SDLPermissionsManager", ^{
             beforeEach(^{
                 [[NSNotificationCenter defaultCenter] postNotification:backgroundHMINotification];
                 [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
-                
+                #pragma clang diagnostic push
+                #pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 testResultStatus = [testPermissionsManager groupStatusOfRPCs:@[testRPCNameFullLimitedAllowed, testRPCNameAllDisallowed]];
+                #pragma clang diagnostic pop
             });
             
             it(@"should return mixed", ^{
@@ -231,8 +247,10 @@ describe(@"SDLPermissionsManager", ^{
             beforeEach(^{
                 [[NSNotificationCenter defaultCenter] postNotification:limitedHMINotification];
                 [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
-                
+                #pragma clang diagnostic push
+                #pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 testResultStatus = [testPermissionsManager groupStatusOfRPCs:@[testRPCNameAllAllowed, testRPCNameAllDisallowed]];
+                #pragma clang diagnostic pop
             });
             
             it(@"should return mixed", ^{
@@ -246,7 +264,10 @@ describe(@"SDLPermissionsManager", ^{
         
         context(@"with no permissions data", ^{
             beforeEach(^{
+                #pragma clang diagnostic push
+                #pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 testResultPermissionStatusDict = [testPermissionsManager statusOfRPCs:@[testRPCNameAllAllowed, testRPCNameAllDisallowed]];
+                #pragma clang diagnostic pop
             });
             
             it(@"should return correct permission statuses", ^{
@@ -259,8 +280,10 @@ describe(@"SDLPermissionsManager", ^{
             beforeEach(^{
                 [[NSNotificationCenter defaultCenter] postNotification:limitedHMINotification];
                 [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
-                
+                #pragma clang diagnostic push
+                #pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 testResultPermissionStatusDict = [testPermissionsManager statusOfRPCs:@[testRPCNameAllAllowed, testRPCNameAllDisallowed]];
+                #pragma clang diagnostic pop
             });
             
             it(@"should return correct permission statuses", ^{
@@ -281,12 +304,14 @@ describe(@"SDLPermissionsManager", ^{
                     testObserverCalled = NO;
                     testObserverStatus = SDLPermissionGroupStatusUnknown;
                     testObserverChangeDict = nil;
-
+                    #pragma clang diagnostic push
+                    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
                     [testPermissionsManager addObserverForRPCs:@[testRPCNameAllAllowed, testRPCNameAllDisallowed] groupType:SDLPermissionGroupTypeAny withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull change, SDLPermissionGroupStatus status) {
                         testObserverChangeDict = change;
                         testObserverStatus = status;
                         testObserverCalled = YES;
                     }];
+                    #pragma clang diagnostic pop
                 });
 
                 it(@"should return correct permission statuses", ^{
@@ -313,11 +338,14 @@ describe(@"SDLPermissionsManager", ^{
                         [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
 
                         // This should be called twice, once for each RPC being observed. It should be called immediately since data should already be present
+                        #pragma clang diagnostic push
+                        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
                         [testPermissionsManager addObserverForRPCs:@[testRPCNameAllAllowed, testRPCNameAllDisallowed] groupType:SDLPermissionGroupTypeAny withHandler:^(NSDictionary<SDLPermissionRPCName, NSNumber *> * _Nonnull changedDict, SDLPermissionGroupStatus status) {
                             numberOfTimesObserverCalled++;
                             testObserverBlockChangedDict = changedDict;
                             testObserverReturnStatus = status;
                         }];
+                        #pragma clang diagnostic pop
                     });
 
                     it(@"should call the observer with proper status", ^{
@@ -340,11 +368,14 @@ describe(@"SDLPermissionsManager", ^{
                         [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
 
                         // This should be called twice, once for each RPC being observed. It should be called immediately since data should already be present
+                        #pragma clang diagnostic push
+                        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
                         [testPermissionsManager addObserverForRPCs:@[testRPCNameAllAllowed, testRPCNameFullLimitedAllowed] groupType:SDLPermissionGroupTypeAllAllowed withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull change, SDLPermissionGroupStatus status) {
                             numberOfTimesObserverCalled++;
                             testObserverBlockChangedDict = change;
                             testObserverReturnStatus = status;
                         }];
+                        #pragma clang diagnostic pop
                     });
 
                     it(@"should call the observer with proper status", ^{
@@ -367,10 +398,13 @@ describe(@"SDLPermissionsManager", ^{
                         [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
 
                         // This should be called twice, once for each RPC being observed. It should be called immediately since data should already be present
+                        #pragma clang diagnostic push
+                        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
                         [testPermissionsManager addObserverForRPCs:@[testRPCNameAllDisallowed, testRPCNameFullLimitedAllowed] groupType:SDLPermissionGroupTypeAllAllowed withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull change, SDLPermissionGroupStatus status) {
                             numberOfTimesObserverCalled++;
                             testObserverReturnStatus = status;
                         }];
+                        #pragma clang diagnostic pop
                     });
 
                     it(@"should call the observer with status Disallowed", ^{
@@ -402,10 +436,13 @@ describe(@"SDLPermissionsManager", ^{
                     [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
 
                     // Set an observer that should be called immediately for the preexisting data, then called again when new data is sent
+                    #pragma clang diagnostic push
+                    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
                     [testPermissionsManager addObserverForRPCs:@[testRPCNameAllAllowed, testRPCNameAllDisallowed] groupType:SDLPermissionGroupTypeAny withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull changedDict, SDLPermissionGroupStatus status) {
                         numberOfTimesObserverCalled++;
                         [changeDicts addObject:changedDict];
                     }];
+                    #pragma clang diagnostic pop
 
                     // Create a permission update disallowing our current HMI level for the observed permission
                     SDLParameterPermissions *testParameterPermissions = [[SDLParameterPermissions alloc] init];
@@ -500,11 +537,14 @@ describe(@"SDLPermissionsManager", ^{
                 context(@"so that it becomes All Allowed", ^{
                     beforeEach(^{
                         // Set an observer that should be called immediately for the preexisting data, then called again when new data is sent
+                        #pragma clang diagnostic push
+                        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
                         [testPermissionsManager addObserverForRPCs:@[testRPCNameAllDisallowed, testRPCNameFullLimitedBackgroundAllowed] groupType:SDLPermissionGroupTypeAllAllowed withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull change, SDLPermissionGroupStatus status) {
                             numberOfTimesObserverCalled++;
                             [changeDicts addObject:change];
                             [testStatuses addObject:@(status)];
                         }];
+                        #pragma clang diagnostic pop
 
                         // Create a permission update allowing our current HMI level for the observed permission
                         SDLParameterPermissions *testParameterPermissions = [[SDLParameterPermissions alloc] init];
@@ -543,11 +583,14 @@ describe(@"SDLPermissionsManager", ^{
                 context(@"so that it goes from All Allowed to mixed", ^{
                     beforeEach(^{
                         // Set an observer that should be called immediately for the preexisting data, then called again when new data is sent
+                        #pragma clang diagnostic push
+                        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
                         [testPermissionsManager addObserverForRPCs:@[testRPCNameAllAllowed] groupType:SDLPermissionGroupTypeAllAllowed withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull change, SDLPermissionGroupStatus status) {
                             numberOfTimesObserverCalled++;
                             [changeDicts addObject:change];
                             [testStatuses addObject:@(status)];
                         }];
+                        #pragma clang diagnostic pop
 
                         // Create a permission update disallowing our current HMI level for the observed permission
                         SDLParameterPermissions *testParameterPermissions = [[SDLParameterPermissions alloc] init];
@@ -606,11 +649,14 @@ describe(@"SDLPermissionsManager", ^{
                 context(@"from mixed to disallowed", ^{
                     beforeEach(^{
                         // Set an observer that should be called immediately for the preexisting data, then called again when new data is sent
+                        #pragma clang diagnostic push
+                        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
                         [testPermissionsManager addObserverForRPCs:@[testRPCNameAllAllowed, testRPCNameAllDisallowed] groupType:SDLPermissionGroupTypeAllAllowed withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull change, SDLPermissionGroupStatus status) {
                             numberOfTimesObserverCalled++;
                             [changeDicts addObject:change];
                             [testStatuses addObject:@(status)];
                         }];
+                        #pragma clang diagnostic pop
 
                         // Create a permission update disallowing our current HMI level for the observed permission
                         SDLParameterPermissions *testParameterPermissions = [[SDLParameterPermissions alloc] init];
@@ -640,11 +686,14 @@ describe(@"SDLPermissionsManager", ^{
                 context(@"from disallowed to mixed", ^{
                     beforeEach(^{
                         // Set an observer that should be called immediately for the preexisting data, then called again when new data is sent
+                        #pragma clang diagnostic push
+                        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
                         [testPermissionsManager addObserverForRPCs:@[testRPCNameFullLimitedAllowed, testRPCNameAllDisallowed] groupType:SDLPermissionGroupTypeAllAllowed withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull change, SDLPermissionGroupStatus status) {
                             numberOfTimesObserverCalled++;
                             [changeDicts addObject:change];
                             [testStatuses addObject:@(status)];
                         }];
+                        #pragma clang diagnostic pop
 
                         // Create a permission update disallowing our current HMI level for the observed permission
                         SDLParameterPermissions *testParameterPermissions = [[SDLParameterPermissions alloc] init];
@@ -691,11 +740,14 @@ describe(@"SDLPermissionsManager", ^{
                     [[NSNotificationCenter defaultCenter] postNotification:testPermissionsNotification];
 
                     // Set an observer that should be called immediately for the preexisting data, then called again when new data is sent
+                    #pragma clang diagnostic push
+                    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
                     [testPermissionsManager addObserverForRPCs:@[testRPCNameAllAllowed, testRPCNameFullLimitedAllowed] groupType:SDLPermissionGroupTypeAny withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull changedDict, SDLPermissionGroupStatus status) {
                         numberOfTimesObserverCalled++;
                         [changeDicts addObject:changedDict];
                         [testStatuses addObject:@(status)];
                     }];
+                    #pragma clang diagnostic pop
 
                     // Upgrade the HMI level to LIMITED
                     [[NSNotificationCenter defaultCenter] postNotification:limitedHMINotification];
@@ -742,11 +794,14 @@ describe(@"SDLPermissionsManager", ^{
                 context(@"so that it becomes All Allowed", ^{
                     beforeEach(^{
                         // Set an observer that should be called immediately for the preexisting data, then called again when new data is sent
+                        #pragma clang diagnostic push
+                        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
                         [testPermissionsManager addObserverForRPCs:@[testRPCNameFullLimitedAllowed] groupType:SDLPermissionGroupTypeAllAllowed withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull changedDict, SDLPermissionGroupStatus status) {
                             numberOfTimesObserverCalled++;
                             [changeDicts addObject:changedDict];
                             [testStatuses addObject:@(status)];
                         }];
+                        #pragma clang diagnostic pop
 
                         [[NSNotificationCenter defaultCenter] postNotification:limitedHMINotification];
                     });
@@ -762,11 +817,14 @@ describe(@"SDLPermissionsManager", ^{
                 context(@"so that it goes from All Allowed to at least some disallowed", ^{
                     beforeEach(^{
                         // Set an observer that should be called immediately for the preexisting data, then called again when new data is sent
+                        #pragma clang diagnostic push
+                        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
                         [testPermissionsManager addObserverForRPCs:@[testRPCNameFullLimitedBackgroundAllowed] groupType:SDLPermissionGroupTypeAllAllowed withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull changedDict, SDLPermissionGroupStatus status) {
                             numberOfTimesObserverCalled++;
                             [changeDicts addObject:changedDict];
                             [testStatuses addObject:@(status)];
                         }];
+                        #pragma clang diagnostic pop
 
                         [[NSNotificationCenter defaultCenter] postNotification:noneHMINotification];
                     });
@@ -811,11 +869,14 @@ describe(@"SDLPermissionsManager", ^{
                 context(@"that goes from disallowed to mixed", ^{
                     beforeEach(^{
                         // Set an observer that should be called immediately for the preexisting data, then called again when new data is sent
+                        #pragma clang diagnostic push
+                        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
                         [testPermissionsManager addObserverForRPCs:@[testRPCNameFullLimitedAllowed, testRPCNameAllDisallowed] groupType:SDLPermissionGroupTypeAllAllowed withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull changedDict, SDLPermissionGroupStatus status) {
                             numberOfTimesObserverCalled++;
                             [changeDicts addObject:changedDict];
                             [testStatuses addObject:@(status)];
                         }];
+                        #pragma clang diagnostic pop
 
                         [[NSNotificationCenter defaultCenter] postNotification:limitedHMINotification];
                     });
@@ -830,11 +891,14 @@ describe(@"SDLPermissionsManager", ^{
                 context(@"that goes from mixed to disallowed", ^{
                     beforeEach(^{
                         // Set an observer that should be called immediately for the preexisting data, then called again when new data is sent
+                        #pragma clang diagnostic push
+                        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
                         [testPermissionsManager addObserverForRPCs:@[testRPCNameFullLimitedAllowed, testRPCNameFullLimitedBackgroundAllowed] groupType:SDLPermissionGroupTypeAllAllowed withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull changedDict, SDLPermissionGroupStatus status) {
                             numberOfTimesObserverCalled++;
                             [changeDicts addObject:changedDict];
                             [testStatuses addObject:@(status)];
                         }];
+                        #pragma clang diagnostic pop
 
                         [[NSNotificationCenter defaultCenter] postNotification:noneHMINotification];
                     });
@@ -857,9 +921,12 @@ describe(@"SDLPermissionsManager", ^{
                 numberOfTimesObserverCalled = 0;
 
                 // Add two observers
+                #pragma clang diagnostic push
+                #pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 NSUUID *observerId = [testPermissionsManager addObserverForRPCs:@[testRPCNameAllAllowed, testRPCNameFullLimitedAllowed] groupType:SDLPermissionGroupTypeAny withHandler:^(NSDictionary<SDLPermissionRPCName, NSNumber *> * _Nonnull changedDict, SDLPermissionGroupStatus status) {
                     numberOfTimesObserverCalled++;
                 }];
+                #pragma clang diagnostic pop
 
                 // Remove one observer
                 [testPermissionsManager removeObserverForIdentifier:observerId];
@@ -882,6 +949,8 @@ describe(@"SDLPermissionsManager", ^{
                 numberOfTimesObserverCalled = 0;
 
                 // Add two observers
+                #pragma clang diagnostic push
+                #pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 NSUUID *testRemovedObserverId = [testPermissionsManager addObserverForRPCs:@[testRPCNameAllAllowed, testRPCNameFullLimitedAllowed] groupType:SDLPermissionGroupTypeAny withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull changedDict, SDLPermissionGroupStatus status) {
                     numberOfTimesObserverCalled++;
                 }];
@@ -889,6 +958,7 @@ describe(@"SDLPermissionsManager", ^{
                 [testPermissionsManager addObserverForRPCs:@[testRPCNameAllAllowed, testRPCNameFullLimitedAllowed] groupType:SDLPermissionGroupTypeAny withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull changedDict, SDLPermissionGroupStatus status) {
                     numberOfTimesObserverCalled++;
                 }];
+                #pragma clang diagnostic pop
 
                 // Remove one observer
                 [testPermissionsManager removeObserverForIdentifier:testRemovedObserverId];
@@ -911,6 +981,8 @@ describe(@"SDLPermissionsManager", ^{
                 numberOfTimesObserverCalled = 0;
 
                 // Add two observers
+                #pragma clang diagnostic push
+                #pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 [testPermissionsManager addObserverForRPCs:@[testRPCNameAllAllowed, testRPCNameAllDisallowed] groupType:SDLPermissionGroupTypeAny withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull changedDict, SDLPermissionGroupStatus status) {
                     numberOfTimesObserverCalled++;
                 }];
@@ -918,6 +990,7 @@ describe(@"SDLPermissionsManager", ^{
                 [testPermissionsManager addObserverForRPCs:@[testRPCNameAllAllowed, testRPCNameAllDisallowed] groupType:SDLPermissionGroupTypeAny withHandler:^(NSDictionary<SDLPermissionRPCName,NSNumber *> * _Nonnull changedDict, SDLPermissionGroupStatus status) {
                     numberOfTimesObserverCalled++;
                 }];
+                #pragma clang diagnostic pop
 
                 // Remove all observers
                 [testPermissionsManager removeAllObservers];


### PR DESCRIPTION
Fixes #1667 and #1661 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Added unit tests for new methods that take a `SDLRPCFunctionName`. Added tests to test the new functionality introduced with `subscribeToRPCs:groupType:withHandler:`.

#### Core Tests
Ran tests against Core and verified that the callback in `subscribeToRPCs:groupType:withHandler:` was not called immediately. Verified appropriate permission responses were passed back from old/new methods by printing out the results of the method call.

Core version / branch / commit hash / module tested against: SYNC 3.0 Build 17276_DEVTEST
HMI name / version / branch / commit hash / module tested against: Manticore v0.7.2

### Summary
Deprecated functions whose parameter took a `SDLPermissionRPCName` and created new methods that take a `SDLRPCFunctionName` instead. New permissions observer method was created to align with Java Suite, now the observer will not be called when it is first set.

### Changelog

##### Enhancements
Deprecated methods -> new method
- `isRPCAllowed:` -> `isRPCPermitted:`
- `groupStatusOfRPCs:` -> `groupStatusOfRPCNames:`
- `statusOfRPCs:` -> `statusOfRPCNames:`
- `addObserverForRPCs:groupType:withHandler:` -> `subscribeToRPCs:groupType:withHandler:`
- `statusOfRPCs:` -> `statusOfRPCNames:`
- `rpcRequiresEncryption:` -> `rpcNameRequiresEncryption:`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
