### PR TITLE
Add BSON and example apps to codecov exclude list

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,7 +5,8 @@ coverage:
   ignore:
   - Carthage/.*
   - SmartDeviceLinkTests/.*
-  - SmartDeviceLinkExample/.*
+  - Example Apps/.*
+  - bson_c_lib/.*
   status:
     project: false
     patch:


### PR DESCRIPTION
Fixes #1678

This PR is **not ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [ ] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [ ] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
n/a This is only for CI testing

#### Core Tests
n/a This is only for CI testing

Core version / branch / commit hash / module tested against: n/a
HMI name / version / branch / commit hash / module tested against: n/a

### Summary
This removes the bson library and the example apps from being checked by Codecov.

### Changelog
n/a No API changes

### Tasks Remaining:
- [ ] Ensure that Codecov no longer checks example apps

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
