### PR TITLE
Fix Soft Buttons handlers are never removed

### DIFF
--- a/SmartDeviceLink/SDLResponseDispatcher.h
+++ b/SmartDeviceLink/SDLResponseDispatcher.h
@@ -46,9 +46,19 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic, readonly) NSMapTable<SDLSubscribeButtonName *, SDLRPCButtonNotificationHandler> *buttonHandlerMap;
 
 /**
- *  Holds a map of soft button ids and their corresponding blocks.
+ *  Holds a map of SDLShow soft button ids and their corresponding blocks.
  */
-@property (strong, nonatomic, readonly) NSMapTable<SDLSoftButtonId *, SDLRPCButtonNotificationHandler> *customButtonHandlerMap;
+@property (strong, nonatomic, readonly) NSMapTable<SDLSoftButtonId *, SDLRPCButtonNotificationHandler> *showButtonHandlerMap;
+
+/**
+*  Holds a map of SDLAlert soft button ids and their corresponding blocks.
+*/
+@property (strong, nonatomic, readonly) NSMapTable<SDLSoftButtonId *, SDLRPCButtonNotificationHandler> *alertButtonHandlerMap;
+
+/**
+*  Holds a map of SDLScrollableMessage soft button ids and their corresponding blocks.
+*/
+@property (strong, nonatomic, readonly) NSMapTable<SDLSoftButtonId *, SDLRPCButtonNotificationHandler> *scrollMsgButtonHandlerMap;
 
 /**
  *  Holds an audio pass thru block.

--- a/SmartDeviceLink/SDLResponseDispatcher.h
+++ b/SmartDeviceLink/SDLResponseDispatcher.h
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic, readonly) NSMapTable<SDLSubscribeButtonName *, SDLRPCButtonNotificationHandler> *buttonHandlerMap;
 
 /**
- *  Holds a map of SDLShow soft button ids and their corresponding blocks.
+ *  Holds a map of SDLShow soft button ids and their corresponding blocks.  
  */
 @property (strong, nonatomic, readonly) NSMapTable<SDLSoftButtonId *, SDLRPCButtonNotificationHandler> *showButtonHandlerMap;
 

--- a/SmartDeviceLinkTests/Notifications/SDLResponseDispatcherSpec.m
+++ b/SmartDeviceLinkTests/Notifications/SDLResponseDispatcherSpec.m
@@ -43,14 +43,18 @@ describe(@"a response dispatcher", ^{
         expect(testDispatcher.rpcRequestDictionary).toNot(beNil());
         expect(testDispatcher.commandHandlerMap).toNot(beNil());
         expect(testDispatcher.buttonHandlerMap).toNot(beNil());
-        expect(testDispatcher.customButtonHandlerMap).toNot(beNil());
+        expect(testDispatcher.showButtonHandlerMap).toNot(beNil());
+        expect(testDispatcher.alertButtonHandlerMap).toNot(beNil());
+        expect(testDispatcher.scrollMsgButtonHandlerMap).toNot(beNil());
 //        expect(testDispatcher.audioPassThruHandler).to(beNil());
 
         expect(testDispatcher.rpcResponseHandlerMap).to(haveCount(@0));
         expect(testDispatcher.rpcRequestDictionary).to(haveCount(@0));
         expect(testDispatcher.commandHandlerMap).to(haveCount(@0));
         expect(testDispatcher.buttonHandlerMap).to(haveCount(@0));
-        expect(testDispatcher.customButtonHandlerMap).to(haveCount(@0));
+        expect(testDispatcher.showButtonHandlerMap).to(haveCount(@0));
+        expect(testDispatcher.alertButtonHandlerMap).to(haveCount(@0));
+        expect(testDispatcher.scrollMsgButtonHandlerMap).to(haveCount(@0));
     });
     
     context(@"storing a request without a handler", ^{
@@ -70,7 +74,9 @@ describe(@"a response dispatcher", ^{
             expect(testDispatcher.rpcRequestDictionary).to(haveCount(@1));
             expect(testDispatcher.commandHandlerMap).to(haveCount(@0));
             expect(testDispatcher.buttonHandlerMap).to(haveCount(@0));
-            expect(testDispatcher.customButtonHandlerMap).to(haveCount(@0));
+            expect(testDispatcher.showButtonHandlerMap).to(haveCount(@0));
+            expect(testDispatcher.alertButtonHandlerMap).to(haveCount(@0));
+            expect(testDispatcher.scrollMsgButtonHandlerMap).to(haveCount(@0));
         });
     });
     
@@ -139,8 +145,8 @@ describe(@"a response dispatcher", ^{
             });
             
             it(@"should add the soft button to the map", ^{
-                expect(testDispatcher.customButtonHandlerMap[testSoftButton1.softButtonID]).toNot(beNil());
-                expect(testDispatcher.customButtonHandlerMap).to(haveCount(@1));
+                expect(testDispatcher.showButtonHandlerMap[testSoftButton1.softButtonID]).toNot(beNil());
+                expect(testDispatcher.showButtonHandlerMap).to(haveCount(@1));
             });
             
             describe(@"when button press and button event notifications arrive", ^{
@@ -197,7 +203,7 @@ describe(@"a response dispatcher", ^{
             });
             
             it(@"should not add the soft button", ^{
-                expect(testDispatcher.customButtonHandlerMap).to(haveCount(@0));
+                expect(testDispatcher.showButtonHandlerMap).to(haveCount(@0));
             });
         });
         
@@ -221,7 +227,7 @@ describe(@"a response dispatcher", ^{
             it(@"should not store the request", ^{
                 [testDispatcher storeRequest:testShow handler:nil];
                 
-                expect(testDispatcher.customButtonHandlerMap).to(haveCount(@0));
+                expect(testDispatcher.showButtonHandlerMap).to(haveCount(@0));
             });
         });
     });
@@ -502,8 +508,8 @@ describe(@"a response dispatcher", ^{
             });
             
             it(@"should add the soft button to the map", ^{
-                expect(testDispatcher.customButtonHandlerMap[testSoftButton1.softButtonID]).toNot(beNil());
-                expect(testDispatcher.customButtonHandlerMap).to(haveCount(@1));
+                expect(testDispatcher.alertButtonHandlerMap[testSoftButton1.softButtonID]).toNot(beNil());
+                expect(testDispatcher.alertButtonHandlerMap).to(haveCount(@1));
             });
             
             describe(@"when button press and button event notifications arrive", ^{
@@ -560,7 +566,7 @@ describe(@"a response dispatcher", ^{
             });
             
             it(@"should not add the soft button", ^{
-                expect(testDispatcher.customButtonHandlerMap).to(haveCount(@0));
+                expect(testDispatcher.alertButtonHandlerMap).to(haveCount(@0));
             });
         });
         
@@ -584,7 +590,7 @@ describe(@"a response dispatcher", ^{
             it(@"should not store the request", ^{
                 [testDispatcher storeRequest:testAlert handler:nil];
                 
-                expect(testDispatcher.customButtonHandlerMap).to(haveCount(@0));
+                expect(testDispatcher.alertButtonHandlerMap).to(haveCount(@0));
             });
         });
     });
@@ -613,8 +619,8 @@ describe(@"a response dispatcher", ^{
             });
             
             it(@"should add the soft button to the map", ^{
-                expect(testDispatcher.customButtonHandlerMap[testSoftButton1.softButtonID]).toNot(beNil());
-                expect(testDispatcher.customButtonHandlerMap).to(haveCount(@1));
+                expect(testDispatcher.scrollMsgButtonHandlerMap[testSoftButton1.softButtonID]).toNot(beNil());
+                expect(testDispatcher.scrollMsgButtonHandlerMap).to(haveCount(@1));
             });
             
             describe(@"when button press and button event notifications arrive", ^{
@@ -671,7 +677,7 @@ describe(@"a response dispatcher", ^{
             });
             
             it(@"should not add the soft button", ^{
-                expect(testDispatcher.customButtonHandlerMap).to(haveCount(@0));
+                expect(testDispatcher.scrollMsgButtonHandlerMap).to(haveCount(@0));
             });
         });
         
@@ -695,7 +701,7 @@ describe(@"a response dispatcher", ^{
             it(@"should not store the request", ^{
                 [testDispatcher storeRequest:testScrollableMessage handler:nil];
                 
-                expect(testDispatcher.customButtonHandlerMap).to(haveCount(@0));
+                expect(testDispatcher.scrollMsgButtonHandlerMap).to(haveCount(@0));
             });
         });
     });


### PR DESCRIPTION
Fixes #515 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
unit tests were run

#### Core Tests
Tested the old SoftButton handlers are removed from memory.

Core version / branch / commit hash / module tested against: 6.0.1
HMI name / version / branch / commit hash / module tested against: N/A

### Summary
1.  Add containers (`showButtonHandlerMap`、`alertButtonHandlerMap`、`scrollMsgButtonHandlerMap`) to restore `softButtonHandlers` of RPC(`SDLShow`、`SDLAlert`、`SDLScrollableMessage`).
2. Every time you want to save a new handler object, first delete the old handler in the corresponding container. If there is no `softbuttonhandler` currently, the container does not need to be emptied.
3. When `softbutton` is clicked, the corresponding handler is found from three containers according to the button ID. If the handler object is found, it will be sent to the app.
![image](https://user-images.githubusercontent.com/35795928/84655649-4a786180-af4c-11ea-99b4-4288e545bf15.png)

### Changelog
##### Breaking Changes
* N/A

##### Enhancements
* N/A

##### Bug Fixes
* N/A

### Tasks Remaining:
* N/A

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
