### PR TITLE
Fixed lockscreen deadlock

### DIFF
--- a/SmartDeviceLink/SDLLockScreenManager.m
+++ b/SmartDeviceLink/SDLLockScreenManager.m
@@ -266,6 +266,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Threading Utilities
 
+/// Checks if we are already on the main queue. If so, the block is added to the queue; if not, the block is dispatched to the main queue.
+/// @discussion Used to ensure that updates to the lock screen UI are done on the main thread.
+/// @param block The block to be executed.
 - (void)sdl_runOnMainQueue:(void (^)(void))block {
     if ([NSThread isMainThread]) {
         block();

--- a/SmartDeviceLink/SDLLockScreenManager.m
+++ b/SmartDeviceLink/SDLLockScreenManager.m
@@ -266,15 +266,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Threading Utilities
 
-/// Checks if we are already on the main queue. If so, the block is added to the queue; if not, the block is dispatched to the main queue.
-/// @discussion Used to ensure that updates to the lock screen UI are done on the main thread.
-/// @param block The block to be executed.
+/// Dispatches the block to the main queue.
+/// @discussion Used to ensure that updates to the lock screen UI are done on the main thread
+/// @param block The block to be executed
 - (void)sdl_runOnMainQueue:(void (^)(void))block {
-    if ([NSThread isMainThread]) {
-        block();
-    } else {
-        dispatch_sync(dispatch_get_main_queue(), block);
-    }
+    dispatch_async(dispatch_get_main_queue(), block);
 }
 
 @end

--- a/SmartDeviceLink/SDLLockScreenManager.m
+++ b/SmartDeviceLink/SDLLockScreenManager.m
@@ -69,7 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
     self.canPresent = NO;
 
     __weak typeof(self) weakSelf = self;
-    [self sdl_runOnMainQueue:^{
+    dispatch_async(dispatch_get_main_queue(), ^{
         __strong typeof(weakSelf) strongSelf = weakSelf;
 
         if (UIApplication.sharedApplication.applicationState != UIApplicationStateActive) {
@@ -86,7 +86,7 @@ NS_ASSUME_NONNULL_BEGIN
         } else {
             [strongSelf sdl_start];
         }
-    }];
+    });
 }
 
 - (void)sdl_start {
@@ -159,7 +159,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)sdl_appDidBecomeActive:(NSNotification *)notification {
     __weak typeof(self) weakSelf = self;
-    [self sdl_runOnMainQueue:^{
+    dispatch_async(dispatch_get_main_queue(), ^{
         __strong typeof(weakSelf) strongSelf = weakSelf;
         // Restart, and potentially dismiss the lock screen if the app was disconnected in the background
         if (!strongSelf.canPresent) {
@@ -167,7 +167,7 @@ NS_ASSUME_NONNULL_BEGIN
         }
 
         [strongSelf sdl_checkLockScreen];
-    }];
+    });
 }
 
 - (void)sdl_driverDistractionStateDidChange:(SDLRPCNotificationNotification *)notification {
@@ -187,9 +187,9 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     __weak typeof(self) weakSelf = self;
-    [self sdl_runOnMainQueue:^{
+    dispatch_async(dispatch_get_main_queue(), ^{
         [weakSelf sdl_updatePresentation];
-    }];
+    });
 }
 
 - (void)sdl_updatePresentation {
@@ -248,7 +248,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
     
     __weak typeof(self) weakSelf = self;
-    [self sdl_runOnMainQueue:^{
+    dispatch_async(dispatch_get_main_queue(), ^{
         __strong typeof(self) strongSelf = weakSelf;
         SDLLockScreenViewController *lockscreenViewController = (SDLLockScreenViewController *)strongSelf.lockScreenViewController;
         if (enabled) {
@@ -261,16 +261,7 @@ NS_ASSUME_NONNULL_BEGIN
             [lockscreenViewController removeDismissGesture];
             lockscreenViewController.lockedLabelText = nil;
         }
-    }];
-}
-
-#pragma mark - Threading Utilities
-
-/// Dispatches the block to the main queue.
-/// @discussion Used to ensure that updates to the lock screen UI are done on the main thread
-/// @param block The block to be executed
-- (void)sdl_runOnMainQueue:(void (^)(void))block {
-    dispatch_async(dispatch_get_main_queue(), block);
+    });
 }
 
 @end

--- a/SmartDeviceLink/SDLLockScreenPresenter.m
+++ b/SmartDeviceLink/SDLLockScreenPresenter.m
@@ -210,6 +210,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Threading Utilities
 
+/// Checks if we are already on the main queue. If so, the block is added to the queue; if not, the block is dispatched to the main queue.
+/// @discussion Used to ensure that updates to the lock screen UI are done on the main thread.
+/// @param block The block to be executed.
 - (void)sdl_runOnMainQueue:(void (^)(void))block {
     if ([NSThread isMainThread]) {
         block();

--- a/SmartDeviceLink/SDLLockScreenPresenter.m
+++ b/SmartDeviceLink/SDLLockScreenPresenter.m
@@ -210,15 +210,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Threading Utilities
 
-/// Checks if we are already on the main queue. If so, the block is added to the queue; if not, the block is dispatched to the main queue.
-/// @discussion Used to ensure that updates to the lock screen UI are done on the main thread.
-/// @param block The block to be executed.
+/// Dispatches the block to the main queue.
+/// @discussion Used to ensure that updates to the lock screen UI are done on the main thread
+/// @param block The block to be executed
 - (void)sdl_runOnMainQueue:(void (^)(void))block {
-    if ([NSThread isMainThread]) {
-        block();
-    } else {
-        dispatch_sync(dispatch_get_main_queue(), block);
-    }
+    dispatch_async(dispatch_get_main_queue(), block);
 }
 
 #pragma mark - Custom Presented / Dismissed Getters

--- a/SmartDeviceLink/SDLLockScreenPresenter.m
+++ b/SmartDeviceLink/SDLLockScreenPresenter.m
@@ -110,7 +110,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     __weak typeof(self) weakself = self;
-    [self sdl_runOnMainQueue:^{
+    dispatch_async(dispatch_get_main_queue(), ^{
         __typeof(weakself) strongself = weakself;
         if (UIApplication.sharedApplication.applicationState != UIApplicationStateActive) {
             // If the the `UIWindow` is created while the app is backgrounded and the app is using `SceneDelegate` class (iOS 13+), then the window will not be created correctly. Wait until the app is foregrounded before creating the window.
@@ -146,7 +146,7 @@ NS_ASSUME_NONNULL_BEGIN
             if (completionHandler == nil) { return; }
             return completionHandler();
         }];
-    }];
+    });
 }
 
 
@@ -162,14 +162,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     __weak typeof(self) weakSelf = self;
-    [self sdl_runOnMainQueue:^{
+    dispatch_async(dispatch_get_main_queue(), ^{
         if (UIApplication.sharedApplication.applicationState != UIApplicationStateActive) {
             SDLLogV(@"Application is backgrounded. The lockscreen will not be dismissed until the app is brought to the foreground.");
             if (completionHandler == nil) { return; }
             return completionHandler(NO);
         }
         [weakSelf sdl_dismissLockscreenWithCompletionHandler:completionHandler];
-    }];
+    });
 }
 
 /// Handles the dismissal of the lockscreen with animation.
@@ -206,15 +206,6 @@ NS_ASSUME_NONNULL_BEGIN
         if (completionHandler == nil) { return; }
         return completionHandler(YES);
     }];
-}
-
-#pragma mark - Threading Utilities
-
-/// Dispatches the block to the main queue.
-/// @discussion Used to ensure that updates to the lock screen UI are done on the main thread
-/// @param block The block to be executed
-- (void)sdl_runOnMainQueue:(void (^)(void))block {
-    dispatch_async(dispatch_get_main_queue(), block);
 }
 
 #pragma mark - Custom Presented / Dismissed Getters

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -474,16 +474,18 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
     }
 
     if (self.useDisplayLink) {
+        __weak typeof(self) weakSelf = self;
         dispatch_async(dispatch_get_main_queue(), ^{
-            NSInteger targetFramerate = ((NSNumber *)self.videoEncoderSettings[(__bridge NSString *)kVTCompressionPropertyKey_ExpectedFrameRate]).integerValue;
+            __strong typeof(weakSelf) strongSelf = weakSelf;
+            NSInteger targetFramerate = ((NSNumber *)strongSelf.videoEncoderSettings[(__bridge NSString *)kVTCompressionPropertyKey_ExpectedFrameRate]).integerValue;
             SDLLogD(@"Initializing CADisplayLink with framerate: %ld", (long)targetFramerate);
-            self.displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(sdl_displayLinkFired:)];
+            strongSelf.displayLink = [CADisplayLink displayLinkWithTarget:strongSelf selector:@selector(sdl_displayLinkFired:)];
             if (@available(iOS 10, *)) {
-                self.displayLink.preferredFramesPerSecond = targetFramerate;
+                strongSelf.displayLink.preferredFramesPerSecond = targetFramerate;
             } else {
-                self.displayLink.frameInterval = (60 / targetFramerate);
+                strongSelf.displayLink.frameInterval = (60 / targetFramerate);
             }
-            [self.displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+            [strongSelf.displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
         });
     } else {
         self.touchManager.enableSyncedPanning = NO;

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLLockScreenManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLLockScreenManagerSpec.m
@@ -34,21 +34,21 @@ QuickSpecBegin(SDLLockScreenManagerSpec)
 
 describe(@"a lock screen manager", ^{
     __block SDLLockScreenManager *testManager = nil;
-    __block SDLFakeViewControllerPresenter *fakePresenter = nil;
+    __block SDLFakeViewControllerPresenter *fakeViewControllerPresenter = nil;
     __block SDLNotificationDispatcher *testNotificationDispatcher = nil;
     
     beforeEach(^{
-        fakePresenter = [[SDLFakeViewControllerPresenter alloc] init];
+        fakeViewControllerPresenter = [[SDLFakeViewControllerPresenter alloc] init];
     });
     
     context(@"with a disabled configuration", ^{
         beforeEach(^{
-            testManager = [[SDLLockScreenManager alloc] initWithConfiguration:[SDLLockScreenConfiguration disabledConfiguration] notificationDispatcher:nil presenter:fakePresenter];
+            testManager = [[SDLLockScreenManager alloc] initWithConfiguration:[SDLLockScreenConfiguration disabledConfiguration] notificationDispatcher:nil presenter:fakeViewControllerPresenter];
         });
         
         it(@"should set properties correctly", ^{
             // Note: We can't check the "lockScreenPresented" flag on the Lock Screen Manager because it's a computer property checking the window
-            expect(fakePresenter.shouldShowLockScreen).toEventually(beFalse());
+            expect(fakeViewControllerPresenter.shouldShowLockScreen).toEventually(beFalse());
             expect(testManager.lockScreenViewController).to(beNil());
         });
         
@@ -58,7 +58,7 @@ describe(@"a lock screen manager", ^{
             });
             
             it(@"should not have a lock screen controller", ^{
-                expect(fakePresenter.shouldShowLockScreen).toEventually(beFalse());
+                expect(fakeViewControllerPresenter.shouldShowLockScreen).toEventually(beFalse());
                 expect(testManager.lockScreenViewController).to(beNil());
             });
             
@@ -75,7 +75,7 @@ describe(@"a lock screen manager", ^{
                 });
                 
                 it(@"should not have presented the lock screen", ^{
-                    expect(fakePresenter.shouldShowLockScreen).toEventually(beFalse());
+                    expect(fakeViewControllerPresenter.shouldShowLockScreen).toEventually(beFalse());
                 });
             });
         });
@@ -83,11 +83,11 @@ describe(@"a lock screen manager", ^{
     
     context(@"with an enabled configuration", ^{
         beforeEach(^{
-            testManager = [[SDLLockScreenManager alloc] initWithConfiguration:[SDLLockScreenConfiguration enabledConfiguration] notificationDispatcher:nil presenter:fakePresenter];
+            testManager = [[SDLLockScreenManager alloc] initWithConfiguration:[SDLLockScreenConfiguration enabledConfiguration] notificationDispatcher:nil presenter:fakeViewControllerPresenter];
         });
         
         it(@"should set properties correctly", ^{
-            expect(fakePresenter.shouldShowLockScreen).toEventually(beFalse());
+            expect(fakeViewControllerPresenter.shouldShowLockScreen).toEventually(beFalse());
             expect(testManager.lockScreenViewController).to(beNil());
         });
         
@@ -97,7 +97,7 @@ describe(@"a lock screen manager", ^{
             });
             
             it(@"should set up the view controller correctly", ^{
-                expect(fakePresenter.shouldShowLockScreen).toEventually(beFalse());
+                expect(fakeViewControllerPresenter.shouldShowLockScreen).toEventually(beFalse());
                 expect(testManager.lockScreenViewController).toNot(beNil());
                 expect(testManager.lockScreenViewController).to(beAnInstanceOf([SDLLockScreenViewController class]));
             });
@@ -120,27 +120,13 @@ describe(@"a lock screen manager", ^{
                 });
                 
                 it(@"should have presented the lock screen", ^{
-                    expect(fakePresenter.shouldShowLockScreen).toEventually(beTrue());
+                    expect(fakeViewControllerPresenter.shouldShowLockScreen).toEventually(beTrue());
                 });
                 
                 it(@"should not have a vehicle icon", ^{
                     expect(((SDLLockScreenViewController *)testManager.lockScreenViewController).vehicleIcon).to(beNil());
                 });
-                
-                describe(@"when a vehicle icon is received", ^{
-                    __block UIImage *testIcon = nil;
-                    
-                    beforeEach(^{
-                        testIcon = [UIImage imageNamed:@"testImagePNG" inBundle:[NSBundle bundleForClass:self.class] compatibleWithTraitCollection:nil];
-                        [[NSNotificationCenter defaultCenter] postNotificationName:SDLDidReceiveLockScreenIcon object:nil userInfo:@{ SDLNotificationUserInfoObject: testIcon }];
-                    });
-                    
-                    it(@"should have a vehicle icon", ^{
-                        expect(((SDLLockScreenViewController *)testManager.lockScreenViewController).vehicleIcon).toNot(beNil());
-                        expect(((SDLLockScreenViewController *)testManager.lockScreenViewController).vehicleIcon).to(equal(testIcon));
-                    });
-                });
-                
+
                 describe(@"when a driver distraction notification is posted with lockScreenDismissableEnabled as true", ^{
                     __block SDLRPCNotificationNotification *testDriverDistractionNotification = nil;
 
@@ -199,7 +185,7 @@ describe(@"a lock screen manager", ^{
                     });
                     
                     it(@"should have dismissed the lock screen", ^{
-                        expect(fakePresenter.shouldShowLockScreen).toEventually(beFalse());
+                        expect(fakeViewControllerPresenter.shouldShowLockScreen).toEventually(beFalse());
                     });
                 });
                 
@@ -217,35 +203,51 @@ describe(@"a lock screen manager", ^{
                     });
                     
                     it(@"should have dismissed the lock screen", ^{
-                        expect(fakePresenter.shouldShowLockScreen).toEventually(beFalse());
+                        expect(fakeViewControllerPresenter.shouldShowLockScreen).toEventually(beFalse());
                     });
                 });
             });
         });
     });
 
-    context(@"with showDeviceLogo as NO",  ^{
+    context(@"when a vehicle icon is received", ^{
+        __block UIImage *testIcon = nil;
+        SDLLockScreenConfiguration *testsConfig = [SDLLockScreenConfiguration enabledConfiguration];
+
         beforeEach(^{
-            SDLLockScreenConfiguration *config = [SDLLockScreenConfiguration enabledConfiguration];
-            config.showDeviceLogo = NO;
-
-            testManager = [[SDLLockScreenManager alloc] initWithConfiguration:config notificationDispatcher:nil presenter:fakePresenter];
-            [testManager start];
+            testIcon = [UIImage imageNamed:@"testImagePNG" inBundle:[NSBundle bundleForClass:self.class] compatibleWithTraitCollection:nil];
         });
 
-        describe(@"when a vehicle icon is received", ^{
-            __block UIImage *testIcon = nil;
+        it(@"should should set the vehicle icon on the default lockscreen if showDeviceLogo set to true", ^{
+            testsConfig.showDeviceLogo = YES;
+            fakeViewControllerPresenter.lockViewController = [[SDLLockScreenViewController alloc] init];
+            testManager = [[SDLLockScreenManager alloc] initWithConfiguration:testsConfig notificationDispatcher:nil presenter:fakeViewControllerPresenter];
 
-            beforeEach(^{
-                testIcon = [UIImage imageNamed:@"testImagePNG" inBundle:[NSBundle bundleForClass:self.class] compatibleWithTraitCollection:nil];
-                [[NSNotificationCenter defaultCenter] postNotificationName:SDLDidReceiveLockScreenIcon object:nil userInfo:@{ SDLNotificationUserInfoObject: testIcon }];
-            });
+            [[NSNotificationCenter defaultCenter] postNotificationName:SDLDidReceiveLockScreenIcon object:nil userInfo:@{ SDLNotificationUserInfoObject: testIcon }];
 
-            it(@"should not have a vehicle icon if showDeviceLogo is set to NO", ^{
-                expect(((SDLLockScreenViewController *)testManager.lockScreenViewController).vehicleIcon).to(beNil());
-            });
+            expect(((SDLLockScreenViewController *)testManager.lockScreenViewController).vehicleIcon).toEventually(equal(testIcon));
         });
 
+        it(@"should should not set the vehicle icon on the default lockscreen if showDeviceLogo set to false", ^{
+            testsConfig.showDeviceLogo = NO;
+            fakeViewControllerPresenter.lockViewController = [[SDLLockScreenViewController alloc] init];
+            testManager = [[SDLLockScreenManager alloc] initWithConfiguration:testsConfig notificationDispatcher:nil presenter:fakeViewControllerPresenter];
+
+            [[NSNotificationCenter defaultCenter] postNotificationName:SDLDidReceiveLockScreenIcon object:nil userInfo:@{ SDLNotificationUserInfoObject: testIcon }];
+
+            expect(((SDLLockScreenViewController *)testManager.lockScreenViewController).vehicleIcon).toEventually(beNil());
+        });
+
+        it(@"should should not modify a custom lockscreen", ^{
+            testsConfig.showDeviceLogo = YES;
+            UIViewController *customLockScreen = [[UIViewController alloc] init];
+            fakeViewControllerPresenter.lockViewController = customLockScreen;
+            testManager = [[SDLLockScreenManager alloc] initWithConfiguration:testsConfig notificationDispatcher:nil presenter:fakeViewControllerPresenter];
+
+            [[NSNotificationCenter defaultCenter] postNotificationName:SDLDidReceiveLockScreenIcon object:nil userInfo:@{ SDLNotificationUserInfoObject: testIcon }];
+
+            expect(fakeViewControllerPresenter.lockViewController).toEventually(equal(customLockScreen));
+        });
     });
 
     context(@"with a custom color configuration", ^{
@@ -256,11 +258,11 @@ describe(@"a lock screen manager", ^{
             testColor = [UIColor blueColor];
             testImage = [UIImage imageNamed:@"testImagePNG" inBundle:[NSBundle bundleForClass:self.class] compatibleWithTraitCollection:nil];
             
-            testManager = [[SDLLockScreenManager alloc] initWithConfiguration:[SDLLockScreenConfiguration enabledConfigurationWithAppIcon:testImage backgroundColor:testColor] notificationDispatcher:nil presenter:fakePresenter];
+            testManager = [[SDLLockScreenManager alloc] initWithConfiguration:[SDLLockScreenConfiguration enabledConfigurationWithAppIcon:testImage backgroundColor:testColor] notificationDispatcher:nil presenter:fakeViewControllerPresenter];
         });
         
         it(@"should set properties correctly", ^{
-            expect(fakePresenter.shouldShowLockScreen).toEventually(beFalse());
+            expect(fakeViewControllerPresenter.shouldShowLockScreen).toEventually(beFalse());
             expect(testManager.lockScreenViewController).to(beNil());
         });
         
@@ -270,7 +272,7 @@ describe(@"a lock screen manager", ^{
             });
             
             it(@"should set up the view controller correctly", ^{
-                expect(fakePresenter.shouldShowLockScreen).toEventually(beFalse());
+                expect(fakeViewControllerPresenter.shouldShowLockScreen).toEventually(beFalse());
                 expect(testManager.lockScreenViewController).toNot(beNil());
                 expect(testManager.lockScreenViewController).to(beAnInstanceOf([SDLLockScreenViewController class]));
                 expect(((SDLLockScreenViewController *)testManager.lockScreenViewController).backgroundColor).to(equal(testColor));
@@ -284,11 +286,11 @@ describe(@"a lock screen manager", ^{
         
         beforeEach(^{
             testViewController = [[UIViewController alloc] init];
-            testManager = [[SDLLockScreenManager alloc] initWithConfiguration:[SDLLockScreenConfiguration enabledConfigurationWithViewController:testViewController] notificationDispatcher:nil presenter:fakePresenter];
+            testManager = [[SDLLockScreenManager alloc] initWithConfiguration:[SDLLockScreenConfiguration enabledConfigurationWithViewController:testViewController] notificationDispatcher:nil presenter:fakeViewControllerPresenter];
         });
         
         it(@"should set properties correctly", ^{
-            expect(fakePresenter.shouldShowLockScreen).toEventually(beFalse());
+            expect(fakeViewControllerPresenter.shouldShowLockScreen).toEventually(beFalse());
             expect(testManager.lockScreenViewController).to(beNil());
         });
         
@@ -298,7 +300,7 @@ describe(@"a lock screen manager", ^{
             });
             
             it(@"should set up the view controller correctly", ^{
-                expect(fakePresenter.shouldShowLockScreen).toEventually(beFalse());
+                expect(fakeViewControllerPresenter.shouldShowLockScreen).toEventually(beFalse());
                 expect(testManager.lockScreenViewController).toNot(beNil());
                 expect(testManager.lockScreenViewController).toNot(beAnInstanceOf([SDLLockScreenViewController class]));
                 expect(testManager.lockScreenViewController).to(equal(testViewController));
@@ -311,7 +313,7 @@ describe(@"a lock screen manager", ^{
             SDLLockScreenConfiguration *config = [SDLLockScreenConfiguration enabledConfiguration];
             config.enableDismissGesture = NO;
 
-            testManager = [[SDLLockScreenManager alloc] initWithConfiguration:config notificationDispatcher:nil presenter:fakePresenter];
+            testManager = [[SDLLockScreenManager alloc] initWithConfiguration:config notificationDispatcher:nil presenter:fakeViewControllerPresenter];
             [testManager start];
         });
 
@@ -341,7 +343,7 @@ describe(@"a lock screen manager", ^{
     });
 
     describe(@"with an always enabled configuration", ^{
-        __block SDLFakeViewControllerPresenter *fakePresenter = nil;
+        __block SDLFakeViewControllerPresenter *fakeViewControllerPresenter = nil;
         __block SDLRPCNotificationNotification *testLockStatusNotification = nil;
 
 #pragma clang diagnostic push
@@ -350,7 +352,7 @@ describe(@"a lock screen manager", ^{
 #pragma clang diagnostic pop
 
         beforeEach(^{
-            fakePresenter = [[SDLFakeViewControllerPresenter alloc] init];
+            fakeViewControllerPresenter = [[SDLFakeViewControllerPresenter alloc] init];
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -360,7 +362,7 @@ describe(@"a lock screen manager", ^{
             SDLLockScreenConfiguration *config = [SDLLockScreenConfiguration enabledConfiguration];
             config.displayMode = SDLLockScreenConfigurationDisplayModeAlways;
 
-            testManager = [[SDLLockScreenManager alloc] initWithConfiguration:config notificationDispatcher:nil presenter:fakePresenter];
+            testManager = [[SDLLockScreenManager alloc] initWithConfiguration:config notificationDispatcher:nil presenter:fakeViewControllerPresenter];
             [testManager start];
         });
 
@@ -376,7 +378,7 @@ describe(@"a lock screen manager", ^{
             });
 
             it(@"should present the lock screen if not already presented", ^{
-                expect(fakePresenter.shouldShowLockScreen).toEventually(beTrue());
+                expect(fakeViewControllerPresenter.shouldShowLockScreen).toEventually(beTrue());
             });
         });
 
@@ -392,7 +394,7 @@ describe(@"a lock screen manager", ^{
             });
 
             it(@"should present the lock screen if not already presented", ^{
-                expect(fakePresenter.shouldShowLockScreen).toEventually(beTrue());
+                expect(fakeViewControllerPresenter.shouldShowLockScreen).toEventually(beTrue());
             });
         });
     });
@@ -422,18 +424,16 @@ describe(@"a lock screen manager", ^{
 #pragma clang diagnostic pop
 
                 testLockScreenManager = [[SDLLockScreenManager alloc] initWithConfiguration:testLockScreenConfig notificationDispatcher:nil presenter:mockViewControllerPresenter];
-
-                [testLockScreenManager start]; // Sets `canPresent` to `true`
+                 testLockScreenManager.canPresent = YES;
             });
 
             it(@"should present the lock screen if not already presented", ^{
                 OCMStub([mockViewControllerPresenter lockViewController]).andReturn([OCMArg any]);
+                OCMExpect([mockViewControllerPresenter updateLockScreenToShow:YES withCompletionHandler:nil]);
 
                 [[NSNotificationCenter defaultCenter] postNotification:testLockStatusNotification];
 
-                // Since lock screen must be presented/dismissed on the main thread, force the test to execute manually on the main thread. If this is not done, the test case may fail.
-                [[NSRunLoop mainRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
-                OCMVerify([mockViewControllerPresenter updateLockScreenToShow:YES withCompletionHandler:nil]);
+                OCMVerifyAllWithDelay(mockViewControllerPresenter, 0.5);
             });
         });
 
@@ -445,18 +445,16 @@ describe(@"a lock screen manager", ^{
 #pragma clang diagnostic pop
 
                 testLockScreenManager = [[SDLLockScreenManager alloc] initWithConfiguration:testLockScreenConfig notificationDispatcher:nil presenter:mockViewControllerPresenter];
-
-                [testLockScreenManager start]; // Sets `canPresent` to `true`
+                testLockScreenManager.canPresent = YES;
             });
 
             it(@"should dismiss the lock screen if already presented", ^{
                 OCMStub([mockViewControllerPresenter lockViewController]).andReturn([OCMArg any]);
+                OCMExpect([mockViewControllerPresenter updateLockScreenToShow:NO withCompletionHandler:nil]);
 
                 [[NSNotificationCenter defaultCenter] postNotification:testLockStatusNotification];
 
-                // Since lock screen must be presented/dismissed on the main thread, force the test to execute manually on the main thread. If this is not done, the test case may fail.
-                [[NSRunLoop mainRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
-                OCMVerify([mockViewControllerPresenter updateLockScreenToShow:NO withCompletionHandler:nil]);
+                OCMVerifyAllWithDelay(mockViewControllerPresenter, 0.5);
             });
         });
     });


### PR DESCRIPTION
Fixes #1629

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
* Fixed unit tests in the **SDLLockScreenManagerSpec**.
* Existing unit tests were run.

#### Core Tests
Tests were performed on SYNC 3.0 except for the last test (a note was added to that test with the sdl_core and sdl_hmi commit versions)

For the following tests: to make the car "move", trigger a driver distraction on notification (DD_ON). To make the car "stationary", trigger a driver distraction off notification (DD_OFF).

##### Driver Not Distracted Tests
- [x] Lock screen should either not show or show briefly and disappear when phone is connected to the module.
- [x] Lock screen should stay hidden when app is disconnected from the module.
- [x] Lock screen should either not show or show briefly when the phone is disconnected and reconnected to the module while the app is in the foreground on the phone.
- [x] Lock screen should either not show or show briefly when the phone is disconnected and reconnected to the module while the app is in the background on the phone and then the app is brought to the foreground on the phone.
- [x] Lock screen should either not show or show briefly when when the phone is disconnected while the app is in the foreground on the phone and reconnected to the module while the app is in the background on the phone and then the app is brought to the foreground on the phone..
- [x] Lock screen should either not show or show briefly when when the phone is disconnected while the app is in the background on the phone and reconnected to the module while the app is in the foreground on the phone.

##### Driver Distracted Tests
- [x] Lock screen should show when a phone is connected to the module and the SDL app is launched.
- [x] Lock screen should disappear when the phone is disconnected from the module.
- [x] Lock screen should show after the phone is disconnected and reconnected to a moving car while the app is in the foreground on the phone.
- [x] Lock screen should show when when the phone is disconnected and reconnected to the module while the app is in the background on the phone.
- [x] Lock screen should show when when the phone is disconnected while the app is in the foreground on the phone and reconnected to the module while the app is in the background on the phone and the app is brought back to the foreground.
- [x] Lock screen should show when when the phone is disconnected while the app is in the background on the phone and reconnected to the module while the app is in the foreground on the phone.

##### Driver Distracted & Not Distracted Tests
- [x] Connect phone to stationary car while app on phone is closed. Trigger DD_ON and launch the app on the phone. The lockscreen should show.
- [x] Connect phone to stationary car while app on phone is in the foreground. Trigger DD_ON. The lockscreen should show.
- [x] Connect phone to stationary car while app on phone is in the background. Trigger DD_ON and foreground the app on the phone. The lockscreen should show.
- [x] Connect phone to moving car while app on phone is closed. Trigger DD_OFF and launch the app on the phone. The lockscreen should either be hidden or should be dismissed.
- [x] Connect phone to moving car while app on phone is in the foreground. Trigger DD_OFF. The lockscreen should either be hidden or should be dismissed.
- [x] Connect phone to moving car while app on phone is in the background. Trigger DD_OFF and launch the app on the phone. The lockscreen should either be hidden or should be dismissed.

##### Other Tests
- [x] Connect to module that sends two DD_OFF notifications immediately on connection. The lockscreen should dismiss with animation (instead of being dismissed without animation) (Tested on SYNC 3.0 with TDK set to Parked)
- [x] Trigger multiple DD_OFF and DD_ON notifications in quick succession. The lockscreen should be presented or dismissed based on the final notification sent.
- [x] Check that lockscreen shows and dismisses on a video streaming app.
- [x] Test with a Swift app using SceneDelegate
- [x] Test with an Obj-C app
- [x] Tested issue reported in #1629 (This was tested on sdl_core (commit a85ef58358c456f69fee93addb7066dc02ecae48) and sdl_hmi (commit 3c29f27bfaaaad37566f3740a6cedbc861b1ebe5)

Core version / branch / commit hash / module tested against: SYNC 3.0 and sdl_core (commit a85ef58358c456f69fee93addb7066dc02ecae48 (HEAD -> release/6.1.0))
HMI name / version / branch / commit hash / module tested against: SYNC 3.0 and sdl_hmi (commit 3c29f27bfaaaad37566f3740a6cedbc861b1ebe5 (HEAD -> develop))

### Summary
Fixed showing or dismissing the lockscreen causing deadlock due to two threads `dispatch_sync`ing to each other at the same time. 

### Changelog 
##### Bug Fixes
* Fixed showing or dismissing the lockscreen causing deadlock when the main thread dispatches to the same thread that is waiting on the main thread to show or dismiss the lockscreen.
* Fixed reference to `self` inside closure.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
