### PR TITLE
Fix soft button image upload failing

### DIFF
--- a/SmartDeviceLink/SDLSoftButtonReplaceOperation.m
+++ b/SmartDeviceLink/SDLSoftButtonReplaceOperation.m
@@ -52,7 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     // Check if soft buttons have images and, if so, if the images need to be uploaded
     if (![self sdl_supportsSoftButtonImages]) {
-        // The modules does not support images
+        // The module does not support images
         SDLLogW(@"Soft button images are not supported. Attempting to send text-only soft buttons. If any button does not contain text, no buttons will be sent.");
 
         // Send text-only buttons if all current states for the soft buttons have text
@@ -231,6 +231,8 @@ NS_ASSUME_NONNULL_BEGIN
     return (artwork != nil && ![self.fileManager hasUploadedFile:artwork] && self.softButtonCapabilities.imageSupported.boolValue && !artwork.isStaticIcon);
 }
 
+/// Checks all the button states for images that need to be uploaded.
+/// @return True if all images have been uploaded; false at least one image needs to be uploaded
 - (BOOL)sdl_allStateImagesAreUploaded {
     for (SDLSoftButtonObject *button in self.softButtonObjects) {
         for (SDLSoftButtonState *state in button.states) {

--- a/SmartDeviceLink/SDLSoftButtonReplaceOperation.m
+++ b/SmartDeviceLink/SDLSoftButtonReplaceOperation.m
@@ -123,6 +123,7 @@ NS_ASSUME_NONNULL_BEGIN
             }
         }
     }
+
     [self sdl_uploadImages:otherStatesToBeUploaded forStateName:@"Other" completionHandler:handler];
 }
 

--- a/SmartDeviceLink/SDLSoftButtonReplaceOperation.m
+++ b/SmartDeviceLink/SDLSoftButtonReplaceOperation.m
@@ -63,7 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
             }
             [weakself finishOperation];
         }];
-    } else if ([self sdl_currentStateHasImages] && ![self sdl_allCurrentStateImagesAreUploaded]) {
+    } else if (![self sdl_allStateImagesAreUploaded]) {
         // If there are images that aren't uploaded
         // Send text buttons if all the soft buttons have text
         [self sdl_sendCurrentStateTextOnlySoftButtonsWithCompletionHandler:^(BOOL success) {}];
@@ -261,10 +261,11 @@ NS_ASSUME_NONNULL_BEGIN
     return NO;
 }
 
-- (BOOL)sdl_allCurrentStateImagesAreUploaded {
+- (BOOL)sdl_allStateImagesAreUploaded {
     for (SDLSoftButtonObject *button in self.softButtonObjects) {
-        SDLArtwork *artwork = button.currentState.artwork;
-        if ([self sdl_artworkNeedsUpload:artwork]) {
+        for (SDLSoftButtonState *state in button.states) {
+            SDLArtwork *artwork = state.artwork;
+            if (![self sdl_artworkNeedsUpload:artwork]) { continue; }
             return NO;
         }
     }

--- a/SmartDeviceLink/SDLSoftButtonReplaceOperation.m
+++ b/SmartDeviceLink/SDLSoftButtonReplaceOperation.m
@@ -64,20 +64,21 @@ NS_ASSUME_NONNULL_BEGIN
             [weakself finishOperation];
         }];
     } else if (![self sdl_allStateImagesAreUploaded]) {
-        // If there are images that aren't uploaded
-        // Send text buttons if all the soft buttons have text
+        // If there are images in the first soft button state that have not yet been uploaded, send a text-only version of the soft buttons (this will only happen if all the first button states have text)
         [self sdl_sendCurrentStateTextOnlySoftButtonsWithCompletionHandler:^(BOOL success) {}];
 
-        // Upload initial images
-        __weak typeof(self) weakself = self;
+        // Upload images used in the first soft button state
+        __weak typeof(self) weakSelf = self;
         [self sdl_uploadInitialStateImagesWithCompletionHandler:^{
-            // Send initial soft buttons w/ images
-            [weakself sdl_sendCurrentStateSoftButtonsWithCompletionHandler:^{
-                // Upload other images
-                [weakself sdl_uploadOtherStateImagesWithCompletionHandler:^{
-                    __strong typeof(weakself) strongself = weakself;
+            // Now that the images have been uploaded, send the soft buttons with images
+            __strong typeof(weakSelf) strongSelf = weakSelf;
+            [strongSelf sdl_sendCurrentStateSoftButtonsWithCompletionHandler:^{
+                // Finally, upload the images used in the other button states
+                __strong typeof(weakSelf) strongSelf = weakSelf;
+                [strongSelf sdl_uploadOtherStateImagesWithCompletionHandler:^{
+                    __strong typeof(weakSelf) strongSelf = weakSelf;
                     SDLLogV(@"Finished sending other images for soft buttons");
-                    [strongself finishOperation];
+                    [strongSelf finishOperation];
                 }];
             }];
         }];

--- a/SmartDeviceLink/SDLSoftButtonReplaceOperation.m
+++ b/SmartDeviceLink/SDLSoftButtonReplaceOperation.m
@@ -52,24 +52,25 @@ NS_ASSUME_NONNULL_BEGIN
 
     // Check the state of our images
     if (![self sdl_supportsSoftButtonImages]) {
-        // We don't support images at all
+        // The modules does not support images
         SDLLogW(@"Soft button images are not supported. Attempting to send text-only soft buttons. If any button does not contain text, no buttons will be sent.");
 
-        // Send text buttons if all the soft buttons have text
+        // Send text-only buttons if all current states for the soft buttons have text
         __weak typeof(self) weakself = self;
         [self sdl_sendCurrentStateTextOnlySoftButtonsWithCompletionHandler:^(BOOL success) {
             if (!success) {
-                SDLLogE(@"Head unit does not support images and some of the soft buttons do not have text, so none of the buttons will be sent.");
+                SDLLogE(@"Buttons will not be sent because the module does not support images and some of the buttons do not have text");
             }
             [weakself finishOperation];
         }];
     } else if (![self sdl_allStateImagesAreUploaded]) {
-        // If there are images in the first soft button state that have not yet been uploaded, send a text-only version of the soft buttons (this will only happen if all the first button states have text)
+        // If there are images in the first soft button state that have not yet been uploaded, send a text-only version of the soft buttons (the text-only buttons will only be sent if all the first button states have text)
         [self sdl_sendCurrentStateTextOnlySoftButtonsWithCompletionHandler:^(BOOL success) {}];
 
         // Upload images used in the first soft button state
         __weak typeof(self) weakSelf = self;
         [self sdl_uploadInitialStateImagesWithCompletionHandler:^{
+            SDLLogV(@"Finished sending images for the first soft button states");
             // Now that the images have been uploaded, send the soft buttons with images
             __strong typeof(weakSelf) strongSelf = weakSelf;
             [strongSelf sdl_sendCurrentStateSoftButtonsWithCompletionHandler:^{
@@ -77,13 +78,13 @@ NS_ASSUME_NONNULL_BEGIN
                 __strong typeof(weakSelf) strongSelf = weakSelf;
                 [strongSelf sdl_uploadOtherStateImagesWithCompletionHandler:^{
                     __strong typeof(weakSelf) strongSelf = weakSelf;
-                    SDLLogV(@"Finished sending other images for soft buttons");
+                    SDLLogV(@"Finished sending images for the other soft button states");
                     [strongSelf finishOperation];
                 }];
             }];
         }];
     } else {
-        // All the images are already uploaded. Send initial soft buttons w/ images.
+        // All the images are already uploaded. Send initial soft buttons with images.
         __weak typeof(self) weakself = self;
         [self sdl_sendCurrentStateSoftButtonsWithCompletionHandler:^{
             __strong typeof(weakself) strongself = weakself;

--- a/SmartDeviceLink/SDLSoftButtonReplaceOperation.m
+++ b/SmartDeviceLink/SDLSoftButtonReplaceOperation.m
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
     [super start];
     if (self.isCancelled) { return; }
 
-    // Check the state of our images
+    // Check if soft buttons have images and, if so, if the images need to be uploaded
     if (![self sdl_supportsSoftButtonImages]) {
         // The modules does not support images
         SDLLogW(@"Soft button images are not supported. Attempting to send text-only soft buttons. If any button does not contain text, no buttons will be sent.");
@@ -68,23 +68,23 @@ NS_ASSUME_NONNULL_BEGIN
         [self sdl_sendCurrentStateTextOnlySoftButtonsWithCompletionHandler:^(BOOL success) {}];
 
         // Upload images used in the first soft button state
-        __weak typeof(self) weakSelf = self;
+        __weak typeof(self) weakself = self;
         [self sdl_uploadInitialStateImagesWithCompletionHandler:^{
             SDLLogV(@"Finished sending images for the first soft button states");
             // Now that the images have been uploaded, send the soft buttons with images
-            __strong typeof(weakSelf) strongSelf = weakSelf;
-            [strongSelf sdl_sendCurrentStateSoftButtonsWithCompletionHandler:^{
+            __strong typeof(weakself) strongself = weakself;
+            [strongself sdl_sendCurrentStateSoftButtonsWithCompletionHandler:^{
                 // Finally, upload the images used in the other button states
-                __strong typeof(weakSelf) strongSelf = weakSelf;
-                [strongSelf sdl_uploadOtherStateImagesWithCompletionHandler:^{
-                    __strong typeof(weakSelf) strongSelf = weakSelf;
+                __strong typeof(weakself) strongself = weakself;
+                [strongself sdl_uploadOtherStateImagesWithCompletionHandler:^{
+                    __strong typeof(weakself) strongself = weakself;
                     SDLLogV(@"Finished sending images for the other soft button states");
-                    [strongSelf finishOperation];
+                    [strongself finishOperation];
                 }];
             }];
         }];
     } else {
-        // All the images are already uploaded. Send initial soft buttons with images.
+        // All the images have been uploaded. Send initial soft buttons with images.
         __weak typeof(self) weakself = self;
         [self sdl_sendCurrentStateSoftButtonsWithCompletionHandler:^{
             __strong typeof(weakself) strongself = weakself;
@@ -251,16 +251,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)sdl_artworkNeedsUpload:(SDLArtwork *)artwork {
     return (artwork != nil && ![self.fileManager hasUploadedFile:artwork] && self.softButtonCapabilities.imageSupported.boolValue && !artwork.isStaticIcon);
-}
-
-- (BOOL)sdl_currentStateHasImages {
-    for (SDLSoftButtonObject *object in self.softButtonObjects) {
-        if (object.currentState.artwork != nil) {
-            return YES;
-        }
-    }
-
-    return NO;
 }
 
 - (BOOL)sdl_allStateImagesAreUploaded {

--- a/SmartDeviceLinkTests/SDLSoftButtonReplaceOperationSpec.m
+++ b/SmartDeviceLinkTests/SDLSoftButtonReplaceOperationSpec.m
@@ -21,7 +21,7 @@ describe(@"a soft button replace operation", ^{
     __block SDLSoftButtonReplaceOperation *testOp = nil;
 
     __block TestConnectionManager *testConnectionManager = nil;
-    __block SDLFileManager *testFileManager = nil;
+    __block id testFileManager = nil;
 
     __block BOOL hasCalledOperationCompletionHandler = NO;
     __block NSError *resultError = nil;
@@ -33,15 +33,20 @@ describe(@"a soft button replace operation", ^{
     __block NSString *object1State2Text = @"O1S2 Text";
     __block SDLSoftButtonState *object1State1 = nil;
     __block SDLSoftButtonState *object1State2 = nil;
-    __block SDLSoftButtonObject *button1 = nil;
+    __block SDLSoftButtonObject *buttonWithText = nil;
 
     __block NSString *object2Name = @"O2 Name";
     __block NSString *object2State1Name = @"O2S1 Name";
+    __block NSString *object2State2Name = @"O2S2 Name";
     __block NSString *object2State1Text = @"O2S1 Text";
+    __block NSString *object2State2Text = @"O2S2 Text";
     __block NSString *object2State1ArtworkName = @"O2S1 Artwork";
+    __block NSString *object2State2ArtworkName = @"O2S2 Artwork";
     __block SDLArtwork *object2State1Art = nil;
+    __block SDLArtwork *object2State2Art = nil;
     __block SDLSoftButtonState *object2State1 = nil;
-    __block SDLSoftButtonObject *button2 = nil;
+    __block SDLSoftButtonState *object2State2 = nil;
+    __block SDLSoftButtonObject *buttonWithTextAndImage = nil;
 
     __block NSString *object3Name = @"O3 Name";
     __block NSString *object3State1Name = @"O3S1 Name";
@@ -49,14 +54,30 @@ describe(@"a soft button replace operation", ^{
     __block NSString *object3State1IconName = SDLStaticIconNameRSS;
     __block SDLArtwork *object3State1Art = nil;
     __block SDLSoftButtonState *object3State1 = nil;
-    __block SDLSoftButtonObject *button3 = nil;
+    __block SDLSoftButtonObject *buttonWithTextAndStaticImage = nil;
 
     __block NSString *object4Name = @"O4 Name";
     __block NSString *object4State1Name = @"O4S1 Name";
     __block NSString *object4State1IconName = SDLStaticIconNameAlbum;
     __block SDLArtwork *object4State1Art = nil;
     __block SDLSoftButtonState *object4State1 = nil;
-    __block SDLSoftButtonObject *button4 = nil;
+    __block SDLSoftButtonObject *buttonWithImage = nil;
+
+    __block NSString *object5Name = @"O5 Name";
+    __block NSString *object5State1Name = @"O5S1 Name";
+    __block NSString *object5State2Name = @"O5S2 Name";
+    __block NSString *object5State3Name = @"O5S3 Name";
+    __block NSString *object5State2IconName = @"O5S2 Name";
+    __block NSString *object5State3IconName = @"O5S3 Name";
+    __block NSString *object5State1Text = @"O5S1 Text";
+    __block NSString *object5State2Text = @"O5S2 Text";
+    __block NSString *object5State3Text = @"O5S3 Text";
+    __block SDLArtwork *object5State2Art = nil;
+    __block SDLArtwork *object5State3Art = nil;
+    __block SDLSoftButtonState *object5State1 = nil;
+    __block SDLSoftButtonState *object5State2 = nil;
+    __block SDLSoftButtonState *object5State3 = nil;
+    __block SDLSoftButtonObject *buttonWithTextAndImage2 = nil;
 
     __block NSString *testMainField1 = @"Test main field 1";
 
@@ -68,25 +89,34 @@ describe(@"a soft button replace operation", ^{
         hasCalledOperationCompletionHandler = NO;
 
         testConnectionManager = [[TestConnectionManager alloc] init];
-        testFileManager = OCMClassMock([SDLFileManager class]);
+        testFileManager = OCMStrictClassMock([SDLFileManager class]);
 
         object1State1 = [[SDLSoftButtonState alloc] initWithStateName:object1State1Name text:object1State1Text artwork:nil];
         object1State2 = [[SDLSoftButtonState alloc] initWithStateName:object1State2Name text:object1State2Text artwork:nil];
-        button1 = [[SDLSoftButtonObject alloc] initWithName:object1Name state:object1State1 handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {}];
+        buttonWithText = [[SDLSoftButtonObject alloc] initWithName:object1Name state:object1State1 handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {}];
 
         object2State1Art = [[SDLArtwork alloc] initWithData:[@"TestData" dataUsingEncoding:NSUTF8StringEncoding] name:object2State1ArtworkName fileExtension:@"png" persistent:YES];
+        object2State2Art = [[SDLArtwork alloc] initWithData:[@"TestData2" dataUsingEncoding:NSUTF8StringEncoding] name:object2State2ArtworkName fileExtension:@"png" persistent:YES];
         object2State1 = [[SDLSoftButtonState alloc] initWithStateName:object2State1Name text:object2State1Text artwork:object2State1Art];
-        button2 = [[SDLSoftButtonObject alloc] initWithName:object2Name state:object2State1 handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {}];
+        object2State2 = [[SDLSoftButtonState alloc] initWithStateName:object2State2Name text:object2State2Text artwork:object2State2Art];
+        buttonWithTextAndImage = [[SDLSoftButtonObject alloc] initWithName:object2Name states:@[object2State1, object2State2] initialStateName:object2State1.name handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {}];
+
+        //[[SDLSoftButtonObject alloc] initWithName:object2Name state:object2State1 handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {}];
 
         object3State1Art = [[SDLArtwork alloc] initWithStaticIcon:object3State1IconName];
         object3State1 = [[SDLSoftButtonState alloc] initWithStateName:object3State1Name text:object3State1Text artwork:object3State1Art];
-        button3 = [[SDLSoftButtonObject alloc] initWithName:object3Name state:object3State1 handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {}];
+        buttonWithTextAndStaticImage = [[SDLSoftButtonObject alloc] initWithName:object3Name state:object3State1 handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {}];
 
         object4State1Art = [[SDLArtwork alloc] initWithStaticIcon:object4State1IconName];
         object4State1 = [[SDLSoftButtonState alloc] initWithStateName:object4State1Name text:nil artwork:object4State1Art];;
-        button4 = [[SDLSoftButtonObject alloc] initWithName:object4Name state:object4State1 handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {}];;
+        buttonWithImage = [[SDLSoftButtonObject alloc] initWithName:object4Name state:object4State1 handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {}];
 
-        OCMStub([testFileManager uploadArtworks:[OCMArg any] progressHandler:[OCMArg invokeBlock] completionHandler:[OCMArg invokeBlock]]);
+        object5State2Art = [[SDLArtwork alloc] initWithData:[@"object5State2Art" dataUsingEncoding:NSUTF8StringEncoding] name:object5State2IconName fileExtension:@"png" persistent:YES];
+        object5State3Art = [[SDLArtwork alloc] initWithData:[@"object5State3Art" dataUsingEncoding:NSUTF8StringEncoding] name:object5State3IconName fileExtension:@"png" persistent:YES];
+        object5State1 = [[SDLSoftButtonState alloc] initWithStateName:object5State1Name text:object5State1Text artwork:nil];
+        object5State2 = [[SDLSoftButtonState alloc] initWithStateName:object5State2Name text:object5State2Text artwork:object5State2Art];
+        object5State3 = [[SDLSoftButtonState alloc] initWithStateName:object5State3Name text:object5State3Text artwork:object5State3Art];
+        buttonWithTextAndImage2 = [[SDLSoftButtonObject alloc] initWithName:object5Name states:@[object5State1, object5State2, object5State3] initialStateName:object5State1.name handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {}];
 
         successResponse = [[SDLRPCResponse alloc] init];
         successResponse.success = @YES;
@@ -99,23 +129,29 @@ describe(@"a soft button replace operation", ^{
 
     it(@"should have a priority of 'normal'", ^{
         testOp = [[SDLSoftButtonReplaceOperation alloc] init];
-
         expect(@(testOp.queuePriority)).to(equal(@(NSOperationQueuePriorityNormal)));
     });
 
     describe(@"running the operation", ^{
         context(@"without artworks", ^{
+            __block NSArray<SDLSoftButtonObject *> *testSoftButtonObjects = nil;
+            __block SDLSoftButtonCapabilities *capabilities = nil;
+
             beforeEach(^{
-                SDLSoftButtonCapabilities *capabilities = [[SDLSoftButtonCapabilities alloc] init];
-                capabilities.imageSupported = @YES;
-
-                NSArray<SDLSoftButtonObject *> *testSoftButtonObjects = @[button1];
-
+                testSoftButtonObjects = @[buttonWithText];
                 testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
-                [testOp start];
+
+                capabilities = [[SDLSoftButtonCapabilities alloc] init];
+                capabilities.imageSupported = @YES;
             });
 
             it(@"should send the correct RPCs", ^{
+                OCMReject([testFileManager uploadArtworks:[OCMArg any] progressHandler:nil completionHandler:nil]);
+
+                [testOp start];
+
+                OCMVerifyAllWithDelay(testFileManager, 0.5);
+
                 NSArray<SDLShow *> *sentRequests = testConnectionManager.receivedRequests;
                 expect(sentRequests).to(haveCount(1));
                 expect(sentRequests.firstObject.mainField1).to(equal(testMainField1));
@@ -126,7 +162,11 @@ describe(@"a soft button replace operation", ^{
                 expect(sentRequests.firstObject.softButtons.firstObject.type).to(equal(SDLSoftButtonTypeText));
             });
 
-            context(@"When a response is received to the text upload", ^{
+            context(@"When a response is received to the upload", ^{
+                beforeEach(^{
+                    [testOp start];
+                });
+
                 it(@"should finish the operation on a successful response", ^{
                     [testConnectionManager respondToLastRequestWithResponse:successResponse];
 
@@ -145,25 +185,27 @@ describe(@"a soft button replace operation", ^{
 
         context(@"with artworks", ^{
             __block NSArray<SDLSoftButtonObject *> *testSoftButtonObjects = nil;
+            __block SDLSoftButtonCapabilities *capabilities = nil;
 
             beforeEach(^{
-                testSoftButtonObjects = @[button1, button2];
+                testSoftButtonObjects = @[buttonWithText, buttonWithTextAndImage];
             });
 
             context(@"but the HMI does not support artworks", ^{
                 beforeEach(^{
-                    SDLSoftButtonCapabilities *capabilities = [[SDLSoftButtonCapabilities alloc] init];
+                    capabilities = [[SDLSoftButtonCapabilities alloc] init];
                     capabilities.imageSupported = @NO;
 
                     testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
-                    [testOp start];
-                });
-
-                it(@"should not upload any artworks", ^{
-                    OCMReject([testFileManager uploadArtworks:[OCMArg any] completionHandler:[OCMArg any]]);
                 });
 
                 it(@"should send the button text", ^{
+                    OCMReject([testFileManager uploadArtworks:[OCMArg any] progressHandler:nil completionHandler:nil]);
+
+                    [testOp start];
+
+                    OCMVerifyAllWithDelay(testFileManager, 0.5);
+
                     NSArray<SDLShow *> *sentRequests = testConnectionManager.receivedRequests;
                     expect(sentRequests).to(haveCount(1));
                     expect(sentRequests.firstObject.mainField1).to(equal(testMainField1));
@@ -177,7 +219,11 @@ describe(@"a soft button replace operation", ^{
                     expect(sentRequests.firstObject.softButtons.lastObject.type).to(equal(SDLSoftButtonTypeText));
                 });
 
-                context(@"When a response is received to the text upload", ^{
+                context(@"When a response is received to the upload", ^{
+                    beforeEach(^{
+                        [testOp start];
+                    });
+
                     it(@"should finish the operation on a successful response", ^{
                         [testConnectionManager respondToLastRequestWithResponse:successResponse];
 
@@ -195,52 +241,49 @@ describe(@"a soft button replace operation", ^{
             });
 
             context(@"but the HMI does not support artworks and some buttons are image-only", ^{
-                __block NSArray<SDLSoftButtonObject *> *testImageOnlySoftButtonObjects = nil;
-
                 beforeEach(^{
-                    testImageOnlySoftButtonObjects = @[button3, button4];
-                });
+                    testSoftButtonObjects = @[buttonWithTextAndStaticImage, buttonWithImage];
 
-                beforeEach(^{
-                    SDLSoftButtonCapabilities *capabilities = [[SDLSoftButtonCapabilities alloc] init];
+                    capabilities = [[SDLSoftButtonCapabilities alloc] init];
                     capabilities.imageSupported = @NO;
 
-                    testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities softButtonObjects:testImageOnlySoftButtonObjects mainField1:testMainField1];
-                    [testOp start];
-                });
-
-                it(@"should not send artworks", ^{
-                    OCMReject([testFileManager uploadArtworks:[OCMArg any] completionHandler:[OCMArg any]]);
+                    testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
                 });
 
                 it(@"should not send any buttons", ^{
+                    OCMReject([testFileManager uploadArtworks:[OCMArg any] progressHandler:nil completionHandler:nil]);
+
+                    [testOp start];
+
+                    OCMVerifyAllWithDelay(testFileManager, 0.5);
+
                     NSArray<SDLShow *> *sentRequests = testConnectionManager.receivedRequests;
                     expect(sentRequests).to(haveCount(0));
-                });
 
-                it(@"should have set the operation to finished", ^ {
                     expect(testOp.isFinished).to(beTrue());
                 });
             });
 
-            context(@"and the HMI supports artworks", ^{
-                __block SDLSoftButtonCapabilities *buttonCapabilities = nil;
-
+            context(@"and the module supports artworks", ^{
                 beforeEach(^{
-                    buttonCapabilities = [[SDLSoftButtonCapabilities alloc] init];
-                    buttonCapabilities.imageSupported = @YES;
+                    capabilities = [[SDLSoftButtonCapabilities alloc] init];
+                    capabilities.imageSupported = @YES;
                 });
 
                 context(@"when artworks are already on the system", ^{
                     beforeEach(^{
                         OCMStub([testFileManager hasUploadedFile:[OCMArg isNotNil]]).andReturn(YES);
 
-                        testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:buttonCapabilities softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
-                        [testOp start];
+                        testSoftButtonObjects = @[buttonWithText, buttonWithTextAndImage];
+                        testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
                     });
 
                     it(@"should not upload artworks", ^{
-                        OCMReject([testFileManager uploadArtworks:[OCMArg any] completionHandler:[OCMArg any]]);
+                        OCMReject([testFileManager uploadArtworks:[OCMArg any] progressHandler:nil completionHandler:nil]);
+
+                        [testOp start];
+
+                        OCMVerifyAllWithDelay(testFileManager, 0.5);
 
                         NSArray<SDLShow *> *sentRequests = testConnectionManager.receivedRequests;
                         expect(sentRequests).to(haveCount(1));
@@ -255,7 +298,11 @@ describe(@"a soft button replace operation", ^{
                         expect(sentRequests.firstObject.softButtons.lastObject.type).to(equal(SDLSoftButtonTypeBoth));
                     });
 
-                    context(@"When a response is received to the text upload", ^{
+                    context(@"When a response is received to the upload", ^{
+                        beforeEach(^{
+                            [testOp start];
+                        });
+
                         it(@"should finish the operation on a successful response", ^{
                             [testConnectionManager respondToLastRequestWithResponse:successResponse];
 
@@ -273,23 +320,23 @@ describe(@"a soft button replace operation", ^{
                 });
 
                 context(@"when the artworks need uploading", ^{
-                    __block SDLSoftButtonCapabilities *buttonCapabilities = nil;
-
                     beforeEach(^{
-                        buttonCapabilities = [[SDLSoftButtonCapabilities alloc] init];
-                        buttonCapabilities.imageSupported = @YES;
+                        OCMStub([testFileManager hasUploadedFile:[OCMArg isNotNil]]).andReturn(NO);
                     });
 
                     context(@"when artworks are static icons", ^{
                         beforeEach(^{
-                            testSoftButtonObjects = @[button3];
+                            testSoftButtonObjects = @[buttonWithTextAndStaticImage];
 
-                            testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:buttonCapabilities softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
-                            [testOp start];
+                            testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
                         });
 
                         it(@"should skip uploading artwork", ^{
-                            OCMReject([testFileManager uploadArtwork:[OCMArg any] completionHandler:[OCMArg any]]);
+                            OCMReject([testFileManager uploadArtworks:[OCMArg any] progressHandler:nil completionHandler:nil]);
+
+                            [testOp start];
+
+                            OCMVerifyAllWithDelay(testFileManager, 0.5);
 
                             NSArray<SDLShow *> *sentRequests = testConnectionManager.receivedRequests;
                             expect(sentRequests).to(haveCount(1));
@@ -301,7 +348,11 @@ describe(@"a soft button replace operation", ^{
                             expect(sentRequests.firstObject.softButtons.firstObject.type).to(equal(SDLSoftButtonTypeBoth));
                         });
 
-                        context(@"When a response is received to the text upload", ^{
+                        context(@"When a response is received to the upload", ^{
+                            beforeEach(^{
+                                [testOp start];
+                            });
+
                             it(@"should finish the operation on a successful response", ^{
                                 [testConnectionManager respondToLastRequestWithResponse:successResponse];
 
@@ -318,20 +369,20 @@ describe(@"a soft button replace operation", ^{
                         });
                     });
 
-                    context(@"when artwork are not already on the system", ^{
-                        beforeEach(^{
-                            OCMStub([testFileManager hasUploadedFile:[OCMArg isNotNil]]).andReturn(NO);
-
-                            testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:buttonCapabilities softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
+                    context(@"when artworks are dynamic icons", ^{
+                        it(@"should upload all artworks", ^{
+                            // Check that the artworks in the initial button states are uploaded
+                            OCMExpect([testFileManager uploadArtworks:@[buttonWithTextAndImage.states[0].artwork] progressHandler:[OCMArg invokeBlock] completionHandler:[OCMArg invokeBlock]]);
+                            testSoftButtonObjects = @[buttonWithText, buttonWithTextAndImage];
+                            testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
                             [testOp start];
-                        });
+                            OCMVerifyAllWithDelay(testFileManager, 0.5);
 
-                        it(@"should upload artworks", ^{
-                            OCMVerify([testFileManager uploadArtworks:[OCMArg checkWithBlock:^BOOL(id obj) {
-                                NSArray<SDLArtwork *> *artworks = (NSArray<SDLArtwork *> *)obj;
-                                return (artworks.count == 1);
-                            }] progressHandler:[OCMArg any] completionHandler:[OCMArg any]]);
-
+                            // Check that the artworks in the other states (i.e. the non-first states) are uploaded
+                            OCMExpect([testFileManager uploadArtworks:@[buttonWithTextAndImage.states[1].artwork] progressHandler:[OCMArg invokeBlock] completionHandler:[OCMArg invokeBlock]]);
+                            [testConnectionManager respondToLastRequestWithResponse:successResponse];
+                            OCMVerifyAllWithDelay(testFileManager, 0.5);
+                            
                             // Both the text only buttons and the image buttons should be sent
                             NSArray<SDLShow *> *sentRequests = testConnectionManager.receivedRequests;
                             expect(sentRequests).to(haveCount(2));
@@ -350,23 +401,76 @@ describe(@"a soft button replace operation", ^{
                             expect(sentRequests.lastObject.softButtons).to(haveCount(2));
                             expect(sentRequests.lastObject.softButtons.firstObject.text).to(equal(object1State1Text));
                             expect(sentRequests.lastObject.softButtons.firstObject.image).to(beNil());
-                            expect(sentRequests.firstObject.softButtons.firstObject.type).to(equal(SDLSoftButtonTypeText));
+                            expect(sentRequests.lastObject.softButtons.firstObject.type).to(equal(SDLSoftButtonTypeText));
                             expect(sentRequests.lastObject.softButtons.lastObject.text).to(equal(object2State1Text));
                             expect(sentRequests.lastObject.softButtons.lastObject.image).toNot(beNil());
                             expect(sentRequests.lastObject.softButtons.lastObject.type).to(equal(SDLSoftButtonTypeBoth));
                         });
 
-                        context(@"When a response is received to the text upload", ^{
+                        it(@"should upload all artworks even if the initial state does not have artworks", ^{
+                            OCMReject([testFileManager uploadFiles:[OCMArg any] progressHandler:[OCMArg invokeBlock] completionHandler:[OCMArg invokeBlock]]);
+
+                            // buttonWithTextAndImage2 has text in the first state and an text and image in the second & third states
+                            testSoftButtonObjects = @[buttonWithTextAndStaticImage, buttonWithTextAndImage2];
+                            testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
+                            [testOp start];
+                            OCMVerifyAllWithDelay(testFileManager, 0.5);
+
+                            NSArray<SDLArtwork *> *testArtworkUploads = @[buttonWithTextAndImage2.states[1].artwork, buttonWithTextAndImage2.states[2].artwork];
+                            OCMExpect([testFileManager uploadArtworks:testArtworkUploads progressHandler:[OCMArg invokeBlock] completionHandler:[OCMArg invokeBlock]]);
+                            [testConnectionManager respondToLastRequestWithResponse:successResponse];
+                            OCMVerifyAllWithDelay(testFileManager, 0.5);
+
+                            // Both the text only buttons and the image buttons should be sent
+                            NSArray<SDLShow *> *sentRequests = testConnectionManager.receivedRequests;
+                            expect(sentRequests).to(haveCount(2));
+                            expect(sentRequests.firstObject.mainField1).to(equal(testMainField1));
+                            expect(sentRequests.firstObject.mainField2).to(beNil());
+                            expect(sentRequests.firstObject.softButtons).to(haveCount(2));
+                            expect(sentRequests.firstObject.softButtons.firstObject.text).to(equal(object3State1Text));
+                            expect(sentRequests.firstObject.softButtons.firstObject.image).to(beNil());
+                            expect(sentRequests.firstObject.softButtons.firstObject.type).to(equal(SDLSoftButtonTypeText));
+                            expect(sentRequests.firstObject.softButtons.lastObject.text).to(equal(object5State1Text));
+                            expect(sentRequests.firstObject.softButtons.lastObject.image).to(beNil());
+                            expect(sentRequests.firstObject.softButtons.lastObject.type).to(equal(SDLSoftButtonTypeText));
+
+                            expect(sentRequests.lastObject.mainField1).to(equal(testMainField1));
+                            expect(sentRequests.lastObject.mainField2).to(beNil());
+                            expect(sentRequests.lastObject.softButtons).to(haveCount(2));
+                            expect(sentRequests.lastObject.softButtons.firstObject.text).to(equal(object3State1Text));
+                            expect(sentRequests.lastObject.softButtons.firstObject.image).to(equal(object3State1Art.imageRPC));
+                            expect(sentRequests.lastObject.softButtons.firstObject.type).to(equal(SDLSoftButtonTypeBoth));
+                            expect(sentRequests.lastObject.softButtons.lastObject.text).to(equal(object5State1Text));
+                            expect(sentRequests.lastObject.softButtons.lastObject.image).to(beNil());
+                            expect(sentRequests.lastObject.softButtons.lastObject.type).to(equal(SDLSoftButtonTypeText));
+                        });
+
+                        context(@"When a response is received to the upload", ^{
+                            beforeEach(^{
+                                OCMExpect([testFileManager uploadArtworks:[OCMArg isNotNil] progressHandler:[OCMArg invokeBlock] completionHandler:[OCMArg invokeBlock]]);
+
+                                testSoftButtonObjects = @[buttonWithTextAndImage];
+                                testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
+                                [testOp start];
+
+                                OCMVerifyAllWithDelay(testFileManager, 0.5);
+                            });
+
                             it(@"should finish the operation on a successful response", ^{
+                                OCMExpect([testFileManager uploadArtworks:[OCMArg isNotNil] progressHandler:[OCMArg invokeBlock] completionHandler:[OCMArg invokeBlock]]);
+
                                 [testConnectionManager respondToLastRequestWithResponse:successResponse];
 
+                                OCMVerifyAllWithDelay(testFileManager, 0.5);
                                 expect(testOp.isFinished).to(beTrue());
                                 expect(testOp.isExecuting).to(beFalse());
                             });
 
                             it(@"should finish the operation on a failed response", ^{
+                                OCMExpect([testFileManager uploadArtworks:[OCMArg isNotNil] progressHandler:[OCMArg invokeBlock] completionHandler:[OCMArg invokeBlock]]);
                                 [testConnectionManager respondToLastRequestWithResponse:failedResponse];
 
+                                OCMVerifyAllWithDelay(testFileManager, 0.5);
                                 expect(testOp.isFinished).to(beTrue());
                                 expect(testOp.isExecuting).to(beFalse());
                             });

--- a/SmartDeviceLinkTests/SDLSoftButtonReplaceOperationSpec.m
+++ b/SmartDeviceLinkTests/SDLSoftButtonReplaceOperationSpec.m
@@ -101,8 +101,6 @@ describe(@"a soft button replace operation", ^{
         object2State2 = [[SDLSoftButtonState alloc] initWithStateName:object2State2Name text:object2State2Text artwork:object2State2Art];
         buttonWithTextAndImage = [[SDLSoftButtonObject alloc] initWithName:object2Name states:@[object2State1, object2State2] initialStateName:object2State1.name handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {}];
 
-        //[[SDLSoftButtonObject alloc] initWithName:object2Name state:object2State1 handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {}];
-
         object3State1Art = [[SDLArtwork alloc] initWithStaticIcon:object3State1IconName];
         object3State1 = [[SDLSoftButtonState alloc] initWithStateName:object3State1Name text:object3State1Text artwork:object3State1Art];
         buttonWithTextAndStaticImage = [[SDLSoftButtonObject alloc] initWithName:object3Name state:object3State1 handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {}];


### PR DESCRIPTION
Fixes #1696

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
* Tests were added to the _SDLSoftButtonReplaceOperationSpec_. 

#### Core Tests
* Tested sending a button with two states: first state has a static icon, second state has a dynamic image. 
* Tested sending a button with two states: first state has text only, second state has a dynamic image. 

Core version / branch / commit hash / module tested against: Manticore
HMI name / version / branch / commit hash / module tested against: Manticore

### Summary
Fixed a bug with the Screen Manager where if the initial `SDLSoftButtonState` does not have an image (or the image does not need to be uploaded), then the images for the other states are never uploaded.

### Changelog
##### Bug Fixes
* Fixed bug with the Screen Manager where all the button images were not uploaded.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
