### PR TITLE
Bugfix/issue 1675 fix encryption manager state on disconnect

### DIFF
--- a/SmartDeviceLink/SDLEncryptionLifecycleManager.m
+++ b/SmartDeviceLink/SDLEncryptionLifecycleManager.m
@@ -247,7 +247,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (BOOL)sdl_appRequiresEncryption {
-    if (self.requiresEncryption && [self sdl_containsAtLeastOneRPCThatRequiresEncryption]) {
+    if (self.requiresEncryption || [self sdl_containsAtLeastOneRPCThatRequiresEncryption]) {
         return YES;
     }
     return NO;

--- a/SmartDeviceLink/SDLEncryptionLifecycleManager.m
+++ b/SmartDeviceLink/SDLEncryptionLifecycleManager.m
@@ -59,6 +59,8 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+#pragma mark - Lifecycle
+
 - (void)startWithProtocol:(SDLProtocol *)protocol {
     SDLLogD(@"Starting encryption manager");
     _protocol = protocol;
@@ -71,13 +73,15 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)stop {
+    SDLLogD(@"Stopping encryption manager");
+
     _permissions = nil;
     _protocol = nil;
     _currentHMILevel = nil;
     _requiresEncryption = NO;
     _delegate = nil;
 
-    SDLLogD(@"Stopping encryption manager");
+    [self.encryptionStateMachine transitionToState:SDLEncryptionLifecycleManagerStateStopped];
 }
 
 - (BOOL)isEncryptionReady {
@@ -117,7 +121,8 @@ NS_ASSUME_NONNULL_BEGIN
     }];
 }
 
-#pragma mark Encryption
+#pragma mark - State Machine
+
 + (NSDictionary<SDLState *, SDLAllowableStateTransitions *> *)sdl_encryptionStateTransitionDictionary {
     return @{
              SDLEncryptionLifecycleManagerStateStopped : @[SDLEncryptionLifecycleManagerStateStarting],
@@ -126,7 +131,6 @@ NS_ASSUME_NONNULL_BEGIN
             };
 }
 
-#pragma mark - State Machine
 - (void)didEnterStateEncryptionStarting {
     SDLLogD(@"Encryption manager is starting");
     [self sdl_sendEncryptionStartService];
@@ -205,7 +209,8 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
-#pragma mark - SDL RPC Notification callbacks
+#pragma mark - Notifications
+
 - (void)sdl_hmiLevelDidChange:(SDLRPCNotificationNotification *)notification {
     if (![notification isNotificationMemberOfClass:[SDLOnHMIStatus class]]) {
         return;
@@ -246,8 +251,10 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
+#pragma mark - Encryption Status
+
 - (BOOL)sdl_appRequiresEncryption {
-    if (self.requiresEncryption || [self sdl_containsAtLeastOneRPCThatRequiresEncryption]) {
+    if (self.requiresEncryption && [self sdl_containsAtLeastOneRPCThatRequiresEncryption]) {
         return YES;
     }
     return NO;

--- a/SmartDeviceLinkTests/SDLEncryptionLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/SDLEncryptionLifecycleManagerSpec.m
@@ -158,6 +158,32 @@ describe(@"the encryption lifecycle manager", ^{
             });
         });
     });
+
+    describe(@"when stopped", ^{
+        it(@"if the encryption manager is ready it should transition to the stopped state", ^{
+            [encryptionLifecycleManager.encryptionStateMachine setToState:SDLEncryptionLifecycleManagerStateReady  fromOldState:nil callEnterTransition:NO];
+
+            [encryptionLifecycleManager stop];
+
+            expect(encryptionLifecycleManager.encryptionStateMachine.currentState).to(equal(SDLEncryptionLifecycleManagerStateStopped));
+        });
+
+        it(@"if the encryption manager is starting it should stay in the stopped state", ^{
+            [encryptionLifecycleManager.encryptionStateMachine setToState:SDLEncryptionLifecycleManagerStateStarting fromOldState:nil callEnterTransition:NO];
+
+            [encryptionLifecycleManager stop];
+
+            expect(encryptionLifecycleManager.encryptionStateMachine.currentState).to(equal(SDLEncryptionLifecycleManagerStateStopped));
+        });
+
+        it(@"if the encryption manager is stopped it should stay in the stopped state", ^{
+            [encryptionLifecycleManager.encryptionStateMachine setToState:SDLEncryptionLifecycleManagerStateStopped  fromOldState:nil callEnterTransition:NO];
+
+            [encryptionLifecycleManager stop];
+
+            expect(encryptionLifecycleManager.encryptionStateMachine.currentState).to(equal(SDLEncryptionLifecycleManagerStateStopped));
+        });
+    });
 });
 
 QuickSpecEnd


### PR DESCRIPTION
Fixes #1675

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
* Unit tests were added to the _SDLEncryptionLifecycleManagerSpec_

#### Core Tests
* Tested sending encrypted RPCs after destroying and re-starting the TCP transport during the same app session.

Core version / branch / commit hash / module tested against: sdl_core (commit 714c72e555938cf62aae976f08407194983ec370 (HEAD -> develop, origin/develop)
HMI name / version / branch / commit hash / module tested against: sdl_hmi (commit 714c72e555938cf62aae976f08407194983ec370 (HEAD -> develop, origin/develop)

### Summary
Fixed a crash in the `SDLEncryptionLifecycleManager` due to an invalid state transition.

### Changelog
##### Bug Fixes
* Fixed the library crashing due to an invalid state transition in the `SDLEncryptionLifecycleManager` after destroying and recreating a new transport during the same app session.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
