### PR TITLE
Fixed video encoding properties not being set when new compression session created

### DIFF
--- a/SmartDeviceLink/SDLH264VideoEncoder.m
+++ b/SmartDeviceLink/SDLH264VideoEncoder.m
@@ -342,7 +342,7 @@ void sdl_videoEncoderOutputCallback(void * CM_NULLABLE outputCallbackRefCon, voi
     return (status == noErr);
 }
 
-/// Validates the video encoder properties.
+/// Validates the properties set by the developer into the encoder settings dictionary. If any are not available for use, the session will be cancelled.
 /// @param compressionSession The compression session on which the video encoder properties will be set
 /// @param error Error set if the video encoder properties are not valid
 /// @return True if the video encoder properties are valid; false if not
@@ -359,7 +359,7 @@ void sdl_videoEncoderOutputCallback(void * CM_NULLABLE outputCallbackRefCon, voi
         return NO;
     }
 
-    NSArray* videoEncoderKeys = self.videoEncoderSettings.allKeys;
+    NSArray<NSString *> *videoEncoderKeys = self.videoEncoderSettings.allKeys;
     for (NSString *key in videoEncoderKeys) {
         if (CFDictionaryContainsKey(supportedProperties, (__bridge CFStringRef)key) == false) {
             if (error != NULL) {


### PR DESCRIPTION
Fixes #1683

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Unit tests were run

#### Core Tests
* Tested putting a video streaming app on the iPhone in the background and bringing it back to the foreground (this sometimes invalidates the `pixelBufferPool`) and made sure the compression session is recreated and the video encoder properties set.
* Tested locking a video streaming app running on iPhone model 6 and iOS version 12 (this sometimes creates a `kVTInvalidSessionErr`) and made sure the compression session is recreated and the video encoder properties set.
* Tested disconnecting and reconnecting the iPhone from the module multiple times during an app session and made sure the compression session is created and the video encoder properties set.
* Tested switching the `rootViewController` to a new view and panning on a map view and made sure the video stream was relatively smooth.

Core version / branch / commit hash / module tested against: SYNC 3.0
HMI name / version / branch / commit hash / module tested against: SYNC 3.0

### Summary
When a new compression session created, the video encoding properties are now set on each new compression session.

### Changelog
##### Bug Fixes
* Fixed video encoding properties not being set when new compression session created.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
