### PR TITLE
Fix PRs from forks not running CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,4 +74,6 @@ jobs:
 
             # Upload coverage reports to Codecov
             - name: Upload coverage to Codecov
-              uses: codecov/codecov-action@v1
+              uses: codecov/codecov-action@v1.0.10
+              with: 
+                yml: ./codecov.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,7 @@
 name: SmartDeviceLink Tests
 
 # This workflow is triggered on a push or pull request.
-on:
-    push:
-        # Runs the workflow when someone pushes to any repository branch.
-    pull_request:
-         # Runs the workflow only when someone opens a pull request (there are a bunch of activity types that can trigger a workflow that we don't want - like labeling, assigning, and locking the PR). The "push" trigger will generate a new workflow if a push is made to a pull request branch.
-        types: [opened]
+on: [push, pull_request]
 
 env:
     PROJECT: 'SmartDeviceLink-iOS.xcodeproj'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
                 scheme: ['SmartDeviceLink-Example-ObjC', 'SmartDeviceLink-Example-Swift']
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v2
+              uses: actions/checkout@v2.3.1
               with:
                   submodules: true
 
@@ -41,7 +41,7 @@ jobs:
                 scheme: ['SmartDeviceLink']
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v2
+              uses: actions/checkout@v2.3.1
               with:
                   submodules: true
 


### PR DESCRIPTION
Fixes #1706 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [ ] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [ ] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
No changes to the library

#### Core Tests
No changes to the library

Core version / branch / commit hash / module tested against: n/a
HMI name / version / branch / commit hash / module tested against: n/a

### Summary
This PR forces the CI to run tests for every PR update, which includes fork branches. It also updates the versions of checkout and codecov that we use.

### Tasks Remaining:
None

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
