### PR TITLE
Make system capability manager thread safe

### DIFF
--- a/SmartDeviceLink/SDLSubscribeButtonManager.m
+++ b/SmartDeviceLink/SDLSubscribeButtonManager.m
@@ -44,7 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (!self) { return nil; }
 
     if (@available(iOS 10.0, *)) {
-        _readWriteQueue = dispatch_queue_create_with_target("com.sdl.lifecycle.responseDispatcher", DISPATCH_QUEUE_SERIAL, [SDLGlobals sharedGlobals].sdlProcessingQueue);
+        _readWriteQueue = dispatch_queue_create_with_target("com.sdl.subscribeButtonManager.readWriteQueue", DISPATCH_QUEUE_SERIAL, [SDLGlobals sharedGlobals].sdlProcessingQueue);
     } else {
         _readWriteQueue = [SDLGlobals sharedGlobals].sdlProcessingQueue;
     }

--- a/SmartDeviceLink/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.m
@@ -462,15 +462,12 @@ typedef NSString * SDLServiceID;
 - (void)sdl_saveAppServicesCapabilitiesUpdate:(SDLAppServicesCapabilities *)newCapabilities {
     SDLLogV(@"Saving app services capability update with new capabilities: %@", newCapabilities);
     for (SDLAppServiceCapability *capability in newCapabilities.appServices) {
-        if (capability.updateReason == nil) {
-            // First update, new capability
-            self.appServicesCapabilitiesDictionary[capability.updatedAppServiceRecord.serviceID] = capability;
-        } else if ([capability.updateReason isEqualToEnum:SDLServiceUpdateRemoved]) {
-            self.appServicesCapabilitiesDictionary[capability.updatedAppServiceRecord.serviceID] = nil;
-        } else {
-            // Everything else involves adding or updating the existing service record
-            self.appServicesCapabilitiesDictionary[capability.updatedAppServiceRecord.serviceID] = capability;
-        }
+
+        // If the capability has been removed, delete the saved capability; otherwise just update with the new capability
+        SDLAppServiceCapability *newcapability = [capability.updateReason isEqualToEnum:SDLServiceUpdateRemoved] ? nil : capability;
+        [self sdl_runSyncOnQueue:^{
+            self.appServicesCapabilitiesDictionary[capability.updatedAppServiceRecord.serviceID] = newcapability;
+        }];
     }
 }
 
@@ -819,8 +816,8 @@ typedef NSString * SDLServiceID;
     return dict;
 }
 
-- (NSMutableDictionary<SDLSystemCapabilityType,NSNumber<SDLBool> *> *)subscriptionStatus {
-    __block  NSMutableDictionary<SDLSystemCapabilityType,NSNumber<SDLBool> *> *dict = nil;
+- (NSMutableDictionary<SDLSystemCapabilityType, NSNumber<SDLBool> *> *)subscriptionStatus {
+    __block  NSMutableDictionary<SDLSystemCapabilityType, NSNumber<SDLBool> *> *dict = nil;
     [self sdl_runSyncOnQueue:^{
         dict = self->_subscriptionStatus;
     }];
@@ -828,8 +825,8 @@ typedef NSString * SDLServiceID;
     return dict;
 }
 
-- (nullable NSMutableDictionary<SDLServiceID,SDLAppServiceCapability *> *)appServicesCapabilitiesDictionary {
-    __block NSMutableDictionary<SDLServiceID,SDLAppServiceCapability *> *dict = nil;
+- (nullable NSMutableDictionary<SDLServiceID, SDLAppServiceCapability *> *)appServicesCapabilitiesDictionary {
+    __block NSMutableDictionary<SDLServiceID, SDLAppServiceCapability *> *dict = nil;
     [self sdl_runSyncOnQueue:^{
         dict = self->_appServicesCapabilitiesDictionary;
     }];

--- a/SmartDeviceLink/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.m
@@ -107,7 +107,7 @@ typedef NSString * SDLServiceID;
 
     _currentHMILevel = SDLHMILevelNone;
 
-    [self sdl_registerForNotifications];    
+    [self sdl_registerForNotifications];
 
     return self;
 }
@@ -119,33 +119,34 @@ typedef NSString * SDLServiceID;
  */
 - (void)stop {
     SDLLogD(@"System Capability manager stopped");
-    _displayCapabilities = nil;
-    _displays = nil;
-    _hmiCapabilities = nil;
-    _softButtonCapabilities = nil;
-    _buttonCapabilities = nil;
-    _presetBankCapabilities = nil;
-    _hmiZoneCapabilities = nil;
-    _speechCapabilities = nil;
-    _prerecordedSpeechCapabilities = nil;
-    _vrCapability = NO;
-    _audioPassThruCapabilities = nil;
-    _pcmStreamCapability = nil;
-    _navigationCapability = nil;
-    _phoneCapability = nil;
-    _videoStreamingCapability = nil;
-    _remoteControlCapability = nil;
-    _seatLocationCapability = nil;
-
-    _supportsSubscriptions = NO;
     [self sdl_runSyncOnQueue:^{
-        self->_appServicesCapabilitiesDictionary = [NSMutableDictionary dictionary];
-        [self->_capabilityObservers removeAllObjects];
-        [self->_subscriptionStatus removeAllObjects];
-    }];
+        self.displayCapabilities = nil;
+        self.displays = nil;
+        self.hmiCapabilities = nil;
+        self.softButtonCapabilities = nil;
+        self.buttonCapabilities = nil;
+        self.presetBankCapabilities = nil;
+        self.hmiZoneCapabilities = nil;
+        self.speechCapabilities = nil;
+        self.prerecordedSpeechCapabilities = nil;
+        self.vrCapability = NO;
+        self.audioPassThruCapabilities = nil;
+        self.pcmStreamCapability = nil;
+        self.navigationCapability = nil;
+        self.phoneCapability = nil;
+        self.videoStreamingCapability = nil;
+        self.remoteControlCapability = nil;
+        self.seatLocationCapability = nil;
 
-    _currentHMILevel = SDLHMILevelNone;
-    _shouldConvertDeprecatedDisplayCapabilities = YES;
+        self.supportsSubscriptions = NO;
+
+        self.appServicesCapabilitiesDictionary = [NSMutableDictionary dictionary];
+        [self.capabilityObservers removeAllObjects];
+        [self.subscriptionStatus removeAllObjects];
+
+        self.currentHMILevel = SDLHMILevelNone;
+        self.shouldConvertDeprecatedDisplayCapabilities = YES;
+    }];
 }
 
 #pragma mark - Getters
@@ -259,17 +260,17 @@ typedef NSString * SDLServiceID;
     
     // Create the deprecated capabilities for backward compatibility if developers try to access them
     SDLDisplayCapabilities *convertedCapabilities = [[SDLDisplayCapabilities alloc] init];
-    #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wdeprecated"
-        convertedCapabilities.displayType = SDLDisplayTypeGeneric; // deprecated but it is mandatory
-    #pragma clang diagnostic pop
-        convertedCapabilities.displayName = self.displays.firstObject.displayName;
-        convertedCapabilities.textFields = [defaultMainWindowCapabilities.textFields copy];
-        convertedCapabilities.imageFields = [defaultMainWindowCapabilities.imageFields copy];
-        convertedCapabilities.templatesAvailable = [defaultMainWindowCapabilities.templatesAvailable copy];
-        convertedCapabilities.numCustomPresetsAvailable = [defaultMainWindowCapabilities.numCustomPresetsAvailable copy];
-        convertedCapabilities.mediaClockFormats = @[]; // mandatory field but allows empty array
-        convertedCapabilities.graphicSupported = @([defaultMainWindowCapabilities.imageTypeSupported containsObject:SDLImageTypeDynamic]);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+    convertedCapabilities.displayType = SDLDisplayTypeGeneric; // deprecated but it is mandatory
+#pragma clang diagnostic pop
+    convertedCapabilities.displayName = self.displays.firstObject.displayName;
+    convertedCapabilities.textFields = [defaultMainWindowCapabilities.textFields copy];
+    convertedCapabilities.imageFields = [defaultMainWindowCapabilities.imageFields copy];
+    convertedCapabilities.templatesAvailable = [defaultMainWindowCapabilities.templatesAvailable copy];
+    convertedCapabilities.numCustomPresetsAvailable = [defaultMainWindowCapabilities.numCustomPresetsAvailable copy];
+    convertedCapabilities.mediaClockFormats = @[]; // mandatory field but allows empty array
+    convertedCapabilities.graphicSupported = @([defaultMainWindowCapabilities.imageTypeSupported containsObject:SDLImageTypeDynamic]);
 
     self.displayCapabilities = convertedCapabilities;
     self.buttonCapabilities = defaultMainWindowCapabilities.buttonCapabilities;
@@ -523,8 +524,8 @@ typedef NSString * SDLServiceID;
     SDLLogD(@"Subscribing to capability type: %@ with a handler (DEPRECATED)", type);
     SDLSystemCapabilityObserver *observerObject = [[SDLSystemCapabilityObserver alloc] initWithObserver:[[NSObject alloc] init] block:block];
 
-     id<NSObject> subscribedObserver = [self sdl_subscribeToCapabilityType:type observerObject:observerObject];
-     return subscribedObserver;
+    id<NSObject> subscribedObserver = [self sdl_subscribeToCapabilityType:type observerObject:observerObject];
+    return subscribedObserver;
 }
 
 - (nullable id<NSObject>)subscribeToCapabilityType:(SDLSystemCapabilityType)type withUpdateHandler:(SDLCapabilityUpdateWithErrorHandler)handler {

--- a/SmartDeviceLink/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.m
@@ -466,7 +466,7 @@ typedef NSString * SDLServiceID;
         // If the capability has been removed, delete the saved capability; otherwise just update with the new capability
         SDLAppServiceCapability *newCapability = [capability.updateReason isEqualToEnum:SDLServiceUpdateRemoved] ? nil : capability;
         [self sdl_runSyncOnQueue:^{
-            self.appServicesCapabilitiesDictionary[capability.updatedAppServiceRecord.serviceID] = newcapability;
+            self.appServicesCapabilitiesDictionary[capability.updatedAppServiceRecord.serviceID] = newCapability;
         }];
     }
 }

--- a/SmartDeviceLink/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.m
@@ -558,6 +558,7 @@ typedef NSString * SDLServiceID;
 /// Helper method for subscribing to a system capability type
 /// @param type The SystemCapabilityType that will be subscribed
 /// @param observerObject An object that can be used to unsubscribe the block. If nil, the subscription was not succesful.
+/// @return The observer if the subscription was succesful; nil if not.
 - (nullable id<NSObject>)sdl_subscribeToCapabilityType:(SDLSystemCapabilityType)type observerObject:(SDLSystemCapabilityObserver *)observerObject {
     if ([self.currentHMILevel isEqualToEnum:SDLHMILevelNone] && ![type isEqualToEnum:SDLSystemCapabilityTypeDisplays]) {
         SDLLogE(@"Attempted to subscribe to type: %@ in HMI level NONE, which is not allowed. Please wait until you are in HMI BACKGROUND, LIMITED, or FULL before attempting to subscribe to any SystemCapabilityType other than DISPLAYS.", type);
@@ -612,19 +613,17 @@ typedef NSString * SDLServiceID;
     // Loop through our observers
     for (SDLSystemCapabilityType key in self.capabilityObservers.allKeys) {
         for (SDLSystemCapabilityObserver *observer in self.capabilityObservers[key]) {
-            // If an observer object is nil, remove it
-            if (observer.observer == nil) {
-                [self sdl_runSyncOnQueue:^{
+            [self sdl_runSyncOnQueue:^{
+                // If an observer object is nil, remove it
+                if (observer.observer == nil) {
                     [self.capabilityObservers[key] removeObject:observer];
-                }];
-            }
+                }
 
-            // If we no longer have any observers for that type, remove the array
-            if (self.capabilityObservers[key].count == 0) {
-                [self sdl_runSyncOnQueue:^{
+                // If we no longer have any observers for that type, remove the array
+                if (self.capabilityObservers[key].count == 0) {
                     [self.capabilityObservers removeObjectForKey:key];
-                }];
-            }
+                }
+            }];
         }
     }
 

--- a/SmartDeviceLink/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/SDLSystemCapabilityManager.m
@@ -387,7 +387,9 @@ typedef NSString * SDLServiceID;
         SDLLogD(@"GetSystemCapability response succeeded, type: %@, response: %@", type, getSystemCapabilityResponse);
 
         if (![weakself.subscriptionStatus[type] isEqualToNumber:subscribe] && weakself.supportsSubscriptions) {
-            weakself.subscriptionStatus[type] = subscribe;
+            [self sdl_runSyncOnQueue:^{
+                weakself.subscriptionStatus[type] = subscribe;
+            }];
         }
 
         [weakself sdl_saveSystemCapability:getSystemCapabilityResponse.systemCapability error:error completionHandler:handler];


### PR DESCRIPTION
Fixes #1709

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Existing unit tests were run. No additional tests added since the system capability manager was made thread safe. 

#### Core Tests
Connected and reconnected to Manticore many times.

Core version / branch / commit hash / module tested against: Manticore (Core v6.1.1)
HMI name / version / branch / commit hash / module tested against: Manticore (Generic HMI v0.8.1)

### Summary
Fixed crash occurring in the System Capability Manager due to a dictionary being mutated during enumeration. 

### Changelog
##### Bug Fixes
* Dictionaries in the System Capability Manager are now thread safe. 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
