### PR TITLE
Fix a deadlock when restarting the lifecycle manager from managerDidDisconnect

### DIFF
--- a/Example Apps/Example Swift/ProxyManager.swift
+++ b/Example Apps/Example Swift/ProxyManager.swift
@@ -21,13 +21,14 @@ enum ProxyState {
 }
 
 class ProxyManager: NSObject {
-    fileprivate var sdlManager: SDLManager!
-    fileprivate var buttonManager: ButtonManager!
-    fileprivate var subscribeButtonManager: SubscribeButtonManager!
-    fileprivate var vehicleDataManager: VehicleDataManager!
-    fileprivate var performInteractionManager: PerformInteractionManager!
-    fileprivate var firstHMILevelState: SDLHMILevel
+    private var sdlManager: SDLManager!
+    private var buttonManager: ButtonManager!
+    private var subscribeButtonManager: SubscribeButtonManager!
+    private var vehicleDataManager: VehicleDataManager!
+    private var performInteractionManager: PerformInteractionManager!
+    private var firstHMILevelState: SDLHMILevel
     weak var delegate: ProxyManagerDelegate?
+
 
     // Singleton
     static let sharedManager = ProxyManager()
@@ -44,12 +45,6 @@ extension ProxyManager {
     ///
     /// - Parameter connectionType: The type of transport layer to use.
     func start(with proxyTransportType: ProxyTransportType) {
-        guard sdlManager == nil else {
-            // Manager already created, just start it again.
-            startManager()
-            return
-        }
-
         delegate?.didChangeProxyState(ProxyState.searching)
         sdlManager = SDLManager(configuration: proxyTransportType == .iap ? ProxyManager.connectIAP() : ProxyManager.connectTCP(), delegate: self)
         startManager()

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -190,10 +190,10 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
     _mobileHMIStateHandler = [[SDLLifecycleMobileHMIStateHandler alloc] initWithConnectionManager:self];
 
     // Notifications
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_rpcServiceDidConnect) name:SDLRPCServiceDidConnect object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_transportDidDisconnect) name:SDLTransportDidDisconnect object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(hmiStatusDidChange:) name:SDLDidChangeHMIStatusNotification object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(remoteHardwareDidUnregister:) name:SDLDidReceiveAppUnregisteredNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_rpcServiceDidConnect) name:SDLRPCServiceDidConnect object:_notificationDispatcher];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_transportDidDisconnect) name:SDLTransportDidDisconnect object:_notificationDispatcher];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(hmiStatusDidChange:) name:SDLDidChangeHMIStatusNotification object:_notificationDispatcher];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(remoteHardwareDidUnregister:) name:SDLDidReceiveAppUnregisteredNotification object:_notificationDispatcher];
 
     _backgroundTaskManager = [[SDLBackgroundTaskManager alloc] initWithBackgroundTaskName:BackgroundTaskTransportName];
 

--- a/SmartDeviceLink/SDLLifecycleManager.m
+++ b/SmartDeviceLink/SDLLifecycleManager.m
@@ -201,9 +201,9 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
 }
 
 - (void)startWithReadyHandler:(SDLManagerReadyBlock)readyHandler {
-    dispatch_sync(_lifecycleQueue, ^{
+    [self sdl_runOnProcessingQueue:^{
         [self sdl_startWithReadyHandler:readyHandler];
-    });
+    }];
 }
 
 - (void)sdl_startWithReadyHandler:(SDLManagerReadyBlock)readyHandler {


### PR DESCRIPTION
Fixes #1710 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Ran the unit tests, no new tests were added

#### Core Tests
Tested hard transport disconnect with a reconnection from `managerDidDisconnect`.

Core version / branch / commit hash / module tested against: 5.1.0
HMI name / version / branch / commit hash / module tested against: SDL HMI 5.1.0

### Summary
Changes startup queuing to only dispatch sync to the lifecycle queue if we're not already on the lifecycle queue.

### Changelog
##### Bug Fixes
* Fixed deadlock when restarting the `SDLManager` from the `managerDidDisconnect` callback.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
