### PR TITLE
Fix unknown RPC crash

### DIFF
--- a/SmartDeviceLink/SDLLifecycleProtocolHandler.m
+++ b/SmartDeviceLink/SDLLifecycleProtocolHandler.m
@@ -142,6 +142,9 @@ NS_ASSUME_NONNULL_BEGIN
     NSString *functionClassName = [NSString stringWithFormat:@"SDL%@", fullName];
     SDLRPCMessage *newMessage = [[NSClassFromString(functionClassName) alloc] initWithDictionary:rpcMessageAsDictionary];
 
+    // If we were unable to create the message, it's an unknown type; discard it
+    if (newMessage == nil) { return; }
+
     // Adapt the incoming message then call the callback
     NSArray<SDLRPCMessage *> *adaptedMessages = [SDLLifecycleRPCAdapter adaptRPC:newMessage direction:SDLRPCDirectionIncoming];
     for (SDLRPCMessage *message in adaptedMessages) {


### PR DESCRIPTION
Fixes #1713 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
No unit test changes

#### Core Tests
Tested receiving the errant RPC type from Sync 3.4

Core version / branch / commit hash / module tested against: Ford Sync 3.4
HMI name / version / branch / commit hash / module tested against: Ford Sync 3.4

### Summary
If a received protocol message cannot be turned into an RPC, discard it.

### Changelog
##### Bug Fixes
* When an unknown RPC is received, discard it instead of crashing.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
