### PR TITLE
The secondary transport manager now only starts a timer when the secondary transport has opened

### DIFF
--- a/SmartDeviceLink/SDLEncryptionLifecycleManager.m
+++ b/SmartDeviceLink/SDLEncryptionLifecycleManager.m
@@ -171,7 +171,7 @@ typedef NSString SDLVehicleMake;
     SDLLogD(@"Encryption manager stopped");
 }
 
-#pragma mark - SDLProtocolListener
+#pragma mark - SDLProtocolDelegate
 #pragma mark Encryption Start Service ACK
 
 - (void)handleProtocolStartServiceACKMessage:(SDLProtocolMessage *)startServiceACK {

--- a/SmartDeviceLink/SDLEncryptionLifecycleManager.m
+++ b/SmartDeviceLink/SDLEncryptionLifecycleManager.m
@@ -174,7 +174,7 @@ typedef NSString SDLVehicleMake;
 #pragma mark - SDLProtocolDelegate
 #pragma mark Encryption Start Service ACK
 
-- (void)handleProtocolStartServiceACKMessage:(SDLProtocolMessage *)startServiceACK {
+- (void)handleProtocolStartServiceACKMessage:(SDLProtocolMessage *)startServiceACK protocol:(SDLProtocol *)protocol {
     switch (startServiceACK.header.serviceType) {
         case SDLServiceTypeRPC: {
             [self sdl_handleEncryptionStartServiceACK:startServiceACK];
@@ -197,7 +197,7 @@ typedef NSString SDLVehicleMake;
 
 #pragma mark Encryption Start Service NAK
 
-- (void)handleProtocolStartServiceNAKMessage:(SDLProtocolMessage *)startServiceNAK {
+- (void)handleProtocolStartServiceNAKMessage:(SDLProtocolMessage *)startServiceNAK protocol:(SDLProtocol *)protocol {
     switch (startServiceNAK.header.serviceType) {
         case SDLServiceTypeRPC: {
             [self sdl_handleEncryptionStartServiceNAK:startServiceNAK];
@@ -214,7 +214,7 @@ typedef NSString SDLVehicleMake;
 
 #pragma mark Encryption End Service
 
-- (void)handleProtocolEndServiceACKMessage:(SDLProtocolMessage *)endServiceACK {
+- (void)handleProtocolEndServiceACKMessage:(SDLProtocolMessage *)endServiceACK protocol:(SDLProtocol *)protocol {
     switch (endServiceACK.header.serviceType) {
         case SDLServiceTypeRPC: {
             SDLLogW(@"Encryption RPC service ended with end service ACK");
@@ -225,7 +225,7 @@ typedef NSString SDLVehicleMake;
     }
 }
 
-- (void)handleProtocolEndServiceNAKMessage:(SDLProtocolMessage *)endServiceNAK {
+- (void)handleProtocolEndServiceNAKMessage:(SDLProtocolMessage *)endServiceNAK protocol:(SDLProtocol *)protocol {
     switch (endServiceNAK.header.serviceType) {
         case SDLServiceTypeRPC: {
             SDLLogW(@"Encryption RPC service ended with end service NAK");

--- a/SmartDeviceLink/SDLEncryptionLifecycleManager.m
+++ b/SmartDeviceLink/SDLEncryptionLifecycleManager.m
@@ -174,7 +174,7 @@ typedef NSString SDLVehicleMake;
 #pragma mark - SDLProtocolDelegate
 #pragma mark Encryption Start Service ACK
 
-- (void)handleProtocolStartServiceACKMessage:(SDLProtocolMessage *)startServiceACK protocol:(SDLProtocol *)protocol {
+- (void)protocol:(SDLProtocol *)protocol didReceiveStartServiceACK:(SDLProtocolMessage *)startServiceACK {
     switch (startServiceACK.header.serviceType) {
         case SDLServiceTypeRPC: {
             [self sdl_handleEncryptionStartServiceACK:startServiceACK];
@@ -197,7 +197,7 @@ typedef NSString SDLVehicleMake;
 
 #pragma mark Encryption Start Service NAK
 
-- (void)handleProtocolStartServiceNAKMessage:(SDLProtocolMessage *)startServiceNAK protocol:(SDLProtocol *)protocol {
+- (void)protocol:(SDLProtocol *)protocol didReceiveStartServiceNAK:(SDLProtocolMessage *)startServiceNAK {
     switch (startServiceNAK.header.serviceType) {
         case SDLServiceTypeRPC: {
             [self sdl_handleEncryptionStartServiceNAK:startServiceNAK];
@@ -214,7 +214,7 @@ typedef NSString SDLVehicleMake;
 
 #pragma mark Encryption End Service
 
-- (void)handleProtocolEndServiceACKMessage:(SDLProtocolMessage *)endServiceACK protocol:(SDLProtocol *)protocol {
+- (void)protocol:(SDLProtocol *)protocol didReceiveEndServiceACK:(SDLProtocolMessage *)endServiceACK {
     switch (endServiceACK.header.serviceType) {
         case SDLServiceTypeRPC: {
             SDLLogW(@"Encryption RPC service ended with end service ACK");
@@ -225,7 +225,7 @@ typedef NSString SDLVehicleMake;
     }
 }
 
-- (void)handleProtocolEndServiceNAKMessage:(SDLProtocolMessage *)endServiceNAK protocol:(SDLProtocol *)protocol {
+- (void)protocol:(SDLProtocol *)protocol didReceiveEndServiceNAK:(SDLProtocolMessage *)endServiceNAK {
     switch (endServiceNAK.header.serviceType) {
         case SDLServiceTypeRPC: {
             SDLLogW(@"Encryption RPC service ended with end service NAK");

--- a/SmartDeviceLink/SDLLifecycleProtocolHandler.m
+++ b/SmartDeviceLink/SDLLifecycleProtocolHandler.m
@@ -83,19 +83,12 @@ NS_ASSUME_NONNULL_BEGIN
         __weak typeof(self) weakSelf = self;
         self.rpcStartServiceTimeoutTimer.elapsedBlock = ^{
             SDLLogE(@"Start session timed out after %f seconds, closing the connection.", StartSessionTime);
-            [weakSelf sdl_closeSessionWithDelay:(float)0.1];
+            [weakSelf.protocol stopWithCompletionHandler:^{}];
         };
     }
     [self.rpcStartServiceTimeoutTimer start];
 }
 
-/// Helper method for closing the current session
-- (void)sdl_closeSessionWithDelay:(float)delay {
-    __weak typeof(self) weakSelf = self;
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        [weakSelf protocolDidClose:self.protocol];
-    });
-}
 
 /// Called when the transport is closed.
 - (void)protocolDidClose:(SDLProtocol *)protocol {

--- a/SmartDeviceLink/SDLLifecycleProtocolHandler.m
+++ b/SmartDeviceLink/SDLLifecycleProtocolHandler.m
@@ -89,7 +89,6 @@ NS_ASSUME_NONNULL_BEGIN
     [self.rpcStartServiceTimeoutTimer start];
 }
 
-
 /// Called when the transport is closed.
 - (void)protocolDidClose:(SDLProtocol *)protocol {
     if (self.protocol != protocol) { return; }

--- a/SmartDeviceLink/SDLLifecycleProtocolHandler.m
+++ b/SmartDeviceLink/SDLLifecycleProtocolHandler.m
@@ -104,7 +104,7 @@ NS_ASSUME_NONNULL_BEGIN
     [self.notificationDispatcher postNotificationName:SDLTransportConnectError infoObject:error];
 }
 
-- (void)handleProtocolStartServiceACKMessage:(SDLProtocolMessage *)startServiceACK {
+- (void)handleProtocolStartServiceACKMessage:(SDLProtocolMessage *)startServiceACK protocol:(SDLProtocol *)protocol {
     SDLLogD(@"Start Service (ACK) SessionId: %d for serviceType %d", startServiceACK.header.sessionID, startServiceACK.header.serviceType);
 
     if (startServiceACK.header.serviceType == SDLServiceTypeRPC) {
@@ -113,7 +113,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
-- (void)handleProtocolStartServiceNAKMessage:(SDLProtocolMessage *)startServiceNAK {
+- (void)handleProtocolStartServiceNAKMessage:(SDLProtocolMessage *)startServiceNAK protocol:(SDLProtocol *)protocol {
     SDLLogD(@"Start Service (NAK): SessionId: %d for serviceType %d", startServiceNAK.header.sessionID, startServiceNAK.header.serviceType);
 
     if (startServiceNAK.header.serviceType == SDLServiceTypeRPC) {
@@ -122,7 +122,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
-- (void)handleProtocolEndServiceACKMessage:(SDLProtocolMessage *)endServiceACK {
+- (void)handleProtocolEndServiceACKMessage:(SDLProtocolMessage *)endServiceACK protocol:(SDLProtocol *)protocol {
     SDLLogD(@"End Service (ACK): SessionId: %d for serviceType %d", endServiceACK.header.sessionID, endServiceACK.header.serviceType);
 
     if (endServiceACK.header.serviceType == SDLServiceTypeRPC) {
@@ -131,14 +131,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
-- (void)handleProtocolEndServiceNAKMessage:(SDLProtocolMessage *)endServiceNAK {
+- (void)handleProtocolEndServiceNAKMessage:(SDLProtocolMessage *)endServiceNAK protocol:(SDLProtocol *)protocol {
     if (endServiceNAK.header.serviceType == SDLServiceTypeRPC) {
         NSError *error = [NSError sdl_lifecycle_unknownRemoteErrorWithDescription:@"RPC Service failed to stop" andReason:nil];
         [self.notificationDispatcher postNotificationName:SDLRPCServiceConnectionDidError infoObject:error];
     }
 }
 
-- (void)onProtocolMessageReceived:(SDLProtocolMessage *)msg {
+- (void)onProtocolMessageReceived:(SDLProtocolMessage *)msg protocol:(SDLProtocol *)protocol {
     NSDictionary<NSString *, id> *rpcMessageAsDictionary = [msg rpcDictionary];
     SDLRPCMessage *receivedMessage = [[SDLRPCMessage alloc] initWithDictionary:rpcMessageAsDictionary];
     NSString *fullName = [self sdl_fullNameForMessage:receivedMessage];

--- a/SmartDeviceLink/SDLLifecycleProtocolHandler.m
+++ b/SmartDeviceLink/SDLLifecycleProtocolHandler.m
@@ -69,7 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - SDLProtocolDelegate
 
 /// Called when the transport is opened. We will send the RPC Start Service and wait for the RPC Start Service ACK
-- (void)onProtocolOpened {
+- (void)onProtocolOpened:(SDLProtocol *)protocol {
     SDLLogD(@"Transport opened, sending an RPC Start Service, and starting timer for RPC Start Service ACK to be received.");
     [self.notificationDispatcher postNotificationName:SDLTransportDidConnect infoObject:nil];
 

--- a/SmartDeviceLink/SDLProtocol.m
+++ b/SmartDeviceLink/SDLProtocol.m
@@ -494,7 +494,7 @@ NS_ASSUME_NONNULL_BEGIN
     self.receiveBuffer = [[self.receiveBuffer subdataWithRange:NSMakeRange(messageSize, self.receiveBuffer.length - messageSize)] mutableCopy];
 
     // Pass on the message to the message router.
-    [self.messageRouter handleReceivedMessage:message];
+    [self.messageRouter handleReceivedMessage:message protocol:self];
 
     // Call recursively until the buffer is empty or incomplete message is encountered
     if (self.receiveBuffer.length > 0) {
@@ -505,7 +505,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - SDLProtocolDelegate from SDLReceivedProtocolMessageRouter
 
-- (void)handleProtocolStartServiceACKMessage:(SDLProtocolMessage *)startServiceACK {
+- (void)handleProtocolStartServiceACKMessage:(SDLProtocolMessage *)startServiceACK protocol:(SDLProtocol *)protocol {
     SDLLogD(@"Received start service ACK: %@", startServiceACK);
 
     // V5+ Packet
@@ -546,65 +546,65 @@ NS_ASSUME_NONNULL_BEGIN
     // Pass along to all the listeners
     NSArray<id<SDLProtocolDelegate>> *listeners = [self sdl_getProtocolListeners];
     for (id<SDLProtocolDelegate> listener in listeners) {
-        if ([listener respondsToSelector:@selector(handleProtocolStartServiceACKMessage:)]) {
-            [listener handleProtocolStartServiceACKMessage:startServiceACK];
+        if ([listener respondsToSelector:@selector(handleProtocolStartServiceACKMessage:protocol:)]) {
+            [listener handleProtocolStartServiceACKMessage:startServiceACK protocol:protocol];
         }
     }
 }
 
-- (void)handleProtocolStartServiceNAKMessage:(SDLProtocolMessage *)startServiceNAK {
+- (void)handleProtocolStartServiceNAKMessage:(SDLProtocolMessage *)startServiceNAK protocol:(SDLProtocol *)protocol {
     [self sdl_logControlNAKPayload:startServiceNAK];
 
     NSArray<id<SDLProtocolDelegate>> *listeners = [self sdl_getProtocolListeners];
     for (id<SDLProtocolDelegate> listener in listeners) {
-        if ([listener respondsToSelector:@selector(handleProtocolStartServiceNAKMessage:)]) {
-            [listener handleProtocolStartServiceNAKMessage:startServiceNAK];
+        if ([listener respondsToSelector:@selector(handleProtocolStartServiceNAKMessage:protocol:)]) {
+            [listener handleProtocolStartServiceNAKMessage:startServiceNAK protocol:protocol];
         }
     }
 }
 
-- (void)handleProtocolEndServiceACKMessage:(SDLProtocolMessage *)endServiceACK {
+- (void)handleProtocolEndServiceACKMessage:(SDLProtocolMessage *)endServiceACK protocol:(SDLProtocol *)protocol {
     SDLLogD(@"End service ACK: %@", endServiceACK);
     // Remove the session id
     [self.serviceHeaders removeObjectForKey:@(endServiceACK.header.serviceType)];
 
     NSArray<id<SDLProtocolDelegate>> *listeners = [self sdl_getProtocolListeners];
     for (id<SDLProtocolDelegate> listener in listeners) {
-        if ([listener respondsToSelector:@selector(handleProtocolEndServiceACKMessage:)]) {
-            [listener handleProtocolEndServiceACKMessage:endServiceACK];
+        if ([listener respondsToSelector:@selector(handleProtocolEndServiceACKMessage:protocol:)]) {
+            [listener handleProtocolEndServiceACKMessage:endServiceACK protocol:protocol];
         }
     }
 }
 
-- (void)handleProtocolEndServiceNAKMessage:(SDLProtocolMessage *)endServiceNAK {
+- (void)handleProtocolEndServiceNAKMessage:(SDLProtocolMessage *)endServiceNAK protocol:(SDLProtocol *)protocol {
     [self sdl_logControlNAKPayload:endServiceNAK];
 
     NSArray<id<SDLProtocolDelegate>> *listeners = [self sdl_getProtocolListeners];
     for (id<SDLProtocolDelegate> listener in listeners) {
-        if ([listener respondsToSelector:@selector(handleProtocolEndServiceNAKMessage:)]) {
-            [listener handleProtocolEndServiceNAKMessage:endServiceNAK];
+        if ([listener respondsToSelector:@selector(handleProtocolEndServiceNAKMessage:protocol:)]) {
+            [listener handleProtocolEndServiceNAKMessage:endServiceNAK protocol:protocol];
         }
     }
 }
 
-- (void)handleProtocolRegisterSecondaryTransportACKMessage:(SDLProtocolMessage *)registerSecondaryTransportACK {
+- (void)handleProtocolRegisterSecondaryTransportACKMessage:(SDLProtocolMessage *)registerSecondaryTransportACK protocol:(SDLProtocol *)protocol {
     SDLLogD(@"Register Secondary Transport ACK: %@", registerSecondaryTransportACK);
 
     NSArray<id<SDLProtocolDelegate>> *listeners = [self sdl_getProtocolListeners];
     for (id<SDLProtocolDelegate> listener in listeners) {
-        if ([listener respondsToSelector:@selector(handleProtocolRegisterSecondaryTransportACKMessage:)]) {
-            [listener handleProtocolRegisterSecondaryTransportACKMessage:registerSecondaryTransportACK];
+        if ([listener respondsToSelector:@selector(handleProtocolRegisterSecondaryTransportACKMessage:protocol:)]) {
+            [listener handleProtocolRegisterSecondaryTransportACKMessage:registerSecondaryTransportACK protocol:protocol];
         }
     }
 }
 
-- (void)handleProtocolRegisterSecondaryTransportNAKMessage:(SDLProtocolMessage *)registerSecondaryTransportNAK {
+- (void)handleProtocolRegisterSecondaryTransportNAKMessage:(SDLProtocolMessage *)registerSecondaryTransportNAK protocol:(SDLProtocol *)protocol {
     [self sdl_logControlNAKPayload:registerSecondaryTransportNAK];
 
     NSArray<id<SDLProtocolDelegate>> *listeners = [self sdl_getProtocolListeners];
     for (id<SDLProtocolDelegate> listener in listeners) {
-        if ([listener respondsToSelector:@selector(handleProtocolRegisterSecondaryTransportNAKMessage:)]) {
-            [listener handleProtocolRegisterSecondaryTransportNAKMessage:registerSecondaryTransportNAK];
+        if ([listener respondsToSelector:@selector(handleProtocolRegisterSecondaryTransportNAKMessage:protocol:)]) {
+            [listener handleProtocolRegisterSecondaryTransportNAKMessage:registerSecondaryTransportNAK protocol:protocol];
         }
     }
 }
@@ -640,18 +640,18 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
-- (void)handleTransportEventUpdateMessage:(SDLProtocolMessage *)transportEventUpdate {
+- (void)handleTransportEventUpdateMessage:(SDLProtocolMessage *)transportEventUpdate protocol:(SDLProtocol *)protocol {
     SDLLogD(@"Received a transport event update: %@", transportEventUpdate);
 
     NSArray<id<SDLProtocolDelegate>> *listeners = [self sdl_getProtocolListeners];
     for (id<SDLProtocolDelegate> listener in listeners) {
-        if ([listener respondsToSelector:@selector(handleTransportEventUpdateMessage:)]) {
-            [listener handleTransportEventUpdateMessage:transportEventUpdate];
+        if ([listener respondsToSelector:@selector(handleTransportEventUpdateMessage:protocol:)]) {
+            [listener handleTransportEventUpdateMessage:transportEventUpdate protocol:protocol];
         }
     }
 }
 
-- (void)onProtocolMessageReceived:(SDLProtocolMessage *)msg {
+- (void)onProtocolMessageReceived:(SDLProtocolMessage *)msg protocol:(SDLProtocol *)protocol {
     // Control service (but not control frame type) messages are TLS handshake messages
     if (msg.header.serviceType == SDLServiceTypeControl) {
         [self sdl_processSecurityMessage:msg];
@@ -662,8 +662,8 @@ NS_ASSUME_NONNULL_BEGIN
 
     NSArray<id<SDLProtocolDelegate>> *listeners = [self sdl_getProtocolListeners];
     for (id<SDLProtocolDelegate> listener in listeners) {
-        if ([listener respondsToSelector:@selector(onProtocolMessageReceived:)]) {
-            [listener onProtocolMessageReceived:msg];
+        if ([listener respondsToSelector:@selector(onProtocolMessageReceived:protocol:)]) {
+            [listener onProtocolMessageReceived:msg protocol:self];
         }
     }
 }

--- a/SmartDeviceLink/SDLProtocol.m
+++ b/SmartDeviceLink/SDLProtocol.m
@@ -128,8 +128,8 @@ NS_ASSUME_NONNULL_BEGIN
         listeners = self.protocolDelegateTable.allObjects;
     }
     for (id<SDLProtocolDelegate> listener in listeners) {
-        if ([listener respondsToSelector:@selector(onProtocolOpened:)]) {
-            [listener onProtocolOpened:self];
+        if ([listener respondsToSelector:@selector(protocolDidOpen:)]) {
+            [listener protocolDidOpen:self];
         }
     }
 }
@@ -141,8 +141,8 @@ NS_ASSUME_NONNULL_BEGIN
         listeners = self.protocolDelegateTable.allObjects;
     }
     for (id<SDLProtocolDelegate> listener in listeners) {
-        if ([listener respondsToSelector:@selector(onProtocolClosed:)]) {
-            [listener onProtocolClosed:self];
+        if ([listener respondsToSelector:@selector(protocolDidClose:)]) {
+            [listener protocolDidClose:self];
         }
     }
 }
@@ -154,8 +154,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)onError:(NSError *)error {
     SDLLogV(@"Transport received an error: %@", error);
     for (id<SDLProtocolDelegate> listener in self.protocolDelegateTable.allObjects) {
-        if ([listener respondsToSelector:@selector(onTransportError:protocol:)]) {
-            [listener onTransportError:error protocol:self];
+        if ([listener respondsToSelector:@selector(protocol:transportDidError:)]) {
+            [listener protocol:self transportDidError:error];
         }
     }
 }
@@ -505,7 +505,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - SDLProtocolDelegate from SDLReceivedProtocolMessageRouter
 
-- (void)handleProtocolStartServiceACKMessage:(SDLProtocolMessage *)startServiceACK protocol:(SDLProtocol *)protocol {
+- (void)protocol:(SDLProtocol *)protocol didReceiveStartServiceACK:(SDLProtocolMessage *)startServiceACK {
     SDLLogD(@"Received start service ACK: %@", startServiceACK);
 
     // V5+ Packet
@@ -546,65 +546,65 @@ NS_ASSUME_NONNULL_BEGIN
     // Pass along to all the listeners
     NSArray<id<SDLProtocolDelegate>> *listeners = [self sdl_getProtocolListeners];
     for (id<SDLProtocolDelegate> listener in listeners) {
-        if ([listener respondsToSelector:@selector(handleProtocolStartServiceACKMessage:protocol:)]) {
-            [listener handleProtocolStartServiceACKMessage:startServiceACK protocol:protocol];
+        if ([listener respondsToSelector:@selector(protocol:didReceiveStartServiceACK:)]) {
+            [listener protocol:protocol didReceiveStartServiceACK:startServiceACK];
         }
     }
 }
 
-- (void)handleProtocolStartServiceNAKMessage:(SDLProtocolMessage *)startServiceNAK protocol:(SDLProtocol *)protocol {
+- (void)protocol:(SDLProtocol *)protocol didReceiveStartServiceNAK:(SDLProtocolMessage *)startServiceNAK {
     [self sdl_logControlNAKPayload:startServiceNAK];
 
     NSArray<id<SDLProtocolDelegate>> *listeners = [self sdl_getProtocolListeners];
     for (id<SDLProtocolDelegate> listener in listeners) {
-        if ([listener respondsToSelector:@selector(handleProtocolStartServiceNAKMessage:protocol:)]) {
-            [listener handleProtocolStartServiceNAKMessage:startServiceNAK protocol:protocol];
+        if ([listener respondsToSelector:@selector(protocol:didReceiveStartServiceNAK:)]) {
+            [listener protocol:protocol didReceiveStartServiceNAK:startServiceNAK];
         }
     }
 }
 
-- (void)handleProtocolEndServiceACKMessage:(SDLProtocolMessage *)endServiceACK protocol:(SDLProtocol *)protocol {
+- (void)protocol:(SDLProtocol *)protocol didReceiveEndServiceACK:(SDLProtocolMessage *)endServiceACK {
     SDLLogD(@"End service ACK: %@", endServiceACK);
     // Remove the session id
     [self.serviceHeaders removeObjectForKey:@(endServiceACK.header.serviceType)];
 
     NSArray<id<SDLProtocolDelegate>> *listeners = [self sdl_getProtocolListeners];
     for (id<SDLProtocolDelegate> listener in listeners) {
-        if ([listener respondsToSelector:@selector(handleProtocolEndServiceACKMessage:protocol:)]) {
-            [listener handleProtocolEndServiceACKMessage:endServiceACK protocol:protocol];
+        if ([listener respondsToSelector:@selector(protocol:didReceiveEndServiceACK:)]) {
+            [listener protocol:protocol didReceiveEndServiceACK:endServiceACK];
         }
     }
 }
 
-- (void)handleProtocolEndServiceNAKMessage:(SDLProtocolMessage *)endServiceNAK protocol:(SDLProtocol *)protocol {
+- (void)protocol:(SDLProtocol *)protocol didReceiveEndServiceNAK:(SDLProtocolMessage *)endServiceNAK {
     [self sdl_logControlNAKPayload:endServiceNAK];
 
     NSArray<id<SDLProtocolDelegate>> *listeners = [self sdl_getProtocolListeners];
     for (id<SDLProtocolDelegate> listener in listeners) {
-        if ([listener respondsToSelector:@selector(handleProtocolEndServiceNAKMessage:protocol:)]) {
-            [listener handleProtocolEndServiceNAKMessage:endServiceNAK protocol:protocol];
+        if ([listener respondsToSelector:@selector(protocol:didReceiveEndServiceNAK:)]) {
+            [listener protocol:protocol didReceiveEndServiceNAK:endServiceNAK];
         }
     }
 }
 
-- (void)handleProtocolRegisterSecondaryTransportACKMessage:(SDLProtocolMessage *)registerSecondaryTransportACK protocol:(SDLProtocol *)protocol {
+- (void)protocol:(SDLProtocol *)protocol didReceiveRegisterSecondaryTransportACK:(SDLProtocolMessage *)registerSecondaryTransportACK {
     SDLLogD(@"Register Secondary Transport ACK: %@", registerSecondaryTransportACK);
 
     NSArray<id<SDLProtocolDelegate>> *listeners = [self sdl_getProtocolListeners];
     for (id<SDLProtocolDelegate> listener in listeners) {
-        if ([listener respondsToSelector:@selector(handleProtocolRegisterSecondaryTransportACKMessage:protocol:)]) {
-            [listener handleProtocolRegisterSecondaryTransportACKMessage:registerSecondaryTransportACK protocol:protocol];
+        if ([listener respondsToSelector:@selector(protocol:didReceiveRegisterSecondaryTransportACK:)]) {
+            [listener protocol:protocol didReceiveRegisterSecondaryTransportACK:registerSecondaryTransportACK];
         }
     }
 }
 
-- (void)handleProtocolRegisterSecondaryTransportNAKMessage:(SDLProtocolMessage *)registerSecondaryTransportNAK protocol:(SDLProtocol *)protocol {
+- (void)protocol:(SDLProtocol *)protocol didReceiveRegisterSecondaryTransportNAK:(SDLProtocolMessage *)registerSecondaryTransportNAK {
     [self sdl_logControlNAKPayload:registerSecondaryTransportNAK];
 
     NSArray<id<SDLProtocolDelegate>> *listeners = [self sdl_getProtocolListeners];
     for (id<SDLProtocolDelegate> listener in listeners) {
-        if ([listener respondsToSelector:@selector(handleProtocolRegisterSecondaryTransportNAKMessage:protocol:)]) {
-            [listener handleProtocolRegisterSecondaryTransportNAKMessage:registerSecondaryTransportNAK protocol:protocol];
+        if ([listener respondsToSelector:@selector(protocol:didReceiveRegisterSecondaryTransportNAK:)]) {
+            [listener protocol:protocol didReceiveRegisterSecondaryTransportNAK:registerSecondaryTransportNAK];
         }
     }
 }
@@ -640,18 +640,18 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
-- (void)handleTransportEventUpdateMessage:(SDLProtocolMessage *)transportEventUpdate protocol:(SDLProtocol *)protocol {
+- (void)protocol:(SDLProtocol *)protocol didReceiveTransportEventUpdate:(SDLProtocolMessage *)transportEventUpdate {
     SDLLogD(@"Received a transport event update: %@", transportEventUpdate);
 
     NSArray<id<SDLProtocolDelegate>> *listeners = [self sdl_getProtocolListeners];
     for (id<SDLProtocolDelegate> listener in listeners) {
-        if ([listener respondsToSelector:@selector(handleTransportEventUpdateMessage:protocol:)]) {
-            [listener handleTransportEventUpdateMessage:transportEventUpdate protocol:protocol];
+        if ([listener respondsToSelector:@selector(protocol:didReceiveTransportEventUpdate:)]) {
+            [listener protocol:protocol didReceiveTransportEventUpdate:transportEventUpdate];
         }
     }
 }
 
-- (void)onProtocolMessageReceived:(SDLProtocolMessage *)msg protocol:(SDLProtocol *)protocol {
+- (void)protocol:(SDLProtocol *)protocol didReceiveMessage:(SDLProtocolMessage *)msg {
     // Control service (but not control frame type) messages are TLS handshake messages
     if (msg.header.serviceType == SDLServiceTypeControl) {
         [self sdl_processSecurityMessage:msg];
@@ -662,8 +662,8 @@ NS_ASSUME_NONNULL_BEGIN
 
     NSArray<id<SDLProtocolDelegate>> *listeners = [self sdl_getProtocolListeners];
     for (id<SDLProtocolDelegate> listener in listeners) {
-        if ([listener respondsToSelector:@selector(onProtocolMessageReceived:protocol:)]) {
-            [listener onProtocolMessageReceived:msg protocol:self];
+        if ([listener respondsToSelector:@selector(protocol:didReceiveMessage:)]) {
+            [listener protocol:protocol didReceiveMessage:msg];
         }
     }
 }

--- a/SmartDeviceLink/SDLProtocol.m
+++ b/SmartDeviceLink/SDLProtocol.m
@@ -141,8 +141,8 @@ NS_ASSUME_NONNULL_BEGIN
         listeners = self.protocolDelegateTable.allObjects;
     }
     for (id<SDLProtocolDelegate> listener in listeners) {
-        if ([listener respondsToSelector:@selector(onProtocolClosed)]) {
-            [listener onProtocolClosed];
+        if ([listener respondsToSelector:@selector(onProtocolClosed:)]) {
+            [listener onProtocolClosed:self];
         }
     }
 }
@@ -154,8 +154,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)onError:(NSError *)error {
     SDLLogV(@"Transport received an error: %@", error);
     for (id<SDLProtocolDelegate> listener in self.protocolDelegateTable.allObjects) {
-        if ([listener respondsToSelector:@selector(onTransportError:)]) {
-            [listener onTransportError:error];
+        if ([listener respondsToSelector:@selector(onTransportError:protocol:)]) {
+            [listener onTransportError:error protocol:self];
         }
     }
 }

--- a/SmartDeviceLink/SDLProtocol.m
+++ b/SmartDeviceLink/SDLProtocol.m
@@ -128,8 +128,8 @@ NS_ASSUME_NONNULL_BEGIN
         listeners = self.protocolDelegateTable.allObjects;
     }
     for (id<SDLProtocolDelegate> listener in listeners) {
-        if ([listener respondsToSelector:@selector(onProtocolOpened)]) {
-            [listener onProtocolOpened];
+        if ([listener respondsToSelector:@selector(onProtocolOpened:)]) {
+            [listener onProtocolOpened:self];
         }
     }
 }

--- a/SmartDeviceLink/SDLProtocolDelegate.h
+++ b/SmartDeviceLink/SDLProtocolDelegate.h
@@ -20,39 +20,46 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param protocol The transport's protocol
 - (void)onProtocolMessageReceived:(SDLProtocolMessage *)msg protocol:(SDLProtocol *)protocol;
 
-/// Called when the start service request succeeds.
+/// Called when the start service frame succeeds.
+/// @discussion This frame can be sent on both the primary and secondary transports
 /// @param startServiceACK A SDLProtocolMessage object
 /// @param protocol The transport's protocol
 - (void)handleProtocolStartServiceACKMessage:(SDLProtocolMessage *)startServiceACK protocol:(SDLProtocol *)protocol;
 
-/// Called when the start service request fails.
+/// Called when the start service frame fails.
+/// @discussion This frame can be sent on both the primary and secondary transports
 /// @param startServiceNAK A SDLProtocolMessage object
 /// @param protocol The transport's protocol
 - (void)handleProtocolStartServiceNAKMessage:(SDLProtocolMessage *)startServiceNAK protocol:(SDLProtocol *)protocol;
 
-/// Called when the end service request succeeds.
+/// Called when the end service frame succeeds.
+/// @discussion This frame can be sent on both the primary and secondary transports
 /// @param endServiceACK A SDLProtocolMessage object
 /// @param protocol The transport's protocol
 - (void)handleProtocolEndServiceACKMessage:(SDLProtocolMessage *)endServiceACK protocol:(SDLProtocol *)protocol;
 
-/// Called when the end service request fails.
+/// Called when the end service frame fails.
+/// @discussion This frame can be sent on both the primary and secondary transports
 /// @param endServiceNAK A SDLProtocolMessage object
 /// @param protocol The transport's protocol
 - (void)handleProtocolEndServiceNAKMessage:(SDLProtocolMessage *)endServiceNAK protocol:(SDLProtocol *)protocol;
 
 #pragma mark Secondary Transport Messages
 
-/// Called when the secondary transport registration succeeds.
+/// Called when the secondary transport registration frame succeeds.
+/// @discussion This frame is only sent on the secondary transport
 /// @param registerSecondaryTransportACK A SDLProtocolMessage object
 /// @param protocol The transport's protocol
 - (void)handleProtocolRegisterSecondaryTransportACKMessage:(SDLProtocolMessage *)registerSecondaryTransportACK protocol:(SDLProtocol *)protocol;
 
-/// Called when the secondary transport registration fails.
+/// Called when the secondary transport registration frame fails.
+/// @discussion This frame is only sent on the secondary transport
 /// @param registerSecondaryTransportNAK A SDLProtocolMessage object
 /// @param protocol The transport's protocol
 - (void)handleProtocolRegisterSecondaryTransportNAKMessage:(SDLProtocolMessage *)registerSecondaryTransportNAK protocol:(SDLProtocol *)protocol;
 
 /// Called when the status or configuration of one or more transports has updated.
+/// @discussion This frame is only sent on the primary transport
 /// @param transportEventUpdate A SDLProtocolMessage object
 /// @param protocol The transport's protocol
 - (void)handleTransportEventUpdateMessage:(SDLProtocolMessage *)transportEventUpdate protocol:(SDLProtocol *)protocol;
@@ -60,10 +67,12 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark Deprecated Messages
 
 /// A ping packet that is sent to ensure the connection is still active and the service is still valid.
+/// @discussion Deprecated - requires protocol major version 3
 /// @param session The session number
 - (void)handleHeartbeatForSession:(Byte)session;
 
-/// Called when the heartbeat message was recieved successfully.
+/// Called when the heartbeat frame was recieved successfully.
+/// @discussion Deprecated - requires protocol major version 3
 - (void)handleHeartbeatACK;
 
 #pragma mark - Transport Lifecycle

--- a/SmartDeviceLink/SDLProtocolDelegate.h
+++ b/SmartDeviceLink/SDLProtocolDelegate.h
@@ -12,73 +12,75 @@ NS_ASSUME_NONNULL_BEGIN
 
 @optional
 
-#pragma mark - v4.7.0 protocol handlers
 
-/**
- *  Called when the message is a start service success message.
- *
- *  @param startServiceACK  A SDLProtocolMessage object
- */
-- (void)handleProtocolStartServiceACKMessage:(SDLProtocolMessage *)startServiceACK;
+#pragma mark - Protocol Messages
 
-/**
- *  Called when the message is a start service failed message.
- *
- *  @param startServiceNAK  A SDLProtocolMessage object
- */
-- (void)handleProtocolStartServiceNAKMessage:(SDLProtocolMessage *)startServiceNAK;
+/// Called when a protocol message is received.
+/// @param msg A SDLProtocolMessage object
+/// @param protocol The transport's protocol
+- (void)onProtocolMessageReceived:(SDLProtocolMessage *)msg protocol:(SDLProtocol *)protocol;
 
-/**
- *  Called when the message is a end service success message.
- *
- *  @param endServiceACK   A SDLProtocolMessage object
- */
-- (void)handleProtocolEndServiceACKMessage:(SDLProtocolMessage *)endServiceACK;
+/// Called when the start service request succeeds.
+/// @param startServiceACK A SDLProtocolMessage object
+/// @param protocol The transport's protocol
+- (void)handleProtocolStartServiceACKMessage:(SDLProtocolMessage *)startServiceACK protocol:(SDLProtocol *)protocol;
 
-/**
- *  Called when the message is a end service failed message.
- *
- *  @param endServiceNAK   A SDLProtocolMessage object
- */
-- (void)handleProtocolEndServiceNAKMessage:(SDLProtocolMessage *)endServiceNAK;
-- (void)handleProtocolRegisterSecondaryTransportACKMessage:(SDLProtocolMessage *)registerSecondaryTransportACK;
-- (void)handleProtocolRegisterSecondaryTransportNAKMessage:(SDLProtocolMessage *)registerSecondaryTransportNAK;
-- (void)handleTransportEventUpdateMessage:(SDLProtocolMessage *)transportEventUpdate;
+/// Called when the start service request fails.
+/// @param startServiceNAK A SDLProtocolMessage object
+/// @param protocol The transport's protocol
+- (void)handleProtocolStartServiceNAKMessage:(SDLProtocolMessage *)startServiceNAK protocol:(SDLProtocol *)protocol;
 
-#pragma mark - Older protocol handlers
+/// Called when the end service request succeeds.
+/// @param endServiceACK A SDLProtocolMessage object
+/// @param protocol The transport's protocol
+- (void)handleProtocolEndServiceACKMessage:(SDLProtocolMessage *)endServiceACK protocol:(SDLProtocol *)protocol;
 
-/**
- *  Called when the message is a heartbeat message.
- *
- *  @param session Session number
- */
-- (void)handleHeartbeatForSession:(Byte)session;
+/// Called when the end service request fails.
+/// @param endServiceNAK A SDLProtocolMessage object
+/// @param protocol The transport's protocol
+- (void)handleProtocolEndServiceNAKMessage:(SDLProtocolMessage *)endServiceNAK protocol:(SDLProtocol *)protocol;
 
-/**
- *  Called when the message is a heartbeat success message.
- */
-- (void)handleHeartbeatACK;
+#pragma mark Secondary Transport Messages
 
-/**
- *  Called when the message is protocol message.
- *
- *  @param msg A SDLProtocolMessage object
- */
-- (void)onProtocolMessageReceived:(SDLProtocolMessage *)msg;
+/// Called when the secondary transport registration succeeds.
+/// @param registerSecondaryTransportACK A SDLProtocolMessage object
+/// @param protocol The transport's protocol
+- (void)handleProtocolRegisterSecondaryTransportACKMessage:(SDLProtocolMessage *)registerSecondaryTransportACK protocol:(SDLProtocol *)protocol;
 
-/// Called when the transport opens
+/// Called when the secondary transport registration fails.
+/// @param registerSecondaryTransportNAK A SDLProtocolMessage object
+/// @param protocol The transport's protocol
+- (void)handleProtocolRegisterSecondaryTransportNAKMessage:(SDLProtocolMessage *)registerSecondaryTransportNAK protocol:(SDLProtocol *)protocol;
+
+/// Called when the status or configuration of one or more transports has updated.
+/// @param transportEventUpdate A SDLProtocolMessage object
+/// @param protocol The transport's protocol
+- (void)handleTransportEventUpdateMessage:(SDLProtocolMessage *)transportEventUpdate protocol:(SDLProtocol *)protocol;
+
+#pragma mark - Transport Lifecycle
+
+/// Called when the transport opens.
 /// @param protocol The transport's protocol
 - (void)onProtocolOpened:(SDLProtocol *)protocol;
 
-/// Called when the transport closes
+/// Called when the transport closes.
 /// @param protocol The transport's protocol
 - (void)onProtocolClosed:(SDLProtocol *)protocol;
 
 /// Called when the transport errors.
-/// @discussion Currently, this is used only by TCP transport.
+/// @discussion Currently only used by TCP transport.
 /// @param error The error
 /// @param protocol The transport's protocol
 - (void)onTransportError:(NSError *)error protocol:(SDLProtocol *)protocol;
+
+#pragma mark - Deprecated Protocol Messages
+
+/// A ping packet that is sent to ensure the connection is still active and the service is still valid.
+/// @param session The session number
+- (void)handleHeartbeatForSession:(Byte)session;
+
+/// Called when the heartbeat message was recieved successfully.
+- (void)handleHeartbeatACK;
 
 @end
 

--- a/SmartDeviceLink/SDLProtocolDelegate.h
+++ b/SmartDeviceLink/SDLProtocolDelegate.h
@@ -18,31 +18,31 @@ NS_ASSUME_NONNULL_BEGIN
 /// Called when a protocol frame is received.
 /// @param msg A SDLProtocolMessage object
 /// @param protocol The transport's protocol
-- (void)onProtocolMessageReceived:(SDLProtocolMessage *)msg protocol:(SDLProtocol *)protocol;
+- (void)protocol:(SDLProtocol *)protocol didReceiveMessage:(SDLProtocolMessage *)msg;
 
 /// Called when the start service frame succeeds.
 /// @discussion This frame can be sent on both the primary and secondary transports
 /// @param startServiceACK A SDLProtocolMessage object
 /// @param protocol The transport's protocol
-- (void)handleProtocolStartServiceACKMessage:(SDLProtocolMessage *)startServiceACK protocol:(SDLProtocol *)protocol;
+- (void)protocol:(SDLProtocol *)protocol didReceiveStartServiceACK:(SDLProtocolMessage *)startServiceACK {
 
 /// Called when the start service frame fails.
 /// @discussion This frame can be sent on both the primary and secondary transports
 /// @param startServiceNAK A SDLProtocolMessage object
 /// @param protocol The transport's protocol
-- (void)handleProtocolStartServiceNAKMessage:(SDLProtocolMessage *)startServiceNAK protocol:(SDLProtocol *)protocol;
+- (void)protocol:(SDLProtocol *)protocol didReceiveStartServiceNAK:(SDLProtocolMessage *)startServiceNAK {
 
 /// Called when the end service frame succeeds.
 /// @discussion This frame can be sent on both the primary and secondary transports
 /// @param endServiceACK A SDLProtocolMessage object
 /// @param protocol The transport's protocol
-- (void)handleProtocolEndServiceACKMessage:(SDLProtocolMessage *)endServiceACK protocol:(SDLProtocol *)protocol;
+- (void)protocol:(SDLProtocol *)protocol didReceiveEndServiceACK:(SDLProtocolMessage *)endServiceACK {
 
 /// Called when the end service frame fails.
 /// @discussion This frame can be sent on both the primary and secondary transports
 /// @param endServiceNAK A SDLProtocolMessage object
 /// @param protocol The transport's protocol
-- (void)handleProtocolEndServiceNAKMessage:(SDLProtocolMessage *)endServiceNAK protocol:(SDLProtocol *)protocol;
+- (void)protocol:(SDLProtocol *)protocol didReceiveEndServiceNAK:(SDLProtocolMessage *)endServiceNAK {
 
 #pragma mark Secondary Transport Messages
 
@@ -50,19 +50,19 @@ NS_ASSUME_NONNULL_BEGIN
 /// @discussion This frame is only sent on the secondary transport
 /// @param registerSecondaryTransportACK A SDLProtocolMessage object
 /// @param protocol The transport's protocol
-- (void)handleProtocolRegisterSecondaryTransportACKMessage:(SDLProtocolMessage *)registerSecondaryTransportACK protocol:(SDLProtocol *)protocol;
+- (void)protocol:(SDLProtocol *)protocol didReceiveRegisterSecondaryTransportACK:(SDLProtocolMessage *)registerSecondaryTransportACK {
 
 /// Called when the secondary transport registration frame fails.
 /// @discussion This frame is only sent on the secondary transport
 /// @param registerSecondaryTransportNAK A SDLProtocolMessage object
 /// @param protocol The transport's protocol
-- (void)handleProtocolRegisterSecondaryTransportNAKMessage:(SDLProtocolMessage *)registerSecondaryTransportNAK protocol:(SDLProtocol *)protocol;
+- (void)protocol:(SDLProtocol *)protocol didReceiveRegisterSecondaryTransportNAK:(SDLProtocolMessage *)registerSecondaryTransportNAK {
 
 /// Called when the status or configuration of one or more transports has updated.
 /// @discussion This frame is only sent on the primary transport
 /// @param transportEventUpdate A SDLProtocolMessage object
 /// @param protocol The transport's protocol
-- (void)handleTransportEventUpdateMessage:(SDLProtocolMessage *)transportEventUpdate protocol:(SDLProtocol *)protocol;
+- (void)protocol:(SDLProtocol *)protocol didReceiveTransportEventUpdate:(SDLProtocolMessage *)transportEventUpdate {
 
 #pragma mark Deprecated Messages
 
@@ -79,17 +79,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Called when the transport opens.
 /// @param protocol The transport's protocol
-- (void)onProtocolOpened:(SDLProtocol *)protocol;
+- (void)protocolDidOpen:(SDLProtocol *)protocol;
 
 /// Called when the transport closes.
 /// @param protocol The transport's protocol
-- (void)onProtocolClosed:(SDLProtocol *)protocol;
+- (void)protocolDidClose:(SDLProtocol *)protocol;
 
 /// Called when the transport errors.
 /// @discussion Currently only used by TCP transport.
 /// @param error The error
 /// @param protocol The transport's protocol
-- (void)onTransportError:(NSError *)error protocol:(SDLProtocol *)protocol;
+- (void)protocol:(SDLProtocol *)protocol transportDidError:(NSError *)error;
 
 
 @end

--- a/SmartDeviceLink/SDLProtocolDelegate.h
+++ b/SmartDeviceLink/SDLProtocolDelegate.h
@@ -24,25 +24,25 @@ NS_ASSUME_NONNULL_BEGIN
 /// @discussion This frame can be sent on both the primary and secondary transports
 /// @param startServiceACK A SDLProtocolMessage object
 /// @param protocol The transport's protocol
-- (void)protocol:(SDLProtocol *)protocol didReceiveStartServiceACK:(SDLProtocolMessage *)startServiceACK {
+- (void)protocol:(SDLProtocol *)protocol didReceiveStartServiceACK:(SDLProtocolMessage *)startServiceACK;
 
 /// Called when the start service frame fails.
 /// @discussion This frame can be sent on both the primary and secondary transports
 /// @param startServiceNAK A SDLProtocolMessage object
 /// @param protocol The transport's protocol
-- (void)protocol:(SDLProtocol *)protocol didReceiveStartServiceNAK:(SDLProtocolMessage *)startServiceNAK {
+- (void)protocol:(SDLProtocol *)protocol didReceiveStartServiceNAK:(SDLProtocolMessage *)startServiceNAK;
 
 /// Called when the end service frame succeeds.
 /// @discussion This frame can be sent on both the primary and secondary transports
 /// @param endServiceACK A SDLProtocolMessage object
 /// @param protocol The transport's protocol
-- (void)protocol:(SDLProtocol *)protocol didReceiveEndServiceACK:(SDLProtocolMessage *)endServiceACK {
+- (void)protocol:(SDLProtocol *)protocol didReceiveEndServiceACK:(SDLProtocolMessage *)endServiceACK;
 
 /// Called when the end service frame fails.
 /// @discussion This frame can be sent on both the primary and secondary transports
 /// @param endServiceNAK A SDLProtocolMessage object
 /// @param protocol The transport's protocol
-- (void)protocol:(SDLProtocol *)protocol didReceiveEndServiceNAK:(SDLProtocolMessage *)endServiceNAK {
+- (void)protocol:(SDLProtocol *)protocol didReceiveEndServiceNAK:(SDLProtocolMessage *)endServiceNAK;
 
 #pragma mark Secondary Transport Messages
 
@@ -50,30 +50,19 @@ NS_ASSUME_NONNULL_BEGIN
 /// @discussion This frame is only sent on the secondary transport
 /// @param registerSecondaryTransportACK A SDLProtocolMessage object
 /// @param protocol The transport's protocol
-- (void)protocol:(SDLProtocol *)protocol didReceiveRegisterSecondaryTransportACK:(SDLProtocolMessage *)registerSecondaryTransportACK {
+- (void)protocol:(SDLProtocol *)protocol didReceiveRegisterSecondaryTransportACK:(SDLProtocolMessage *)registerSecondaryTransportACK;
 
 /// Called when the secondary transport registration frame fails.
 /// @discussion This frame is only sent on the secondary transport
 /// @param registerSecondaryTransportNAK A SDLProtocolMessage object
 /// @param protocol The transport's protocol
-- (void)protocol:(SDLProtocol *)protocol didReceiveRegisterSecondaryTransportNAK:(SDLProtocolMessage *)registerSecondaryTransportNAK {
+- (void)protocol:(SDLProtocol *)protocol didReceiveRegisterSecondaryTransportNAK:(SDLProtocolMessage *)registerSecondaryTransportNAK;
 
 /// Called when the status or configuration of one or more transports has updated.
 /// @discussion This frame is only sent on the primary transport
 /// @param transportEventUpdate A SDLProtocolMessage object
 /// @param protocol The transport's protocol
-- (void)protocol:(SDLProtocol *)protocol didReceiveTransportEventUpdate:(SDLProtocolMessage *)transportEventUpdate {
-
-#pragma mark Deprecated Messages
-
-/// A ping packet that is sent to ensure the connection is still active and the service is still valid.
-/// @discussion Deprecated - requires protocol major version 3
-/// @param session The session number
-- (void)handleHeartbeatForSession:(Byte)session;
-
-/// Called when the heartbeat frame was recieved successfully.
-/// @discussion Deprecated - requires protocol major version 3
-- (void)handleHeartbeatACK;
+- (void)protocol:(SDLProtocol *)protocol didReceiveTransportEventUpdate:(SDLProtocolMessage *)transportEventUpdate;
 
 #pragma mark - Transport Lifecycle
 
@@ -90,6 +79,18 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param error The error
 /// @param protocol The transport's protocol
 - (void)protocol:(SDLProtocol *)protocol transportDidError:(NSError *)error;
+
+#pragma mark - Deprecated Protocol Messages
+
+/// A ping packet that is sent to ensure the connection is still active and the service is still valid.
+/// @discussion Deprecated - requires protocol major version 3
+/// @param session The session number
+- (void)handleHeartbeatForSession:(Byte)session;
+
+/// Called when the heartbeat frame was recieved successfully.
+/// @discussion Deprecated - requires protocol major version 3
+- (void)handleHeartbeatACK;
+
 
 
 @end

--- a/SmartDeviceLink/SDLProtocolDelegate.h
+++ b/SmartDeviceLink/SDLProtocolDelegate.h
@@ -3,6 +3,7 @@
 
 #import "SDLProtocolHeader.h"
 
+@class SDLProtocol;
 @class SDLProtocolMessage;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -68,7 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Called when the message is a protocol opened message.
  */
-- (void)onProtocolOpened;
+- (void)onProtocolOpened:(SDLProtocol *)protocol;
 
 /**
  *  Called when the message is a protocol closed message.

--- a/SmartDeviceLink/SDLProtocolDelegate.h
+++ b/SmartDeviceLink/SDLProtocolDelegate.h
@@ -1,4 +1,4 @@
-//  SDLProtocolListener.h
+//  SDLProtocolDelegate.h
 //
 
 #import "SDLProtocolHeader.h"

--- a/SmartDeviceLink/SDLProtocolDelegate.h
+++ b/SmartDeviceLink/SDLProtocolDelegate.h
@@ -66,24 +66,19 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)onProtocolMessageReceived:(SDLProtocolMessage *)msg;
 
-/**
- *  Called when the message is a protocol opened message.
- */
+/// Called when the transport opens
+/// @param protocol The transport's protocol
 - (void)onProtocolOpened:(SDLProtocol *)protocol;
 
-/**
- *  Called when the message is a protocol closed message.
- */
-- (void)onProtocolClosed;
+/// Called when the transport closes
+/// @param protocol The transport's protocol
+- (void)onProtocolClosed:(SDLProtocol *)protocol;
 
-/**
- *  Called when an error is notified from transport.
- *
- *  Note: currently, this is used only by TCP transport.
- *
- *  @param error The type of the error
- */
-- (void)onTransportError:(NSError *)error;
+/// Called when the transport errors.
+/// @discussion Currently, this is used only by TCP transport.
+/// @param error The error
+/// @param protocol The transport's protocol
+- (void)onTransportError:(NSError *)error protocol:(SDLProtocol *)protocol;
 
 @end
 

--- a/SmartDeviceLink/SDLProtocolDelegate.h
+++ b/SmartDeviceLink/SDLProtocolDelegate.h
@@ -57,6 +57,15 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param protocol The transport's protocol
 - (void)handleTransportEventUpdateMessage:(SDLProtocolMessage *)transportEventUpdate protocol:(SDLProtocol *)protocol;
 
+#pragma mark Deprecated Messages
+
+/// A ping packet that is sent to ensure the connection is still active and the service is still valid.
+/// @param session The session number
+- (void)handleHeartbeatForSession:(Byte)session;
+
+/// Called when the heartbeat message was recieved successfully.
+- (void)handleHeartbeatACK;
+
 #pragma mark - Transport Lifecycle
 
 /// Called when the transport opens.
@@ -73,14 +82,6 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param protocol The transport's protocol
 - (void)onTransportError:(NSError *)error protocol:(SDLProtocol *)protocol;
 
-#pragma mark - Deprecated Protocol Messages
-
-/// A ping packet that is sent to ensure the connection is still active and the service is still valid.
-/// @param session The session number
-- (void)handleHeartbeatForSession:(Byte)session;
-
-/// Called when the heartbeat message was recieved successfully.
-- (void)handleHeartbeatACK;
 
 @end
 

--- a/SmartDeviceLink/SDLProtocolDelegate.h
+++ b/SmartDeviceLink/SDLProtocolDelegate.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Protocol Messages
 
-/// Called when a protocol message is received.
+/// Called when a protocol frame is received.
 /// @param msg A SDLProtocolMessage object
 /// @param protocol The transport's protocol
 - (void)onProtocolMessageReceived:(SDLProtocolMessage *)msg protocol:(SDLProtocol *)protocol;

--- a/SmartDeviceLink/SDLProtocolReceivedMessageRouter.h
+++ b/SmartDeviceLink/SDLProtocolReceivedMessageRouter.h
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @param message A SDLProtocolMessage object
  */
-- (void)handleReceivedMessage:(SDLProtocolMessage *)message;
+- (void)handleReceivedMessage:(SDLProtocolMessage *)message protocol:(SDLProtocol *)protocol;
 
 @end
 

--- a/SmartDeviceLink/SDLProtocolReceivedMessageRouter.m
+++ b/SmartDeviceLink/SDLProtocolReceivedMessageRouter.m
@@ -45,41 +45,41 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)sdl_dispatchProtocolMessage:(SDLProtocolMessage *)message protocol:(SDLProtocol *)protocol {
-    if ([self.delegate respondsToSelector:@selector(onProtocolMessageReceived:protocol:)]) {
-        [self.delegate onProtocolMessageReceived:message protocol:protocol];
+    if ([self.delegate respondsToSelector:@selector(protocol:didReceiveMessage:)]) {
+        [self.delegate protocol:protocol didReceiveMessage:message];
     }
 }
 
 - (void)sdl_dispatchControlMessage:(SDLProtocolMessage *)message protocol:(SDLProtocol *)protocol {
     switch (message.header.frameData) {
         case SDLFrameInfoStartServiceACK: {
-            if ([self.delegate respondsToSelector:@selector(handleProtocolStartServiceACKMessage:protocol:)]) {
-                [self.delegate handleProtocolStartServiceACKMessage:message protocol:protocol];
+            if ([self.delegate respondsToSelector:@selector(protocol:didReceiveStartServiceACK:)]) {
+                [self.delegate protocol:protocol didReceiveStartServiceACK:message];
             }
         } break;
         case SDLFrameInfoStartServiceNACK: {
-            if ([self.delegate respondsToSelector:@selector(handleProtocolStartServiceNAKMessage:protocol:)]) {
-                [self.delegate handleProtocolStartServiceNAKMessage:message protocol:protocol];
+            if ([self.delegate respondsToSelector:@selector(protocol:didReceiveStartServiceNAK:)]) {
+                [self.delegate protocol:protocol didReceiveStartServiceNAK:message];
             }
         } break;
         case SDLFrameInfoEndServiceACK: {
-            if ([self.delegate respondsToSelector:@selector(handleProtocolEndServiceACKMessage:protocol:)]) {
-                [self.delegate handleProtocolEndServiceACKMessage:message protocol:protocol];
+            if ([self.delegate respondsToSelector:@selector(protocol:didReceiveEndServiceACK:)]) {
+                [self.delegate protocol:protocol didReceiveEndServiceACK:message];
             }
         } break;
         case SDLFrameInfoEndServiceNACK: {
-            if ([self.delegate respondsToSelector:@selector(handleProtocolEndServiceNAKMessage:protocol:)]) {
-                [self.delegate handleProtocolEndServiceNAKMessage:message protocol:protocol];
+            if ([self.delegate respondsToSelector:@selector(protocol:didReceiveEndServiceNAK:)]) {
+                [self.delegate protocol:protocol didReceiveEndServiceNAK:message];
             }
         } break;
         case SDLFrameInfoRegisterSecondaryTransportACK: {
-            if ([self.delegate respondsToSelector:@selector(handleProtocolRegisterSecondaryTransportACKMessage:protocol:)]) {
-                [self.delegate handleProtocolRegisterSecondaryTransportACKMessage:message protocol:protocol];
+            if ([self.delegate respondsToSelector:@selector(protocol:didReceiveRegisterSecondaryTransportACK:)]) {
+                [self.delegate protocol:protocol didReceiveRegisterSecondaryTransportACK:message];
             }
         } break;
         case SDLFrameInfoRegisterSecondaryTransportNACK: {
-            if ([self.delegate respondsToSelector:@selector(handleProtocolRegisterSecondaryTransportNAKMessage:protocol:)]) {
-                [self.delegate handleProtocolRegisterSecondaryTransportNAKMessage:message protocol:protocol];
+            if ([self.delegate respondsToSelector:@selector(protocol:didReceiveRegisterSecondaryTransportNAK:)]) {
+                [self.delegate protocol:protocol didReceiveRegisterSecondaryTransportNAK:message];
             }
         } break;
         case SDLFrameInfoHeartbeat: {
@@ -93,8 +93,8 @@ NS_ASSUME_NONNULL_BEGIN
             }
         } break;
         case SDLFrameInfoTransportEventUpdate: {
-            if ([self.delegate respondsToSelector:@selector(handleTransportEventUpdateMessage:protocol:)]) {
-                [self.delegate handleTransportEventUpdateMessage:message protocol:protocol];
+            if ([self.delegate respondsToSelector:@selector(protocol:didReceiveTransportEventUpdate:)]) {
+                [self.delegate protocol:protocol didReceiveTransportEventUpdate:message];
             }
         } break;
         default: break; // Other frame data is possible, but we don't care about them

--- a/SmartDeviceLink/SDLProtocolReceivedMessageRouter.m
+++ b/SmartDeviceLink/SDLProtocolReceivedMessageRouter.m
@@ -26,60 +26,60 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (void)handleReceivedMessage:(SDLProtocolMessage *)message {
+- (void)handleReceivedMessage:(SDLProtocolMessage *)message protocol:(SDLProtocol *)protocol {
     SDLFrameType frameType = message.header.frameType;
 
     switch (frameType) {
         case SDLFrameTypeSingle: {
-            [self sdl_dispatchProtocolMessage:message];
+            [self sdl_dispatchProtocolMessage:message protocol:protocol];
         } break;
         case SDLFrameTypeControl: {
-            [self sdl_dispatchControlMessage:message];
+            [self sdl_dispatchControlMessage:message protocol:protocol];
         } break;
         case SDLFrameTypeFirst: // fallthrough
         case SDLFrameTypeConsecutive: {
-            [self sdl_dispatchMultiPartMessage:message];
+            [self sdl_dispatchMultiPartMessage:message protocol:protocol];
         } break;
         default: break;
     }
 }
 
-- (void)sdl_dispatchProtocolMessage:(SDLProtocolMessage *)message {
-    if ([self.delegate respondsToSelector:@selector(onProtocolMessageReceived:)]) {
-        [self.delegate onProtocolMessageReceived:message];
+- (void)sdl_dispatchProtocolMessage:(SDLProtocolMessage *)message protocol:(SDLProtocol *)protocol {
+    if ([self.delegate respondsToSelector:@selector(onProtocolMessageReceived:protocol:)]) {
+        [self.delegate onProtocolMessageReceived:message protocol:protocol];
     }
 }
 
-- (void)sdl_dispatchControlMessage:(SDLProtocolMessage *)message {
+- (void)sdl_dispatchControlMessage:(SDLProtocolMessage *)message protocol:(SDLProtocol *)protocol {
     switch (message.header.frameData) {
         case SDLFrameInfoStartServiceACK: {
-            if ([self.delegate respondsToSelector:@selector(handleProtocolStartServiceACKMessage:)]) {
-                [self.delegate handleProtocolStartServiceACKMessage:message];
+            if ([self.delegate respondsToSelector:@selector(handleProtocolStartServiceACKMessage:protocol:)]) {
+                [self.delegate handleProtocolStartServiceACKMessage:message protocol:protocol];
             }
         } break;
         case SDLFrameInfoStartServiceNACK: {
-            if ([self.delegate respondsToSelector:@selector(handleProtocolStartServiceNAKMessage:)]) {
-                [self.delegate handleProtocolStartServiceNAKMessage:message];
+            if ([self.delegate respondsToSelector:@selector(handleProtocolStartServiceNAKMessage:protocol:)]) {
+                [self.delegate handleProtocolStartServiceNAKMessage:message protocol:protocol];
             }
         } break;
         case SDLFrameInfoEndServiceACK: {
-            if ([self.delegate respondsToSelector:@selector(handleProtocolEndServiceACKMessage:)]) {
-                [self.delegate handleProtocolEndServiceACKMessage:message];
+            if ([self.delegate respondsToSelector:@selector(handleProtocolEndServiceACKMessage:protocol:)]) {
+                [self.delegate handleProtocolEndServiceACKMessage:message protocol:protocol];
             }
         } break;
         case SDLFrameInfoEndServiceNACK: {
-            if ([self.delegate respondsToSelector:@selector(handleProtocolStartServiceNAKMessage:)]) {
-                [self.delegate handleProtocolEndServiceNAKMessage:message];
+            if ([self.delegate respondsToSelector:@selector(handleProtocolEndServiceNAKMessage:protocol:)]) {
+                [self.delegate handleProtocolEndServiceNAKMessage:message protocol:protocol];
             }
         } break;
         case SDLFrameInfoRegisterSecondaryTransportACK: {
-            if ([self.delegate respondsToSelector:@selector(handleProtocolRegisterSecondaryTransportACKMessage:)]) {
-                [self.delegate handleProtocolRegisterSecondaryTransportACKMessage:message];
+            if ([self.delegate respondsToSelector:@selector(handleProtocolRegisterSecondaryTransportACKMessage:protocol:)]) {
+                [self.delegate handleProtocolRegisterSecondaryTransportACKMessage:message protocol:protocol];
             }
         } break;
         case SDLFrameInfoRegisterSecondaryTransportNACK: {
-            if ([self.delegate respondsToSelector:@selector(handleProtocolRegisterSecondaryTransportNAKMessage:)]) {
-                [self.delegate handleProtocolRegisterSecondaryTransportNAKMessage:message];
+            if ([self.delegate respondsToSelector:@selector(handleProtocolRegisterSecondaryTransportNAKMessage:protocol:)]) {
+                [self.delegate handleProtocolRegisterSecondaryTransportNAKMessage:message protocol:protocol];
             }
         } break;
         case SDLFrameInfoHeartbeat: {
@@ -93,15 +93,15 @@ NS_ASSUME_NONNULL_BEGIN
             }
         } break;
         case SDLFrameInfoTransportEventUpdate: {
-            if ([self.delegate respondsToSelector:@selector(handleTransportEventUpdateMessage:)]) {
-                [self.delegate handleTransportEventUpdateMessage:message];
+            if ([self.delegate respondsToSelector:@selector(handleTransportEventUpdateMessage:protocol:)]) {
+                [self.delegate handleTransportEventUpdateMessage:message protocol:protocol];
             }
         } break;
         default: break; // Other frame data is possible, but we don't care about them
     }
 }
 
-- (void)sdl_dispatchMultiPartMessage:(SDLProtocolMessage *)message {
+- (void)sdl_dispatchMultiPartMessage:(SDLProtocolMessage *)message protocol:(SDLProtocol *)protocol {
     // Pass multipart messages to an assembler and call delegate when done.
     NSNumber *sessionID = [NSNumber numberWithUnsignedChar:message.header.sessionID];
 
@@ -113,7 +113,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     SDLMessageAssemblyCompletionHandler completionHandler = ^void(BOOL done, SDLProtocolMessage *assembledMessage) {
         if (done) {
-            [self sdl_dispatchProtocolMessage:assembledMessage];
+            [self sdl_dispatchProtocolMessage:assembledMessage protocol:protocol];
         }
     };
     [assembler handleMessage:message withCompletionHandler:completionHandler];

--- a/SmartDeviceLink/SDLSecondaryTransportManager.m
+++ b/SmartDeviceLink/SDLSecondaryTransportManager.m
@@ -540,10 +540,8 @@ struct TransportProtocolUpdated {
 
 // called on transport's thread, notifying that the transport is established
 - (void)onProtocolOpened {
-    if (self.secondaryProtocol == nil) {
-        // The primary transport opened
-        return;
-    }
+    // The primary transport opened
+    if (self.secondaryProtocol == nil) { return; }
 
     SDLLogD(@"Secondary transport connected");
 

--- a/SmartDeviceLink/SDLSecondaryTransportManager.m
+++ b/SmartDeviceLink/SDLSecondaryTransportManager.m
@@ -536,7 +536,7 @@ struct TransportProtocolUpdated {
     return YES;
 }
 
-#pragma mark - SDLProtocolListener Implementation
+#pragma mark - SDLProtocolDelegate Implementation
 
 // called on transport's thread, notifying that the transport is established
 - (void)onProtocolOpened {

--- a/SmartDeviceLink/SDLSecondaryTransportManager.m
+++ b/SmartDeviceLink/SDLSecondaryTransportManager.m
@@ -539,9 +539,9 @@ struct TransportProtocolUpdated {
 #pragma mark - SDLProtocolDelegate Implementation
 
 // called on transport's thread, notifying that the transport is established
-- (void)onProtocolOpened {
+- (void)onProtocolOpened:(SDLProtocol *)protocol {
     // The primary transport opened
-    if (self.secondaryProtocol == nil) { return; }
+    if (protocol != self.secondaryProtocol) { return; }
 
     SDLLogD(@"Secondary transport connected");
 

--- a/SmartDeviceLink/SDLSecondaryTransportManager.m
+++ b/SmartDeviceLink/SDLSecondaryTransportManager.m
@@ -569,16 +569,22 @@ struct TransportProtocolUpdated {
     [self.secondaryProtocol registerSecondaryTransport];
 }
 
-/// Called on the transport's thread, notifying that the transport has errored before a connection was established
+/// Called on the transport's thread, notifying that the transport has errored before a connection was established.
 /// @param error The error
-- (void)onTransportError:(NSError *)error {
+/// @param protocol The protocol
+- (void)onTransportError:(NSError *)error protocol:(SDLProtocol *)protocol {
+    if (protocol != self.secondaryProtocol) { return; }
+
     SDLLogE(@"The secondary transport errored.");
     [self sdl_transportClosed];
 }
 
-// Called on transport's thread, notifying that the transport is disconnected
-// (Note: when transport's disconnect method is called, this method will not be called)
-- (void)onProtocolClosed {
+/// Called on transport's thread, notifying that the transport is disconnected.
+/// @discussion When the transport's disconnect method is called, this method will not be called.
+/// @param protocol The protocol
+- (void)onProtocolClosed:(SDLProtocol *)protocol{
+    if (protocol != self.secondaryProtocol) { return; }
+
     SDLLogE(@"The secondary transport disconnected.");
     [self sdl_transportClosed];
 }

--- a/SmartDeviceLink/SDLSecondaryTransportManager.m
+++ b/SmartDeviceLink/SDLSecondaryTransportManager.m
@@ -402,7 +402,7 @@ struct TransportProtocolUpdated {
 
 #pragma mark Primary transport
 
-- (void)handleProtocolStartServiceACKMessage:(SDLProtocolMessage *)startServiceACK protocol:(SDLProtocol *)protocol {
+- (void)protocol:(SDLProtocol *)protocol didReceiveStartServiceACK:(SDLProtocolMessage *)startServiceACK {
     if (startServiceACK.header.serviceType != SDLServiceTypeRPC || self.primaryProtocol != protocol) { return; }
 
     SDLLogV(@"Received Start Service ACK header of RPC service on primary (%@) transport", protocol.transport);
@@ -415,7 +415,7 @@ struct TransportProtocolUpdated {
     [self sdl_onStartServiceAckReceived:payload];
 }
 
-- (void)handleTransportEventUpdateMessage:(SDLProtocolMessage *)transportEventUpdate protocol:(SDLProtocol *)protocol {
+- (void)protocol:(SDLProtocol *)protocol didReceiveTransportEventUpdate:(SDLProtocolMessage *)transportEventUpdate {
     if (self.primaryProtocol != protocol) { return; }
 
     SDLControlFramePayloadTransportEventUpdate *payload = [[SDLControlFramePayloadTransportEventUpdate alloc] initWithData:transportEventUpdate.payload];
@@ -543,7 +543,7 @@ struct TransportProtocolUpdated {
 #pragma mark - SDLProtocolDelegate Implementation
 
 // called on transport's thread, notifying that the transport is established
-- (void)onProtocolOpened:(SDLProtocol *)protocol {
+- (void)protocolDidOpen:(SDLProtocol *)protocol {
     // The primary transport opened
     if (self.secondaryProtocol != protocol) { return; }
 
@@ -576,7 +576,7 @@ struct TransportProtocolUpdated {
 /// Called on the transport's thread, notifying that the transport has errored before a connection was established.
 /// @param error The error
 /// @param protocol The protocol
-- (void)onTransportError:(NSError *)error protocol:(SDLProtocol *)protocol {
+- (void)protocol:(SDLProtocol *)protocol transportDidError:(NSError *)error {
     if (self.secondaryProtocol != protocol) { return; }
 
     SDLLogE(@"The secondary transport errored.");
@@ -586,7 +586,7 @@ struct TransportProtocolUpdated {
 /// Called on transport's thread, notifying that the transport is disconnected.
 /// @discussion When the transport's disconnect method is called, this method will not be called.
 /// @param protocol The protocol
-- (void)onProtocolClosed:(SDLProtocol *)protocol{
+- (void)protocolDidClose:(SDLProtocol *)protocol {
     if (self.secondaryProtocol != protocol) { return; }
 
     SDLLogE(@"The secondary transport disconnected.");
@@ -607,7 +607,7 @@ struct TransportProtocolUpdated {
 }
 
 // called from SDLProtocol's _receiveQueue of secondary transport
-- (void)handleProtocolRegisterSecondaryTransportACKMessage:(SDLProtocolMessage *)registerSecondaryTransportACK protocol:(SDLProtocol *)protocol {
+- (void)protocol:(SDLProtocol *)protocol didReceiveRegisterSecondaryTransportACK:(SDLProtocolMessage *)registerSecondaryTransportACK {
     if (self.secondaryProtocol != protocol) { return; }
 
     SDLLogD(@"Received Register Secondary Transport ACK frame");
@@ -618,7 +618,7 @@ struct TransportProtocolUpdated {
 }
 
 // called from SDLProtocol's _receiveQueue of secondary transport
-- (void)handleProtocolRegisterSecondaryTransportNAKMessage:(SDLProtocolMessage *)registerSecondaryTransportNAK protocol:(SDLProtocol *)protocol {
+- (void)protocol:(SDLProtocol *)protocol didReceiveRegisterSecondaryTransportNAK:(SDLProtocolMessage *)registerSecondaryTransportNAK {
     if (self.secondaryProtocol != protocol) { return; }
 
     SDLLogW(@"Received Register Secondary Transport NAK frame");

--- a/SmartDeviceLink/SDLSecondaryTransportManager.m
+++ b/SmartDeviceLink/SDLSecondaryTransportManager.m
@@ -540,6 +540,11 @@ struct TransportProtocolUpdated {
 
 // called on transport's thread, notifying that the transport is established
 - (void)onProtocolOpened {
+    if (self.secondaryProtocol == nil) {
+        // The primary transport opened
+        return;
+    }
+
     SDLLogD(@"Secondary transport connected");
 
     self.registerTransportTimer = [[SDLTimer alloc] initWithDuration:RegisterTransportTime repeat:NO];

--- a/SmartDeviceLink/SDLSecondaryTransportManager.m
+++ b/SmartDeviceLink/SDLSecondaryTransportManager.m
@@ -544,7 +544,6 @@ struct TransportProtocolUpdated {
 
 // called on transport's thread, notifying that the transport is established
 - (void)protocolDidOpen:(SDLProtocol *)protocol {
-    // The primary transport opened
     if (self.secondaryProtocol != protocol) { return; }
 
     SDLLogD(@"Secondary transport connected");
@@ -610,7 +609,7 @@ struct TransportProtocolUpdated {
 - (void)protocol:(SDLProtocol *)protocol didReceiveRegisterSecondaryTransportACK:(SDLProtocolMessage *)registerSecondaryTransportACK {
     if (self.secondaryProtocol != protocol) { return; }
 
-    SDLLogD(@"Received Register Secondary Transport ACK frame");
+    SDLLogD(@"Received Register Secondary Transport ACK on the secondary (%@) transport", protocol.transport);
     dispatch_async(self.stateMachineQueue, ^{
         // secondary transport is now ready
         [self.stateMachine transitionToState:SDLSecondaryTransportStateRegistered];
@@ -621,7 +620,7 @@ struct TransportProtocolUpdated {
 - (void)protocol:(SDLProtocol *)protocol didReceiveRegisterSecondaryTransportNAK:(SDLProtocolMessage *)registerSecondaryTransportNAK {
     if (self.secondaryProtocol != protocol) { return; }
 
-    SDLLogW(@"Received Register Secondary Transport NAK frame");
+    SDLLogW(@"Received Register Secondary Transport NAK on the secondary (%@) transport", protocol.transport);
     dispatch_async(self.stateMachineQueue, ^{
         if ([self.stateMachine.currentState isEqualToEnum:SDLSecondaryTransportStateRegistered]) {
             [self sdl_handleTransportUpdateWithPrimaryAvailable:YES secondaryAvailable:NO];

--- a/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
@@ -228,7 +228,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (endServiceNAK.header.serviceType != SDLServiceTypeAudio) { return; }
 
     SDLControlFramePayloadNak *nakPayload = [[SDLControlFramePayloadNak alloc] initWithData:endServiceNAK.payload];
-    SDLLogE(@"Request to end audio service NAKed on transport %@, with playlod: %@", protocol.transport, nakPayload);
+    SDLLogE(@"Request to end audio service NAKed on transport %@, with payload: %@", protocol.transport, nakPayload);
 
     /// Core will NAK the audio end service control frame if audio is not streaming or if video is streaming but the HMI does not recognize that audio is streaming.
     [self.audioStreamStateMachine transitionToState:SDLAudioStreamManagerStateStopped];

--- a/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
@@ -193,7 +193,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - SDLProtocolDelegate
 #pragma mark Start Service ACK/NAK
 
-- (void)handleProtocolStartServiceACKMessage:(SDLProtocolMessage *)startServiceACK protocol:(SDLProtocol *)protocol {
+- (void)protocol:(SDLProtocol *)protocol didReceiveStartServiceACK:(SDLProtocolMessage *)startServiceACK {
     if (startServiceACK.header.serviceType != SDLServiceTypeAudio) { return; }
 
     self.audioEncrypted = startServiceACK.header.encrypted;
@@ -208,7 +208,7 @@ NS_ASSUME_NONNULL_BEGIN
     [self.audioStreamStateMachine transitionToState:SDLAudioStreamManagerStateReady];
 }
 
-- (void)handleProtocolStartServiceNAKMessage:(SDLProtocolMessage *)startServiceNAK protocol:(SDLProtocol *)protocol {
+- (void)protocol:(SDLProtocol *)protocol didReceiveStartServiceNAK:(SDLProtocolMessage *)startServiceNAK {
     if (startServiceNAK.header.serviceType != SDLServiceTypeAudio) { return; }
     SDLLogE(@"Request to start audio service NAKed on transport %@", protocol.transport);
 
@@ -217,14 +217,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark End Service ACK/NAK
 
-- (void)handleProtocolEndServiceACKMessage:(SDLProtocolMessage *)endServiceACK protocol:(SDLProtocol *)protocol {
+- (void)protocol:(SDLProtocol *)protocol didReceiveEndServiceACK:(SDLProtocolMessage *)endServiceACK {
     if (endServiceACK.header.serviceType != SDLServiceTypeAudio) { return; }
     SDLLogD(@"Request to end audio service ACKed on transport %@", protocol.transport);
 
     [self.audioStreamStateMachine transitionToState:SDLAudioStreamManagerStateStopped];
 }
 
-- (void)handleProtocolEndServiceNAKMessage:(SDLProtocolMessage *)endServiceNAK protocol:(SDLProtocol *)protocol {
+- (void)protocol:(SDLProtocol *)protocol didReceiveEndServiceNAK:(SDLProtocolMessage *)endServiceNAK {
     if (endServiceNAK.header.serviceType != SDLServiceTypeAudio) { return; }
 
     SDLControlFramePayloadNak *nakPayload = [[SDLControlFramePayloadNak alloc] initWithData:endServiceNAK.payload];

--- a/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
@@ -190,7 +190,7 @@ NS_ASSUME_NONNULL_BEGIN
     [self.protocol endServiceWithType:SDLServiceTypeAudio];
 }
 
-#pragma mark - SDLProtocolListener
+#pragma mark - SDLProtocolDelegate
 #pragma mark Start Service ACK/NAK
 
 - (void)handleProtocolStartServiceACKMessage:(SDLProtocolMessage *)startServiceACK {

--- a/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
@@ -193,7 +193,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - SDLProtocolDelegate
 #pragma mark Start Service ACK/NAK
 
-- (void)handleProtocolStartServiceACKMessage:(SDLProtocolMessage *)startServiceACK {
+- (void)handleProtocolStartServiceACKMessage:(SDLProtocolMessage *)startServiceACK protocol:(SDLProtocol *)protocol {
     if (startServiceACK.header.serviceType != SDLServiceTypeAudio) { return; }
 
     self.audioEncrypted = startServiceACK.header.encrypted;
@@ -208,27 +208,27 @@ NS_ASSUME_NONNULL_BEGIN
     [self.audioStreamStateMachine transitionToState:SDLAudioStreamManagerStateReady];
 }
 
-- (void)handleProtocolStartServiceNAKMessage:(SDLProtocolMessage *)startServiceNAK {
+- (void)handleProtocolStartServiceNAKMessage:(SDLProtocolMessage *)startServiceNAK protocol:(SDLProtocol *)protocol {
     if (startServiceNAK.header.serviceType != SDLServiceTypeAudio) { return; }
-    SDLLogE(@"Request to start audio service NAKed");
+    SDLLogE(@"Request to start audio service NAKed on transport %@", protocol.transport);
 
     [self.audioStreamStateMachine transitionToState:SDLAudioStreamManagerStateStopped];
 }
 
 #pragma mark End Service ACK/NAK
 
-- (void)handleProtocolEndServiceACKMessage:(SDLProtocolMessage *)endServiceACK {
+- (void)handleProtocolEndServiceACKMessage:(SDLProtocolMessage *)endServiceACK protocol:(SDLProtocol *)protocol {
     if (endServiceACK.header.serviceType != SDLServiceTypeAudio) { return; }
-    SDLLogD(@"Request to end audio service ACKed");
+    SDLLogD(@"Request to end audio service ACKed on transport %@", protocol.transport);
 
     [self.audioStreamStateMachine transitionToState:SDLAudioStreamManagerStateStopped];
 }
 
-- (void)handleProtocolEndServiceNAKMessage:(SDLProtocolMessage *)endServiceNAK {
+- (void)handleProtocolEndServiceNAKMessage:(SDLProtocolMessage *)endServiceNAK protocol:(SDLProtocol *)protocol {
     if (endServiceNAK.header.serviceType != SDLServiceTypeAudio) { return; }
 
     SDLControlFramePayloadNak *nakPayload = [[SDLControlFramePayloadNak alloc] initWithData:endServiceNAK.payload];
-    SDLLogE(@"Request to end audio service NAKed with playlod: %@", nakPayload);
+    SDLLogE(@"Request to end audio service NAKed on transport %@, with playlod: %@", protocol.transport, nakPayload);
 
     /// Core will NAK the audio end service control frame if audio is not streaming or if video is streaming but the HMI does not recognize that audio is streaming.
     [self.audioStreamStateMachine transitionToState:SDLAudioStreamManagerStateStopped];

--- a/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingAudioLifecycleManager.m
@@ -199,7 +199,7 @@ NS_ASSUME_NONNULL_BEGIN
     self.audioEncrypted = startServiceACK.header.encrypted;
 
     SDLControlFramePayloadAudioStartServiceAck *audioAckPayload = [[SDLControlFramePayloadAudioStartServiceAck alloc] initWithData:startServiceACK.payload];
-    SDLLogD(@"Request to start audio service ACKed with payload: %@", audioAckPayload);
+    SDLLogD(@"Request to start audio service ACKed on transport %@, with payload: %@", protocol.transport, audioAckPayload);
 
     if (audioAckPayload.mtu != SDLControlFrameInt64NotFound) {
         [[SDLGlobals sharedGlobals] setDynamicMTUSize:(NSUInteger)audioAckPayload.mtu forServiceType:SDLServiceTypeAudio];
@@ -210,7 +210,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)protocol:(SDLProtocol *)protocol didReceiveStartServiceNAK:(SDLProtocolMessage *)startServiceNAK {
     if (startServiceNAK.header.serviceType != SDLServiceTypeAudio) { return; }
-    SDLLogE(@"Request to start audio service NAKed on transport %@", protocol.transport);
+    
+    SDLLogE(@"Request to start audio service NAKed on transport %@, with payload: %@", protocol.transport, startServiceNAK.payload);
 
     [self.audioStreamStateMachine transitionToState:SDLAudioStreamManagerStateStopped];
 }

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -512,7 +512,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
 #pragma mark - SDLProtocolDelegate
 #pragma mark Start Service ACK/NAK
 
-- (void)handleProtocolStartServiceACKMessage:(SDLProtocolMessage *)startServiceACK protocol:(SDLProtocol *)protocol {
+- (void)protocol:(SDLProtocol *)protocol didReceiveStartServiceACK:(SDLProtocolMessage *)startServiceACK {
     if (startServiceACK.header.serviceType != SDLServiceTypeVideo) { return; }
 
     self.videoEncrypted = startServiceACK.header.encrypted;
@@ -545,7 +545,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
     [self.videoStreamStateMachine transitionToState:SDLVideoStreamManagerStateReady];
 }
 
-- (void)handleProtocolStartServiceNAKMessage:(SDLProtocolMessage *)startServiceNAK protocol:(SDLProtocol *)protocol {
+- (void)protocol:(SDLProtocol *)protocol didReceiveStartServiceNAK:(SDLProtocolMessage *)startServiceNAK {
     if (startServiceNAK.header.serviceType != SDLServiceTypeVideo) { return; }
 
     SDLControlFramePayloadNak *nakPayload = [[SDLControlFramePayloadNak alloc] initWithData:startServiceNAK.payload];
@@ -573,14 +573,14 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
 
 #pragma mark End Service ACK/NAK
 
-- (void)handleProtocolEndServiceACKMessage:(SDLProtocolMessage *)endServiceACK protocol:(SDLProtocol *)protocol {
+- (void)protocol:(SDLProtocol *)protocol didReceiveEndServiceACK:(SDLProtocolMessage *)endServiceACK {
     if (endServiceACK.header.serviceType != SDLServiceTypeVideo) { return; }
     SDLLogD(@"Request to end video service ACKed on transport %@", protocol.transport);
 
     [self.videoStreamStateMachine transitionToState:SDLVideoStreamManagerStateStopped];
 }
 
-- (void)handleProtocolEndServiceNAKMessage:(SDLProtocolMessage *)endServiceNAK protocol:(SDLProtocol *)protocol {
+- (void)protocol:(SDLProtocol *)protocol didReceiveEndServiceNAK:(SDLProtocolMessage *)endServiceNAK {
     if (endServiceNAK.header.serviceType != SDLServiceTypeVideo) { return; }
 
     SDLControlFramePayloadNak *nakPayload = [[SDLControlFramePayloadNak alloc] initWithData:endServiceNAK.payload];

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -549,7 +549,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
     if (startServiceNAK.header.serviceType != SDLServiceTypeVideo) { return; }
 
     SDLControlFramePayloadNak *nakPayload = [[SDLControlFramePayloadNak alloc] initWithData:startServiceNAK.payload];
-    SDLLogE(@"Request to start video service NAKed on transport %@, with reason: %@", protocol.transport, nakPayload.description);
+    SDLLogE(@"Request to start video service NAKed on transport %@, with payload: %@", protocol.transport, nakPayload);
 
     // If we have no payload rejected params, we don't know what to do to retry, so we'll just stop and maybe cry
     if (nakPayload.rejectedParams.count == 0) {
@@ -584,7 +584,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
     if (endServiceNAK.header.serviceType != SDLServiceTypeVideo) { return; }
 
     SDLControlFramePayloadNak *nakPayload = [[SDLControlFramePayloadNak alloc] initWithData:endServiceNAK.payload];
-    SDLLogE(@"Request to end video service NAKed on transport %@, with reason: %@", protocol.transport, nakPayload);
+    SDLLogE(@"Request to end video service NAKed on transport %@, with payload: %@", protocol.transport, nakPayload);
 
     /// Core will NAK the video end service control frame if video is not streaming or if video is streaming but the HMI does not recognize that video is streaming.
     [self.videoStreamStateMachine transitionToState:SDLVideoStreamManagerStateStopped];

--- a/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/SDLStreamingVideoLifecycleManager.m
@@ -509,7 +509,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
     [self.protocol endServiceWithType:SDLServiceTypeVideo];
 }
 
-#pragma mark - SDLProtocolListener
+#pragma mark - SDLProtocolDelegate
 #pragma mark Start Service ACK/NAK
 
 - (void)handleProtocolStartServiceACKMessage:(SDLProtocolMessage *)startServiceACK {

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleProtocolHandlerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleProtocolHandlerSpec.m
@@ -93,7 +93,7 @@ describe(@"SDLLifecycleProtocolHandler tests", ^{
         context(@"of the transport closing", ^{
             beforeEach(^{
                 OCMExpect([mockNotificationDispatcher postNotificationName:[OCMArg isEqual:SDLTransportDidDisconnect] infoObject:[OCMArg isNil]]);
-                [testHandler onProtocolClosed];
+                [testHandler onProtocolClosed:mockProtocol];
             });
 
             it(@"should send a notification", ^{
@@ -104,7 +104,7 @@ describe(@"SDLLifecycleProtocolHandler tests", ^{
         context(@"of the transport erroring", ^{
             beforeEach(^{
                 OCMExpect([mockNotificationDispatcher postNotificationName:[OCMArg isEqual:SDLTransportConnectError] infoObject:[OCMArg isNotNil]]);
-                [testHandler onTransportError:[NSError errorWithDomain:@"test" code:1 userInfo:nil]];
+                [testHandler onTransportError:[NSError errorWithDomain:@"test" code:1 userInfo:nil] protocol:mockProtocol];
             });
 
             it(@"should send a notification", ^{

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleProtocolHandlerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleProtocolHandlerSpec.m
@@ -156,11 +156,11 @@ describe(@"SDLLifecycleProtocolHandler tests", ^{
             });
 
             it(@"should send a transport disconnected notification when the timer elapses", ^{
-                OCMExpect([mockNotificationDispatcher postNotificationName:[OCMArg isEqual:SDLTransportDidDisconnect] infoObject:[OCMArg isNil]]);
+                OCMExpect([mockProtocol stopWithCompletionHandler:[OCMArg any]]);
 
                 [testHandler protocolDidOpen:mockProtocol];
 
-                OCMVerifyAllWithDelay(mockNotificationDispatcher, 11.0);
+                OCMVerifyAllWithDelay(mockProtocol, 11.0);
             });
         });
 

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleProtocolHandlerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleProtocolHandlerSpec.m
@@ -80,7 +80,7 @@ describe(@"SDLLifecycleProtocolHandler tests", ^{
                 OCMExpect([mockNotificationDispatcher postNotificationName:[OCMArg isEqual:SDLTransportDidConnect] infoObject:[OCMArg isNil]]);
                 OCMExpect([mockProtocol startServiceWithType:0 payload:[OCMArg any]]).ignoringNonObjectArgs();
                 OCMExpect([(SDLTimer *)mockTimer start]);
-                [testHandler onProtocolOpened];
+                [testHandler onProtocolOpened:mockProtocol];
             });
 
             it(@"should set everything up", ^{

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleProtocolHandlerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleProtocolHandlerSpec.m
@@ -80,7 +80,7 @@ describe(@"SDLLifecycleProtocolHandler tests", ^{
                 OCMExpect([mockNotificationDispatcher postNotificationName:[OCMArg isEqual:SDLTransportDidConnect] infoObject:[OCMArg isNil]]);
                 OCMExpect([mockProtocol startServiceWithType:0 payload:[OCMArg any]]).ignoringNonObjectArgs();
                 OCMExpect([(SDLTimer *)mockTimer start]);
-                [testHandler onProtocolOpened:mockProtocol];
+                [testHandler protocolDidOpen:mockProtocol];
             });
 
             it(@"should set everything up", ^{
@@ -93,7 +93,7 @@ describe(@"SDLLifecycleProtocolHandler tests", ^{
         context(@"of the transport closing", ^{
             beforeEach(^{
                 OCMExpect([mockNotificationDispatcher postNotificationName:[OCMArg isEqual:SDLTransportDidDisconnect] infoObject:[OCMArg isNil]]);
-                [testHandler onProtocolClosed:mockProtocol];
+                [testHandler protocolDidClose:mockProtocol];
             });
 
             it(@"should send a notification", ^{
@@ -104,7 +104,7 @@ describe(@"SDLLifecycleProtocolHandler tests", ^{
         context(@"of the transport erroring", ^{
             beforeEach(^{
                 OCMExpect([mockNotificationDispatcher postNotificationName:[OCMArg isEqual:SDLTransportConnectError] infoObject:[OCMArg isNotNil]]);
-                [testHandler onTransportError:[NSError errorWithDomain:@"test" code:1 userInfo:nil] protocol:mockProtocol];
+                [testHandler protocol:mockProtocol transportDidError:[NSError errorWithDomain:@"test" code:1 userInfo:nil]];
             });
 
             it(@"should send a notification", ^{
@@ -122,7 +122,7 @@ describe(@"SDLLifecycleProtocolHandler tests", ^{
                 OCMExpect([mockNotificationDispatcher postNotificationName:[OCMArg isEqual:SDLRPCServiceDidConnect] infoObject:[OCMArg isNil]]);
                 OCMExpect([(SDLTimer *)mockTimer cancel]);
 
-                [testHandler handleProtocolStartServiceACKMessage:message protocol:mockProtocol];
+                [testHandler protocol:mockProtocol didReceiveStartServiceACK:message];
             });
 
             it(@"should stop the timer and send a notification", ^{
@@ -141,7 +141,7 @@ describe(@"SDLLifecycleProtocolHandler tests", ^{
                 OCMExpect([mockNotificationDispatcher postNotificationName:[OCMArg isEqual:SDLRPCServiceConnectionDidError] infoObject:[OCMArg isNil]]);
                 OCMExpect([(SDLTimer *)mockTimer cancel]);
 
-                [testHandler handleProtocolStartServiceNAKMessage:message protocol:mockProtocol];
+                [testHandler protocol:mockProtocol didReceiveStartServiceNAK:message];
             });
 
             it(@"should stop the timer and send a notification", ^{
@@ -158,7 +158,7 @@ describe(@"SDLLifecycleProtocolHandler tests", ^{
             it(@"should send a transport disconnected notification when the timer elapses", ^{
                 OCMExpect([mockNotificationDispatcher postNotificationName:[OCMArg isEqual:SDLTransportDidDisconnect] infoObject:[OCMArg isNil]]);
 
-                [testHandler onProtocolOpened:mockProtocol];
+                [testHandler protocolDidOpen:mockProtocol];
 
                 OCMVerifyAllWithDelay(mockNotificationDispatcher, 11.0);
             });
@@ -174,7 +174,7 @@ describe(@"SDLLifecycleProtocolHandler tests", ^{
                 OCMExpect([mockNotificationDispatcher postNotificationName:[OCMArg isEqual:SDLRPCServiceDidDisconnect] infoObject:[OCMArg isNil]]);
                 OCMExpect([(SDLTimer *)mockTimer cancel]);
 
-                [testHandler handleProtocolEndServiceACKMessage:message protocol:mockProtocol];
+                [testHandler protocol:mockProtocol didReceiveEndServiceACK:message];
             });
 
             it(@"should stop the timer and send a notification", ^{
@@ -192,7 +192,7 @@ describe(@"SDLLifecycleProtocolHandler tests", ^{
 
                 OCMExpect([mockNotificationDispatcher postNotificationName:[OCMArg isEqual:SDLRPCServiceConnectionDidError] infoObject:[OCMArg any]]);
 
-                [testHandler handleProtocolEndServiceNAKMessage:message protocol:mockProtocol];
+                [testHandler protocol:mockProtocol didReceiveEndServiceNAK:message];
             });
 
             it(@"should send a RPC service connection error notification", ^{
@@ -220,7 +220,7 @@ describe(@"SDLLifecycleProtocolHandler tests", ^{
 
                 OCMExpect([mockNotificationDispatcher postRPCRequestNotification:[OCMArg isEqual:SDLDidReceiveShowRequest] request:[OCMArg isNotNil]]);
 
-                [testHandler onProtocolMessageReceived:testMessage protocol:mockProtocol];
+                [testHandler protocol:mockProtocol didReceiveMessage:testMessage];
             });
 
             it(@"should send the notification", ^{

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleProtocolHandlerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleProtocolHandlerSpec.m
@@ -122,7 +122,7 @@ describe(@"SDLLifecycleProtocolHandler tests", ^{
                 OCMExpect([mockNotificationDispatcher postNotificationName:[OCMArg isEqual:SDLRPCServiceDidConnect] infoObject:[OCMArg isNil]]);
                 OCMExpect([(SDLTimer *)mockTimer cancel]);
 
-                [testHandler handleProtocolStartServiceACKMessage:message];
+                [testHandler handleProtocolStartServiceACKMessage:message protocol:mockProtocol];
             });
 
             it(@"should stop the timer and send a notification", ^{
@@ -141,7 +141,7 @@ describe(@"SDLLifecycleProtocolHandler tests", ^{
                 OCMExpect([mockNotificationDispatcher postNotificationName:[OCMArg isEqual:SDLRPCServiceConnectionDidError] infoObject:[OCMArg isNil]]);
                 OCMExpect([(SDLTimer *)mockTimer cancel]);
 
-                [testHandler handleProtocolStartServiceNAKMessage:message];
+                [testHandler handleProtocolStartServiceNAKMessage:message protocol:mockProtocol];
             });
 
             it(@"should stop the timer and send a notification", ^{
@@ -160,7 +160,7 @@ describe(@"SDLLifecycleProtocolHandler tests", ^{
                 OCMExpect([mockNotificationDispatcher postNotificationName:[OCMArg isEqual:SDLRPCServiceDidDisconnect] infoObject:[OCMArg isNil]]);
                 OCMExpect([(SDLTimer *)mockTimer cancel]);
 
-                [testHandler handleProtocolEndServiceACKMessage:message];
+                [testHandler handleProtocolEndServiceACKMessage:message protocol:mockProtocol];
             });
 
             it(@"should stop the timer and send a notification", ^{
@@ -189,7 +189,7 @@ describe(@"SDLLifecycleProtocolHandler tests", ^{
 
                 OCMExpect([mockNotificationDispatcher postRPCRequestNotification:[OCMArg isEqual:SDLDidReceiveShowRequest] request:[OCMArg isNotNil]]);
 
-                [testHandler onProtocolMessageReceived:testMessage];
+                [testHandler onProtocolMessageReceived:testMessage protocol:mockProtocol];
             });
 
             it(@"should send the notification", ^{

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingAudioLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingAudioLifecycleManagerSpec.m
@@ -311,7 +311,7 @@ describe(@"the streaming audio manager", ^{
 
                 testAudioStartServicePayload = [[SDLControlFramePayloadAudioStartServiceAck alloc] initWithMTU:testMTU];
                 testAudioMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testAudioHeader andPayload:testAudioStartServicePayload.data];
-                [streamingLifecycleManager handleProtocolStartServiceACKMessage:testAudioMessage protocol:protocolMock];
+                [streamingLifecycleManager protocol:protocolMock didReceiveStartServiceACK:testAudioMessage];
             });
 
             it(@"should have set all the right properties", ^{
@@ -335,7 +335,7 @@ describe(@"the streaming audio manager", ^{
                 testAudioHeader.serviceType = SDLServiceTypeAudio;
 
                 testAudioMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testAudioHeader andPayload:nil];
-                [streamingLifecycleManager handleProtocolEndServiceACKMessage:testAudioMessage protocol:protocolMock];
+                [streamingLifecycleManager protocol:protocolMock didReceiveEndServiceACK:testAudioMessage];
             });
 
             it(@"should have set all the right properties", ^{
@@ -357,7 +357,7 @@ describe(@"the streaming audio manager", ^{
                 testAudioHeader.serviceType = SDLServiceTypeAudio;
 
                 testAudioMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testAudioHeader andPayload:nil];
-                [streamingLifecycleManager handleProtocolEndServiceACKMessage:testAudioMessage protocol:protocolMock];
+                [streamingLifecycleManager protocol:protocolMock didReceiveEndServiceACK:testAudioMessage];
             });
 
             it(@"should have set all the right properties", ^{
@@ -379,7 +379,7 @@ describe(@"the streaming audio manager", ^{
                 testAudioHeader.serviceType = SDLServiceTypeAudio;
 
                 testAudioMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testAudioHeader andPayload:nil];
-                [streamingLifecycleManager handleProtocolEndServiceNAKMessage:testAudioMessage protocol:protocolMock];
+                [streamingLifecycleManager protocol:protocolMock didReceiveEndServiceNAK:testAudioMessage];
             });
 
             it(@"should have set all the right properties", ^{
@@ -464,7 +464,7 @@ describe(@"the streaming audio manager", ^{
                     testAudioHeader.serviceType = SDLServiceTypeAudio;
                     testAudioMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testAudioHeader andPayload:nil];
 
-                    [streamingLifecycleManager handleProtocolEndServiceACKMessage:testAudioMessage protocol:protocolMock];
+                    [streamingLifecycleManager protocol:protocolMock didReceiveEndServiceACK:testAudioMessage];
                 });
 
                 it(@"should transistion to the stopped state", ^{
@@ -484,7 +484,7 @@ describe(@"the streaming audio manager", ^{
                     testAudioHeader.serviceType = SDLServiceTypeAudio;
                     testAudioMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testAudioHeader andPayload:nil];
 
-                    [streamingLifecycleManager handleProtocolEndServiceNAKMessage:testAudioMessage protocol:protocolMock];
+                    [streamingLifecycleManager protocol:protocolMock didReceiveEndServiceNAK:testAudioMessage];
                 });
 
                 it(@"should transistion to the stopped state", ^{

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingAudioLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingAudioLifecycleManagerSpec.m
@@ -311,7 +311,7 @@ describe(@"the streaming audio manager", ^{
 
                 testAudioStartServicePayload = [[SDLControlFramePayloadAudioStartServiceAck alloc] initWithMTU:testMTU];
                 testAudioMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testAudioHeader andPayload:testAudioStartServicePayload.data];
-                [streamingLifecycleManager handleProtocolStartServiceACKMessage:testAudioMessage];
+                [streamingLifecycleManager handleProtocolStartServiceACKMessage:testAudioMessage protocol:protocolMock];
             });
 
             it(@"should have set all the right properties", ^{
@@ -335,7 +335,7 @@ describe(@"the streaming audio manager", ^{
                 testAudioHeader.serviceType = SDLServiceTypeAudio;
 
                 testAudioMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testAudioHeader andPayload:nil];
-                [streamingLifecycleManager handleProtocolEndServiceACKMessage:testAudioMessage];
+                [streamingLifecycleManager handleProtocolEndServiceACKMessage:testAudioMessage protocol:protocolMock];
             });
 
             it(@"should have set all the right properties", ^{
@@ -357,7 +357,7 @@ describe(@"the streaming audio manager", ^{
                 testAudioHeader.serviceType = SDLServiceTypeAudio;
 
                 testAudioMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testAudioHeader andPayload:nil];
-                [streamingLifecycleManager handleProtocolEndServiceACKMessage:testAudioMessage];
+                [streamingLifecycleManager handleProtocolEndServiceACKMessage:testAudioMessage protocol:protocolMock];
             });
 
             it(@"should have set all the right properties", ^{
@@ -379,7 +379,7 @@ describe(@"the streaming audio manager", ^{
                 testAudioHeader.serviceType = SDLServiceTypeAudio;
 
                 testAudioMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testAudioHeader andPayload:nil];
-                [streamingLifecycleManager handleProtocolEndServiceNAKMessage:testAudioMessage];
+                [streamingLifecycleManager handleProtocolEndServiceNAKMessage:testAudioMessage protocol:protocolMock];
             });
 
             it(@"should have set all the right properties", ^{
@@ -464,7 +464,7 @@ describe(@"the streaming audio manager", ^{
                     testAudioHeader.serviceType = SDLServiceTypeAudio;
                     testAudioMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testAudioHeader andPayload:nil];
 
-                    [streamingLifecycleManager handleProtocolEndServiceACKMessage:testAudioMessage];
+                    [streamingLifecycleManager handleProtocolEndServiceACKMessage:testAudioMessage protocol:protocolMock];
                 });
 
                 it(@"should transistion to the stopped state", ^{
@@ -484,7 +484,7 @@ describe(@"the streaming audio manager", ^{
                     testAudioHeader.serviceType = SDLServiceTypeAudio;
                     testAudioMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testAudioHeader andPayload:nil];
 
-                    [streamingLifecycleManager handleProtocolEndServiceNAKMessage:testAudioMessage];
+                    [streamingLifecycleManager handleProtocolEndServiceNAKMessage:testAudioMessage protocol:protocolMock];
                 });
 
                 it(@"should transistion to the stopped state", ^{

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingVideoLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingVideoLifecycleManagerSpec.m
@@ -552,7 +552,7 @@ describe(@"the streaming video manager", ^{
                     beforeEach(^{
                         testVideoStartServicePayload = [[SDLControlFramePayloadVideoStartServiceAck alloc] initWithMTU:testMTU height:testVideoHeight width:testVideoWidth protocol:testVideoProtocol codec:testVideoCodec];
                         testVideoMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testVideoHeader andPayload:testVideoStartServicePayload.data];
-                        [streamingLifecycleManager handleProtocolStartServiceACKMessage:testVideoMessage protocol:protocolMock];
+                        [streamingLifecycleManager protocol:protocolMock didReceiveStartServiceACK:testVideoMessage];
                     });
 
                     it(@"should have set all the right properties", ^{
@@ -568,7 +568,7 @@ describe(@"the streaming video manager", ^{
                     beforeEach(^{
                         testVideoStartServicePayload = [[SDLControlFramePayloadVideoStartServiceAck alloc] initWithMTU:testMTU height:testVideoHeight width:testVideoWidth protocol:nil codec:nil];
                         testVideoMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testVideoHeader andPayload:testVideoStartServicePayload.data];
-                        [streamingLifecycleManager handleProtocolStartServiceACKMessage:testVideoMessage protocol:protocolMock];
+                        [streamingLifecycleManager protocol:protocolMock didReceiveStartServiceACK:testVideoMessage];
                     });
 
                     it(@"should fall back correctly", ^{
@@ -589,7 +589,7 @@ describe(@"the streaming video manager", ^{
                     context(@"If no preferred resolutions were set in the data source", ^{
                         beforeEach(^{
                             streamingLifecycleManager.dataSource = nil;
-                            [streamingLifecycleManager handleProtocolStartServiceACKMessage:testVideoMessage protocol:protocolMock];
+                            [streamingLifecycleManager protocol:protocolMock didReceiveStartServiceACK:testVideoMessage];
                         });
                         it(@"should not replace the existing screen resolution", ^{
                             expect(@(CGSizeEqualToSize(streamingLifecycleManager.videoScaleManager.displayViewportResolution, CGSizeZero))).to(beTrue());
@@ -606,7 +606,7 @@ describe(@"the streaming video manager", ^{
                             streamingLifecycleManager.dataSource = testDataSource;
                             streamingLifecycleManager.preferredResolutions = @[preferredResolutionLow, preferredResolutionHigh];
 
-                            [streamingLifecycleManager handleProtocolStartServiceACKMessage:testVideoMessage protocol:protocolMock];
+                            [streamingLifecycleManager protocol:protocolMock didReceiveStartServiceACK:testVideoMessage];
                         });
                         it(@"should set the screen size using the first provided preferred resolution", ^{
                             CGSize preferredFormat = CGSizeMake(preferredResolutionLow.resolutionWidth.floatValue, preferredResolutionLow.resolutionHeight.floatValue);
@@ -648,7 +648,7 @@ describe(@"the streaming video manager", ^{
 
                         testVideoStartNakPayload = [[SDLControlFramePayloadNak alloc] initWithRejectedParams:@[[NSString stringWithUTF8String:SDLControlFrameHeightKey], [NSString stringWithUTF8String:SDLControlFrameVideoCodecKey]]];
                         testVideoMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testVideoHeader andPayload:testVideoStartNakPayload.data];
-                        [streamingLifecycleManager handleProtocolStartServiceNAKMessage:testVideoMessage protocol:protocolMock];
+                        [streamingLifecycleManager protocol:protocolMock didReceiveStartServiceNAK:testVideoMessage];
                     });
 
                     it(@"should have retried with new properties", ^{
@@ -670,7 +670,7 @@ describe(@"the streaming video manager", ^{
 
                         testVideoStartNakPayload = [[SDLControlFramePayloadNak alloc] initWithRejectedParams:@[[NSString stringWithUTF8String:SDLControlFrameVideoCodecKey]]];
                         testVideoMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testVideoHeader andPayload:testVideoStartNakPayload.data];
-                        [streamingLifecycleManager handleProtocolStartServiceNAKMessage:testVideoMessage protocol:protocolMock];
+                        [streamingLifecycleManager protocol:protocolMock didReceiveStartServiceNAK:testVideoMessage];
                     });
 
                     it(@"should have retried with new properties", ^{
@@ -691,7 +691,7 @@ describe(@"the streaming video manager", ^{
 
                         testVideoStartNakPayload = [[SDLControlFramePayloadNak alloc] initWithRejectedParams:@[[NSString stringWithUTF8String:SDLControlFrameVideoCodecKey]]];
                         testVideoMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testVideoHeader andPayload:testVideoStartNakPayload.data];
-                        [streamingLifecycleManager handleProtocolStartServiceNAKMessage:testVideoMessage protocol:protocolMock];
+                        [streamingLifecycleManager protocol:protocolMock didReceiveStartServiceNAK:testVideoMessage];
                     });
 
                     it(@"should end the service", ^{
@@ -706,7 +706,7 @@ describe(@"the streaming video manager", ^{
 
                         testVideoStartNakPayload = [[SDLControlFramePayloadNak alloc] initWithRejectedParams:nil];
                         testVideoMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testVideoHeader andPayload:testVideoStartNakPayload.data];
-                        [streamingLifecycleManager handleProtocolStartServiceNAKMessage:testVideoMessage protocol:protocolMock];
+                        [streamingLifecycleManager protocol:protocolMock didReceiveStartServiceNAK:testVideoMessage];
                     });
 
                     it(@"should end the service", ^{
@@ -729,7 +729,7 @@ describe(@"the streaming video manager", ^{
                     testVideoHeader.serviceType = SDLServiceTypeVideo;
 
                     testVideoMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testVideoHeader andPayload:nil];
-                    [streamingLifecycleManager handleProtocolEndServiceACKMessage:testVideoMessage protocol:protocolMock];
+                    [streamingLifecycleManager protocol:protocolMock didReceiveEndServiceACK:testVideoMessage];
                 });
 
                 it(@"should have set all the right properties", ^{
@@ -751,7 +751,7 @@ describe(@"the streaming video manager", ^{
                     testVideoHeader.serviceType = SDLServiceTypeVideo;
 
                     testVideoMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testVideoHeader andPayload:nil];
-                    [streamingLifecycleManager handleProtocolEndServiceNAKMessage:testVideoMessage protocol:protocolMock];
+                    [streamingLifecycleManager protocol:protocolMock didReceiveEndServiceNAK:testVideoMessage];
                 });
 
                 it(@"should have set all the right properties", ^{
@@ -837,7 +837,7 @@ describe(@"the streaming video manager", ^{
                     testVideoHeader.serviceType = SDLServiceTypeVideo;
                     testVideoMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testVideoHeader andPayload:nil];
 
-                    [streamingLifecycleManager handleProtocolEndServiceACKMessage:testVideoMessage protocol:protocolMock];
+                    [streamingLifecycleManager protocol:protocolMock didReceiveEndServiceACK:testVideoMessage];
                 });
 
                 it(@"should transistion to the stopped state", ^{
@@ -857,7 +857,7 @@ describe(@"the streaming video manager", ^{
                     testVideoHeader.serviceType = SDLServiceTypeVideo;
                     testVideoMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testVideoHeader andPayload:nil];
 
-                    [streamingLifecycleManager handleProtocolEndServiceNAKMessage:testVideoMessage protocol:protocolMock ];
+                    [streamingLifecycleManager protocol:protocolMock didReceiveEndServiceNAK:testVideoMessage];
                 });
 
                 it(@"should transistion to the stopped state", ^{

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingVideoLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingVideoLifecycleManagerSpec.m
@@ -552,7 +552,7 @@ describe(@"the streaming video manager", ^{
                     beforeEach(^{
                         testVideoStartServicePayload = [[SDLControlFramePayloadVideoStartServiceAck alloc] initWithMTU:testMTU height:testVideoHeight width:testVideoWidth protocol:testVideoProtocol codec:testVideoCodec];
                         testVideoMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testVideoHeader andPayload:testVideoStartServicePayload.data];
-                        [streamingLifecycleManager handleProtocolStartServiceACKMessage:testVideoMessage];
+                        [streamingLifecycleManager handleProtocolStartServiceACKMessage:testVideoMessage protocol:protocolMock];
                     });
 
                     it(@"should have set all the right properties", ^{
@@ -568,7 +568,7 @@ describe(@"the streaming video manager", ^{
                     beforeEach(^{
                         testVideoStartServicePayload = [[SDLControlFramePayloadVideoStartServiceAck alloc] initWithMTU:testMTU height:testVideoHeight width:testVideoWidth protocol:nil codec:nil];
                         testVideoMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testVideoHeader andPayload:testVideoStartServicePayload.data];
-                        [streamingLifecycleManager handleProtocolStartServiceACKMessage:testVideoMessage];
+                        [streamingLifecycleManager handleProtocolStartServiceACKMessage:testVideoMessage protocol:protocolMock];
                     });
 
                     it(@"should fall back correctly", ^{
@@ -589,7 +589,7 @@ describe(@"the streaming video manager", ^{
                     context(@"If no preferred resolutions were set in the data source", ^{
                         beforeEach(^{
                             streamingLifecycleManager.dataSource = nil;
-                            [streamingLifecycleManager handleProtocolStartServiceACKMessage:testVideoMessage];
+                            [streamingLifecycleManager handleProtocolStartServiceACKMessage:testVideoMessage protocol:protocolMock];
                         });
                         it(@"should not replace the existing screen resolution", ^{
                             expect(@(CGSizeEqualToSize(streamingLifecycleManager.videoScaleManager.displayViewportResolution, CGSizeZero))).to(beTrue());
@@ -606,7 +606,7 @@ describe(@"the streaming video manager", ^{
                             streamingLifecycleManager.dataSource = testDataSource;
                             streamingLifecycleManager.preferredResolutions = @[preferredResolutionLow, preferredResolutionHigh];
 
-                            [streamingLifecycleManager handleProtocolStartServiceACKMessage:testVideoMessage];
+                            [streamingLifecycleManager handleProtocolStartServiceACKMessage:testVideoMessage protocol:protocolMock];
                         });
                         it(@"should set the screen size using the first provided preferred resolution", ^{
                             CGSize preferredFormat = CGSizeMake(preferredResolutionLow.resolutionWidth.floatValue, preferredResolutionLow.resolutionHeight.floatValue);
@@ -648,7 +648,7 @@ describe(@"the streaming video manager", ^{
 
                         testVideoStartNakPayload = [[SDLControlFramePayloadNak alloc] initWithRejectedParams:@[[NSString stringWithUTF8String:SDLControlFrameHeightKey], [NSString stringWithUTF8String:SDLControlFrameVideoCodecKey]]];
                         testVideoMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testVideoHeader andPayload:testVideoStartNakPayload.data];
-                        [streamingLifecycleManager handleProtocolStartServiceNAKMessage:testVideoMessage];
+                        [streamingLifecycleManager handleProtocolStartServiceNAKMessage:testVideoMessage protocol:protocolMock];
                     });
 
                     it(@"should have retried with new properties", ^{
@@ -670,7 +670,7 @@ describe(@"the streaming video manager", ^{
 
                         testVideoStartNakPayload = [[SDLControlFramePayloadNak alloc] initWithRejectedParams:@[[NSString stringWithUTF8String:SDLControlFrameVideoCodecKey]]];
                         testVideoMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testVideoHeader andPayload:testVideoStartNakPayload.data];
-                        [streamingLifecycleManager handleProtocolStartServiceNAKMessage:testVideoMessage];
+                        [streamingLifecycleManager handleProtocolStartServiceNAKMessage:testVideoMessage protocol:protocolMock];
                     });
 
                     it(@"should have retried with new properties", ^{
@@ -691,7 +691,7 @@ describe(@"the streaming video manager", ^{
 
                         testVideoStartNakPayload = [[SDLControlFramePayloadNak alloc] initWithRejectedParams:@[[NSString stringWithUTF8String:SDLControlFrameVideoCodecKey]]];
                         testVideoMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testVideoHeader andPayload:testVideoStartNakPayload.data];
-                        [streamingLifecycleManager handleProtocolStartServiceNAKMessage:testVideoMessage];
+                        [streamingLifecycleManager handleProtocolStartServiceNAKMessage:testVideoMessage protocol:protocolMock];
                     });
 
                     it(@"should end the service", ^{
@@ -706,7 +706,7 @@ describe(@"the streaming video manager", ^{
 
                         testVideoStartNakPayload = [[SDLControlFramePayloadNak alloc] initWithRejectedParams:nil];
                         testVideoMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testVideoHeader andPayload:testVideoStartNakPayload.data];
-                        [streamingLifecycleManager handleProtocolStartServiceNAKMessage:testVideoMessage];
+                        [streamingLifecycleManager handleProtocolStartServiceNAKMessage:testVideoMessage protocol:protocolMock];
                     });
 
                     it(@"should end the service", ^{
@@ -729,7 +729,7 @@ describe(@"the streaming video manager", ^{
                     testVideoHeader.serviceType = SDLServiceTypeVideo;
 
                     testVideoMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testVideoHeader andPayload:nil];
-                    [streamingLifecycleManager handleProtocolEndServiceACKMessage:testVideoMessage];
+                    [streamingLifecycleManager handleProtocolEndServiceACKMessage:testVideoMessage protocol:protocolMock];
                 });
 
                 it(@"should have set all the right properties", ^{
@@ -751,7 +751,7 @@ describe(@"the streaming video manager", ^{
                     testVideoHeader.serviceType = SDLServiceTypeVideo;
 
                     testVideoMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testVideoHeader andPayload:nil];
-                    [streamingLifecycleManager handleProtocolEndServiceNAKMessage:testVideoMessage];
+                    [streamingLifecycleManager handleProtocolEndServiceNAKMessage:testVideoMessage protocol:protocolMock];
                 });
 
                 it(@"should have set all the right properties", ^{
@@ -837,7 +837,7 @@ describe(@"the streaming video manager", ^{
                     testVideoHeader.serviceType = SDLServiceTypeVideo;
                     testVideoMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testVideoHeader andPayload:nil];
 
-                    [streamingLifecycleManager handleProtocolEndServiceACKMessage:testVideoMessage];
+                    [streamingLifecycleManager handleProtocolEndServiceACKMessage:testVideoMessage protocol:protocolMock];
                 });
 
                 it(@"should transistion to the stopped state", ^{
@@ -857,7 +857,7 @@ describe(@"the streaming video manager", ^{
                     testVideoHeader.serviceType = SDLServiceTypeVideo;
                     testVideoMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testVideoHeader andPayload:nil];
 
-                    [streamingLifecycleManager handleProtocolEndServiceNAKMessage:testVideoMessage];
+                    [streamingLifecycleManager handleProtocolEndServiceNAKMessage:testVideoMessage protocol:protocolMock ];
                 });
 
                 it(@"should transistion to the stopped state", ^{

--- a/SmartDeviceLinkTests/ProtocolSpecs/MessageSpecs/SDLProtocolSpec.m
+++ b/SmartDeviceLinkTests/ProtocolSpecs/MessageSpecs/SDLProtocolSpec.m
@@ -702,7 +702,7 @@ describe(@"OnProtocolClosed Tests", ^ {
         testProtocol = [[SDLProtocol alloc] initWithTransport:transportMock encryptionManager:nil];
 
         delegateMock = OCMProtocolMock(@protocol(SDLProtocolDelegate));
-        OCMExpect([delegateMock onProtocolClosed]);
+        OCMExpect([delegateMock onProtocolClosed:testProtocol]);
 
         [testProtocol.protocolDelegateTable addObject:delegateMock];
         [testProtocol onTransportDisconnected];

--- a/SmartDeviceLinkTests/ProtocolSpecs/MessageSpecs/SDLProtocolSpec.m
+++ b/SmartDeviceLinkTests/ProtocolSpecs/MessageSpecs/SDLProtocolSpec.m
@@ -129,7 +129,7 @@ describe(@"Send EndSession Tests", ^ {
             SDLV1ProtocolHeader *testHeader = [[SDLV1ProtocolHeader alloc] init];
             testHeader.serviceType = SDLServiceTypeRPC;
             testHeader.sessionID = 0x03;
-            [testProtocol handleProtocolStartServiceACKMessage:[SDLProtocolMessage messageWithHeader:testHeader andPayload:nil]];
+            [testProtocol handleProtocolStartServiceACKMessage:[SDLProtocolMessage messageWithHeader:testHeader andPayload:nil] protocol:testProtocol];
             
             [testProtocol endServiceWithType:SDLServiceTypeRPC];
             
@@ -157,7 +157,7 @@ describe(@"Send EndSession Tests", ^ {
             SDLV2ProtocolHeader *testHeader = [[SDLV2ProtocolHeader alloc] initWithVersion:2];
             testHeader.serviceType = SDLServiceTypeRPC;
             testHeader.sessionID = 0x61;
-            [testProtocol handleProtocolStartServiceACKMessage:[SDLProtocolMessage messageWithHeader:testHeader andPayload:nil]];
+            [testProtocol handleProtocolStartServiceACKMessage:[SDLProtocolMessage messageWithHeader:testHeader andPayload:nil] protocol:testProtocol];
             
             [testProtocol endServiceWithType:SDLServiceTypeRPC];
             
@@ -188,7 +188,7 @@ describe(@"Send Register Secondary Transport Tests", ^ {
         refHeader.serviceType = SDLServiceTypeRPC;
         refHeader.frameData = SDLFrameInfoStartServiceACK;
         refHeader.sessionID = 0x11;
-        [testProtocol handleProtocolStartServiceACKMessage:[SDLProtocolMessage messageWithHeader:refHeader andPayload:nil]];
+        [testProtocol handleProtocolStartServiceACKMessage:[SDLProtocolMessage messageWithHeader:refHeader andPayload:nil] protocol:testProtocol];
 
         // store the header to apply Session ID value to Register Secondary Transport frame
         [testProtocol storeHeader:refHeader forServiceType:SDLServiceTypeControl];
@@ -233,7 +233,7 @@ describe(@"SendRPCRequest Tests", ^ {
             SDLV1ProtocolHeader *testHeader = [[SDLV1ProtocolHeader alloc] init];
             testHeader.serviceType = SDLServiceTypeRPC;
             testHeader.sessionID = 0xFF;
-            [testProtocol handleProtocolStartServiceACKMessage:[SDLProtocolMessage messageWithHeader:testHeader andPayload:nil]];
+            [testProtocol handleProtocolStartServiceACKMessage:[SDLProtocolMessage messageWithHeader:testHeader andPayload:nil] protocol:testProtocol];
             
             [testProtocol sendRPC:mockRequest];
             
@@ -279,7 +279,7 @@ describe(@"SendRPCRequest Tests", ^ {
             SDLV2ProtocolHeader *testHeader = [[SDLV2ProtocolHeader alloc] initWithVersion:2];
             testHeader.serviceType = SDLServiceTypeRPC;
             testHeader.sessionID = 0x01;
-            [testProtocol handleProtocolStartServiceACKMessage:[SDLProtocolMessage messageWithHeader:testHeader andPayload:nil]];
+            [testProtocol handleProtocolStartServiceACKMessage:[SDLProtocolMessage messageWithHeader:testHeader andPayload:nil] protocol:testProtocol];
             
             [testProtocol sendRPC:mockRequest];
             
@@ -430,10 +430,10 @@ describe(@"HandleProtocolSessionStarted tests", ^ {
                 testHeader.bytesInPayload = (UInt32)testData.length;
 
                 SDLProtocolMessage *ackMessage = [SDLProtocolMessage messageWithHeader:testHeader andPayload:testData];
-                OCMExpect([delegateMock handleProtocolStartServiceACKMessage:ackMessage]);
+                OCMExpect([delegateMock handleProtocolStartServiceACKMessage:ackMessage protocol:testProtocol]);
 
                 [testProtocol.protocolDelegateTable addObject:delegateMock];
-                [testProtocol handleProtocolStartServiceACKMessage:ackMessage];
+                [testProtocol handleProtocolStartServiceACKMessage:ackMessage protocol:testProtocol];
 
                 OCMVerifyAllWithDelay(delegateMock, 0.1);
 
@@ -454,10 +454,10 @@ describe(@"HandleProtocolSessionStarted tests", ^ {
                 testHeader.bytesInPayload = (UInt32)testData.length;
 
                 SDLProtocolMessage *ackMessage = [SDLProtocolMessage messageWithHeader:testHeader andPayload:testData];
-                OCMExpect([delegateMock handleProtocolStartServiceACKMessage:ackMessage]);
+                OCMExpect([delegateMock handleProtocolStartServiceACKMessage:ackMessage protocol:testProtocol]);
 
                 [testProtocol.protocolDelegateTable addObject:delegateMock];
-                [testProtocol handleProtocolStartServiceACKMessage:ackMessage];
+                [testProtocol handleProtocolStartServiceACKMessage:ackMessage protocol:testProtocol];
 
                 OCMVerifyAllWithDelay(delegateMock, 0.1);
 
@@ -478,10 +478,10 @@ describe(@"HandleProtocolSessionStarted tests", ^ {
                 testHeader.bytesInPayload = (UInt32)testData.length;
 
                 SDLProtocolMessage *ackMessage = [SDLProtocolMessage messageWithHeader:testHeader andPayload:testData];
-                OCMExpect([delegateMock handleProtocolStartServiceACKMessage:ackMessage]);
+                OCMExpect([delegateMock handleProtocolStartServiceACKMessage:ackMessage protocol:testProtocol]);
 
                 [testProtocol.protocolDelegateTable addObject:delegateMock];
-                [testProtocol handleProtocolStartServiceACKMessage:ackMessage];
+                [testProtocol handleProtocolStartServiceACKMessage:ackMessage protocol:testProtocol];
 
                 OCMVerifyAllWithDelay(delegateMock, 0.1);
 
@@ -504,10 +504,10 @@ describe(@"HandleProtocolSessionStarted tests", ^ {
                 testHeader.bytesInPayload = (UInt32)testData.length;
 
                 SDLProtocolMessage *ackMessage = [SDLProtocolMessage messageWithHeader:testHeader andPayload:testData];
-                OCMExpect([delegateMock handleProtocolStartServiceACKMessage:ackMessage]);
+                OCMExpect([delegateMock handleProtocolStartServiceACKMessage:ackMessage protocol:testProtocol]);
 
                 [testProtocol.protocolDelegateTable addObject:delegateMock];
-                [testProtocol handleProtocolStartServiceACKMessage:ackMessage];
+                [testProtocol handleProtocolStartServiceACKMessage:ackMessage protocol:testProtocol];
 
                 OCMVerifyAllWithDelay(delegateMock, 0.1);
 
@@ -533,10 +533,10 @@ describe(@"HandleProtocolSessionStarted tests", ^ {
                 testHeader.bytesInPayload = (UInt32)testData.length;
 
                 SDLProtocolMessage *ackMessage = [SDLProtocolMessage messageWithHeader:testHeader andPayload:testData];
-                OCMExpect([delegateMock handleProtocolStartServiceACKMessage:ackMessage]);
+                OCMExpect([delegateMock handleProtocolStartServiceACKMessage:ackMessage protocol:testProtocol]);
 
                 [testProtocol.protocolDelegateTable addObject:delegateMock];
-                [testProtocol handleProtocolStartServiceACKMessage:ackMessage];
+                [testProtocol handleProtocolStartServiceACKMessage:ackMessage protocol:testProtocol];
 
                 OCMVerifyAllWithDelay(delegateMock, 0.1);
 
@@ -558,10 +558,10 @@ describe(@"HandleProtocolSessionStarted tests", ^ {
                 testHeader.bytesInPayload = (UInt32)testData.length;
 
                 SDLProtocolMessage *ackMessage = [SDLProtocolMessage messageWithHeader:testHeader andPayload:testData];
-                OCMExpect([delegateMock handleProtocolStartServiceACKMessage:ackMessage]);
+                OCMExpect([delegateMock handleProtocolStartServiceACKMessage:ackMessage protocol:testProtocol]);
 
                 [testProtocol.protocolDelegateTable addObject:delegateMock];
-                [testProtocol handleProtocolStartServiceACKMessage:ackMessage];
+                [testProtocol handleProtocolStartServiceACKMessage:ackMessage protocol:testProtocol];
 
                 // Should keep their default values
                 expect([SDLGlobals sharedGlobals].protocolVersion.stringVersion).to(equal(@"1.0.0"));
@@ -593,10 +593,10 @@ describe(@"HandleProtocolRegisterSecondaryTransport Tests", ^{
         testHeader.bytesInPayload = 0;
 
         SDLProtocolMessage *ackMessage = [SDLProtocolMessage messageWithHeader:testHeader andPayload:nil];
-        OCMExpect([delegateMock handleProtocolRegisterSecondaryTransportACKMessage:ackMessage]);
+        OCMExpect([delegateMock handleProtocolRegisterSecondaryTransportACKMessage:ackMessage protocol:testProtocol]);
 
         [testProtocol.protocolDelegateTable addObject:delegateMock];
-        [testProtocol handleProtocolRegisterSecondaryTransportACKMessage:ackMessage];
+        [testProtocol handleProtocolRegisterSecondaryTransportACKMessage:ackMessage protocol:testProtocol];
 
         OCMVerifyAllWithDelay(delegateMock, 0.1);
     });
@@ -615,10 +615,10 @@ describe(@"HandleProtocolRegisterSecondaryTransport Tests", ^{
         NSData *payloadData = payload.data;
 
         SDLProtocolMessage *nakMessage = [SDLProtocolMessage messageWithHeader:testHeader andPayload:payloadData];
-        OCMExpect([delegateMock handleProtocolRegisterSecondaryTransportNAKMessage:nakMessage]);
+        OCMExpect([delegateMock handleProtocolRegisterSecondaryTransportNAKMessage:nakMessage protocol:testProtocol]);
 
         [testProtocol.protocolDelegateTable addObject:delegateMock];
-        [testProtocol handleProtocolRegisterSecondaryTransportNAKMessage:nakMessage];
+        [testProtocol handleProtocolRegisterSecondaryTransportNAKMessage:nakMessage protocol:testProtocol];
 
         OCMVerifyAllWithDelay(delegateMock, 0.1);
     });
@@ -660,10 +660,10 @@ describe(@"OnProtocolMessageReceived Tests", ^ {
         testMessage.header = testHeader;
 
         id delegateMock = OCMProtocolMock(@protocol(SDLProtocolDelegate));
-        OCMExpect([delegateMock onProtocolMessageReceived:[OCMArg any]]);
+        OCMExpect([delegateMock onProtocolMessageReceived:[OCMArg any] protocol:testProtocol]);
 
         [testProtocol.protocolDelegateTable addObject:delegateMock];
-        [testProtocol onProtocolMessageReceived:testMessage];
+        [testProtocol onProtocolMessageReceived:testMessage protocol:testProtocol];
     });
 
     it(@"Should pass information along to delegate", ^ {

--- a/SmartDeviceLinkTests/ProtocolSpecs/MessageSpecs/SDLProtocolSpec.m
+++ b/SmartDeviceLinkTests/ProtocolSpecs/MessageSpecs/SDLProtocolSpec.m
@@ -681,7 +681,7 @@ describe(@"OnProtocolOpened Tests", ^ {
         testProtocol = [[SDLProtocol alloc] initWithTransport:transportMock encryptionManager:nil];
 
         id delegateMock = OCMProtocolMock(@protocol(SDLProtocolDelegate));
-        OCMExpect([delegateMock onProtocolOpened]);
+        OCMExpect([delegateMock onProtocolOpened:testProtocol]);
 
         [testProtocol.protocolDelegateTable addObject:delegateMock];
         [testProtocol onTransportConnected];

--- a/SmartDeviceLinkTests/ProtocolSpecs/MessageSpecs/SDLProtocolSpec.m
+++ b/SmartDeviceLinkTests/ProtocolSpecs/MessageSpecs/SDLProtocolSpec.m
@@ -129,7 +129,7 @@ describe(@"Send EndSession Tests", ^ {
             SDLV1ProtocolHeader *testHeader = [[SDLV1ProtocolHeader alloc] init];
             testHeader.serviceType = SDLServiceTypeRPC;
             testHeader.sessionID = 0x03;
-            [testProtocol handleProtocolStartServiceACKMessage:[SDLProtocolMessage messageWithHeader:testHeader andPayload:nil] protocol:testProtocol];
+            [testProtocol protocol:testProtocol didReceiveStartServiceACK:[SDLProtocolMessage messageWithHeader:testHeader andPayload:nil]];
             
             [testProtocol endServiceWithType:SDLServiceTypeRPC];
             
@@ -157,7 +157,7 @@ describe(@"Send EndSession Tests", ^ {
             SDLV2ProtocolHeader *testHeader = [[SDLV2ProtocolHeader alloc] initWithVersion:2];
             testHeader.serviceType = SDLServiceTypeRPC;
             testHeader.sessionID = 0x61;
-            [testProtocol handleProtocolStartServiceACKMessage:[SDLProtocolMessage messageWithHeader:testHeader andPayload:nil] protocol:testProtocol];
+            [testProtocol protocol:testProtocol didReceiveStartServiceACK:[SDLProtocolMessage messageWithHeader:testHeader andPayload:nil]];
             
             [testProtocol endServiceWithType:SDLServiceTypeRPC];
             
@@ -188,7 +188,7 @@ describe(@"Send Register Secondary Transport Tests", ^ {
         refHeader.serviceType = SDLServiceTypeRPC;
         refHeader.frameData = SDLFrameInfoStartServiceACK;
         refHeader.sessionID = 0x11;
-        [testProtocol handleProtocolStartServiceACKMessage:[SDLProtocolMessage messageWithHeader:refHeader andPayload:nil] protocol:testProtocol];
+        [testProtocol protocol:testProtocol didReceiveStartServiceACK:[SDLProtocolMessage messageWithHeader:refHeader andPayload:nil]];
 
         // store the header to apply Session ID value to Register Secondary Transport frame
         [testProtocol storeHeader:refHeader forServiceType:SDLServiceTypeControl];
@@ -233,7 +233,7 @@ describe(@"SendRPCRequest Tests", ^ {
             SDLV1ProtocolHeader *testHeader = [[SDLV1ProtocolHeader alloc] init];
             testHeader.serviceType = SDLServiceTypeRPC;
             testHeader.sessionID = 0xFF;
-            [testProtocol handleProtocolStartServiceACKMessage:[SDLProtocolMessage messageWithHeader:testHeader andPayload:nil] protocol:testProtocol];
+            [testProtocol protocol:testProtocol didReceiveStartServiceACK:[SDLProtocolMessage messageWithHeader:testHeader andPayload:nil]];
             
             [testProtocol sendRPC:mockRequest];
             
@@ -279,7 +279,7 @@ describe(@"SendRPCRequest Tests", ^ {
             SDLV2ProtocolHeader *testHeader = [[SDLV2ProtocolHeader alloc] initWithVersion:2];
             testHeader.serviceType = SDLServiceTypeRPC;
             testHeader.sessionID = 0x01;
-            [testProtocol handleProtocolStartServiceACKMessage:[SDLProtocolMessage messageWithHeader:testHeader andPayload:nil] protocol:testProtocol];
+            [testProtocol protocol:testProtocol didReceiveStartServiceACK:[SDLProtocolMessage messageWithHeader:testHeader andPayload:nil]];
             
             [testProtocol sendRPC:mockRequest];
             
@@ -430,10 +430,10 @@ describe(@"HandleProtocolSessionStarted tests", ^ {
                 testHeader.bytesInPayload = (UInt32)testData.length;
 
                 SDLProtocolMessage *ackMessage = [SDLProtocolMessage messageWithHeader:testHeader andPayload:testData];
-                OCMExpect([delegateMock handleProtocolStartServiceACKMessage:ackMessage protocol:testProtocol]);
+                OCMExpect([delegateMock protocol:testProtocol didReceiveStartServiceACK:ackMessage]);
 
                 [testProtocol.protocolDelegateTable addObject:delegateMock];
-                [testProtocol handleProtocolStartServiceACKMessage:ackMessage protocol:testProtocol];
+                [testProtocol protocol:testProtocol didReceiveStartServiceACK:ackMessage];
 
                 OCMVerifyAllWithDelay(delegateMock, 0.1);
 
@@ -454,10 +454,10 @@ describe(@"HandleProtocolSessionStarted tests", ^ {
                 testHeader.bytesInPayload = (UInt32)testData.length;
 
                 SDLProtocolMessage *ackMessage = [SDLProtocolMessage messageWithHeader:testHeader andPayload:testData];
-                OCMExpect([delegateMock handleProtocolStartServiceACKMessage:ackMessage protocol:testProtocol]);
+                OCMExpect([delegateMock protocol:testProtocol didReceiveStartServiceACK:ackMessage]);
 
                 [testProtocol.protocolDelegateTable addObject:delegateMock];
-                [testProtocol handleProtocolStartServiceACKMessage:ackMessage protocol:testProtocol];
+                [testProtocol protocol:testProtocol didReceiveStartServiceACK:ackMessage];
 
                 OCMVerifyAllWithDelay(delegateMock, 0.1);
 
@@ -478,10 +478,10 @@ describe(@"HandleProtocolSessionStarted tests", ^ {
                 testHeader.bytesInPayload = (UInt32)testData.length;
 
                 SDLProtocolMessage *ackMessage = [SDLProtocolMessage messageWithHeader:testHeader andPayload:testData];
-                OCMExpect([delegateMock handleProtocolStartServiceACKMessage:ackMessage protocol:testProtocol]);
+                OCMExpect([delegateMock protocol:testProtocol didReceiveStartServiceACK:ackMessage]);
 
                 [testProtocol.protocolDelegateTable addObject:delegateMock];
-                [testProtocol handleProtocolStartServiceACKMessage:ackMessage protocol:testProtocol];
+                [testProtocol protocol:testProtocol didReceiveStartServiceACK:ackMessage];
 
                 OCMVerifyAllWithDelay(delegateMock, 0.1);
 
@@ -504,10 +504,10 @@ describe(@"HandleProtocolSessionStarted tests", ^ {
                 testHeader.bytesInPayload = (UInt32)testData.length;
 
                 SDLProtocolMessage *ackMessage = [SDLProtocolMessage messageWithHeader:testHeader andPayload:testData];
-                OCMExpect([delegateMock handleProtocolStartServiceACKMessage:ackMessage protocol:testProtocol]);
+                OCMExpect([delegateMock protocol:testProtocol didReceiveStartServiceACK:ackMessage]);
 
                 [testProtocol.protocolDelegateTable addObject:delegateMock];
-                [testProtocol handleProtocolStartServiceACKMessage:ackMessage protocol:testProtocol];
+                [testProtocol protocol:testProtocol didReceiveStartServiceACK:ackMessage];
 
                 OCMVerifyAllWithDelay(delegateMock, 0.1);
 
@@ -533,10 +533,10 @@ describe(@"HandleProtocolSessionStarted tests", ^ {
                 testHeader.bytesInPayload = (UInt32)testData.length;
 
                 SDLProtocolMessage *ackMessage = [SDLProtocolMessage messageWithHeader:testHeader andPayload:testData];
-                OCMExpect([delegateMock handleProtocolStartServiceACKMessage:ackMessage protocol:testProtocol]);
+                OCMExpect([delegateMock protocol:testProtocol didReceiveStartServiceACK:ackMessage]);
 
                 [testProtocol.protocolDelegateTable addObject:delegateMock];
-                [testProtocol handleProtocolStartServiceACKMessage:ackMessage protocol:testProtocol];
+                [testProtocol protocol:testProtocol didReceiveStartServiceACK:ackMessage];
 
                 OCMVerifyAllWithDelay(delegateMock, 0.1);
 
@@ -558,10 +558,10 @@ describe(@"HandleProtocolSessionStarted tests", ^ {
                 testHeader.bytesInPayload = (UInt32)testData.length;
 
                 SDLProtocolMessage *ackMessage = [SDLProtocolMessage messageWithHeader:testHeader andPayload:testData];
-                OCMExpect([delegateMock handleProtocolStartServiceACKMessage:ackMessage protocol:testProtocol]);
+                OCMExpect([delegateMock protocol:testProtocol didReceiveStartServiceACK:ackMessage]);
 
                 [testProtocol.protocolDelegateTable addObject:delegateMock];
-                [testProtocol handleProtocolStartServiceACKMessage:ackMessage protocol:testProtocol];
+                [testProtocol protocol:testProtocol didReceiveStartServiceACK:ackMessage];
 
                 // Should keep their default values
                 expect([SDLGlobals sharedGlobals].protocolVersion.stringVersion).to(equal(@"1.0.0"));
@@ -593,10 +593,10 @@ describe(@"HandleProtocolRegisterSecondaryTransport Tests", ^{
         testHeader.bytesInPayload = 0;
 
         SDLProtocolMessage *ackMessage = [SDLProtocolMessage messageWithHeader:testHeader andPayload:nil];
-        OCMExpect([delegateMock handleProtocolRegisterSecondaryTransportACKMessage:ackMessage protocol:testProtocol]);
+        OCMExpect([delegateMock protocol:testProtocol didReceiveRegisterSecondaryTransportACK:ackMessage]);
 
         [testProtocol.protocolDelegateTable addObject:delegateMock];
-        [testProtocol handleProtocolRegisterSecondaryTransportACKMessage:ackMessage protocol:testProtocol];
+        [testProtocol protocol:testProtocol didReceiveRegisterSecondaryTransportACK:ackMessage];
 
         OCMVerifyAllWithDelay(delegateMock, 0.1);
     });
@@ -615,10 +615,10 @@ describe(@"HandleProtocolRegisterSecondaryTransport Tests", ^{
         NSData *payloadData = payload.data;
 
         SDLProtocolMessage *nakMessage = [SDLProtocolMessage messageWithHeader:testHeader andPayload:payloadData];
-        OCMExpect([delegateMock handleProtocolRegisterSecondaryTransportNAKMessage:nakMessage protocol:testProtocol]);
+        OCMExpect([delegateMock protocol:testProtocol didReceiveRegisterSecondaryTransportNAK:nakMessage]);
 
         [testProtocol.protocolDelegateTable addObject:delegateMock];
-        [testProtocol handleProtocolRegisterSecondaryTransportNAKMessage:nakMessage protocol:testProtocol];
+        [testProtocol protocol:testProtocol didReceiveRegisterSecondaryTransportNAK:nakMessage];
 
         OCMVerifyAllWithDelay(delegateMock, 0.1);
     });
@@ -660,10 +660,10 @@ describe(@"OnProtocolMessageReceived Tests", ^ {
         testMessage.header = testHeader;
 
         id delegateMock = OCMProtocolMock(@protocol(SDLProtocolDelegate));
-        OCMExpect([delegateMock onProtocolMessageReceived:[OCMArg any] protocol:testProtocol]);
+        OCMExpect([delegateMock protocol:testProtocol didReceiveMessage:[OCMArg any]]);
 
         [testProtocol.protocolDelegateTable addObject:delegateMock];
-        [testProtocol onProtocolMessageReceived:testMessage protocol:testProtocol];
+        [testProtocol protocol:testProtocol didReceiveMessage:testMessage];
     });
 
     it(@"Should pass information along to delegate", ^ {
@@ -681,7 +681,7 @@ describe(@"OnProtocolOpened Tests", ^ {
         testProtocol = [[SDLProtocol alloc] initWithTransport:transportMock encryptionManager:nil];
 
         id delegateMock = OCMProtocolMock(@protocol(SDLProtocolDelegate));
-        OCMExpect([delegateMock onProtocolOpened:testProtocol]);
+        OCMExpect([delegateMock protocolDidOpen:testProtocol]);
 
         [testProtocol.protocolDelegateTable addObject:delegateMock];
         [testProtocol onTransportConnected];
@@ -702,7 +702,7 @@ describe(@"OnProtocolClosed Tests", ^ {
         testProtocol = [[SDLProtocol alloc] initWithTransport:transportMock encryptionManager:nil];
 
         delegateMock = OCMProtocolMock(@protocol(SDLProtocolDelegate));
-        OCMExpect([delegateMock onProtocolClosed:testProtocol]);
+        OCMExpect([delegateMock protocolDidClose:testProtocol]);
 
         [testProtocol.protocolDelegateTable addObject:delegateMock];
         [testProtocol onTransportDisconnected];

--- a/SmartDeviceLinkTests/ProtocolSpecs/SDLProtocolReceivedMessageRouterSpec.m
+++ b/SmartDeviceLinkTests/ProtocolSpecs/SDLProtocolReceivedMessageRouterSpec.m
@@ -39,7 +39,6 @@ describe(@"HandleReceivedMessage Tests", ^{
             
             testHeader.frameType = SDLFrameTypeControl;
             testHeader.serviceType = SDLServiceTypeRPC;
-            testHeader.frameData = SDLFrameInfoStartServiceNACK;
             testHeader.sessionID = 0x93;
             testHeader.bytesInPayload = 0;
             testMessage.header = testHeader;

--- a/SmartDeviceLinkTests/SDLEncryptionLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/SDLEncryptionLifecycleManagerSpec.m
@@ -91,7 +91,7 @@ describe(@"the encryption lifecycle manager", ^{
                 testRPCHeader.serviceType = SDLServiceTypeRPC;
                 
                 testRPCMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testRPCHeader andPayload:nil];
-                [encryptionLifecycleManager handleProtocolStartServiceACKMessage:testRPCMessage protocol:protocolMock];
+                [encryptionLifecycleManager protocol:protocolMock didReceiveStartServiceACK:testRPCMessage];
             });
             
             it(@"should have set all the right properties", ^{
@@ -114,7 +114,7 @@ describe(@"the encryption lifecycle manager", ^{
                 testRPCHeader.serviceType = SDLServiceTypeRPC;
                 
                 testRPCMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testRPCHeader andPayload:nil];
-                [encryptionLifecycleManager handleProtocolEndServiceACKMessage:testRPCMessage protocol:protocolMock];
+                [encryptionLifecycleManager protocol:protocolMock didReceiveEndServiceACK:testRPCMessage];
             });
             
             it(@"should have set all the right properties", ^{
@@ -136,7 +136,7 @@ describe(@"the encryption lifecycle manager", ^{
                 testRPCHeader.serviceType = SDLServiceTypeRPC;
                 
                 testRPCMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testRPCHeader andPayload:nil];
-                [encryptionLifecycleManager handleProtocolEndServiceACKMessage:testRPCMessage protocol:protocolMock];
+                [encryptionLifecycleManager protocol:protocolMock didReceiveEndServiceACK:testRPCMessage];
             });
             
             it(@"should have set all the right properties", ^{
@@ -158,7 +158,7 @@ describe(@"the encryption lifecycle manager", ^{
                 testRPCHeader.serviceType = SDLServiceTypeRPC;
                 
                 testRPCMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testRPCHeader andPayload:nil];
-                [encryptionLifecycleManager handleProtocolEndServiceNAKMessage:testRPCMessage protocol:protocolMock];
+                [encryptionLifecycleManager protocol:protocolMock didReceiveEndServiceNAK:testRPCMessage];
             });
             
             it(@"should have set all the right properties", ^{

--- a/SmartDeviceLinkTests/SDLEncryptionLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/SDLEncryptionLifecycleManagerSpec.m
@@ -91,7 +91,7 @@ describe(@"the encryption lifecycle manager", ^{
                 testRPCHeader.serviceType = SDLServiceTypeRPC;
                 
                 testRPCMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testRPCHeader andPayload:nil];
-                [encryptionLifecycleManager handleProtocolStartServiceACKMessage:testRPCMessage];
+                [encryptionLifecycleManager handleProtocolStartServiceACKMessage:testRPCMessage protocol:protocolMock];
             });
             
             it(@"should have set all the right properties", ^{
@@ -114,7 +114,7 @@ describe(@"the encryption lifecycle manager", ^{
                 testRPCHeader.serviceType = SDLServiceTypeRPC;
                 
                 testRPCMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testRPCHeader andPayload:nil];
-                [encryptionLifecycleManager handleProtocolEndServiceACKMessage:testRPCMessage];
+                [encryptionLifecycleManager handleProtocolEndServiceACKMessage:testRPCMessage protocol:protocolMock];
             });
             
             it(@"should have set all the right properties", ^{
@@ -136,7 +136,7 @@ describe(@"the encryption lifecycle manager", ^{
                 testRPCHeader.serviceType = SDLServiceTypeRPC;
                 
                 testRPCMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testRPCHeader andPayload:nil];
-                [encryptionLifecycleManager handleProtocolEndServiceACKMessage:testRPCMessage];
+                [encryptionLifecycleManager handleProtocolEndServiceACKMessage:testRPCMessage protocol:protocolMock];
             });
             
             it(@"should have set all the right properties", ^{
@@ -158,7 +158,7 @@ describe(@"the encryption lifecycle manager", ^{
                 testRPCHeader.serviceType = SDLServiceTypeRPC;
                 
                 testRPCMessage = [[SDLV2ProtocolMessage alloc] initWithHeader:testRPCHeader andPayload:nil];
-                [encryptionLifecycleManager handleProtocolEndServiceNAKMessage:testRPCMessage];
+                [encryptionLifecycleManager handleProtocolEndServiceNAKMessage:testRPCMessage protocol:protocolMock];
             });
             
             it(@"should have set all the right properties", ^{


### PR DESCRIPTION
Fixes #1716, #1718 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Unit tests were added to the `SDLSecondaryTransportManagerSpec` and the `SDLProtocolReceivedMessageRouterSpec`

#### Core Tests
Tested against the SdlTcpApp_0_4_0 Fake TCP server and SYNC 3.0.

Core version / branch / commit hash / module tested against: SYNC 3.0.
HMI name / version / branch / commit hash / module tested against: SYNC 3.0.

### Summary
When the primary transport opens, the `SDLSecondaryTransportManager` is notified via the onProtocolOpened delegate method. Since the secondary transport has not yet been established, the `SDLSecondaryTransportManager` no longer starts a timer to watch for a response to the request to register the secondary transport.

### Changelog
##### Bug Fixes
* The `SDLSecondaryTransportManager` now only starts a timer to watch for a response to the request to register the secondary transport when the secondary transport has opened. 
* Fixed the protocol message router not routing the `EndServiceNAK` frame correctly.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
