### PR TITLE
Fix documentation on permission manager subscribe method callback parameters

### DIFF
--- a/SmartDeviceLink/SDLPermissionConstants.h
+++ b/SmartDeviceLink/SDLPermissionConstants.h
@@ -64,17 +64,17 @@ typedef NS_ENUM(NSUInteger, SDLPermissionGroupStatus) {
 /**
  *  This is a block that is passed in to some methods that will be stored and called when specified permissions change.
  *
- *  @param change A dictionary of permission changes containing <key(String): RPC Name, object(BOOL): YES if the RPC is allowed, NO if it is not allowed>
- *  @param status The unified group status of the RPCs in the change dictionary. Allowed, if all RPCs are now allowed, Disallowed if all RPCs are now disallowed, or Mixed if some are allowed, and some are disallowed
+ *  @param updatedPermissionStatuses A dictionary of the new current status of all subscription items containing <key(String): RPC Name, object(BOOL): YES if the RPC is allowed, NO if it is not allowed>
+ *  @param status The unified group status of the RPCs in the updatedPermissionStatuses dictionary. Allowed, if all RPCs are now allowed, Disallowed if all RPCs are now disallowed, or Mixed if some are allowed, and some are disallowed
  */
-typedef void (^SDLPermissionsChangedHandler)(NSDictionary<SDLPermissionRPCName, NSNumber *> *_Nonnull change, SDLPermissionGroupStatus status);
+typedef void (^SDLPermissionsChangedHandler)(NSDictionary<SDLPermissionRPCName, NSNumber *> *_Nonnull updatedPermissionStatuses, SDLPermissionGroupStatus status);
 
 /**
  *  A block that will be called when specified permissions change. It will return whether each RPC and its parameters are allowed as well as the permission group status of all the RPCs.
  *
- *  @param change A dictionary of permission changes containing <key(String): SDLPermissionRPCName, object(SDLRPCPermissionStatus)>
- *  @param status The change made to all of the RPCs in the change dictionary. Allowed, if all RPCs are now allowed, Disallowed if all RPCs are now disallowed, or Mixed if some are allowed, and some are disallowed
+ *  @param updatedPermissionStatuses A dictionary of permission changes containing <key(String): SDLPermissionRPCName, object(SDLRPCPermissionStatus)>
+ *  @param status The change made to all of the RPCs in the updatedPermissionStatuses dictionary. Allowed, if all RPCs are now allowed, Disallowed if all RPCs are now disallowed, or Mixed if some are allowed, and some are disallowed
  */
-typedef void (^SDLRPCPermissionStatusChangedHandler)(NSDictionary<SDLRPCFunctionName, SDLRPCPermissionStatus *> *_Nonnull change, SDLPermissionGroupStatus status);
+typedef void (^SDLRPCPermissionStatusChangedHandler)(NSDictionary<SDLRPCFunctionName, SDLRPCPermissionStatus *> *_Nonnull updatedPermissionStatuses, SDLPermissionGroupStatus status);
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLPermissionConstants.h
+++ b/SmartDeviceLink/SDLPermissionConstants.h
@@ -64,7 +64,7 @@ typedef NS_ENUM(NSUInteger, SDLPermissionGroupStatus) {
 /**
  *  This is a block that is passed in to some methods that will be stored and called when specified permissions change.
  *
- *  @param updatedPermissionStatuses A dictionary of the new current status of all subscription items containing <key(String): RPC Name, object(BOOL): YES if the RPC is allowed, NO if it is not allowed>
+ *  @param updatedPermissionStatuses A dictionary of the new current status of all subscription items; containing <key(String): RPC Name, object(BOOL): YES if the RPC is allowed, NO if it is not allowed>
  *  @param status The unified group status of the RPCs in the updatedPermissionStatuses dictionary. Allowed, if all RPCs are now allowed, Disallowed if all RPCs are now disallowed, or Mixed if some are allowed, and some are disallowed
  */
 typedef void (^SDLPermissionsChangedHandler)(NSDictionary<SDLPermissionRPCName, NSNumber *> *_Nonnull updatedPermissionStatuses, SDLPermissionGroupStatus status);
@@ -72,8 +72,8 @@ typedef void (^SDLPermissionsChangedHandler)(NSDictionary<SDLPermissionRPCName, 
 /**
  *  A block that will be called when specified permissions change. It will return whether each RPC and its parameters are allowed as well as the permission group status of all the RPCs.
  *
- *  @param updatedPermissionStatuses A dictionary of permission changes containing <key(String): SDLPermissionRPCName, object(SDLRPCPermissionStatus)>
- *  @param status The change made to all of the RPCs in the updatedPermissionStatuses dictionary. Allowed, if all RPCs are now allowed, Disallowed if all RPCs are now disallowed, or Mixed if some are allowed, and some are disallowed
+ *  @param updatedPermissionStatuses A dictionary of the new current status of all subscription items; containing <key(String): SDLPermissionRPCName, object(SDLRPCPermissionStatus)>
+ *  @param status The unified group status of the RPCs in the updatedPermissionStatuses dictionary. Allowed, if all RPCs are now allowed, Disallowed if all RPCs are now disallowed, or Mixed if some are allowed, and some are disallowed
  */
 typedef void (^SDLRPCPermissionStatusChangedHandler)(NSDictionary<SDLRPCFunctionName, SDLRPCPermissionStatus *> *_Nonnull updatedPermissionStatuses, SDLPermissionGroupStatus status);
 


### PR DESCRIPTION
Fixes #1724 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
No changes were made to actual code.

#### Core Tests
Tested subscribing a permission item

Core version / branch / commit hash / module tested against: Manticore (Core v6.1.1)
HMI name / version / branch / commit hash / module tested against: Manticore (Generic HMI v0.8.1)

### Summary
This PR updates the `SDLRPCPermissionStatusChangedHandler` and `SDLPermissionsChangedHandler` inline documentation to reflect how the code actually works as well as changes a default parameter name (this has no actual effect on the API) to better reflect what the parameter contains.

### Changelog
##### Bug Fixes
* Fixed documentation and parameter naming on `SDLPermissionsChangedHandler` and `SDLRPCPermissionStatusChangedHandler`.

### Tasks Remaining:
None

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
