### PR TITLE
Implement SDL-0202 - Supported Character Sets

### DIFF
--- a/SmartDeviceLink/SDLCharacterSet.h
+++ b/SmartDeviceLink/SDLCharacterSet.h
@@ -1,33 +1,101 @@
-//  SDLCharacterSet.h
-//
+/*
+* Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* Redistributions in binary form must reproduce the above copyright notice,
+* this list of conditions and the following
+* disclaimer in the documentation and/or other materials provided with the
+* distribution.
+*
+* Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+* its contributors may be used to endorse or promote products derived
+* from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
 
 
 #import "SDLEnum.h"
 
 /**
- * Character sets supported by SDL. Used to describe text field capabilities.
+ * The list of potential character sets
  *
- * @since SDL 1.0
+ * @since SDL 1.0.0
  */
 typedef SDLEnum SDLCharacterSet SDL_SWIFT_ENUM;
 
 /**
- Character Set Type 2
+ * @deprecated
+ * @since SDL 7.0.0
  */
-extern SDLCharacterSet const SDLCharacterSetType2;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+extern SDLCharacterSet const SDLCharacterSetType2 __deprecated_msg("Use Ascii, Iso88591, or Utf8 instead");
+#pragma clang diagnostic pop
 
 /**
- Character Set Type 5
+ * @deprecated
+ * @since SDL 7.0.0
  */
-extern SDLCharacterSet const SDLCharacterSetType5;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+extern SDLCharacterSet const SDLCharacterSetType5 __deprecated_msg("Use Ascii, Iso88591, or Utf8 instead");
+#pragma clang diagnostic pop
 
 /**
- Character Set CID1
+ * @deprecated
+ * @since SDL 7.0.0
  */
-extern SDLCharacterSet const SDLCharacterSetCID1;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+extern SDLCharacterSet const SDLCharacterSetCID1 __deprecated_msg("Use Ascii, Iso88591, or Utf8 instead");
+#pragma clang diagnostic pop
 
 /**
- Character Set CID2
+ * @deprecated
+ * @since SDL 7.0.0
  */
-extern SDLCharacterSet const SDLCharacterSetCID2;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+extern SDLCharacterSet const SDLCharacterSetCID2 __deprecated_msg("Use Ascii, Iso88591, or Utf8 instead");
+#pragma clang diagnostic pop
+
+/**
+ * ASCII as defined in https://en.wikipedia.org/wiki/ASCII as defined in codes 0-127. Non-printable characters such
+ * as tabs and back spaces are ignored.
+ *
+ * @since SDL 7.0.0
+ */
+extern SDLCharacterSet const SDLCharacterSetAscii;
+
+/**
+ * Latin-1, as defined in https://en.wikipedia.org/wiki/ISO/IEC_8859-1
+ *
+ * @since SDL 7.0.0
+ */
+extern SDLCharacterSet const SDLCharacterSetIso88591;
+
+/**
+ * The UTF-8 character set that uses variable bytes per code point. See https://en.wikipedia.org/wiki/UTF-8 for more
+ * details. This is the preferred character set.
+ *
+ * @since SDL 7.0.0
+ */
+extern SDLCharacterSet const SDLCharacterSetUtf8;
 

--- a/SmartDeviceLink/SDLCharacterSet.m
+++ b/SmartDeviceLink/SDLCharacterSet.m
@@ -1,10 +1,57 @@
-//  SDLCharacterSet.m
-//
-
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #import "SDLCharacterSet.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 SDLCharacterSet const SDLCharacterSetType2 = @"TYPE2SET";
+#pragma clang diagnostic pop
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 SDLCharacterSet const SDLCharacterSetType5 = @"TYPE5SET";
+#pragma clang diagnostic pop
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 SDLCharacterSet const SDLCharacterSetCID1 = @"CID1SET";
+#pragma clang diagnostic pop
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 SDLCharacterSet const SDLCharacterSetCID2 = @"CID2SET";
+#pragma clang diagnostic pop
+
+SDLCharacterSet const SDLCharacterSetAscii = @"ASCII";
+SDLCharacterSet const SDLCharacterSetIso88591 = @"ISO_8859_1";
+SDLCharacterSet const SDLCharacterSetUtf8 = @"UTF_8";

--- a/SmartDeviceLink/SDLTextField+ScreenManagerExtensions.m
+++ b/SmartDeviceLink/SDLTextField+ScreenManagerExtensions.m
@@ -17,7 +17,7 @@
 + (NSArray<SDLTextField *> *)allTextFields {
     NSMutableArray<SDLTextField *> *tempTextFields = [NSMutableArray array];
     for (SDLTextFieldName fieldName in [self sdl_allTextFieldNames]) {
-        [tempTextFields addObject:[[SDLTextField alloc] initWithName:fieldName characterSet:SDLCharacterSetCID1 width:500 rows:8]];
+        [tempTextFields addObject:[[SDLTextField alloc] initWithName:fieldName characterSet:SDLCharacterSetUtf8 width:500 rows:8]];
     }
 
     return tempTextFields;

--- a/SmartDeviceLink/SDLTextField.h
+++ b/SmartDeviceLink/SDLTextField.h
@@ -26,11 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic) SDLTextFieldName name;
 
 /**
- * The character set that is supported in this field.
- *
- * @see SDLCharacterSet
- *
- * Required
+ * The set of characters that are supported by this text field. All text is sent in UTF-8 format, but not all systems may support all of the characters expressed by UTF-8. All systems will support at least ASCII, but they may support more, either the LATIN-1 character set, or the full UTF-8 character set.
  */
 @property (strong, nonatomic) SDLCharacterSet characterSet;
 

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLChoiceSetManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLChoiceSetManagerSpec.m
@@ -95,7 +95,7 @@ describe(@"choice set manager tests", ^{
         testCell3 = [[SDLChoiceCell alloc] initWithText:@"test3"];
 
         enabledWindowCapability = [[SDLWindowCapability alloc] init];
-        enabledWindowCapability.textFields = @[[[SDLTextField alloc] initWithName:SDLTextFieldNameMenuName characterSet:SDLCharacterSetType5 width:500 rows:1]];
+        enabledWindowCapability.textFields = @[[[SDLTextField alloc] initWithName:SDLTextFieldNameMenuName characterSet:SDLCharacterSetUtf8 width:500 rows:1]];
         disabledWindowCapability = [[SDLWindowCapability alloc] init];
         disabledWindowCapability.textFields = @[];
         blankWindowCapability = [[SDLWindowCapability alloc] init];

--- a/SmartDeviceLinkTests/RPCSpecs/EnumSpecs/SDLCharacterSetSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/EnumSpecs/SDLCharacterSetSpec.m
@@ -14,10 +14,13 @@ QuickSpecBegin(SDLCharacterSetSpec)
 
 describe(@"Individual Enum Value Tests", ^ {
     it(@"Should match internal values", ^ {
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
         expect(SDLCharacterSetType2).to(equal(@"TYPE2SET"));
         expect(SDLCharacterSetType5).to(equal(@"TYPE5SET"));
         expect(SDLCharacterSetCID1).to(equal(@"CID1SET"));
         expect(SDLCharacterSetCID2).to(equal(@"CID2SET"));
+        #pragma clang diagnostic pop
         expect(SDLCharacterSetAscii).to(equal(@"ASCII"));
         expect(SDLCharacterSetIso88591).to(equal(@"ISO_8859_1"));
         expect(SDLCharacterSetUtf8).to(equal(@"UTF_8"));

--- a/SmartDeviceLinkTests/RPCSpecs/EnumSpecs/SDLCharacterSetSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/EnumSpecs/SDLCharacterSetSpec.m
@@ -18,6 +18,9 @@ describe(@"Individual Enum Value Tests", ^ {
         expect(SDLCharacterSetType5).to(equal(@"TYPE5SET"));
         expect(SDLCharacterSetCID1).to(equal(@"CID1SET"));
         expect(SDLCharacterSetCID2).to(equal(@"CID2SET"));
+        expect(SDLCharacterSetAscii).to(equal(@"ASCII"));
+        expect(SDLCharacterSetIso88591).to(equal(@"ISO_8859_1"));
+        expect(SDLCharacterSetUtf8).to(equal(@"UTF_8"));
     });
 });
 

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTextFieldSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTextFieldSpec.m
@@ -18,7 +18,7 @@ QuickSpecBegin(SDLTextFieldSpec)
 
 describe(@"Getter/Setter Tests", ^ {
     __block SDLTextFieldName testName = SDLTextFieldNameETA;
-    __block SDLCharacterSet testCharacterSet = SDLCharacterSetCID1;
+    __block SDLCharacterSet testCharacterSet = SDLCharacterSetUtf8;
     __block NSUInteger testWidth = 100;
     __block NSUInteger testRows = 4;
 

--- a/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
+++ b/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
@@ -104,7 +104,7 @@ describe(@"System capability manager", ^{
 #pragma clang diagnostic pop
         SDLTextField *textField = [[SDLTextField alloc] init];
         textField.name = SDLTextFieldNameMainField1;
-        textField.characterSet = SDLCharacterSetCID1;
+        textField.characterSet = SDLCharacterSetUtf8;
         textField.width = @(123);
         textField.rows = @(1);
         testDisplayCapabilities.textFields = @[textField];


### PR DESCRIPTION
Fixes #1139

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Unit tests for the affected class have been updated

#### Core Tests
Tested in-progress Generic_HMI that uses character set UTF_8.

Core version / branch / commit hash / module tested against: Core e630938b2b5a012d0c9f8cb9fa4f73a7e7d4a198
HMI name / version / branch / commit hash / module tested against: Generic_HMI 203cb9dbb39f72795721fccd29a2acb3f9c856af

### Summary
Implement [SDL-0202 - Supported Character Sets](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0202-character-sets.md) to use actual character sets with SDL.

### Changelog
##### Enhancements
* Implement [SDL-0202 - Supported Character Sets](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0202-character-sets.md) to use actual character sets with SDL (#1139).

### Tasks Remaining:
- [x] Test against Core branch

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
