### PR TITLE
Force response non-mandatory inits to use `self` not `super`

### DIFF
--- a/generator/templates/base_struct_function.m.jinja2
+++ b/generator/templates/base_struct_function.m.jinja2
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 {%- endif %}
 - (instancetype)initWith{{c.init}} {
-    self = [{{ 'self' if c.self else 'super' }} init{{ 'With' + c.self if c.self and c.self is string }}];
+    self = [self init{{ 'With' + c.self if c.self and c.self is string }}];
     if (!self) {
         return nil;
     }


### PR DESCRIPTION
Fixes #1734 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Unit tests were run

#### Core Tests
n/a - only the RPC generator

Core version / branch / commit hash / module tested against: n/a
HMI name / version / branch / commit hash / module tested against: n/a

### Summary
This PR fixes the RPC generator creating RPC responses calling `super init` if they have non-mandatory-parameter-only initializers instead of `self init`.

### Changelog
##### Bug Fixes
* Fix the RPC generator creating RPC responses with initializers that call `super init` instead of `self init`.

### Tasks Remaining:
n/a

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
