### PR TITLE
RPC Generator: Increase width of description columns from 113 chars to 2048 chars

### DIFF
--- a/generator/transformers/common_producer.py
+++ b/generator/transformers/common_producer.py
@@ -147,7 +147,7 @@ class InterfaceProducerCommon(ABC):
         return name[:1].lower() + name[1:]
 
     @staticmethod
-    def extract_description(data, length: int = 113) -> list:
+    def extract_description(data, length: int = 1024) -> list:
         """
         Evaluate, align and delete @TODO
         :param data: list with description

--- a/generator/transformers/common_producer.py
+++ b/generator/transformers/common_producer.py
@@ -147,7 +147,7 @@ class InterfaceProducerCommon(ABC):
         return name[:1].lower() + name[1:]
 
     @staticmethod
-    def extract_description(data, length: int = 1024) -> list:
+    def extract_description(data, length: int = 2048) -> list:
         """
         Evaluate, align and delete @TODO
         :param data: list with description


### PR DESCRIPTION
Fixes #1723 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [ ] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Unit tests were not run

#### Core Tests
This is an RPC generator only change

Core version / branch / commit hash / module tested against: n/a
HMI name / version / branch / commit hash / module tested against: n/a

### Summary
This PR updates comments that are generated by the RPC generator to wrap at 2048 characters instead of 113 characters.

### Changelog
##### Bug Fixes
* RPC spec generator now wraps lines at 2048 characters instead of 113 characters.

### Tasks Remaining:
None

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
