### PR TITLE
Consolidate running on a serial sub-queue to SDLGlobals

### DIFF
--- a/SmartDeviceLink/SDLGlobals.h
+++ b/SmartDeviceLink/SDLGlobals.h
@@ -43,6 +43,8 @@ extern void *const SDLConcurrentQueueName;
 - (void)setDynamicMTUSize:(NSUInteger)maxMTUSize forServiceType:(SDLServiceType)serviceType;
 - (NSUInteger)mtuSizeForServiceType:(SDLServiceType)serviceType;
 
++ (void)runSyncOnSerialSubQueue:(dispatch_queue_t)queue block:(void (^)(void))block;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLGlobals.h
+++ b/SmartDeviceLink/SDLGlobals.h
@@ -43,6 +43,9 @@ extern void *const SDLConcurrentQueueName;
 - (void)setDynamicMTUSize:(NSUInteger)maxMTUSize forServiceType:(SDLServiceType)serviceType;
 - (NSUInteger)mtuSizeForServiceType:(SDLServiceType)serviceType;
 
+/// Calls a block on an SDL sub-queue of the internal serial SDLProcessingQueue. If the call to this method is already on that queue, the block will be run, if it is not, a `dispatch_sync` will occur to that queue first.
+/// @param queue The queue to run on. The passed queue should be a sub-queue of the SDLProcessingQueue. If it is not and the call to this method occurs on the passed queue, a deadlock will occur because the check will not pass correctly.
+/// @param block The block to run on the serial sub-queue.
 + (void)runSyncOnSerialSubQueue:(dispatch_queue_t)queue block:(void (^)(void))block;
 
 @end

--- a/SmartDeviceLink/SDLGlobals.m
+++ b/SmartDeviceLink/SDLGlobals.m
@@ -71,6 +71,13 @@ typedef NSNumber *MTUBox;
     return self;
 }
 
++ (void)runSyncOnSerialSubQueue:(dispatch_queue_t)queue block:(void (^)(void))block {
+    if (dispatch_get_specific(SDLProcessingQueueName) != nil) {
+        block();
+    } else {
+        dispatch_sync(queue, block);
+    }
+}
 
 #pragma mark - Custom Getters / Setters
 

--- a/SmartDeviceLink/SDLResponseDispatcher.m
+++ b/SmartDeviceLink/SDLResponseDispatcher.m
@@ -162,7 +162,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     __block NSArray<SDLResponseHandler> *handlers = nil;
     __block NSArray<SDLRPCRequest *> *requests = nil;
-    [self sdl_runSyncOnQueue:^{
+    [SDLGlobals runSyncOnSerialSubQueue:self.readWriteQueue block:^{
         __strong typeof(weakself) strongself = weakself;
         NSMutableArray *handlerArray = [NSMutableArray array];
         NSMutableArray *requestArray = [NSMutableArray array];
@@ -236,7 +236,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     __block SDLResponseHandler handler = nil;
     __block SDLRPCRequest *request = nil;
-    [self sdl_runSyncOnQueue:^{
+    [SDLGlobals runSyncOnSerialSubQueue:self.readWriteQueue block:^{
         handler = self->_rpcResponseHandlerMap[response.correlationID];
         request = self->_rpcRequestDictionary[response.correlationID];
     }];
@@ -336,14 +336,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark Utilities
 
-- (void)sdl_runSyncOnQueue:(void (^)(void))block {
-    if (dispatch_get_specific(SDLProcessingQueueName) != nil) {
-        block();
-    } else {
-        dispatch_sync(self.readWriteQueue, block);
-    }
-}
-
 - (void)sdl_runAsyncOnQueue:(void (^)(void))block {
     if (dispatch_get_specific(SDLProcessingQueueName) != nil) {
         block();
@@ -356,7 +348,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSMapTable<SDLRPCCorrelationId *, SDLResponseHandler> *)rpcResponseHandlerMap {
     __block NSMapTable<SDLRPCCorrelationId *, SDLResponseHandler> *map = nil;
-    [self sdl_runSyncOnQueue:^{
+    [SDLGlobals runSyncOnSerialSubQueue:self.readWriteQueue block:^{
         map = self->_rpcResponseHandlerMap;
     }];
 
@@ -365,7 +357,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSMutableDictionary<SDLRPCCorrelationId *, SDLRPCRequest *> *)rpcRequestDictionary {
     __block NSMutableDictionary<SDLRPCCorrelationId *, SDLRPCRequest *> *dict = nil;
-    [self sdl_runSyncOnQueue:^{
+    [SDLGlobals runSyncOnSerialSubQueue:self.readWriteQueue block:^{
         dict = self->_rpcRequestDictionary;
     }];
 
@@ -374,7 +366,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSMapTable<SDLAddCommandCommandId *, SDLRPCCommandNotificationHandler> *)commandHandlerMap {
     __block NSMapTable<SDLAddCommandCommandId *, SDLRPCCommandNotificationHandler> *map = nil;
-    [self sdl_runSyncOnQueue:^{
+    [SDLGlobals runSyncOnSerialSubQueue:self.readWriteQueue block:^{
         map = self->_commandHandlerMap;
     }];
 
@@ -383,7 +375,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSMapTable<SDLSubscribeButtonName *, SDLRPCButtonNotificationHandler> *)buttonHandlerMap {
     __block NSMapTable<SDLSubscribeButtonName *, SDLRPCButtonNotificationHandler> *map = nil;
-    [self sdl_runSyncOnQueue:^{
+    [SDLGlobals runSyncOnSerialSubQueue:self.readWriteQueue block:^{
         map = self->_buttonHandlerMap;
     }];
 
@@ -392,7 +384,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSMapTable<SDLSoftButtonId *, SDLRPCButtonNotificationHandler> *)customButtonHandlerMap {
     __block NSMapTable<SDLSoftButtonId *, SDLRPCButtonNotificationHandler> *map = nil;
-    [self sdl_runSyncOnQueue:^{
+    [SDLGlobals runSyncOnSerialSubQueue:self.readWriteQueue block:^{
         map = self->_customButtonHandlerMap;
     }];
 
@@ -401,7 +393,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable SDLAudioPassThruHandler)audioPassThruHandler {
     __block SDLAudioPassThruHandler audioPassThruHandler = nil;
-    [self sdl_runSyncOnQueue:^{
+    [SDLGlobals runSyncOnSerialSubQueue:self.readWriteQueue block:^{
         audioPassThruHandler = self->_audioPassThruHandler;
     }];
 


### PR DESCRIPTION
Fixes #1614 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
No unit tests were necessary

#### Core Tests
Basic smoke tests were done to make sure everything is still working correctly (ran through the example app).

Core version / branch / commit hash / module tested against: Sync 3.4 19353_DEVTEST
HMI name / version / branch / commit hash / module tested against: ☝️ 

### Summary
This PR consolidates some logic for running SDL serial sub-queues sync.

### Changelog
##### Other
* Consolidate some logic spread out between classes.

### Tasks Remaining:
none

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
