### PR TITLE
Bugfix/issue 1745 simplify locking

### DIFF
--- a/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
+++ b/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
@@ -439,6 +439,10 @@
 		4A457DD924A5137100386CBA /* SDLLifecycleProtocolHandlerSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A457DD824A5137100386CBA /* SDLLifecycleProtocolHandlerSpec.m */; };
 		4A4AD8A424894260008FC414 /* TestOldConfigurationUpdateManagerDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A4AD8A324894260008FC414 /* TestOldConfigurationUpdateManagerDelegate.m */; };
 		4A4AD8A724894270008FC414 /* TestNewConfigurationUpdateManagerDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A4AD8A624894270008FC414 /* TestNewConfigurationUpdateManagerDelegate.m */; };
+		4A8F464824D9F581003BDAE4 /* SDLLockedMutableDictionary.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A8F464624D9F581003BDAE4 /* SDLLockedMutableDictionary.h */; };
+		4A8F464924D9F581003BDAE4 /* SDLLockedMutableDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A8F464724D9F581003BDAE4 /* SDLLockedMutableDictionary.m */; };
+		4A8F464C24DA0019003BDAE4 /* SDLLockedMutableArray.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A8F464A24DA0019003BDAE4 /* SDLLockedMutableArray.h */; };
+		4A8F464D24DA0019003BDAE4 /* SDLLockedMutableArray.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A8F464B24DA0019003BDAE4 /* SDLLockedMutableArray.m */; };
 		4A99D00E247576B7009B43E6 /* SDLTextField+ScreenManagerExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A99D00C247576B7009B43E6 /* SDLTextField+ScreenManagerExtensions.h */; };
 		4A99D00F247576B7009B43E6 /* SDLTextField+ScreenManagerExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A99D00D247576B7009B43E6 /* SDLTextField+ScreenManagerExtensions.m */; };
 		4A99D0122475773C009B43E6 /* SDLImageField+ScreenManagerExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A99D0102475773C009B43E6 /* SDLImageField+ScreenManagerExtensions.h */; };
@@ -2183,6 +2187,10 @@
 		4A4AD8A324894260008FC414 /* TestOldConfigurationUpdateManagerDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = TestOldConfigurationUpdateManagerDelegate.m; path = DevAPISpecs/TestOldConfigurationUpdateManagerDelegate.m; sourceTree = "<group>"; };
 		4A4AD8A524894270008FC414 /* TestNewConfigurationUpdateManagerDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestNewConfigurationUpdateManagerDelegate.h; sourceTree = "<group>"; };
 		4A4AD8A624894270008FC414 /* TestNewConfigurationUpdateManagerDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TestNewConfigurationUpdateManagerDelegate.m; sourceTree = "<group>"; };
+		4A8F464624D9F581003BDAE4 /* SDLLockedMutableDictionary.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDLLockedMutableDictionary.h; sourceTree = "<group>"; };
+		4A8F464724D9F581003BDAE4 /* SDLLockedMutableDictionary.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLLockedMutableDictionary.m; sourceTree = "<group>"; };
+		4A8F464A24DA0019003BDAE4 /* SDLLockedMutableArray.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDLLockedMutableArray.h; sourceTree = "<group>"; };
+		4A8F464B24DA0019003BDAE4 /* SDLLockedMutableArray.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLLockedMutableArray.m; sourceTree = "<group>"; };
 		4A99D00C247576B7009B43E6 /* SDLTextField+ScreenManagerExtensions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SDLTextField+ScreenManagerExtensions.h"; sourceTree = "<group>"; };
 		4A99D00D247576B7009B43E6 /* SDLTextField+ScreenManagerExtensions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "SDLTextField+ScreenManagerExtensions.m"; sourceTree = "<group>"; };
 		4A99D0102475773C009B43E6 /* SDLImageField+ScreenManagerExtensions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SDLImageField+ScreenManagerExtensions.h"; sourceTree = "<group>"; };
@@ -3554,7 +3562,7 @@
 			name = Encryption;
 			sourceTree = "<group>";
 		};
-		10415106241BBB8B00F163CC /* Lock Screen Icon Cache */ = {
+		10415106241BBB8B00F163CC /* Icon Cache */ = {
 			isa = PBXGroup;
 			children = (
 				10893C142417D78300BA347E /* SDLIconArchiveFile.h */,
@@ -3562,7 +3570,7 @@
 				10893C182418188600BA347E /* SDLCacheFileManager.h */,
 				10893C192418188600BA347E /* SDLCacheFileManager.m */,
 			);
-			name = "Lock Screen Icon Cache";
+			name = "Icon Cache";
 			sourceTree = "<group>";
 		};
 		109566F42429865500E24F66 /* Lock Screen Icon Cache */ = {
@@ -4103,6 +4111,28 @@
 			name = Utilities;
 			sourceTree = "<group>";
 		};
+		4A8F463E24D9EE6D003BDAE4 /* Names */ = {
+			isa = PBXGroup;
+			children = (
+				883C22C6222ED84D00939C4C /* SDLRPCFunctionNames.h */,
+				883C22C7222ED84D00939C4C /* SDLRPCFunctionNames.m */,
+				5D61FB0F1A84238A00846EE7 /* SDLRPCParameterNames.h */,
+				DA0C46AC1DCD35080001F2A8 /* SDLRPCParameterNames.m */,
+			);
+			name = Names;
+			sourceTree = "<group>";
+		};
+		4A8F463F24D9F39D003BDAE4 /* Locked Collections */ = {
+			isa = PBXGroup;
+			children = (
+				4A8F464624D9F581003BDAE4 /* SDLLockedMutableDictionary.h */,
+				4A8F464724D9F581003BDAE4 /* SDLLockedMutableDictionary.m */,
+				4A8F464A24DA0019003BDAE4 /* SDLLockedMutableArray.h */,
+				4A8F464B24DA0019003BDAE4 /* SDLLockedMutableArray.m */,
+			);
+			name = "Locked Collections";
+			sourceTree = "<group>";
+		};
 		4A9D02BB2497EEB400FBE99B /* Custom RPC Adapters */ = {
 			isa = PBXGroup;
 			children = (
@@ -4540,13 +4570,14 @@
 		5D5934EF1A85160F00687FB9 /* RPCs */ = {
 			isa = PBXGroup;
 			children = (
-				5D5934FF1A851B8400687FB9 /* Superclasses */,
+				5D5934F41A85165E00687FB9 /* Enums */,
+				4A8F463E24D9EE6D003BDAE4 /* Names */,
+				5D5934F81A8519C300687FB9 /* Notification */,
 				5D5935041A851E1A00687FB9 /* Payload */,
 				5D5934F11A85162800687FB9 /* Requests */,
 				5D5934F21A85163200687FB9 /* Responses */,
 				5D5934F31A85164500687FB9 /* Structs */,
-				5D5934F41A85165E00687FB9 /* Enums */,
-				5D5934F81A8519C300687FB9 /* Notification */,
+				5D5934FF1A851B8400687FB9 /* Superclasses */,
 			);
 			name = RPCs;
 			sourceTree = "<group>";
@@ -5289,24 +5320,18 @@
 		5D5934F61A85189500687FB9 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
-				8803DCED22C2B84B00FBB7CE /* SDLBackgroundTaskManager.h */,
-				8803DCEE22C2B84B00FBB7CE /* SDLBackgroundTaskManager.m */,
-				97E26DEA1E807AD70074A3C7 /* SDLMutableDataQueue.h */,
-				97E26DEB1E807AD70074A3C7 /* SDLMutableDataQueue.m */,
 				E9C32B831AB20B2900F283AF /* @categories */,
+				4A8F463F24D9F39D003BDAE4 /* Locked Collections */,
 				5D5934F91A851A8000687FB9 /* Prioritized Objects */,
 				5D535DC31B72473800CF7760 /* SDLGlobals.h */,
 				5D535DC41B72473800CF7760 /* SDLGlobals.m */,
 				5D61FAD21A84238A00846EE7 /* SDLHexUtility.h */,
 				5D61FAD31A84238A00846EE7 /* SDLHexUtility.m */,
-				883C22C6222ED84D00939C4C /* SDLRPCFunctionNames.h */,
-				883C22C7222ED84D00939C4C /* SDLRPCFunctionNames.m */,
-				5D61FB0F1A84238A00846EE7 /* SDLRPCParameterNames.h */,
-				DA0C46AC1DCD35080001F2A8 /* SDLRPCParameterNames.m */,
+				DA0C46AE1DCD41E30001F2A8 /* SDLMacros.h */,
 				E9C32B8E1AB20BA200F283AF /* SDLTimer.h */,
 				E9C32B8F1AB20BA200F283AF /* SDLTimer.m */,
-				DA0C46AE1DCD41E30001F2A8 /* SDLMacros.h */,
-				10415106241BBB8B00F163CC /* Lock Screen Icon Cache */,
+				5DD60D96221C5D7D00A82A4F /* SDLVersion.h */,
+				5DD60D97221C5D7D00A82A4F /* SDLVersion.m */,
 			);
 			name = Utilities;
 			sourceTree = "<group>";
@@ -5367,6 +5392,8 @@
 		5D5934F91A851A8000687FB9 /* Prioritized Objects */ = {
 			isa = PBXGroup;
 			children = (
+				97E26DEA1E807AD70074A3C7 /* SDLMutableDataQueue.h */,
+				97E26DEB1E807AD70074A3C7 /* SDLMutableDataQueue.m */,
 				5D61FB101A84238A00846EE7 /* SDLObjectWithPriority.h */,
 				5D61FB111A84238A00846EE7 /* SDLObjectWithPriority.m */,
 				5D61FB521A84238B00846EE7 /* SDLPrioritizedObjectCollection.h */,
@@ -5484,11 +5511,11 @@
 			isa = PBXGroup;
 			children = (
 				5DA3F3511BC4477B0026F2D0 /* Developer API */,
-				5D5934F61A85189500687FB9 /* Utilities */,
 				5D5934F51A8516C800687FB9 /* Logging */,
 				5D5934EF1A85160F00687FB9 /* RPCs */,
 				5D5934EE1A85160900687FB9 /* Protocol */,
 				5D5934F01A85161A00687FB9 /* Transport */,
+				5D5934F61A85189500687FB9 /* Utilities */,
 				5D61FA201A84237100846EE7 /* SmartDeviceLink.h */,
 				5D1665A01CF5D5DA00CC4CA1 /* .gitignore */,
 				5D1665A11CF5D5DA00CC4CA1 /* .travis.yml */,
@@ -5565,15 +5592,17 @@
 			name = Categories;
 			sourceTree = "<group>";
 		};
-		5D6F7A301BC5B7100070BF37 /* Lock Screen UI */ = {
+		5D6F7A301BC5B7100070BF37 /* UI */ = {
 			isa = PBXGroup;
 			children = (
 				5D6F7A3D1BC811FC0070BF37 /* SDLAssets.xcassets */,
 				5D616B481D552F7A00553F6B /* SDLLockScreen.storyboard */,
+				880723E923A2CFB4003D0489 /* SDLLockScreenRootViewController.h */,
+				880723EA23A2CFB4003D0489 /* SDLLockScreenRootViewController.m */,
 				5D6F7A331BC5B9B60070BF37 /* SDLLockScreenViewController.h */,
 				5D6F7A341BC5B9B60070BF37 /* SDLLockScreenViewController.m */,
 			);
-			name = "Lock Screen UI";
+			name = UI;
 			sourceTree = "<group>";
 		};
 		5D75960A22972F620013207C /* Utilities */ = {
@@ -5616,8 +5645,6 @@
 		5D76E31F1D39731100647CFA /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
-				880723E923A2CFB4003D0489 /* SDLLockScreenRootViewController.h */,
-				880723EA23A2CFB4003D0489 /* SDLLockScreenRootViewController.m */,
 				5D76E3201D39742300647CFA /* SDLViewControllerPresentable.h */,
 				5D76E3221D39767000647CFA /* SDLLockScreenPresenter.h */,
 				5D76E3231D39767000647CFA /* SDLLockScreenPresenter.m */,
@@ -5836,9 +5863,9 @@
 		5DA3F3511BC4477B0026F2D0 /* Developer API */ = {
 			isa = PBXGroup;
 			children = (
-				5DA3F3561BC4480E0026F2D0 /* Utilities */,
-				5DBAE0A61D355EF200CE00BF /* Managers */,
 				5DBAE0A71D355F0C00CE00BF /* Dispatchers */,
+				5DBAE0A61D355EF200CE00BF /* Managers */,
+				5DA3F3561BC4480E0026F2D0 /* Utilities */,
 			);
 			name = "Developer API";
 			sourceTree = "<group>";
@@ -5846,14 +5873,14 @@
 		5DA3F3561BC4480E0026F2D0 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
-				5DFFB9141BD7C89700DB3F04 /* SDLConnectionManagerType.h */,
-				EE6CBF872064CAEE00EEE0CA /* SDLStreamingProtocolDelegate.h */,
+				5DA3F3571BC448160026F2D0 /* Categories */,
 				5D616B501D59042B00553F6B /* Errors */,
 				5DA3F35C1BC4484B0026F2D0 /* Notifications */,
-				5DA3F3571BC448160026F2D0 /* Categories */,
 				5D6008871BE3ED470094A505 /* State Machine */,
-				5DD60D96221C5D7D00A82A4F /* SDLVersion.h */,
-				5DD60D97221C5D7D00A82A4F /* SDLVersion.m */,
+				8803DCED22C2B84B00FBB7CE /* SDLBackgroundTaskManager.h */,
+				8803DCEE22C2B84B00FBB7CE /* SDLBackgroundTaskManager.m */,
+				5DFFB9141BD7C89700DB3F04 /* SDLConnectionManagerType.h */,
+				EE6CBF872064CAEE00EEE0CA /* SDLStreamingProtocolDelegate.h */,
 			);
 			name = Utilities;
 			sourceTree = "<group>";
@@ -6099,8 +6126,9 @@
 			isa = PBXGroup;
 			children = (
 				5D0A7376203F0C8F0001595D /* Configuration */,
-				5D6F7A301BC5B7100070BF37 /* Lock Screen UI */,
+				10415106241BBB8B00F163CC /* Icon Cache */,
 				4A9D02C02497F9AA00FBE99B /* Status Manager */,
+				5D6F7A301BC5B7100070BF37 /* UI */,
 				5D76E31F1D39731100647CFA /* Utilities */,
 				5D4D67B21D30161600468B4A /* SDLLockScreenManager.h */,
 				5D4D67B31D30161600468B4A /* SDLLockScreenManager.m */,
@@ -6724,6 +6752,7 @@
 				9FE2470D22D77A5A00F8D2FC /* SDLDeleteWindowResponse.h in Headers */,
 				9FE2470922D77A3600F8D2FC /* SDLDeleteWindow.h in Headers */,
 				9FE2471122D77AA400F8D2FC /* SDLCreateWindowResponse.h in Headers */,
+				4A8F464C24DA0019003BDAE4 /* SDLLockedMutableArray.h in Headers */,
 				9FD334E022DC6E7500F62736 /* SDLCreateWindow.h in Headers */,
 				8BA12B1122DCCE1F00371E82 /* SDLUnpublishAppService.h in Headers */,
 				8BA12B1522DCEACB00371E82 /* SDLUnpublishAppServiceResponse.h in Headers */,
@@ -7251,6 +7280,7 @@
 				5D7F87EB1CE3C1A1002DD7C4 /* SDLDeleteFileOperation.h in Headers */,
 				5D61FCFC1A84238C00846EE7 /* SDLRPCParameterNames.h in Headers */,
 				DA9F7E8F1DCC04C000ACAE48 /* SDLUnsubscribeWayPointsResponse.h in Headers */,
+				4A8F464824D9F581003BDAE4 /* SDLLockedMutableDictionary.h in Headers */,
 				5D61FCFD1A84238C00846EE7 /* SDLObjectWithPriority.h in Headers */,
 				4A3BA4E1248EB133003E56B8 /* SDLLifecycleSyncPDataHandler.h in Headers */,
 				88EF8EBD22D8FE5800CB06C2 /* SDLCancelInteractionResponse.h in Headers */,
@@ -7401,7 +7431,7 @@
 					};
 					5D61FA1B1A84237100846EE7 = {
 						CreatedOnToolsVersion = 6.1.1;
-						LastSwiftMigration = 1150;
+						LastSwiftMigration = 1160;
 					};
 					5D61FA251A84237100846EE7 = {
 						CreatedOnToolsVersion = 6.1.1;
@@ -7614,6 +7644,7 @@
 				5D61FD261A84238C00846EE7 /* SDLPerformAudioPassThru.m in Sources */,
 				1EAA471E203410BB000FE74B /* SDLAudioControlCapabilities.m in Sources */,
 				88BCEA932266250B00BB7E70 /* SDLIAPControlSession.m in Sources */,
+				4A8F464924D9F581003BDAE4 /* SDLLockedMutableDictionary.m in Sources */,
 				5D61FC971A84238C00846EE7 /* SDLECallConfirmationStatus.m in Sources */,
 				8816772D222097C3001FACFF /* SDLNavigationServiceData.m in Sources */,
 				1E5AD04D1F1F79640029B8AF /* SDLDefrostZone.m in Sources */,
@@ -7784,6 +7815,7 @@
 				5DD8406320FCD6C10082CE04 /* SDLElectronicParkBrakeStatus.m in Sources */,
 				88EF8EB822D8E02E00CB06C2 /* SDLCancelInteraction.m in Sources */,
 				8BBEA6071F324165003EEA26 /* SDLMetadataType.m in Sources */,
+				4A8F464D24DA0019003BDAE4 /* SDLLockedMutableArray.m in Sources */,
 				5DA150C82271FDC20032928D /* SDLSoftButtonTransitionOperation.m in Sources */,
 				9FE2471222D77AA400F8D2FC /* SDLCreateWindowResponse.m in Sources */,
 				5D61FDBC1A84238C00846EE7 /* SDLSystemAction.m in Sources */,

--- a/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
+++ b/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
@@ -443,6 +443,8 @@
 		4A8F464924D9F581003BDAE4 /* SDLLockedMutableDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A8F464724D9F581003BDAE4 /* SDLLockedMutableDictionary.m */; };
 		4A8F464C24DA0019003BDAE4 /* SDLLockedMutableArray.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A8F464A24DA0019003BDAE4 /* SDLLockedMutableArray.h */; };
 		4A8F464D24DA0019003BDAE4 /* SDLLockedMutableArray.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A8F464B24DA0019003BDAE4 /* SDLLockedMutableArray.m */; };
+		4A8F465124DB37CC003BDAE4 /* SDLLockedMutableDictionarySpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A8F465024DB37CC003BDAE4 /* SDLLockedMutableDictionarySpec.m */; };
+		4A8F465324DB439A003BDAE4 /* SDLLockedMutableArraySpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A8F465224DB439A003BDAE4 /* SDLLockedMutableArraySpec.m */; };
 		4A99D00E247576B7009B43E6 /* SDLTextField+ScreenManagerExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A99D00C247576B7009B43E6 /* SDLTextField+ScreenManagerExtensions.h */; };
 		4A99D00F247576B7009B43E6 /* SDLTextField+ScreenManagerExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A99D00D247576B7009B43E6 /* SDLTextField+ScreenManagerExtensions.m */; };
 		4A99D0122475773C009B43E6 /* SDLImageField+ScreenManagerExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A99D0102475773C009B43E6 /* SDLImageField+ScreenManagerExtensions.h */; };
@@ -2191,6 +2193,8 @@
 		4A8F464724D9F581003BDAE4 /* SDLLockedMutableDictionary.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLLockedMutableDictionary.m; sourceTree = "<group>"; };
 		4A8F464A24DA0019003BDAE4 /* SDLLockedMutableArray.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDLLockedMutableArray.h; sourceTree = "<group>"; };
 		4A8F464B24DA0019003BDAE4 /* SDLLockedMutableArray.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLLockedMutableArray.m; sourceTree = "<group>"; };
+		4A8F465024DB37CC003BDAE4 /* SDLLockedMutableDictionarySpec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLLockedMutableDictionarySpec.m; sourceTree = "<group>"; };
+		4A8F465224DB439A003BDAE4 /* SDLLockedMutableArraySpec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLLockedMutableArraySpec.m; sourceTree = "<group>"; };
 		4A99D00C247576B7009B43E6 /* SDLTextField+ScreenManagerExtensions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SDLTextField+ScreenManagerExtensions.h"; sourceTree = "<group>"; };
 		4A99D00D247576B7009B43E6 /* SDLTextField+ScreenManagerExtensions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "SDLTextField+ScreenManagerExtensions.m"; sourceTree = "<group>"; };
 		4A99D0102475773C009B43E6 /* SDLImageField+ScreenManagerExtensions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SDLImageField+ScreenManagerExtensions.h"; sourceTree = "<group>"; };
@@ -4133,6 +4137,24 @@
 			name = "Locked Collections";
 			sourceTree = "<group>";
 		};
+		4A8F464E24DB3737003BDAE4 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				5D61FAD21A84238A00846EE7 /* SDLHexUtility.h */,
+				5D61FAD31A84238A00846EE7 /* SDLHexUtility.m */,
+			);
+			name = Utilities;
+			sourceTree = "<group>";
+		};
+		4A8F464F24DB379F003BDAE4 /* Locked Collections */ = {
+			isa = PBXGroup;
+			children = (
+				4A8F465024DB37CC003BDAE4 /* SDLLockedMutableDictionarySpec.m */,
+				4A8F465224DB439A003BDAE4 /* SDLLockedMutableArraySpec.m */,
+			);
+			name = "Locked Collections";
+			sourceTree = "<group>";
+		};
 		4A9D02BB2497EEB400FBE99B /* Custom RPC Adapters */ = {
 			isa = PBXGroup;
 			children = (
@@ -5301,8 +5323,9 @@
 		5D5934F51A8516C800687FB9 /* Logging */ = {
 			isa = PBXGroup;
 			children = (
-				5DD67CC01E68AE66009CD394 /* Modules */,
 				5DBF063D1E64BDAE00A5CF03 /* Log Targets */,
+				5DD67CC01E68AE66009CD394 /* Modules */,
+				4A8F464E24DB3737003BDAE4 /* Utilities */,
 				5DBF06211E64A83F00A5CF03 /* SDLLogManager.h */,
 				5DBF06221E64A83F00A5CF03 /* SDLLogManager.m */,
 				5DBF062B1E64A93A00A5CF03 /* SDLLogFilter.h */,
@@ -5325,8 +5348,6 @@
 				5D5934F91A851A8000687FB9 /* Prioritized Objects */,
 				5D535DC31B72473800CF7760 /* SDLGlobals.h */,
 				5D535DC41B72473800CF7760 /* SDLGlobals.m */,
-				5D61FAD21A84238A00846EE7 /* SDLHexUtility.h */,
-				5D61FAD31A84238A00846EE7 /* SDLHexUtility.m */,
 				DA0C46AE1DCD41E30001F2A8 /* SDLMacros.h */,
 				E9C32B8E1AB20BA200F283AF /* SDLTimer.h */,
 				E9C32B8F1AB20BA200F283AF /* SDLTimer.m */,
@@ -6085,8 +6106,9 @@
 			isa = PBXGroup;
 			children = (
 				5DEE55BE1B8509A5004F0D0F /* HTTP Connection */,
-				5DB92D2B1AC4A32A00C15BB0 /* Prioritized Objects */,
 				109566F42429865500E24F66 /* Lock Screen Icon Cache */,
+				4A8F464F24DB379F003BDAE4 /* Locked Collections */,
+				5DB92D2B1AC4A32A00C15BB0 /* Prioritized Objects */,
 				5DB92D231AC47B2C00C15BB0 /* SDLHexUtilitySpec.m */,
 				5DC978251B7A38640012C2F1 /* SDLGlobalsSpec.m */,
 			);
@@ -8371,6 +8393,7 @@
 				1EAA47582035AFD9000FE74B /* SDLHMISettingsControlDataSpec.m in Sources */,
 				162E83161A9BDE8B00906325 /* SDLOnHashChangeSpec.m in Sources */,
 				8886EB982111F4FA008294A5 /* SDLFileManagerConfigurationSpec.m in Sources */,
+				4A8F465324DB439A003BDAE4 /* SDLLockedMutableArraySpec.m in Sources */,
 				162E82FE1A9BDE8B00906325 /* SDLTBTStateSpec.m in Sources */,
 				5D5DBF0B1D48E5E600D4F914 /* SDLLockScreenViewControllerSnapshotTests.m in Sources */,
 				5DB1BCD41D243A8E002FFC37 /* SDLListFilesOperationSpec.m in Sources */,
@@ -8565,6 +8588,7 @@
 				162E82CF1A9BDE8A00906325 /* SDLBitsPerSampleSpec.m in Sources */,
 				883581B022D659BE00405C42 /* SDLCloseApplicationResponseSpec.m in Sources */,
 				162E831E1A9BDE8B00906325 /* SDLOnTBTClientStateSpec.m in Sources */,
+				4A8F465124DB37CC003BDAE4 /* SDLLockedMutableDictionarySpec.m in Sources */,
 				162E83351A9BDE8B00906325 /* SDLReadDIDSpec.m in Sources */,
 				5DF40B28208FDA9700DD6FDA /* SDLVoiceCommandManagerSpec.m in Sources */,
 				88B3BFA020DA8FD000943565 /* SDLFuelTypeSpec.m in Sources */,

--- a/SmartDeviceLink/SDLLockedDictionary.m
+++ b/SmartDeviceLink/SDLLockedDictionary.m
@@ -1,0 +1,32 @@
+//
+//  SDLLockedDictionary.m
+//  SmartDeviceLink
+//
+//  Created by Joel Fischer on 8/4/20.
+//  Copyright © 2020 smartdevicelink. All rights reserved.
+//
+
+#import "SDLLockedMutableDictionary.h"
+
+@interface SDLLockedMutableDictionary ()
+
+@property (strong, nonatomic) NSDictionary *internalDict;
+
+@end
+
+@implementation SDLLockedMutableDictionary
+
+- (instancetype)init {
+    self = [super init];
+    if (!self) { return nil; }
+
+    _internalDict = [[NSDictionary alloc] init];
+
+    return self;
+}
+
+- (void)setObject:(ObjectType)object forKey:(KeyType <NSCopying>)key {
+
+}
+
+@end

--- a/SmartDeviceLink/SDLLockedMutableArray.h
+++ b/SmartDeviceLink/SDLLockedMutableArray.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Create a new locked mutable array with a given dispatch queue. All calls will be reader/writer locked on the queue so that only one operation will occur at a time.
 ///
 /// @param queue The queue to use. It can be either a serial or concurrent queue.
-- (instancetype)initWithSerialQueue:(dispatch_queue_t)queue;
+- (instancetype)initWithQueue:(dispatch_queue_t)queue;
 
 #pragma mark - Removing
 /// Empties the array of its entries.

--- a/SmartDeviceLink/SDLLockedMutableArray.h
+++ b/SmartDeviceLink/SDLLockedMutableArray.h
@@ -15,14 +15,50 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Initializers
 - (instancetype)init NS_UNAVAILABLE;
 
+/// Create a new locked mutable array with a given dispatch queue. All calls will be reader/writer locked on the queue so that only one operation will occur at a time.
+///
+/// @param queue The queue to use. It can be either a serial or concurrent queue.
 - (instancetype)initWithSerialQueue:(dispatch_queue_t)queue;
 
 #pragma mark - Removing
+/// Empties the array of its entries.
+///
+/// This will occur asynchronously and may return before the operation completes.
 - (void)removeAllObjects;
+
+/// Removes the object at `index`.
+///
+/// To fill the gap, all elements beyond index are moved by subtracting 1 from their index.
+///
+/// This will occur asynchronously and may return before the operation completes.
+/// @param index The index from which to remove the object in the array. The value must not exceed the bounds of the array.
 - (void)removeObjectAtIndex:(NSUInteger)index;
 
 #pragma mark - Getting / Setting
+
+#pragma mark Retrieving information
+
+/// The number of objects in the array.
+///
+/// This will occur synchronously and will not return until the operation completes.
+/// @return The number of objects in the array
+- (NSUInteger)count;
+
+#pragma mark Adding Objects
+/// Inserts a given object at the end of the array.
+///
+/// This will occur asynchronously and may return before the operation completes.
+/// @param object The object to add to the end of the array’s content. This value must not be nil.
 - (void)addObject:(ObjectType)object;
+
+/// Inserts a given object into the array’s contents at a given index.
+///
+/// If index is already occupied, the objects at index and beyond are shifted by adding 1 to their indices to make room.
+/// Note that NSArray objects are not like C arrays. That is, even though you specify a size when you create an array, the specified size is regarded as a “hint”; the actual size of the array is still 0. This means that you cannot insert an object at an index greater than the current count of an array. For example, if an array contains two objects, its size is 2, so you can add objects at indices 0, 1, or 2. Index 3 is illegal and out of bounds; if you try to add an object at index 3 (when the size of the array is 2), NSMutableArray raises an exception.
+///
+/// This will occur asynchronously and may return before the operation completes.
+/// @param anObject The object to add to the array's content. This value must not be nil.
+/// @param index The index in the array at which to insert anObject. This value must not be greater than the count of elements in the array.
 - (void)insertObject:(ObjectType)anObject atIndex:(NSUInteger)index;
 
 #pragma mark Subscripting

--- a/SmartDeviceLink/SDLLockedMutableArray.h
+++ b/SmartDeviceLink/SDLLockedMutableArray.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithSerialQueue:(dispatch_queue_t)queue;
 
 #pragma mark - Removing
-- (void)removeLastObject;
+- (void)removeAllObjects;
 - (void)removeObjectAtIndex:(NSUInteger)index;
 
 #pragma mark - Getting / Setting

--- a/SmartDeviceLink/SDLLockedMutableArray.h
+++ b/SmartDeviceLink/SDLLockedMutableArray.h
@@ -14,21 +14,20 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Initializers
 - (instancetype)init NS_UNAVAILABLE;
+
 - (instancetype)initWithSerialQueue:(dispatch_queue_t)queue;
 
 #pragma mark - Removing
-- (void)removeObjectForKey:(KeyType<NSCopying>)key;
-- (void)removeAllObjects;
+- (void)removeLastObject;
+- (void)removeObjectAtIndex:(NSUInteger)index;
 
 #pragma mark - Getting / Setting
 - (void)addObject:(ObjectType)object;
 - (void)insertObject:(ObjectType)anObject atIndex:(NSUInteger)index;
-- (void)removeLastObject;
-- (void)removeObjectAtIndex:(NSUInteger)index;
 
 #pragma mark Subscripting
-- (void)setObject:(ObjectType)object atIndexedSubscript:(KeyType<NSCopying>)key;
-- (ObjectType)objectAtIndexedSubscript:(KeyType<NSCopying>)key;
+- (void)setObject:(ObjectType)object atIndexedSubscript:(NSUInteger)idx;
+- (ObjectType)objectAtIndexedSubscript:(NSUInteger)idx;
 
 @end
 

--- a/SmartDeviceLink/SDLLockedMutableArray.h
+++ b/SmartDeviceLink/SDLLockedMutableArray.h
@@ -1,0 +1,35 @@
+//
+//  SDLLockedMutableArray.h
+//  SmartDeviceLink
+//
+//  Created by Joel Fischer on 8/4/20.
+//  Copyright © 2020 smartdevicelink. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SDLLockedMutableArray<ObjectType> : NSObject
+
+#pragma mark - Initializers
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithSerialQueue:(dispatch_queue_t)queue;
+
+#pragma mark - Removing
+- (void)removeObjectForKey:(KeyType<NSCopying>)key;
+- (void)removeAllObjects;
+
+#pragma mark - Getting / Setting
+- (void)addObject:(ObjectType)object;
+- (void)insertObject:(ObjectType)anObject atIndex:(NSUInteger)index;
+- (void)removeLastObject;
+- (void)removeObjectAtIndex:(NSUInteger)index;
+
+#pragma mark Subscripting
+- (void)setObject:(ObjectType)object atIndexedSubscript:(KeyType<NSCopying>)key;
+- (ObjectType)objectAtIndexedSubscript:(KeyType<NSCopying>)key;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLLockedMutableArray.m
+++ b/SmartDeviceLink/SDLLockedMutableArray.m
@@ -8,6 +8,93 @@
 
 #import "SDLLockedMutableArray.h"
 
+@interface SDLLockedMutableArray ()
+
+@property (assign, nonatomic) dispatch_queue_t internalQueue;
+@property (assign, nonatomic) const char *internalQueueID;
+
+@property (strong, nonatomic) NSMutableArray *internalArray;
+
+@end
+
 @implementation SDLLockedMutableArray
+
+- (instancetype)initWithSerialQueue:(dispatch_queue_t)queue {
+    self = [super init];
+    if (!self) { return nil; }
+
+    _internalQueue = queue;
+    _internalQueueID = [[NSUUID alloc] init].UUIDString.UTF8String;
+    dispatch_queue_set_specific(_internalQueue, _internalQueueID, (void *)_internalQueueID, NULL);
+
+    _internalArray = [[NSMutableArray alloc] init];
+
+    return self;
+}
+
+#pragma mark - Removing
+- (void)removeAllObjects {
+    __weak typeof(self) weakSelf = self;
+    [self sdl_runAsyncWithBlock:^{
+        [weakSelf.internalArray removeAllObjects];
+    }];
+}
+
+- (void)removeObjectAtIndex:(NSUInteger)index {
+    __weak typeof(self) weakSelf = self;
+    [self sdl_runAsyncWithBlock:^{
+        [weakSelf.internalArray removeObjectAtIndex:index];
+    }];
+}
+
+#pragma mark - Getting / Setting
+- (void)addObject:(id)object {
+    __weak typeof(self) weakSelf = self;
+    [self sdl_runAsyncWithBlock:^{
+        [weakSelf addObject:object];
+    }];
+}
+
+- (void)insertObject:(id)anObject atIndex:(NSUInteger)index {
+    __weak typeof(self) weakSelf = self;
+    [self sdl_runAsyncWithBlock:^{
+        [weakSelf insertObject:anObject atIndex:index];
+    }];
+}
+
+#pragma mark Subscripting
+- (id)objectAtIndexedSubscript:(NSUInteger)idx {
+    __block id retVal = nil;
+    [self sdl_runSyncWithBlock:^{
+        retVal = self.internalArray[idx];
+    }];
+
+    return retVal;
+}
+
+- (void)setObject:(id)object atIndexedSubscript:(NSUInteger)idx {
+    __weak typeof(self) weakSelf = self;
+    [self sdl_runAsyncWithBlock:^{
+        weakSelf[idx] = object;
+    }];
+}
+
+
+# pragma mark - Utilities
+- (void)sdl_runSyncWithBlock:(void (^)(void))block {
+    if (dispatch_get_specific(_internalQueueID) != NULL) {
+        block();
+    } else {
+        dispatch_sync(_internalQueue, block);
+    }
+}
+
+- (void)sdl_runAsyncWithBlock:(void (^)(void))block {
+    if (dispatch_get_specific(_internalQueueID) != NULL) {
+        block();
+    } else {
+        dispatch_barrier_async(_internalQueue, block);
+    }
+}
 
 @end

--- a/SmartDeviceLink/SDLLockedMutableArray.m
+++ b/SmartDeviceLink/SDLLockedMutableArray.m
@@ -1,0 +1,13 @@
+//
+//  SDLLockedMutableArray.m
+//  SmartDeviceLink
+//
+//  Created by Joel Fischer on 8/4/20.
+//  Copyright © 2020 smartdevicelink. All rights reserved.
+//
+
+#import "SDLLockedMutableArray.h"
+
+@implementation SDLLockedMutableArray
+
+@end

--- a/SmartDeviceLink/SDLLockedMutableArray.m
+++ b/SmartDeviceLink/SDLLockedMutableArray.m
@@ -19,6 +19,7 @@
 
 @implementation SDLLockedMutableArray
 
+#pragma mark - Initializers
 - (instancetype)initWithSerialQueue:(dispatch_queue_t)queue {
     self = [super init];
     if (!self) { return nil; }
@@ -48,6 +49,18 @@
 }
 
 #pragma mark - Getting / Setting
+
+#pragma mark Retrieving information
+- (NSUInteger)count {
+    __block NSUInteger retVal = 0;
+    [self sdl_runSyncWithBlock:^{
+        retVal = self.internalArray.count;
+    }];
+
+    return retVal;
+}
+
+#pragma mark Adding Objects
 - (void)addObject:(id)object {
     __weak typeof(self) weakSelf = self;
     [self sdl_runAsyncWithBlock:^{

--- a/SmartDeviceLink/SDLLockedMutableArray.m
+++ b/SmartDeviceLink/SDLLockedMutableArray.m
@@ -20,7 +20,7 @@
 @implementation SDLLockedMutableArray
 
 #pragma mark - Initializers
-- (instancetype)initWithSerialQueue:(dispatch_queue_t)queue {
+- (instancetype)initWithQueue:(dispatch_queue_t)queue {
     self = [super init];
     if (!self) { return nil; }
 
@@ -64,14 +64,14 @@
 - (void)addObject:(id)object {
     __weak typeof(self) weakSelf = self;
     [self sdl_runAsyncWithBlock:^{
-        [weakSelf addObject:object];
+        [weakSelf.internalArray addObject:object];
     }];
 }
 
 - (void)insertObject:(id)anObject atIndex:(NSUInteger)index {
     __weak typeof(self) weakSelf = self;
     [self sdl_runAsyncWithBlock:^{
-        [weakSelf insertObject:anObject atIndex:index];
+        [weakSelf.internalArray insertObject:anObject atIndex:index];
     }];
 }
 
@@ -88,7 +88,7 @@
 - (void)setObject:(id)object atIndexedSubscript:(NSUInteger)idx {
     __weak typeof(self) weakSelf = self;
     [self sdl_runAsyncWithBlock:^{
-        weakSelf[idx] = object;
+        weakSelf.internalArray[idx] = object;
     }];
 }
 

--- a/SmartDeviceLink/SDLLockedMutableDictionary.h
+++ b/SmartDeviceLink/SDLLockedMutableDictionary.h
@@ -16,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init NS_UNAVAILABLE;
 
 /// Create a new locked mutable dictionary with a given dispatch queue. All calls will be reader/writer locked on the queue so that only one operation will occur at a time.
+/// If the 
 /// @param queue The queue to use. It can be either a serial or concurrent queue.
 - (instancetype)initWithQueue:(dispatch_queue_t)queue;
 
@@ -24,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Removes a given key and its associated value from the dictionary.
 ///
-/// This will occur asynchronously and will return before the operation completes.
+/// This will occur asynchronously and may return before the operation completes.
 /// @param key The key to search for and remove the associated object. Does nothing if key does not exist.
 - (void)removeObjectForKey:(KeyType<NSCopying>)key;
 
@@ -44,7 +45,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (ObjectType)objectForKey:(KeyType<NSCopying>)key;
 
 /// Adds a given key-value pair to the dictionary.
-/// 
+///
+/// This will occur asynchronously and may return before the operation completes.
 /// @param object The value for aKey. A strong reference to the object is maintained by the dictionary.
 /// @param key The key for value. The key is copied (using copyWithZone:; keys must conform to the NSCopying protocol). If aKey already exists in the dictionary, anObject takes its place.
 - (void)setObject:(ObjectType)object forKey:(KeyType<NSCopying>)key;

--- a/SmartDeviceLink/SDLLockedMutableDictionary.h
+++ b/SmartDeviceLink/SDLLockedMutableDictionary.h
@@ -52,8 +52,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setObject:(ObjectType)object forKey:(KeyType<NSCopying>)key;
 
 #pragma mark Subscripting
-- (void)setObject:(ObjectType)object atIndexedSubscript:(KeyType<NSCopying>)key;
-- (ObjectType)objectAtIndexedSubscript:(KeyType<NSCopying>)key;
+- (void)setObject:(nullable ObjectType)object forKeyedSubscript:(KeyType<NSCopying>)key;
+- (nullable ObjectType)objectForKeyedSubscript:(KeyType<NSCopying>)key;
+
+/// The number of objects in the dictionary.
+///
+/// This will occur synchronously and will not return until the operation completes.
+/// @return The number of objects in the dictionary.
+- (NSUInteger)count;
 
 @end
 

--- a/SmartDeviceLink/SDLLockedMutableDictionary.h
+++ b/SmartDeviceLink/SDLLockedMutableDictionary.h
@@ -1,0 +1,33 @@
+//
+//  SDLLockedDictionary.h
+//  SmartDeviceLink
+//
+//  Created by Joel Fischer on 8/4/20.
+//  Copyright © 2020 smartdevicelink. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SDLLockedMutableDictionary<KeyType, ObjectType> : NSObject
+
+#pragma mark - Initializers
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithSerialQueue:(dispatch_queue_t)queue;
+
+#pragma mark - Removing
+- (void)removeObjectForKey:(KeyType<NSCopying>)key;
+- (void)removeAllObjects;
+
+#pragma mark - Getting / Setting
+- (ObjectType)objectForKey:(KeyType<NSCopying>)key;
+- (void)setObject:(ObjectType)object forKey:(KeyType<NSCopying>)key;
+
+#pragma mark Subscripting
+- (void)setObject:(ObjectType)object atIndexedSubscript:(KeyType<NSCopying>)key;
+- (ObjectType)objectAtIndexedSubscript:(KeyType<NSCopying>)key;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/SDLLockedMutableDictionary.h
+++ b/SmartDeviceLink/SDLLockedMutableDictionary.h
@@ -14,14 +14,39 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Initializers
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithSerialQueue:(dispatch_queue_t)queue;
+
+/// Create a new locked mutable dictionary with a given dispatch queue. All calls will be reader/writer locked on the queue so that only one operation will occur at a time.
+/// @param queue The queue to use. It can be either a serial or concurrent queue.
+- (instancetype)initWithQueue:(dispatch_queue_t)queue;
+
 
 #pragma mark - Removing
+
+/// Removes a given key and its associated value from the dictionary.
+///
+/// This will occur asynchronously and will return before the operation completes.
+/// @param key The key to search for and remove the associated object. Does nothing if key does not exist.
 - (void)removeObjectForKey:(KeyType<NSCopying>)key;
+
+/// Empties the dictionary of its entries.
+///
+/// This will occur asynchronously and will return before the operation completes.
 - (void)removeAllObjects;
 
+
 #pragma mark - Getting / Setting
+
+/// Returns the value associated with a given key.
+///
+/// This will occur synchronously and will not return until the operation completes.
+/// @param key The key for which to return the corresponding value.
+/// @return The value associated with aKey, or nil if no value is associated with aKey.
 - (ObjectType)objectForKey:(KeyType<NSCopying>)key;
+
+/// Adds a given key-value pair to the dictionary.
+/// 
+/// @param object The value for aKey. A strong reference to the object is maintained by the dictionary.
+/// @param key The key for value. The key is copied (using copyWithZone:; keys must conform to the NSCopying protocol). If aKey already exists in the dictionary, anObject takes its place.
 - (void)setObject:(ObjectType)object forKey:(KeyType<NSCopying>)key;
 
 #pragma mark Subscripting

--- a/SmartDeviceLink/SDLLockedMutableDictionary.h
+++ b/SmartDeviceLink/SDLLockedMutableDictionary.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init NS_UNAVAILABLE;
 
 /// Create a new locked mutable dictionary with a given dispatch queue. All calls will be reader/writer locked on the queue so that only one operation will occur at a time.
-/// If the 
+///
 /// @param queue The queue to use. It can be either a serial or concurrent queue.
 - (instancetype)initWithQueue:(dispatch_queue_t)queue;
 

--- a/SmartDeviceLink/SDLLockedMutableDictionary.m
+++ b/SmartDeviceLink/SDLLockedMutableDictionary.m
@@ -11,6 +11,8 @@
 @interface SDLLockedMutableDictionary ()
 
 @property (assign, nonatomic) dispatch_queue_t internalQueue;
+@property (assign, nonatomic) const char *internalQueueID;
+
 @property (strong, nonatomic) NSMutableDictionary *internalDict;
 
 @end
@@ -22,6 +24,9 @@
     if (!self) { return nil; }
 
     _internalQueue = queue;
+    _internalQueueID = [[NSUUID alloc] init].UUIDString.UTF8String;
+    dispatch_queue_set_specific(_internalQueue, _internalQueueID, (void *)_internalQueueID, NULL);
+
     _internalDict = [[NSMutableDictionary alloc] init];
 
     return self;
@@ -30,33 +35,33 @@
 #pragma mark - Removing
 - (void)removeAllObjects {
     __weak typeof(self) weakSelf = self;
-    dispatch_barrier_async(_internalQueue, ^{
+    [self sdl_runAsyncWithBlock:^{
         [weakSelf.internalDict removeAllObjects];
-    });
+    }];
 }
 
 - (void)removeObjectForKey:(id<NSCopying>)key {
     __weak typeof(self) weakSelf = self;
-    dispatch_barrier_async(_internalQueue, ^{
+    [self sdl_runAsyncWithBlock:^{
         [weakSelf.internalDict removeObjectForKey:key];
-    });
+    }];
 }
 
 #pragma mark - Getting / Setting
 - (id)objectForKey:(id<NSCopying>)key {
     __block id retVal = nil;
-    dispatch_sync(_internalQueue, ^{
-        retVal = [_internalDict objectForKey:key];
-    });
+    [self sdl_runSyncWithBlock:^{
+        retVal = [self.internalDict objectForKey:key];
+    }];
 
     return retVal;
 }
 
 - (void)setObject:(id)object forKey:(id<NSCopying>)key {
     __weak typeof(self) weakSelf = self;
-    dispatch_barrier_async(_internalQueue, ^{
+    [self sdl_runAsyncWithBlock:^{
         [weakSelf.internalDict setObject:object forKey:key];
-    });
+    }];
 }
 
 #pragma mark Subscripting
@@ -66,6 +71,24 @@
 
 - (void)setObject:(id)object atIndexedSubscript:(id<NSCopying>)key {
     [self setObject:object forKey:key];
+}
+
+
+# pragma mark - Utilities
+- (void)sdl_runSyncWithBlock:(void (^)(void))block {
+    if (dispatch_get_specific(_internalQueueID) != NULL) {
+        block();
+    } else {
+        dispatch_sync(_internalQueue, block);
+    }
+}
+
+- (void)sdl_runAsyncWithBlock:(void (^)(void))block {
+    if (dispatch_get_specific(_internalQueueID) != NULL) {
+        block();
+    } else {
+        dispatch_barrier_async(_internalQueue, block);
+    }
 }
 
 @end

--- a/SmartDeviceLink/SDLLockedMutableDictionary.m
+++ b/SmartDeviceLink/SDLLockedMutableDictionary.m
@@ -65,12 +65,31 @@
 }
 
 #pragma mark Subscripting
-- (id)objectAtIndexedSubscript:(id<NSCopying>)key {
-    return [self objectForKey:key];
+- (id)objectForKeyedSubscript:(id<NSCopying>)key {
+    __block id retVal = nil;
+    [self sdl_runSyncWithBlock:^{
+        retVal = self.internalDict[key];
+    }];
+
+    return retVal;
 }
 
-- (void)setObject:(id)object atIndexedSubscript:(id<NSCopying>)key {
-    [self setObject:object forKey:key];
+- (void)setObject:(id)object forKeyedSubscript:(id<NSCopying>)key {
+    __weak typeof(self) weakSelf = self;
+    [self sdl_runAsyncWithBlock:^{
+        weakSelf.internalDict[key] = object;
+    }];
+}
+
+#pragma mark Retrieving Information
+
+- (NSUInteger)count {
+    __block NSUInteger retVal = 0;
+    [self sdl_runSyncWithBlock:^{
+        retVal = self.internalDict.count;
+    }];
+
+    return retVal;
 }
 
 

--- a/SmartDeviceLink/SDLLockedMutableDictionary.m
+++ b/SmartDeviceLink/SDLLockedMutableDictionary.m
@@ -17,7 +17,7 @@
 
 @implementation SDLLockedMutableDictionary
 
-- (instancetype)initWithSerialQueue:(dispatch_queue_t)queue {
+- (instancetype)initWithQueue:(dispatch_queue_t)queue {
     self = [super init];
     if (!self) { return nil; }
 
@@ -30,14 +30,14 @@
 #pragma mark - Removing
 - (void)removeAllObjects {
     __weak typeof(self) weakSelf = self;
-    dispatch_async(_internalQueue, ^{
+    dispatch_barrier_async(_internalQueue, ^{
         [weakSelf.internalDict removeAllObjects];
     });
 }
 
 - (void)removeObjectForKey:(id<NSCopying>)key {
     __weak typeof(self) weakSelf = self;
-    dispatch_async(_internalQueue, ^{
+    dispatch_barrier_async(_internalQueue, ^{
         [weakSelf.internalDict removeObjectForKey:key];
     });
 }
@@ -46,7 +46,7 @@
 - (id)objectForKey:(id<NSCopying>)key {
     __block id retVal = nil;
     dispatch_sync(_internalQueue, ^{
-        retVal = _internalDict[key];
+        retVal = [_internalDict objectForKey:key];
     });
 
     return retVal;
@@ -54,8 +54,8 @@
 
 - (void)setObject:(id)object forKey:(id<NSCopying>)key {
     __weak typeof(self) weakSelf = self;
-    dispatch_async(_internalQueue, ^{
-        weakSelf.internalDict[key] = object;
+    dispatch_barrier_async(_internalQueue, ^{
+        [weakSelf.internalDict setObject:object forKey:key];
     });
 }
 

--- a/SmartDeviceLink/SDLLockedMutableDictionary.m
+++ b/SmartDeviceLink/SDLLockedMutableDictionary.m
@@ -1,0 +1,71 @@
+//
+//  SDLLockedDictionary.m
+//  SmartDeviceLink
+//
+//  Created by Joel Fischer on 8/4/20.
+//  Copyright © 2020 smartdevicelink. All rights reserved.
+//
+
+#import "SDLLockedMutableDictionary.h"
+
+@interface SDLLockedMutableDictionary ()
+
+@property (assign, nonatomic) dispatch_queue_t internalQueue;
+@property (strong, nonatomic) NSMutableDictionary *internalDict;
+
+@end
+
+@implementation SDLLockedMutableDictionary
+
+- (instancetype)initWithSerialQueue:(dispatch_queue_t)queue {
+    self = [super init];
+    if (!self) { return nil; }
+
+    _internalQueue = queue;
+    _internalDict = [[NSMutableDictionary alloc] init];
+
+    return self;
+}
+
+#pragma mark - Removing
+- (void)removeAllObjects {
+    __weak typeof(self) weakSelf = self;
+    dispatch_async(_internalQueue, ^{
+        [weakSelf.internalDict removeAllObjects];
+    });
+}
+
+- (void)removeObjectForKey:(id<NSCopying>)key {
+    __weak typeof(self) weakSelf = self;
+    dispatch_async(_internalQueue, ^{
+        [weakSelf.internalDict removeObjectForKey:key];
+    });
+}
+
+#pragma mark - Getting / Setting
+- (id)objectForKey:(id<NSCopying>)key {
+    __block id retVal = nil;
+    dispatch_sync(_internalQueue, ^{
+        retVal = _internalDict[key];
+    });
+
+    return retVal;
+}
+
+- (void)setObject:(id)object forKey:(id<NSCopying>)key {
+    __weak typeof(self) weakSelf = self;
+    dispatch_async(_internalQueue, ^{
+        weakSelf.internalDict[key] = object;
+    });
+}
+
+#pragma mark Subscripting
+- (id)objectAtIndexedSubscript:(id<NSCopying>)key {
+    return [self objectForKey:key];
+}
+
+- (void)setObject:(id)object atIndexedSubscript:(id<NSCopying>)key {
+    [self setObject:object forKey:key];
+}
+
+@end

--- a/SmartDeviceLinkTests/SDLLockedMutableArraySpec.m
+++ b/SmartDeviceLinkTests/SDLLockedMutableArraySpec.m
@@ -1,0 +1,73 @@
+//
+//  SDLLockedMutableArraySpec.m
+//  SmartDeviceLinkTests
+//
+//  Created by Joel Fischer on 8/5/20.
+//  Copyright © 2020 smartdevicelink. All rights reserved.
+//
+
+#import <Quick/Quick.h>
+#import <Nimble/Nimble.h>
+
+#import "SDLLockedMutableArray.h"
+
+QuickSpecBegin(SDLLockedMutableArraySpec)
+
+describe(@"a locked dictionary", ^{
+    __block dispatch_queue_t testQueue = NULL;
+    __block SDLLockedMutableArray *testArray = nil;
+
+    __block NSString *objectString = @"testObj";
+
+    beforeEach(^{
+        testQueue = dispatch_queue_create("com.testqueue", DISPATCH_QUEUE_SERIAL);
+        testArray = [[SDLLockedMutableArray alloc] initWithQueue:testQueue];
+    });
+
+    context(@"on a different queue", ^{
+        it(@"should add, retrieve, and remove an object repeatedly", ^{
+            for(int i = 0; i < 5000; i++) {
+                [testArray addObject:objectString];
+                (void)testArray[0];
+                [testArray removeObjectAtIndex:0];
+                expect(testArray.count).to(equal(0));
+            }
+        });
+
+        it(@"should remove all objects properly", ^{
+            for(int i = 0; i < 5000; i++) {
+                [testArray addObject:objectString];
+            }
+
+            expect(testArray.count).to(equal(5000));
+            [testArray removeAllObjects];
+            expect(testArray.count).to(equal(0));
+        });
+
+        it(@"should insert objects at the front properly", ^{
+            for(int i = 0; i < 5000; i++) {
+                [testArray insertObject:@(i) atIndex:0];
+            }
+
+            expect(testArray.count).to(equal(5000));
+            expect(testArray[4999]).to(equal(@0));
+            expect(testArray[0]).to(equal(@4999));
+        });
+    });
+
+    context(@"on the same queue", ^{
+        it(@"should add, retrieve, and remove an object repeatedly", ^{
+            dispatch_sync(testQueue, ^{
+                for(int i = 0; i < 5000; i++) {
+                    [testArray addObject:objectString];
+                    (void)testArray[0];
+                    [testArray removeObjectAtIndex:0];
+                    expect(testArray.count).to(equal(0));
+                }
+            });
+        });
+    });
+});
+
+QuickSpecEnd
+

--- a/SmartDeviceLinkTests/SDLLockedMutableDictionarySpec.m
+++ b/SmartDeviceLinkTests/SDLLockedMutableDictionarySpec.m
@@ -1,0 +1,93 @@
+//
+//  SDLLockedMutableDictionarySpec.m
+//  SmartDeviceLinkTests
+//
+//  Created by Joel Fischer on 8/5/20.
+//  Copyright © 2020 smartdevicelink. All rights reserved.
+//
+
+#import <Quick/Quick.h>
+#import <Nimble/Nimble.h>
+
+#import "SDLLockedMutableDictionary.h"
+
+QuickSpecBegin(SDLLockedMutableDictionarySpec)
+
+describe(@"a locked dictionary", ^{
+    __block dispatch_queue_t testQueue = NULL;
+    __block SDLLockedMutableDictionary *testDict = nil;
+
+    __block NSString *objectString = @"testObj";
+    __block NSString *keyString = @"testKey";
+
+    beforeEach(^{
+        testQueue = dispatch_queue_create("com.testqueue", DISPATCH_QUEUE_SERIAL);
+        testDict = [[SDLLockedMutableDictionary alloc] initWithQueue:testQueue];
+    });
+
+    context(@"on a different queue", ^{
+        context(@"not using subscripting", ^{
+            it(@"should set, get, and remove a key-value pair repeatedly", ^{
+                for(int i = 0; i < 5000; i++) {
+                    [testDict setObject:objectString forKey:keyString];
+                    [testDict objectForKey:keyString];
+                    [testDict removeObjectForKey:keyString];
+
+                    expect(testDict.count).to(equal(0));
+                }
+            });
+        });
+        context(@"using subscripting", ^{
+            it(@"should set, get, and remove a key-value pair repeatedly", ^{
+                for(int i = 0; i < 5000; i++) {
+                    testDict[keyString] = objectString;
+                    (void)testDict[keyString];
+                    testDict[keyString] = nil;
+
+                    expect(testDict.count).to(equal(0));
+                }
+            });
+        });
+
+        it(@"should remove all objects properly", ^{
+            for(int i = 0; i < 5000; i++) {
+                [testDict setObject:@(i) forKey:@(i)];
+            }
+
+            expect(testDict.count).to(equal(5000));
+            [testDict removeAllObjects];
+            expect(testDict.count).to(equal(0));
+        });
+    });
+
+    context(@"on the same queue", ^{
+        context(@"not using subscripting", ^{
+            it(@"should set, get, and remove a key-value pair repeatedly", ^{
+                dispatch_sync(testQueue, ^{
+                    for(int i = 0; i < 5000; i++) {
+                        [testDict setObject:objectString forKey:keyString];
+                        [testDict objectForKey:keyString];
+                        [testDict removeObjectForKey:keyString];
+
+                        expect(testDict.count).to(equal(0));
+                    }
+                });
+            });
+        });
+        context(@"using subscripting", ^{
+            it(@"should set, get, and remove a key-value pair repeatedly", ^{
+                dispatch_sync(testQueue, ^{
+                    for(int i = 0; i < 5000; i++) {
+                        testDict[keyString] = objectString;
+                        (void)testDict[keyString];
+                        testDict[keyString] = nil;
+
+                        expect(testDict.count).to(equal(0));
+                    }
+                });
+            });
+        });
+    });
+});
+
+QuickSpecEnd


### PR DESCRIPTION
Fixes #1745 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [ ] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [ ] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Unit tests were added for the new classes.

#### Core Tests
[List of tests performed against Core and behaviors verified]

Core version / branch / commit hash / module tested against: [INSERT]
HMI name / version / branch / commit hash / module tested against: [INSERT]

### Summary
This PR adds a new mutable dictionary class and mutable array class that provide thread-safety around accesses by using a queue passed to the class. This is intended to simplify locks around dictionaries and arrays in the SDL project by unifying them into one testable class.

### Changelog
##### Other
* Simplify locking around "hot" mutable dictionaries and arrays by providing thread-safe versions.

### Tasks Remaining:
- [ ] Replace existing locked dictionaries and arrays with the new versions.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
