### PR TITLE
Generate documentation for an array using the RPC spec generator

### DIFF
--- a/generator/transformers/common_producer.py
+++ b/generator/transformers/common_producer.py
@@ -346,21 +346,20 @@ class InterfaceProducerCommon(ABC):
 
     def create_param_descriptor(self, param_type, parameterItems):
         """
-        Recursively creates a documentation string of all the descriptors for a parameter (i.e. {"string_min_length": 1, string_min_length": 500}). The parameters should be returned in the same order they were added to the parameterItems dictionary
+        Recursively creates a documentation string of all the descriptors for a parameter (e.g. {"string_min_length": 1, string_max_length": 500}). The parameters should be returned in the same order they were added to the parameterItems dictionary
         :param param_type: param_type from the initial Model
         :param parameterItems: Ordered dictionary that stores each of the parameter's descriptors
         :return: All the descriptor params from param_type concatenated into one string
         """
-        # The key is a descriptor (i.e. `max_size`) and value is the associated value (i.e. 100). Some values will be dictionaries that have to be parsed to get additional descriptors (e.g. the value for an array of strings' data type will be sub-dictionary describing the min_length, max_length, and default value for the strings used in the array)
+        # The key is a descriptor (i.e. max_value) and value is the associated value (i.e. 100). Some values will be dictionaries that have to be parsed to get additional descriptors (e.g. the value for an array of strings' data type will be sub-dictionary describing the min_length, max_length, and default value for the strings used in the array)
         for key, value in param_type.__dict__.items():
-            # If a value contains a dictionary, recurse until all the descriptors have been found
+            # If a value contains a dictionary, recurse until all the descriptors have been found. Once a descriptor (i.e. `max_size`) has been found along with its associated value (i.e. 100), add the descriptor/value pair to the parameterItems dictionary
             if hasattr(value, '__dict__'):
                 if isinstance(value, Enum) or isinstance(value, Struct):
                     # Skip adding documentation for the data type if it is a struct or enum. This is unnecessary as each enum or struct has its own documentation
                     continue
                 else:
                     self.create_param_descriptor(value, parameterItems)
-            # A descriptor (i.e. `max_size`) has been found along with its associated value (i.e. 100). Add the pair to the parameterItems dictionary
             else:
                 if key == 'default_value' and value is None:
                     # Do not add the default_value key/value pair unless it has been explicitly set in the RPC Spec

--- a/generator/transformers/common_producer.py
+++ b/generator/transformers/common_producer.py
@@ -346,18 +346,21 @@ class InterfaceProducerCommon(ABC):
 
     def create_param_descriptor(self, param_type, parameterItems):
         """
-        Recursively creates a documentation string of all the descriptors for a parameter. The parameters should be returned in the same order they were added to the parameterItems dictionary
+        Recursively creates a documentation string of all the descriptors for a parameter (i.e. {"string_min_length": 1, string_min_length": 500}). The parameters should be returned in the same order they were added to the parameterItems dictionary
         :param param_type: param_type from the initial Model
         :param parameterItems: Ordered dictionary that stores each of the parameter's descriptors
         :return: All the descriptor params from param_type concatenated into one string
         """
+        # The key is a descriptor (i.e. `max_size`) and value is the associated value (i.e. 100). Some values will be dictionaries that have to be parsed to get additional descriptors (e.g. the value for an array of strings' data type will be sub-dictionary describing the min_length, max_length, and default value for the strings used in the array)
         for key, value in param_type.__dict__.items():
+            # If a value contains a dictionary, recurse until all the descriptors have been found
             if hasattr(value, '__dict__'):
                 if isinstance(value, Enum) or isinstance(value, Struct):
-                    # Skip adding documentation for the data type if it is a struct or enum. This is unnecessary as each enum/struct has its own documentation.
+                    # Skip adding documentation for the data type if it is a struct or enum. This is unnecessary as each enum or struct has its own documentation
                     continue
                 else:
                     self.create_param_descriptor(value, parameterItems)
+            # A descriptor (i.e. `max_size`) has been found along with its associated value (i.e. 100). Add the pair to the parameterItems dictionary
             else:
                 if key == 'default_value' and value is None:
                     # Do not add the default_value key/value pair unless it has been explicitly set in the RPC Spec

--- a/generator/transformers/common_producer.py
+++ b/generator/transformers/common_producer.py
@@ -337,9 +337,7 @@ class InterfaceProducerCommon(ABC):
                 'mandatory': param.is_mandatory,
                 'deprecated': json.loads(param.deprecated.lower()) if param.deprecated else False,
                 'modifier': 'strong'}
-        if isinstance(param.param_type, (Integer, Float, String)):
-            data['description'].append(json.dumps(vars(param.param_type), sort_keys=True))
-        if isinstance(param.param_type, (Array)):
+        if isinstance(param.param_type, (Integer, Float, String, Array)):
             data['description'].append(self.extract_struct_param(param.param_type, {}))
 
         data.update(self.extract_type(param))

--- a/generator/transformers/common_producer.py
+++ b/generator/transformers/common_producer.py
@@ -353,13 +353,13 @@ class InterfaceProducerCommon(ABC):
         for key, value in param_type.__dict__.items():
             if hasattr(value, '__dict__'):
                 if isinstance(value, Enum) or isinstance(value, Struct):
-                    # Skip adding documentation for the array's data type if it is a struct or enum
+                    # Skip adding documentation for the data type if it is a struct or enum. This is unnecessary as each enum/struct has its own documentation.
                     continue
                 else:
                     self.create_param_descriptor(value, parameterItems)
             else:
                 if key == 'default_value' and value is None:
-                    # Do not add the default_value for the array unless it has been explicitly set in the RPC Spec
+                    # Do not add the default_value key/value pair unless it has been explicitly set in the RPC Spec
                     continue
                 else:
                     parameterDescriptor = self.update_param_descriptor(key)
@@ -369,7 +369,7 @@ class InterfaceProducerCommon(ABC):
 
     def update_param_descriptor(self, parameterName):
         """
-        Updates the parameter's descriptor name for clarity. This is helpful for arrays as the descriptors can contain both the size of the array and the size of the array's data type. 
+        Updates the parameter's descriptor name for clarity. This is helpful for array documentation as the descriptors can contain both the size of the array and the size of the array's data type.
         :param parameterName: The name of the parameter
         :return: All the descriptor params from param_type concatenated into one string
         """

--- a/generator/transformers/common_producer.py
+++ b/generator/transformers/common_producer.py
@@ -338,7 +338,7 @@ class InterfaceProducerCommon(ABC):
                 'deprecated': json.loads(param.deprecated.lower()) if param.deprecated else False,
                 'modifier': 'strong'}
         if isinstance(param.param_type, (Integer, Float, String, Array)):
-            data['description'].append(self.create_param_descriptor(param.param_type, {}))
+            data['description'].append(self.create_param_descriptor(param.param_type, OrderedDict()))
 
         data.update(self.extract_type(param))
         data.update(self.param_origin_change(param.name))
@@ -365,7 +365,7 @@ class InterfaceProducerCommon(ABC):
                     parameterDescriptor = self.update_param_descriptor(key)
                     parameterItems[parameterDescriptor] = value
 
-        return json.dumps(parameterItems, sort_keys=True)
+        return json.dumps(parameterItems, sort_keys=False)
 
     def update_param_descriptor(self, parameterName):
         """

--- a/generator/transformers/common_producer.py
+++ b/generator/transformers/common_producer.py
@@ -346,8 +346,9 @@ class InterfaceProducerCommon(ABC):
 
     def create_param_descriptor(self, param_type, parameterItems):
         """
-        Recursively creates a documentation string of all the descriptors for a parameter.
+        Recursively creates a documentation string of all the descriptors for a parameter. The parameters should be returned in the same order they were added to the parameterItems dictionary
         :param param_type: param_type from the initial Model
+        :param parameterItems: Ordered dictionary that stores each of the parameter's descriptors
         :return: All the descriptor params from param_type concatenated into one string
         """
         for key, value in param_type.__dict__.items():
@@ -369,7 +370,7 @@ class InterfaceProducerCommon(ABC):
 
     def update_param_descriptor(self, parameterName):
         """
-        Updates the parameter's descriptor name for clarity. This is helpful for array documentation as the descriptors can contain both the size of the array and the size of the array's data type.
+        Updates the parameter's descriptor name for clarity. This is helpful for array documentation as the descriptors can contain both the size of the array and the size of the array's data type
         :param parameterName: The name of the parameter
         :return: All the descriptor params from param_type concatenated into one string
         """


### PR DESCRIPTION
Fixes #1736

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Unit tests were run.

#### Core Tests
The library was not modified. Only the RPC Spec generator was modified. 

Core version / branch / commit hash / module tested against: N/A
HMI name / version / branch / commit hash / module tested against: N/A

### Summary
* The RPC spec generator now creates documentation for an array
* If the default value for a parameter was not set in the RPC Spec via `defvalue`, then it is now omitted from the generated documentation.
* Updated some of descriptors used in the parameters' documentation (i.e. changed **max_length** to **string_ max_length**) for clarity.

### Changelog
##### Bug Fixes
* The RPC spec generator now creates documentation for an array 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
