### PR TITLE
Removed deprecated parameters from inits created by the RPC spec generator

### DIFF
--- a/generator/transformers/common_producer.py
+++ b/generator/transformers/common_producer.py
@@ -199,10 +199,6 @@ class InterfaceProducerCommon(ABC):
         arguments = [self.argument_named(origin=first.origin, constructor_argument=self.parentheses(first),
                                          variable=first.constructor_argument, deprecated=first.deprecated)]
         for param in data:
-            if param.deprecated:
-                # Omit deprecated parameters from the constructors
-                continue
-
             arguments.append(self.argument_named(origin=param.origin, constructor_argument=self.parentheses(param),
                                                  variable=param.constructor_argument, deprecated=param.deprecated))
             init.append('{}:({}{}){}'.format(self.minimize_first(param.constructor_prefix),
@@ -220,6 +216,9 @@ class InterfaceProducerCommon(ABC):
         mandatory = []
         not_mandatory = []
         for param in data.values():
+            if param.deprecated:
+                # Omit deprecated parameters from the constructors
+                continue
             if param.mandatory:
                 mandatory.append(param)
             else:


### PR DESCRIPTION
Fixes #1722

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Unit tests were run.

#### Core Tests
The library was not modified. Only the RPC spec generator was modified.

Core version / branch / commit hash / module tested against: N/A
HMI name / version / branch / commit hash / module tested against: N/A

### Summary
* If a parameter is deprecated it is no longer included in the generated inits for a struct or class. 
* Since the deprecated parameters are not longer included in the generated inits, the generated inits are no longer wrapped with push/pop pragmas to suppress deprecated warnings.

### Changelog
##### Bug Fixes
* The RPC spec generator now omits deprecated parameters from the class and struct inits.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
