### PR TITLE
RPC spec generator no longer cut text after @TODO

### DIFF
--- a/generator/transformers/common_producer.py
+++ b/generator/transformers/common_producer.py
@@ -337,7 +337,7 @@ class InterfaceProducerCommon(ABC):
                 'mandatory': param.is_mandatory,
                 'deprecated': json.loads(param.deprecated.lower()) if param.deprecated else False,
                 'modifier': 'strong'}
-        if isinstance(param.param_type, (Integer, Float, String, Array, Boolean)):
+        if isinstance(param.param_type, (Integer, Float, String, Array)):
             data['description'].append(self.create_param_descriptor(param.param_type, OrderedDict()))
 
         data.update(self.extract_type(param))

--- a/generator/transformers/common_producer.py
+++ b/generator/transformers/common_producer.py
@@ -156,9 +156,10 @@ class InterfaceProducerCommon(ABC):
         """
         if not data:
             return []
-        if isinstance(data, list):
-            data = ' '.join(data)
-        return textwrap.wrap(re.sub(r'(\s{2,}|\n|\[@TODO.+)', ' ', data).strip(), length)
+#        if isinstance(data, list):
+#            data = ' '.join(data)
+#        return textwrap.wrap(re.sub(r'(\s{2,}|\n|\[@TODO.+)', ' ', data).strip(), length)
+        return data
 
     @staticmethod
     def nullable(type_native: str, mandatory: bool) -> str:

--- a/generator/transformers/common_producer.py
+++ b/generator/transformers/common_producer.py
@@ -156,9 +156,6 @@ class InterfaceProducerCommon(ABC):
         """
         if not data:
             return []
-#        if isinstance(data, list):
-#            data = ' '.join(data)
-#        return textwrap.wrap(re.sub(r'(\s{2,}|\n|\[@TODO.+)', ' ', data).strip(), length)
         return data
 
     @staticmethod

--- a/generator/transformers/common_producer.py
+++ b/generator/transformers/common_producer.py
@@ -156,7 +156,9 @@ class InterfaceProducerCommon(ABC):
         """
         if not data:
             return []
-        return data
+        if isinstance(data, list):
+            data = ' '.join(data)
+        return textwrap.wrap(re.sub(r'(\s{2,}|\n)', ' ', data).strip(), length)
 
     @staticmethod
     def nullable(type_native: str, mandatory: bool) -> str:
@@ -335,7 +337,7 @@ class InterfaceProducerCommon(ABC):
                 'mandatory': param.is_mandatory,
                 'deprecated': json.loads(param.deprecated.lower()) if param.deprecated else False,
                 'modifier': 'strong'}
-        if isinstance(param.param_type, (Integer, Float, String, Array)):
+        if isinstance(param.param_type, (Integer, Float, String, Array, Boolean)):
             data['description'].append(self.create_param_descriptor(param.param_type, OrderedDict()))
 
         data.update(self.extract_type(param))


### PR DESCRIPTION
Fixes #1744

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
[N/A]

#### Core Tests
[N/A]

Core version / branch / commit hash / module tested against: [N/A]
HMI name / version / branch / commit hash / module tested against: [N/A]

### Summary
Bug fixes - Updated the generator to change the extract description method to no longer cut off after @TODO in RPC description.

### Changelog

##### Bug Fixes
Generated RPC descriptions no longer cut off after @TODO.

### Tasks Remaining:
- N/A

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
