### PR TITLE
include userLocation in SetGlobalProperties init

### DIFF
--- a/SmartDeviceLink/public/SDLSetGlobalProperties.h
+++ b/SmartDeviceLink/public/SDLSetGlobalProperties.h
@@ -74,8 +74,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Initialize SetGlobalProperties with all possible items
 
- @param helpText A string that will be turned into TTS chunks for the help prompt
- @param timeoutText A string that will be turned into TTS chunks for the timeout prompt
+ @param helpPrompt A string that will be turned into TTS chunks for the help prompt
+ @param timeoutPrompt A string that will be turned into TTS chunks for the timeout prompt
  @param vrHelpTitle The title of the help interface prompt
  @param vrHelp The items of the help interface prompt
  @param menuTitle The title of the menu button
@@ -86,7 +86,7 @@ NS_ASSUME_NONNULL_BEGIN
  @return The SetGlobalProperties RPC
  */
 
-- (instancetype)initWithHelpText:(nullable NSString *)helpText timeoutText:(nullable NSString *)timeoutText vrHelpTitle:(nullable NSString *)vrHelpTitle vrHelp:(nullable NSArray<SDLVRHelpItem *> *)vrHelp menuTitle:(nullable NSString *)menuTitle menuIcon:(nullable SDLImage *)menuIcon keyboardProperties:(nullable SDLKeyboardProperties *)keyboardProperties userLocation:(nullable SDLSeatLocation *)userLocation menuLayout:(nullable SDLMenuLayout)menuLayout;
+- (instancetype)initWithUserLocation:(nullable SDLSeatLocation *)userLocation helpPrompt:(nullable NSArray<SDLTTSChunk *> *)helpPrompt timeoutPrompt:(nullable NSArray<SDLTTSChunk *> *)timeoutPrompt vrHelpTitle:(nullable NSString *)vrHelpTitle vrHelp:(nullable NSArray<SDLVRHelpItem *> *)vrHelp menuTitle:(nullable NSString *)menuTitle menuIcon:(nullable SDLImage *)menuIcon keyboardProperties:(nullable SDLKeyboardProperties *)keyboardProperties menuLayout:(nullable SDLMenuLayout)menuLayout;
 
 /**
  Help prompt for when the user asks for help with an interface prompt

--- a/SmartDeviceLink/public/SDLSetGlobalProperties.h
+++ b/SmartDeviceLink/public/SDLSetGlobalProperties.h
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param timeoutText A string that will be turned into TTS chunks for the timeout prompt
  @return The SetGlobalProperties RPC
  */
-- (instancetype)initWithHelpText:(nullable NSString *)helpText timeoutText:(nullable NSString *)timeoutText __deprecated_msg("Use initWithHelpText:timeoutText:vrHelpTitle:vrHelp:menuTitle:menuIcon:keyboardProperties:menuLayout: instead");
+- (instancetype)initWithHelpText:(nullable NSString *)helpText timeoutText:(nullable NSString *)timeoutText __deprecated_msg("Use initWithHelpText:timeoutText:vrHelpTitle:vrHelp:menuTitle:menuIcon:keyboardProperties:userLocation:menuLayout: instead");
 
 /**
  Initialize SetGlobalProperties with help text, timeout text, help title, and help items
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param vrHelp The items of the help interface prompt
  @return The SetGlobalProperties RPC
  */
-- (instancetype)initWithHelpText:(nullable NSString *)helpText timeoutText:(nullable NSString *)timeoutText vrHelpTitle:(nullable NSString *)vrHelpTitle vrHelp:(nullable NSArray<SDLVRHelpItem *> *)vrHelp __deprecated_msg("Use initWithHelpText:timeoutText:vrHelpTitle:vrHelp:menuTitle:menuIcon:keyboardProperties:menuLayout: instead");
+- (instancetype)initWithHelpText:(nullable NSString *)helpText timeoutText:(nullable NSString *)timeoutText vrHelpTitle:(nullable NSString *)vrHelpTitle vrHelp:(nullable NSArray<SDLVRHelpItem *> *)vrHelp __deprecated_msg("Use initWithHelpText:timeoutText:vrHelpTitle:vrHelp:menuTitle:menuIcon:keyboardProperties:userLocation:menuLayout: instead");
 
 /**
  Initialize SetGlobalProperties with all possible items
@@ -54,7 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param keyboardProperties The properties of a keyboard prompt
  @return The SetGlobalProperties RPC
  */
-- (instancetype)initWithHelpText:(nullable NSString *)helpText timeoutText:(nullable NSString *)timeoutText vrHelpTitle:(nullable NSString *)vrHelpTitle vrHelp:(nullable NSArray<SDLVRHelpItem *> *)vrHelp menuTitle:(nullable NSString *)menuTitle menuIcon:(nullable SDLImage *)menuIcon keyboardProperties:(nullable SDLKeyboardProperties *)keyboardProperties __deprecated_msg("Use initWithHelpText:timeoutText:vrHelpTitle:vrHelp:menuTitle:menuIcon:keyboardProperties:menuLayout: instead");
+- (instancetype)initWithHelpText:(nullable NSString *)helpText timeoutText:(nullable NSString *)timeoutText vrHelpTitle:(nullable NSString *)vrHelpTitle vrHelp:(nullable NSArray<SDLVRHelpItem *> *)vrHelp menuTitle:(nullable NSString *)menuTitle menuIcon:(nullable SDLImage *)menuIcon keyboardProperties:(nullable SDLKeyboardProperties *)keyboardProperties __deprecated_msg("Use initWithHelpText:timeoutText:vrHelpTitle:vrHelp:menuTitle:menuIcon:keyboardProperties:userLocation:menuLayout: instead");
 
 /**
  Initialize SetGlobalProperties with all possible items
@@ -69,7 +69,24 @@ NS_ASSUME_NONNULL_BEGIN
  @param menuLayout The layout of the top-level main menu
  @return The SetGlobalProperties RPC
  */
-- (instancetype)initWithHelpText:(nullable NSString *)helpText timeoutText:(nullable NSString *)timeoutText vrHelpTitle:(nullable NSString *)vrHelpTitle vrHelp:(nullable NSArray<SDLVRHelpItem *> *)vrHelp menuTitle:(nullable NSString *)menuTitle menuIcon:(nullable SDLImage *)menuIcon keyboardProperties:(nullable SDLKeyboardProperties *)keyboardProperties menuLayout:(nullable SDLMenuLayout)menuLayout;
+- (instancetype)initWithHelpText:(nullable NSString *)helpText timeoutText:(nullable NSString *)timeoutText vrHelpTitle:(nullable NSString *)vrHelpTitle vrHelp:(nullable NSArray<SDLVRHelpItem *> *)vrHelp menuTitle:(nullable NSString *)menuTitle menuIcon:(nullable SDLImage *)menuIcon keyboardProperties:(nullable SDLKeyboardProperties *)keyboardProperties menuLayout:(nullable SDLMenuLayout)menuLayout __deprecated_msg("Use initWithHelpText:timeoutText:vrHelpTitle:vrHelp:menuTitle:menuIcon:keyboardProperties:userLocation:menuLayout: instead");
+
+/**
+ Initialize SetGlobalProperties with all possible items
+
+ @param helpText A string that will be turned into TTS chunks for the help prompt
+ @param timeoutText A string that will be turned into TTS chunks for the timeout prompt
+ @param vrHelpTitle The title of the help interface prompt
+ @param vrHelp The items of the help interface prompt
+ @param menuTitle The title of the menu button
+ @param menuIcon The icon on the menu button
+ @param keyboardProperties The properties of a keyboard prompt
+ @param userLocation userLocation
+ @param menuLayout The layout of the top-level main menu
+ @return The SetGlobalProperties RPC
+ */
+
+- (instancetype)initWithHelpText:(nullable NSString *)helpText timeoutText:(nullable NSString *)timeoutText vrHelpTitle:(nullable NSString *)vrHelpTitle vrHelp:(nullable NSArray<SDLVRHelpItem *> *)vrHelp menuTitle:(nullable NSString *)menuTitle menuIcon:(nullable SDLImage *)menuIcon keyboardProperties:(nullable SDLKeyboardProperties *)keyboardProperties userLocation:(nullable SDLSeatLocation *)userLocation menuLayout:(nullable SDLMenuLayout)menuLayout;
 
 /**
  Help prompt for when the user asks for help with an interface prompt

--- a/SmartDeviceLink/public/SDLSetGlobalProperties.h
+++ b/SmartDeviceLink/public/SDLSetGlobalProperties.h
@@ -72,19 +72,19 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithHelpText:(nullable NSString *)helpText timeoutText:(nullable NSString *)timeoutText vrHelpTitle:(nullable NSString *)vrHelpTitle vrHelp:(nullable NSArray<SDLVRHelpItem *> *)vrHelp menuTitle:(nullable NSString *)menuTitle menuIcon:(nullable SDLImage *)menuIcon keyboardProperties:(nullable SDLKeyboardProperties *)keyboardProperties menuLayout:(nullable SDLMenuLayout)menuLayout __deprecated_msg("Use initWithHelpText:timeoutText:vrHelpTitle:vrHelp:menuTitle:menuIcon:keyboardProperties:userLocation:menuLayout: instead");
 
 /**
- Initialize SetGlobalProperties with all possible items
-
- @param helpPrompt A string that will be turned into TTS chunks for the help prompt
- @param timeoutPrompt A string that will be turned into TTS chunks for the timeout prompt
- @param vrHelpTitle The title of the help interface prompt
- @param vrHelp The items of the help interface prompt
- @param menuTitle The title of the menu button
- @param menuIcon The icon on the menu button
- @param keyboardProperties The properties of a keyboard prompt
- @param userLocation userLocation
- @param menuLayout The layout of the top-level main menu
- @return The SetGlobalProperties RPC
- */
+* Convenience init for setting all possible global properties
+*
+* @param userLocation - userLocation
+* @param helpPrompt - helpPrompt
+* @param timeoutPrompt - timeoutPrompt
+* @param vrHelpTitle - vrHelpTitle
+* @param vrHelp - vrHelp
+* @param menuTitle - menuTitle
+* @param menuIcon - menuIcon
+* @param keyboardProperties - keyboardProperties
+* @param menuLayout - menuLayout
+* @return A SDLSetGlobalProperties object
+*/
 
 - (instancetype)initWithUserLocation:(nullable SDLSeatLocation *)userLocation helpPrompt:(nullable NSArray<SDLTTSChunk *> *)helpPrompt timeoutPrompt:(nullable NSArray<SDLTTSChunk *> *)timeoutPrompt vrHelpTitle:(nullable NSString *)vrHelpTitle vrHelp:(nullable NSArray<SDLVRHelpItem *> *)vrHelp menuTitle:(nullable NSString *)menuTitle menuIcon:(nullable SDLImage *)menuIcon keyboardProperties:(nullable SDLKeyboardProperties *)keyboardProperties menuLayout:(nullable SDLMenuLayout)menuLayout;
 

--- a/SmartDeviceLink/public/SDLSetGlobalProperties.m
+++ b/SmartDeviceLink/public/SDLSetGlobalProperties.m
@@ -27,29 +27,29 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma clang diagnostic pop
 
 - (instancetype)initWithHelpText:(nullable NSString *)helpText timeoutText:(nullable NSString *)timeoutText {
-    return [self initWithHelpText:helpText timeoutText:timeoutText vrHelpTitle:nil vrHelp:nil menuTitle:nil menuIcon:nil keyboardProperties:nil menuLayout:nil];
+    return [self initWithUserLocation:nil helpPrompt:[SDLTTSChunk textChunksFromString:helpText] timeoutPrompt:[SDLTTSChunk textChunksFromString:timeoutText] vrHelpTitle:nil vrHelp:nil menuTitle:nil menuIcon:nil keyboardProperties:nil menuLayout:nil];
 }
 
 - (instancetype)initWithHelpText:(nullable NSString *)helpText timeoutText:(nullable NSString *)timeoutText vrHelpTitle:(nullable NSString *)vrHelpTitle vrHelp:(nullable NSArray<SDLVRHelpItem *> *)vrHelp {
-    return [self initWithHelpText:helpText timeoutText:timeoutText vrHelpTitle:vrHelpTitle vrHelp:vrHelp menuTitle:nil menuIcon:nil keyboardProperties:nil menuLayout:nil];
+    return [self initWithUserLocation:nil helpPrompt:[SDLTTSChunk textChunksFromString:helpText] timeoutPrompt:[SDLTTSChunk textChunksFromString:timeoutText] vrHelpTitle:vrHelpTitle vrHelp:vrHelp menuTitle:nil menuIcon:nil keyboardProperties:nil menuLayout:nil];
 }
 
 - (instancetype)initWithHelpText:(nullable NSString *)helpText timeoutText:(nullable NSString *)timeoutText vrHelpTitle:(nullable NSString *)vrHelpTitle vrHelp:(nullable NSArray<SDLVRHelpItem *> *)vrHelp menuTitle:(nullable NSString *)menuTitle menuIcon:(nullable SDLImage *)menuIcon keyboardProperties:(nullable SDLKeyboardProperties *)keyboardProperties {
-    return [self initWithHelpText:helpText timeoutText:timeoutText vrHelpTitle:vrHelpTitle vrHelp:vrHelp menuTitle:menuTitle menuIcon:menuIcon keyboardProperties:keyboardProperties menuLayout:nil];
+    return [self initWithUserLocation:nil helpPrompt:[SDLTTSChunk textChunksFromString:helpText] timeoutPrompt:[SDLTTSChunk textChunksFromString:timeoutText] vrHelpTitle:vrHelpTitle vrHelp:vrHelp menuTitle:menuTitle menuIcon:menuIcon keyboardProperties:keyboardProperties menuLayout:nil];
 }
 
 - (instancetype)initWithHelpText:(nullable NSString *)helpText timeoutText:(nullable NSString *)timeoutText vrHelpTitle:(nullable NSString *)vrHelpTitle vrHelp:(nullable NSArray<SDLVRHelpItem *> *)vrHelp menuTitle:(nullable NSString *)menuTitle menuIcon:(nullable SDLImage *)menuIcon keyboardProperties:(nullable SDLKeyboardProperties *)keyboardProperties menuLayout:(nullable SDLMenuLayout)menuLayout {
-    return [self initWithHelpText:helpText timeoutText:timeoutText vrHelpTitle:vrHelpTitle vrHelp:vrHelp menuTitle:menuTitle menuIcon:menuIcon keyboardProperties:keyboardProperties userLocation:nil menuLayout:menuLayout];
+    return [self initWithUserLocation:nil helpPrompt:[SDLTTSChunk textChunksFromString:helpText] timeoutPrompt:[SDLTTSChunk textChunksFromString:timeoutText] vrHelpTitle:vrHelpTitle vrHelp:vrHelp menuTitle:menuTitle menuIcon:menuIcon keyboardProperties:keyboardProperties menuLayout:menuLayout];
 }
 
-- (instancetype)initWithHelpText:(nullable NSString *)helpText timeoutText:(nullable NSString *)timeoutText vrHelpTitle:(nullable NSString *)vrHelpTitle vrHelp:(nullable NSArray<SDLVRHelpItem *> *)vrHelp menuTitle:(nullable NSString *)menuTitle menuIcon:(nullable SDLImage *)menuIcon keyboardProperties:(nullable SDLKeyboardProperties *)keyboardProperties userLocation:(nullable SDLSeatLocation *)userLocation menuLayout:(nullable SDLMenuLayout)menuLayout {
+- (instancetype)initWithUserLocation:(nullable SDLSeatLocation *)userLocation helpPrompt:(nullable NSArray<SDLTTSChunk *> *)helpPrompt timeoutPrompt:(nullable NSArray<SDLTTSChunk *> *)timeoutPrompt vrHelpTitle:(nullable NSString *)vrHelpTitle vrHelp:(nullable NSArray<SDLVRHelpItem *> *)vrHelp menuTitle:(nullable NSString *)menuTitle menuIcon:(nullable SDLImage *)menuIcon keyboardProperties:(nullable SDLKeyboardProperties *)keyboardProperties menuLayout:(nullable SDLMenuLayout)menuLayout {
     self = [self init];
     if (!self) {
         return nil;
     }
 
-    self.helpPrompt = [SDLTTSChunk textChunksFromString:helpText];
-    self.timeoutPrompt = [SDLTTSChunk textChunksFromString:timeoutText];
+    self.helpPrompt = helpPrompt;
+    self.timeoutPrompt = timeoutPrompt;
     self.vrHelpTitle = vrHelpTitle;
     self.vrHelp = [vrHelp mutableCopy];
     self.menuTitle = menuTitle;

--- a/SmartDeviceLink/public/SDLSetGlobalProperties.m
+++ b/SmartDeviceLink/public/SDLSetGlobalProperties.m
@@ -39,6 +39,10 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (instancetype)initWithHelpText:(nullable NSString *)helpText timeoutText:(nullable NSString *)timeoutText vrHelpTitle:(nullable NSString *)vrHelpTitle vrHelp:(nullable NSArray<SDLVRHelpItem *> *)vrHelp menuTitle:(nullable NSString *)menuTitle menuIcon:(nullable SDLImage *)menuIcon keyboardProperties:(nullable SDLKeyboardProperties *)keyboardProperties menuLayout:(nullable SDLMenuLayout)menuLayout {
+    return [self initWithHelpText:helpText timeoutText:timeoutText vrHelpTitle:vrHelpTitle vrHelp:vrHelp menuTitle:menuTitle menuIcon:menuIcon keyboardProperties:keyboardProperties userLocation:nil menuLayout:menuLayout];
+}
+
+- (instancetype)initWithHelpText:(nullable NSString *)helpText timeoutText:(nullable NSString *)timeoutText vrHelpTitle:(nullable NSString *)vrHelpTitle vrHelp:(nullable NSArray<SDLVRHelpItem *> *)vrHelp menuTitle:(nullable NSString *)menuTitle menuIcon:(nullable SDLImage *)menuIcon keyboardProperties:(nullable SDLKeyboardProperties *)keyboardProperties userLocation:(nullable SDLSeatLocation *)userLocation menuLayout:(nullable SDLMenuLayout)menuLayout {
     self = [self init];
     if (!self) {
         return nil;
@@ -51,6 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
     self.menuTitle = menuTitle;
     self.menuIcon = menuIcon;
     self.keyboardProperties = keyboardProperties;
+    self.userLocation = userLocation;
     self.menuLayout = menuLayout;
 
     return self;

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSetGlobalPropertiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSetGlobalPropertiesSpec.m
@@ -93,6 +93,14 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testRequest.keyboardProperties).to(beNil());
         expect(testRequest.userLocation).to(beNil());
     });
+
+    it(@"Should return new init", ^ {
+        SDLSetGlobalProperties* testRequest = [[SDLSetGlobalProperties alloc] initWithHelpText:helpTest timeoutText:timeoutTest vrHelpTitle:vrHelpTitle vrHelp:[@[help] mutableCopy] menuTitle:menuTitle menuIcon:image keyboardProperties:keyboard menuLayout:nil];
+        
+        SDLSetGlobalProperties* testRequest2 = [[SDLSetGlobalProperties alloc] initWithHelpText:helpTest timeoutText:timeoutTest vrHelpTitle:vrHelpTitle vrHelp:[@[help] mutableCopy] menuTitle:menuTitle menuIcon:image keyboardProperties:keyboard userLocation:nil menuLayout:nil];
+
+        expect(testRequest).to(equal(testRequest2));
+    });
     
     it(@"Should set initWithHelpText", ^ {
         SDLSetGlobalProperties* testRequest = [[SDLSetGlobalProperties alloc] initWithHelpText:helpTest timeoutText:timeoutTest vrHelpTitle:vrHelpTitle vrHelp:[@[help] mutableCopy] menuTitle:menuTitle menuIcon:image keyboardProperties:keyboard userLocation:seatLocation menuLayout:nil];

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSetGlobalPropertiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSetGlobalPropertiesSpec.m
@@ -22,8 +22,8 @@ QuickSpecBegin(SDLSetGlobalPropertiesSpec)
 
 NSString *menuTitle = @"TheNewMenu";
 NSString *vrHelpTitle = @"vr";
-NSString *helpTest =@"TheHelpText";
-NSString *timeoutTest =@"timeout Test";
+NSString *helpTest = @"TheHelpText";
+NSString *timeoutTest = @"timeout Test";
 SDLTTSChunk* chunk1 = [[SDLTTSChunk alloc] init];
 SDLTTSChunk* chunk2 = [[SDLTTSChunk alloc] init];
 SDLVRHelpItem* help = [[SDLVRHelpItem alloc] init];
@@ -35,19 +35,19 @@ describe(@"Getter/Setter Tests", ^ {
     it(@"Should set and get correctly", ^ {
         SDLSetGlobalProperties* testRequest = [[SDLSetGlobalProperties alloc] init];
         
-        testRequest.helpPrompt = [@[chunk1] mutableCopy];
-        testRequest.timeoutPrompt = [@[chunk2] mutableCopy];
+        testRequest.helpPrompt = @[chunk1];
+        testRequest.timeoutPrompt = @[chunk2];
         testRequest.vrHelpTitle = vrHelpTitle;
-        testRequest.vrHelp = [@[help] mutableCopy];
+        testRequest.vrHelp = @[help];
         testRequest.menuTitle = menuTitle;
         testRequest.menuIcon = image;
         testRequest.keyboardProperties = keyboard;
         testRequest.userLocation = seatLocation;
         
-        expect(testRequest.helpPrompt).to(equal([@[chunk1] mutableCopy]));
-        expect(testRequest.timeoutPrompt).to(equal([@[chunk2] mutableCopy]));
+        expect(testRequest.helpPrompt).to(equal(@[chunk1]));
+        expect(testRequest.timeoutPrompt).to(equal(@[chunk2]));
         expect(testRequest.vrHelpTitle).to(equal(vrHelpTitle));
-        expect(testRequest.vrHelp).to(equal([@[help] mutableCopy]));
+        expect(testRequest.vrHelp).to(equal(@[help]));
         expect(testRequest.menuTitle).to(equal(menuTitle));
         expect(testRequest.menuIcon).to(equal(image));
         expect(testRequest.keyboardProperties).to(equal(keyboard));
@@ -57,10 +57,10 @@ describe(@"Getter/Setter Tests", ^ {
     it(@"Should get correctly when initialized", ^ {
         NSMutableDictionary<NSString *, id> *dict = [@{SDLRPCParameterNameRequest:
                                                            @{SDLRPCParameterNameParameters:
-                                                                 @{SDLRPCParameterNameHelpPrompt:[@[chunk1] mutableCopy],
-                                                                   SDLRPCParameterNameTimeoutPrompt:[@[chunk2] mutableCopy],
+                                                                 @{SDLRPCParameterNameHelpPrompt:@[chunk1],
+                                                                   SDLRPCParameterNameTimeoutPrompt:@[chunk2],
                                                                    SDLRPCParameterNameVRHelpTitle:vrHelpTitle,
-                                                                   SDLRPCParameterNameVRHelp:[@[help] mutableCopy],
+                                                                   SDLRPCParameterNameVRHelp:@[help],
                                                                    SDLRPCParameterNameMenuTitle:menuTitle,
                                                                    SDLRPCParameterNameUserLocation: seatLocation,
                                                                    SDLRPCParameterNameMenuIcon:image,
@@ -71,10 +71,10 @@ describe(@"Getter/Setter Tests", ^ {
         SDLSetGlobalProperties* testRequest = [[SDLSetGlobalProperties alloc] initWithDictionary:dict];
 #pragma clang diagnostic pop
         
-        expect(testRequest.helpPrompt).to(equal([@[chunk1] mutableCopy]));
-        expect(testRequest.timeoutPrompt).to(equal([@[chunk2] mutableCopy]));
+        expect(testRequest.helpPrompt).to(equal(@[chunk1]));
+        expect(testRequest.timeoutPrompt).to(equal(@[chunk2]));
         expect(testRequest.vrHelpTitle).to(equal(vrHelpTitle));
-        expect(testRequest.vrHelp).to(equal([@[help] mutableCopy]));
+        expect(testRequest.vrHelp).to(equal(@[help]));
         expect(testRequest.menuTitle).to(equal(menuTitle));
         expect(testRequest.menuIcon).to(equal(image));
         expect(testRequest.keyboardProperties).to(equal(keyboard));
@@ -94,24 +94,82 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testRequest.userLocation).to(beNil());
     });
 
-    it(@"Should return new init", ^ {
-        SDLSetGlobalProperties* testRequest = [[SDLSetGlobalProperties alloc] initWithHelpText:helpTest timeoutText:timeoutTest vrHelpTitle:vrHelpTitle vrHelp:[@[help] mutableCopy] menuTitle:menuTitle menuIcon:image keyboardProperties:keyboard menuLayout:nil];
-        
-        SDLSetGlobalProperties* testRequest2 = [[SDLSetGlobalProperties alloc] initWithHelpText:helpTest timeoutText:timeoutTest vrHelpTitle:vrHelpTitle vrHelp:[@[help] mutableCopy] menuTitle:menuTitle menuIcon:image keyboardProperties:keyboard userLocation:nil menuLayout:nil];
-
-        expect(testRequest).to(equal(testRequest2));
-    });
-    
-    it(@"Should set initWithHelpText", ^ {
-        SDLSetGlobalProperties* testRequest = [[SDLSetGlobalProperties alloc] initWithHelpText:helpTest timeoutText:timeoutTest vrHelpTitle:vrHelpTitle vrHelp:[@[help] mutableCopy] menuTitle:menuTitle menuIcon:image keyboardProperties:keyboard userLocation:seatLocation menuLayout:nil];
+    it(@"Should init correctly with initWithUserLocation:helpPrompt:timeoutPrompt:vrHelpTitle:vrHelp:menuTitle:menuIcon:keyboardProperties:menuLayout:", ^ {
+        SDLSetGlobalProperties* testRequest = [[SDLSetGlobalProperties alloc] initWithUserLocation:seatLocation helpPrompt:[SDLTTSChunk textChunksFromString:helpTest] timeoutPrompt:[SDLTTSChunk textChunksFromString:timeoutTest] vrHelpTitle:vrHelpTitle vrHelp:@[help] menuTitle:menuTitle menuIcon:image keyboardProperties:keyboard menuLayout:nil];
         
         expect(testRequest.helpPrompt).to(equal([SDLTTSChunk textChunksFromString:helpTest]));
         expect(testRequest.timeoutPrompt).to(equal([SDLTTSChunk textChunksFromString:timeoutTest]));
         expect(testRequest.vrHelpTitle).to(equal(vrHelpTitle));
-        expect(testRequest.vrHelp).to(equal([@[help] mutableCopy]));
+        expect(testRequest.vrHelp).to(equal(@[help]));
         expect(testRequest.menuTitle).to(equal(menuTitle));
         expect(testRequest.menuIcon).to(equal(image));
         expect(testRequest.userLocation).to(equal(seatLocation));
+        expect(testRequest.keyboardProperties).to(equal(keyboard));
+        expect(testRequest.menuLayout).to(beNil());
+    });
+
+    it(@"Should init correctly with initWithHelpText:timeoutText:", ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        SDLSetGlobalProperties *testRequest = [[SDLSetGlobalProperties alloc] initWithHelpText:helpTest timeoutText:timeoutTest];
+#pragma clang diagnostic pop
+        expect(testRequest.helpPrompt).to(equal([SDLTTSChunk textChunksFromString:helpTest]));
+        expect(testRequest.timeoutPrompt).to(equal([SDLTTSChunk textChunksFromString:timeoutTest]));
+        expect(testRequest.vrHelpTitle).to(beNil());
+        expect(testRequest.vrHelp).to(beNil());
+        expect(testRequest.menuTitle).to(beNil());
+        expect(testRequest.menuIcon).to(beNil());
+        expect(testRequest.userLocation).to(beNil());
+        expect(testRequest.keyboardProperties).to(beNil());
+        expect(testRequest.menuLayout).to(beNil());
+    });
+
+    it(@"Should init correctly with initWithHelpText:timeoutText:vrHelpTitle:vrHelp:", ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        SDLSetGlobalProperties *testRequest = [[SDLSetGlobalProperties alloc] initWithHelpText:helpTest timeoutText:timeoutTest vrHelpTitle:vrHelpTitle vrHelp:@[help]];
+#pragma clang diagnostic pop
+        expect(testRequest.helpPrompt).to(equal([SDLTTSChunk textChunksFromString:helpTest]));
+        expect(testRequest.timeoutPrompt).to(equal([SDLTTSChunk textChunksFromString:timeoutTest]));
+        expect(testRequest.vrHelpTitle).to(equal(vrHelpTitle));
+        expect(testRequest.vrHelp).to(equal(@[help]));
+        expect(testRequest.menuTitle).to(beNil());
+        expect(testRequest.menuIcon).to(beNil());
+        expect(testRequest.userLocation).to(beNil());
+        expect(testRequest.keyboardProperties).to(beNil());
+        expect(testRequest.menuLayout).to(beNil());
+    });
+    
+    it(@"Should init correctly with initWithHelpText:timeoutText:vrHelpTitle:vrHelp:menuTitle:menuIcon:keyboardProperties:", ^ {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        SDLSetGlobalProperties* testRequest = [[SDLSetGlobalProperties alloc] initWithHelpText:helpTest timeoutText:timeoutTest vrHelpTitle:vrHelpTitle vrHelp:@[help] menuTitle:menuTitle menuIcon:image keyboardProperties:keyboard];
+#pragma clang diagnostic pop
+        
+        expect(testRequest.helpPrompt).to(equal([SDLTTSChunk textChunksFromString:helpTest]));
+        expect(testRequest.timeoutPrompt).to(equal([SDLTTSChunk textChunksFromString:timeoutTest]));
+        expect(testRequest.vrHelpTitle).to(equal(vrHelpTitle));
+        expect(testRequest.vrHelp).to(equal(@[help]));
+        expect(testRequest.menuTitle).to(equal(menuTitle));
+        expect(testRequest.menuIcon).to(equal(image));
+        expect(testRequest.userLocation).to(beNil());
+        expect(testRequest.keyboardProperties).to(equal(keyboard));
+        expect(testRequest.menuLayout).to(beNil());
+    });
+    
+    it(@"Should init correctly with initWithHelpText:timeoutText:vrHelpTitle:vrHelp:menuTitle:menuIcon:keyboardProperties:menuLayout:", ^ {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        SDLSetGlobalProperties* testRequest = [[SDLSetGlobalProperties alloc] initWithHelpText:helpTest timeoutText:timeoutTest vrHelpTitle:vrHelpTitle vrHelp:@[help] menuTitle:menuTitle menuIcon:image keyboardProperties:keyboard menuLayout:nil];
+#pragma clang diagnostic pop
+        
+        expect(testRequest.helpPrompt).to(equal([SDLTTSChunk textChunksFromString:helpTest]));
+        expect(testRequest.timeoutPrompt).to(equal([SDLTTSChunk textChunksFromString:timeoutTest]));
+        expect(testRequest.vrHelpTitle).to(equal(vrHelpTitle));
+        expect(testRequest.vrHelp).to(equal(@[help]));
+        expect(testRequest.menuTitle).to(equal(menuTitle));
+        expect(testRequest.menuIcon).to(equal(image));
+        expect(testRequest.userLocation).to(beNil());
         expect(testRequest.keyboardProperties).to(equal(keyboard));
         expect(testRequest.menuLayout).to(beNil());
     });

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSetGlobalPropertiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSetGlobalPropertiesSpec.m
@@ -20,6 +20,10 @@
 
 QuickSpecBegin(SDLSetGlobalPropertiesSpec)
 
+NSString *menuTitle = @"TheNewMenu";
+NSString *vrHelpTitle = @"vr";
+NSString *helpTest =@"TheHelpText";
+NSString *timeoutTest =@"timeout Test";
 SDLTTSChunk* chunk1 = [[SDLTTSChunk alloc] init];
 SDLTTSChunk* chunk2 = [[SDLTTSChunk alloc] init];
 SDLVRHelpItem* help = [[SDLVRHelpItem alloc] init];
@@ -33,18 +37,18 @@ describe(@"Getter/Setter Tests", ^ {
         
         testRequest.helpPrompt = [@[chunk1] mutableCopy];
         testRequest.timeoutPrompt = [@[chunk2] mutableCopy];
-        testRequest.vrHelpTitle = @"vr";
+        testRequest.vrHelpTitle = vrHelpTitle;
         testRequest.vrHelp = [@[help] mutableCopy];
-        testRequest.menuTitle = @"TheNewMenu";
+        testRequest.menuTitle = menuTitle;
         testRequest.menuIcon = image;
         testRequest.keyboardProperties = keyboard;
         testRequest.userLocation = seatLocation;
         
         expect(testRequest.helpPrompt).to(equal([@[chunk1] mutableCopy]));
         expect(testRequest.timeoutPrompt).to(equal([@[chunk2] mutableCopy]));
-        expect(testRequest.vrHelpTitle).to(equal(@"vr"));
+        expect(testRequest.vrHelpTitle).to(equal(vrHelpTitle));
         expect(testRequest.vrHelp).to(equal([@[help] mutableCopy]));
-        expect(testRequest.menuTitle).to(equal(@"TheNewMenu"));
+        expect(testRequest.menuTitle).to(equal(menuTitle));
         expect(testRequest.menuIcon).to(equal(image));
         expect(testRequest.keyboardProperties).to(equal(keyboard));
         expect(testRequest.userLocation).to(equal(seatLocation));
@@ -55,9 +59,9 @@ describe(@"Getter/Setter Tests", ^ {
                                                            @{SDLRPCParameterNameParameters:
                                                                  @{SDLRPCParameterNameHelpPrompt:[@[chunk1] mutableCopy],
                                                                    SDLRPCParameterNameTimeoutPrompt:[@[chunk2] mutableCopy],
-                                                                   SDLRPCParameterNameVRHelpTitle:@"vr",
+                                                                   SDLRPCParameterNameVRHelpTitle:vrHelpTitle,
                                                                    SDLRPCParameterNameVRHelp:[@[help] mutableCopy],
-                                                                   SDLRPCParameterNameMenuTitle:@"TheNewMenu",
+                                                                   SDLRPCParameterNameMenuTitle:menuTitle,
                                                                    SDLRPCParameterNameUserLocation: seatLocation,
                                                                    SDLRPCParameterNameMenuIcon:image,
                                                                    SDLRPCParameterNameKeyboardProperties:keyboard},
@@ -69,9 +73,9 @@ describe(@"Getter/Setter Tests", ^ {
         
         expect(testRequest.helpPrompt).to(equal([@[chunk1] mutableCopy]));
         expect(testRequest.timeoutPrompt).to(equal([@[chunk2] mutableCopy]));
-        expect(testRequest.vrHelpTitle).to(equal(@"vr"));
+        expect(testRequest.vrHelpTitle).to(equal(vrHelpTitle));
         expect(testRequest.vrHelp).to(equal([@[help] mutableCopy]));
-        expect(testRequest.menuTitle).to(equal(@"TheNewMenu"));
+        expect(testRequest.menuTitle).to(equal(menuTitle));
         expect(testRequest.menuIcon).to(equal(image));
         expect(testRequest.keyboardProperties).to(equal(keyboard));
         expect(testRequest.userLocation).to(equal(seatLocation));
@@ -88,6 +92,20 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testRequest.menuIcon).to(beNil());
         expect(testRequest.keyboardProperties).to(beNil());
         expect(testRequest.userLocation).to(beNil());
+    });
+    
+    it(@"Should set initWithHelpText", ^ {
+        SDLSetGlobalProperties* testRequest = [[SDLSetGlobalProperties alloc] initWithHelpText:helpTest timeoutText:timeoutTest vrHelpTitle:vrHelpTitle vrHelp:[@[help] mutableCopy] menuTitle:menuTitle menuIcon:image keyboardProperties:keyboard userLocation:seatLocation menuLayout:nil];
+        
+        expect(testRequest.helpPrompt).to(equal([SDLTTSChunk textChunksFromString:helpTest]));
+        expect(testRequest.timeoutPrompt).to(equal([SDLTTSChunk textChunksFromString:timeoutTest]));
+        expect(testRequest.vrHelpTitle).to(equal(vrHelpTitle));
+        expect(testRequest.vrHelp).to(equal([@[help] mutableCopy]));
+        expect(testRequest.menuTitle).to(equal(menuTitle));
+        expect(testRequest.menuIcon).to(equal(image));
+        expect(testRequest.userLocation).to(equal(seatLocation));
+        expect(testRequest.keyboardProperties).to(equal(keyboard));
+        expect(testRequest.menuLayout).to(beNil());
     });
 });
 


### PR DESCRIPTION
Fixes #1771

### Risk
This PR makes **[minor]** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
N/A

#### Core Tests
N/A

Core version / branch / commit hash / module tested against: N/A
HMI name / version / branch / commit hash / module tested against: N/A

### Summary
included 'userLocation' variable in SetGlobalProperties init.

### Changelog
##### Breaking Changes
* N/A

##### Enhancements
* N/A

##### Bug Fixes
* included 'userLocation' variable in SetGlobalProperties init and deprecated the previous one.

### Tasks Remaining:
N/A

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
