### PR TITLE
Rpc generator fix to generate optional floats

### DIFF
--- a/generator/transformers/common_producer.py
+++ b/generator/transformers/common_producer.py
@@ -168,7 +168,7 @@ class InterfaceProducerCommon(ABC):
         :param mandatory: is parameter mandatory
         :return: string with modificator
         """
-        if mandatory or re.match(r'BOOL|double', type_native):
+        if mandatory or re.match(r'BOOL', type_native):
             return ''
         return 'nullable '
 
@@ -307,9 +307,7 @@ class InterfaceProducerCommon(ABC):
         else:
             data = self.evaluate_type(param.param_type)
 
-        if not param.is_mandatory and re.match(r'\w*Int\d*|BOOL', data['type_native']):
-            data['type_native'] = data['type_sdl']
-        elif not param.is_mandatory and re.match(r'\w*float\d*', data['type_native']):
+        if not param.is_mandatory and re.match(r'\w*Int\d*|BOOL|\w*float\d*', data['type_native']):
             data['type_native'] = data['type_sdl']
 
         return data

--- a/generator/transformers/common_producer.py
+++ b/generator/transformers/common_producer.py
@@ -168,7 +168,7 @@ class InterfaceProducerCommon(ABC):
         :param mandatory: is parameter mandatory
         :return: string with modificator
         """
-        if mandatory or re.match(r'BOOL|float|double', type_native):
+        if mandatory or re.match(r'BOOL|double', type_native):
             return ''
         return 'nullable '
 
@@ -308,6 +308,8 @@ class InterfaceProducerCommon(ABC):
             data = self.evaluate_type(param.param_type)
 
         if not param.is_mandatory and re.match(r'\w*Int\d*|BOOL', data['type_native']):
+            data['type_native'] = data['type_sdl']
+        elif not param.is_mandatory and re.match(r'\w*float\d*', data['type_native']):
             data['type_native'] = data['type_sdl']
 
         return data


### PR DESCRIPTION
Fixes #1763

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [ ] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
N/A

#### Core Tests
N/A

Core version / branch / commit hash / module tested against: N/A
HMI name / version / branch / commit hash / module tested against: N/A

### Summary
Fixed the generator init function that was not properly generating float optional values.

### Changelog
##### Breaking Changes
* N/A

##### Enhancements
* N/A

##### Bug Fixes
* Fixed the generator init function that was not properly generating float optional values.

### Tasks Remaining:
N/A

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
