### PR TITLE
Fixed RPC spec generator unsorted imports

### DIFF
--- a/generator/templates/base_struct_function.m.jinja2
+++ b/generator/templates/base_struct_function.m.jinja2
@@ -2,8 +2,6 @@
     "templates/functions/template.m" and "templates/structs/template.m". -#}
 {% include 'copyright.jinja2' %}
 {%- block imports %}
-#import "{{name}}.h"
-#import "NSMutableDictionary+Store.h"
 {%- for import in imports %}
 #import "{{import}}.h"
 {%- endfor %}

--- a/generator/templates/functions/template.m.jinja2
+++ b/generator/templates/functions/template.m.jinja2
@@ -2,8 +2,6 @@
 {% extends "base_struct_function.m.jinja2" %}
 {% block imports %}
 {{super()}}
-#import "SDLRPCFunctionNames.h"
-#import "SDLRPCParameterNames.h"
 {%- endblock %}
 {% block constructors %}
 #pragma clang diagnostic push

--- a/generator/templates/structs/template.m.jinja2
+++ b/generator/templates/structs/template.m.jinja2
@@ -2,6 +2,5 @@
 {% extends "base_struct_function.m.jinja2" %}
 {% block imports %}
 {{super()}}
-#import "SDLRPCParameterNames.h"
 {%- endblock %}
 {% set parameters_store = 'store' %}

--- a/generator/transformers/common_producer.py
+++ b/generator/transformers/common_producer.py
@@ -64,6 +64,32 @@ class InterfaceProducerCommon(ABC):
             render['params'][param.name] = self.extract_param(param, item.name)
             if isinstance(item, (Struct, Function)):
                 self.extract_imports(param, render['imports'])
+        
+        name = 'SDL'
+        render['imports']['.m'].add( "NSMutableDictionary+Store" )
+        render['imports']['.m'].add(name)
+
+        if isinstance(item, Struct):
+            render['imports']['.m'].add( "SDLRPCParameterNames" )
+        
+        if isinstance(item, Function):
+            render['imports']['.m'].add( "SDLRPCFunctionNames" )
+            render['imports']['.m'].add( "SDLRPCParameterNames" )
+        
+        # if isinstance(item, Enum):
+
+        render['imports']['.m'] = list(render['imports']['.m'])
+        (render['imports']['.m']).sort()
+
+                # render['imports']['.h']['.enum'] = list(render['imports']['.h']['.enum'])
+        # print('@-- ' + str(render['imports']['.m']))
+        # sorted(render.get('imports').get('.m'))
+        # j = list(render['imports']['.m'])
+        # j.sort()
+        # temp = render.get('imports').get('.h')
+        # tempo = sorted(temp.get('.m'))
+        # print('$-- ' + str(render.get('imports').get('.m')))
+        # print('%-- ' + str(temp))
 
         if 'constructors' not in render and isinstance(item, (Struct, Function)):
             render['constructors'] = self.extract_constructors(render['params'])

--- a/generator/transformers/common_producer.py
+++ b/generator/transformers/common_producer.py
@@ -65,9 +65,10 @@ class InterfaceProducerCommon(ABC):
             if isinstance(item, (Struct, Function)):
                 self.extract_imports(param, render['imports'])
         
-        name = 'SDL'
-        render['imports']['.m'].add( "NSMutableDictionary+Store" )
-        render['imports']['.m'].add(name)
+        if isinstance(item, (Struct, Function)):
+            name = 'SDL'
+            render['imports']['.m'].add( "NSMutableDictionary+Store" )
+            render['imports']['.m'].add(name)
 
         if isinstance(item, Struct):
             render['imports']['.m'].add( "SDLRPCParameterNames" )

--- a/generator/transformers/common_producer.py
+++ b/generator/transformers/common_producer.py
@@ -49,6 +49,11 @@ class InterfaceProducerCommon(ABC):
         :param render: dictionary with pre filled entries, which going to be filled/changed by reference
         :return: dictionary which going to be applied to Jinja2 template
         """
+
+        importsKey = 'imports'
+        enumKey = 'enum'
+        structKey = 'struct'
+
         if item.description:
             render['description'] = self.extract_description(item.description)
         if item.since:
@@ -66,31 +71,24 @@ class InterfaceProducerCommon(ABC):
                 self.extract_imports(param, render['imports'])
         
         if isinstance(item, (Struct, Function)):
-            name = 'SDL'
-            render['imports']['.m'].add( "NSMutableDictionary+Store" )
-            render['imports']['.m'].add(name)
+            name = 'SDL' + item.name
+            render[importsKey]['.m'].add( "NSMutableDictionary+Store" )
+            render[importsKey]['.m'].add(name)
+            render[importsKey]['.h'][enumKey] = list(render[importsKey]['.h'][enumKey])
+            (render[importsKey]['.h'][enumKey]).sort()
+            render[importsKey]['.h'][structKey] = list(render[importsKey]['.h'][structKey])
+            (render[importsKey]['.h'][structKey]).sort()
 
         if isinstance(item, Struct):
-            render['imports']['.m'].add( "SDLRPCParameterNames" )
-        
+            name = 'SDL' + item.name
+            render[importsKey]['.m'].add( "SDLRPCParameterNames" )
+
         if isinstance(item, Function):
-            render['imports']['.m'].add( "SDLRPCFunctionNames" )
-            render['imports']['.m'].add( "SDLRPCParameterNames" )
-        
-        # if isinstance(item, Enum):
+            render[importsKey]['.m'].add( "SDLRPCFunctionNames" )
+            render[importsKey]['.m'].add( "SDLRPCParameterNames" )
 
-        render['imports']['.m'] = list(render['imports']['.m'])
-        (render['imports']['.m']).sort()
-
-                # render['imports']['.h']['.enum'] = list(render['imports']['.h']['.enum'])
-        # print('@-- ' + str(render['imports']['.m']))
-        # sorted(render.get('imports').get('.m'))
-        # j = list(render['imports']['.m'])
-        # j.sort()
-        # temp = render.get('imports').get('.h')
-        # tempo = sorted(temp.get('.m'))
-        # print('$-- ' + str(render.get('imports').get('.m')))
-        # print('%-- ' + str(temp))
+        render[importsKey]['.m'] = list(render[importsKey]['.m'])
+        (render[importsKey]['.m']).sort()
 
         if 'constructors' not in render and isinstance(item, (Struct, Function)):
             render['constructors'] = self.extract_constructors(render['params'])

--- a/generator/transformers/common_producer.py
+++ b/generator/transformers/common_producer.py
@@ -70,7 +70,7 @@ class InterfaceProducerCommon(ABC):
             if isinstance(item, (Struct, Function)):
                 self.extract_imports(param, render['imports'])
         
-# Add additional known imports to the import list
+        # Add additional known imports to the import list
         if isinstance(item, (Struct, Function)):
             name = 'SDL' + item.name
             render[importsKey]['.m'].add( "NSMutableDictionary+Store" )
@@ -88,7 +88,7 @@ class InterfaceProducerCommon(ABC):
             render[importsKey]['.m'].add( "SDLRPCFunctionNames" )
             render[importsKey]['.m'].add( "SDLRPCParameterNames" )
 
-# Sort the import list to ensure they appear in alphabetical order in the template
+        # Sort the import list to ensure they appear in alphabetical order in the template
         render[importsKey]['.m'] = list(render[importsKey]['.m'])
         (render[importsKey]['.m']).sort()
 

--- a/generator/transformers/common_producer.py
+++ b/generator/transformers/common_producer.py
@@ -70,6 +70,7 @@ class InterfaceProducerCommon(ABC):
             if isinstance(item, (Struct, Function)):
                 self.extract_imports(param, render['imports'])
         
+# Add additional known imports to the import list
         if isinstance(item, (Struct, Function)):
             name = 'SDL' + item.name
             render[importsKey]['.m'].add( "NSMutableDictionary+Store" )
@@ -87,6 +88,7 @@ class InterfaceProducerCommon(ABC):
             render[importsKey]['.m'].add( "SDLRPCFunctionNames" )
             render[importsKey]['.m'].add( "SDLRPCParameterNames" )
 
+# Sort the import list to ensure they appear in alphabetical order in the template
         render[importsKey]['.m'] = list(render[importsKey]['.m'])
         (render[importsKey]['.m']).sort()
 


### PR DESCRIPTION
Fixes #1720 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [ ] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
N/A

#### Core Tests
N/A

Core version / branch / commit hash / module tested against: N/A
HMI name / version / branch / commit hash / module tested against: N/A

### Summary
The #import lines were not being displayed in an alphabetical order, and could not be sorted since they were being passed in a Set of strings instead of a regular list.

### Changelog
##### Breaking Changes
* N/A

##### Enhancements
* N/A

##### Bug Fixes
* The #import lines were not being displayed in an alphabetical order and could not be sorted since they were being passed in a Set of strings instead of a regular list in addition to some import lines being added statically in template files without being included in Set. Cleaned the template and handled the issue in python producer files.

### Tasks Remaining:
- N/A

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
