### PR TITLE
Fix for RPC spec generator to stop producing #pragmas that suppress deprecated warnings to property and enum definitions

### DIFF
--- a/generator/templates/base_struct_function.h.jinja2
+++ b/generator/templates/base_struct_function.h.jinja2
@@ -29,27 +29,13 @@ NS_ASSUME_NONNULL_BEGIN
  {%- endfor %}
  * @return A {{name}} object
  */
-{%- if deprecated or c.deprecated %}
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-{%- endif %}
 - (instancetype)initWith{{c.init}};
-{%- if deprecated or c.deprecated %}
-#pragma clang diagnostic pop
-{%- endif %}
 {% endfor -%}
 {%- endblock -%}
 {%- block methods %}
 {%- for param in params %}
 {%- include 'description_param.jinja2' %}
-{%- if deprecated or param.deprecated %}
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-{%- endif %}
 @property ({{'nullable, ' if not param.mandatory}}{{param.modifier}}, nonatomic) {{param.type_sdl}}{{param.origin}}{{' __deprecated' if param.deprecated and param.deprecated is sameas true }};
-{%- if deprecated or param.deprecated %}
-#pragma clang diagnostic pop
-{%- endif %}
 {% endfor %}
 {%- endblock %}
 @end

--- a/generator/templates/base_struct_function.m.jinja2
+++ b/generator/templates/base_struct_function.m.jinja2
@@ -10,20 +10,9 @@
 {%- endblock %}
 
 NS_ASSUME_NONNULL_BEGIN
-{% if deprecated %}
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-implementations"
-{%- endif %}
 @implementation {{name}}
-{%- if deprecated %}
-#pragma clang diagnostic pop
-{%- endif %}
 {% block constructors %}
 {%- for c in constructors %}
-{%- if deprecated or c.deprecated %}
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-{%- endif %}
 - (instancetype)initWith{{c.init}} {
     self = [self init{{ 'With' + c.self if c.self and c.self is string }}];
     if (!self) {
@@ -34,31 +23,14 @@ NS_ASSUME_NONNULL_BEGIN
     {%- endfor %}
     return self;
 }
-{%- if deprecated or c.deprecated %}
-#pragma clang diagnostic pop
-{%- endif %}
 {% endfor -%}
 {% endblock -%}
 {%- block methods %}
 {%- for param in params %}
-{%- if deprecated or param.deprecated %}
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-{%- endif %}
 - (void)set{{param.origin|title}}:({{'nullable ' if not param.mandatory}}{{param.type_generic}}{{param.type_sdl|trim}}){{param.origin}} {
-{%- if deprecated or param.deprecated %}
-#pragma clang diagnostic pop
-{%- endif %}
     [self.{{parameters_store}} sdl_setObject:{{param.origin}} forName:SDLRPCParameterName{{param.method_suffix}}];
 }
-{% if deprecated or param.deprecated %}
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-{%- endif %}
 - ({{'nullable ' if not param.mandatory}}{{param.type_generic}}{{param.type_sdl|trim}}){{param.origin}} {
-{%- if deprecated or param.deprecated %}
-#pragma clang diagnostic pop
-{%- endif %}
     {% if param.mandatory -%}
     NSError *error = nil;
     {% endif -%}

--- a/generator/templates/base_struct_function.m.jinja2
+++ b/generator/templates/base_struct_function.m.jinja2
@@ -30,6 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)set{{param.origin|title}}:({{'nullable ' if not param.mandatory}}{{param.type_generic}}{{param.type_sdl|trim}}){{param.origin}} {
     [self.{{parameters_store}} sdl_setObject:{{param.origin}} forName:SDLRPCParameterName{{param.method_suffix}}];
 }
+
 - ({{'nullable ' if not param.mandatory}}{{param.type_generic}}{{param.type_sdl|trim}}){{param.origin}} {
     {% if param.mandatory -%}
     NSError *error = nil;

--- a/generator/templates/enums/template.h.jinja2
+++ b/generator/templates/enums/template.h.jinja2
@@ -8,21 +8,8 @@
 {%- block body %}
 {% include 'description.jinja2' %}
 typedef SDLEnum {{ name }} SDL_SWIFT_ENUM{{ending}};
-{% if deprecated %}
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-{% endif %}
 {%- for param in params %}
-{%- include 'description_param.jinja2' %}{% if param.deprecated %}
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-{%- endif %}
+{%- include 'description_param.jinja2' %}
 extern {{ name }} const {{ name }}{{param.name}}{{ " __deprecated" if param.deprecated and param.deprecated }};
-{% if param.deprecated -%}
-#pragma clang diagnostic pop
-{%- endif -%}
 {% endfor -%}
-{%- if deprecated %}
-#pragma clang diagnostic pop
-{%- endif %}
 {% endblock -%}

--- a/generator/templates/enums/template.m.jinja2
+++ b/generator/templates/enums/template.m.jinja2
@@ -5,21 +5,7 @@
 {% if add_typedef %}
 typedef SDLEnum {{name}} SDL_SWIFT_ENUM;
 {% endif -%}
-{%- if deprecated %}
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-{%- endif %}
 {%- for param in params %}
-{%- if param.deprecated %}
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-{%- endif %}
 {{ name }} const {{ name }}{{param.name}} = @"{{param.origin}}";
-{%- if param.deprecated %}
-#pragma clang diagnostic pop
-{% endif %}
 {%- endfor -%}
-{%- if deprecated %}
-#pragma clang diagnostic pop
-{%- endif %}
 {% endblock -%}

--- a/generator/templates/functions/template.m.jinja2
+++ b/generator/templates/functions/template.m.jinja2
@@ -6,8 +6,6 @@
 #import "SDLRPCParameterNames.h"
 {%- endblock %}
 {% block constructors %}
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     self = [super initWithName:SDLRPCFunctionName{{origin}}];
     if (!self) {
@@ -15,7 +13,6 @@
     }
     return self;
 }
-#pragma clang diagnostic pop
 {{super()}}
 {%- endblock -%}
 {% set parameters_store = 'parameters' %}

--- a/generator/templates/functions/template.m.jinja2
+++ b/generator/templates/functions/template.m.jinja2
@@ -6,6 +6,8 @@
 #import "SDLRPCParameterNames.h"
 {%- endblock %}
 {% block constructors %}
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (instancetype)init {
     self = [super initWithName:SDLRPCFunctionName{{origin}}];
     if (!self) {
@@ -13,6 +15,7 @@
     }
     return self;
 }
+#pragma clang diagnostic pop
 {{super()}}
 {%- endblock -%}
 {% set parameters_store = 'parameters' %}


### PR DESCRIPTION
Fixes #1757 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [ ] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
N/A

#### Core Tests
N/A

Core version / branch / commit hash / module tested against: N/A
HMI name / version / branch / commit hash / module tested against: N/A

### Summary
removed #pragmas from RPC spec generator that suppress deprecation warnings to property and enum definitions

### Changelog
##### Breaking Changes
* N/A

##### Enhancements
* N/A

##### Bug Fixes
* removed #pragmas from RPC spec generator that suppress deprecation warnings to property and enum definitions

### Tasks Remaining:
N/A

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
