### PR TITLE
WIP: Fixing start session failure on legacy modules

### DIFF
--- a/SmartDeviceLink/private/SDLIAPTransport.m
+++ b/SmartDeviceLink/private/SDLIAPTransport.m
@@ -432,7 +432,9 @@ int const CreateSessionRetries = 3;
 #pragma mark Retry Delay
 
 /**
- *  Generates a random number of seconds between 1.5 and 9.5 used to delay the retry control and data session attempts.
+ *  Generates a random number of seconds used to delay the retry control and data session attempts.
+ *
+ *  @discussion The retry delay is a HAX to fix a race condition in legacy SYNC head units (https://github.com/smartdevicelink/sdl_ios/issues/1783) where the module does not get the start RPC service frame and thus never responds to the request. Previously the min and max retry seconds were bounded at 1.5 and 9.5, however connection performance improved when the min retry seconds was upped to 10.
  *
  *  @return A random number of seconds.
  */

--- a/SmartDeviceLink/private/SDLIAPTransport.m
+++ b/SmartDeviceLink/private/SDLIAPTransport.m
@@ -437,8 +437,8 @@ int const CreateSessionRetries = 3;
  *  @return A random number of seconds.
  */
 - (double)sdl_retryDelay {
-    const double MinRetrySeconds = 1.5;
-    const double MaxRetrySeconds = 9.5;
+    const double MinRetrySeconds = 10.0;
+    const double MaxRetrySeconds = 15.0;
     double RetryRangeSeconds = MaxRetrySeconds - MinRetrySeconds;
 
     static double appDelaySeconds = 0;

--- a/SmartDeviceLink/private/SDLLifecycleProtocolHandler.m
+++ b/SmartDeviceLink/private/SDLLifecycleProtocolHandler.m
@@ -82,13 +82,15 @@ NS_ASSUME_NONNULL_BEGIN
     [self sdl_sendStartServiceSession:self.rpcStartServiceRetryCounter];
 }
 
+/// TODO
+/// @param retryCount The retry attempt count
 - (void)sdl_sendStartServiceSession:(int)retryCount {
     if (retryCount > RPCStartServiceRetries) {
-        SDLLogE(@"Starting the RPC session retries failed %d times. Closing the session", RPCStartServiceRetries);
+        SDLLogE(@"Starting the RPC service failed %d times. Closing the session", RPCStartServiceRetries);
         return [self.protocol stopWithCompletionHandler:^{}];
     }
 
-    SDLLogD(@"Starting timer for RPC Start Service ACK to be received.");
+    SDLLogD(@"Starting timeout timer for the module's response to the RPC start service");
 
     SDLControlFramePayloadRPCStartService *startServicePayload = [[SDLControlFramePayloadRPCStartService alloc] initWithVersion:SDLMaxProxyProtocolVersion];
     [self.protocol startServiceWithType:SDLServiceTypeRPC payload:startServicePayload.data];
@@ -102,7 +104,7 @@ NS_ASSUME_NONNULL_BEGIN
     __weak typeof(self) weakSelf = self;
     self.rpcStartServiceTimeoutTimer.elapsedBlock = ^{
         weakSelf.rpcStartServiceRetryCounter += 1;
-        SDLLogE(@"Module did no respond to the RPC start session request within %.f seconds. Retrying sending the start RPC start session request %d", StartSessionTime, weakSelf.rpcStartServiceRetryCounter);
+        SDLLogE(@"Module did not respond to the RPC start service within %.f seconds. Retrying (#%d) sending the request.", StartSessionTime, weakSelf.rpcStartServiceRetryCounter);
         [weakSelf sdl_sendStartServiceSession:weakSelf.rpcStartServiceRetryCounter];
     };
 


### PR DESCRIPTION
Fixes #1795

### Risk
This PR makes **no** API changes.

### Testing Plan
- [ ] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [ ] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
// TODO

#### Core Tests
Tested connecting and disconnecting 15 apps to SYNC 3.0 head unit multiple times during the same app session.

Core version / branch / commit hash / module tested against: SYNC 3.0
HMI name / version / branch / commit hash / module tested against: SYNC 3.0

### Summary
Added a workaround to fix an issue on legacy modules where the module never responds to the app's request to start an RPC service. 

##### Bug Fixes
* Fixed some apps failing to establish a connection with the module when more than 15 SDL apps are connected at once.

### Tasks Remaining:
- [ ] Run unit tests

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
