### PR TITLE
Deprecate SetDisplayLayout RPC

### DIFF
--- a/Example Apps/Example ObjC/MenuManager.m
+++ b/Example Apps/Example ObjC/MenuManager.m
@@ -97,9 +97,8 @@ NS_ASSUME_NONNULL_BEGIN
     
     // Non - Media
     SDLMenuCell *cell = [[SDLMenuCell alloc] initWithTitle:@"Non - Media (Default)" icon:nil voiceCommands:nil handler:^(SDLTriggerSource  _Nonnull triggerSource) {
-        SDLSetDisplayLayout* display = [[SDLSetDisplayLayout alloc] initWithPredefinedLayout:SDLPredefinedLayoutNonMedia];
-        [manager sendRequest:display withResponseHandler:^(SDLRPCRequest *request, SDLRPCResponse *response, NSError *error) {
-            if (!response.success) {
+        [manager.screenManager changeLayout:[[SDLTemplateConfiguration alloc] initWithPredefinedLayout:SDLPredefinedLayoutNonMedia] withCompletionHandler:^(NSError * _Nullable error) {
+            if (error != nil) {
                 [AlertManager sendAlertWithManager:manager image:nil textField1:errorMessage textField2:nil];
             }
         }];
@@ -108,9 +107,8 @@ NS_ASSUME_NONNULL_BEGIN
     
     // Graphic With Text
     SDLMenuCell *cell2 = [[SDLMenuCell alloc] initWithTitle:@"Graphic With Text" icon:nil voiceCommands:nil handler:^(SDLTriggerSource  _Nonnull triggerSource) {
-        SDLSetDisplayLayout* display = [[SDLSetDisplayLayout alloc] initWithPredefinedLayout:SDLPredefinedLayoutGraphicWithText];
-        [manager sendRequest:display withResponseHandler:^(SDLRPCRequest *request, SDLRPCResponse *response, NSError *error) {
-            if (!response.success) {
+        [manager.screenManager changeLayout:[[SDLTemplateConfiguration alloc] initWithPredefinedLayout:SDLPredefinedLayoutGraphicWithText] withCompletionHandler:^(NSError * _Nullable error) {
+            if (error != nil) {
                 [AlertManager sendAlertWithManager:manager image:nil textField1:errorMessage textField2:nil];
             }
         }];

--- a/Example Apps/Example ObjC/ProxyManager.m
+++ b/Example Apps/Example ObjC/ProxyManager.m
@@ -166,8 +166,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)sdlex_showInitialData {
     if (![self.sdlManager.hmiLevel isEqualToEnum:SDLHMILevelFull]) { return; }
 
-    SDLSetDisplayLayout *setDisplayLayout = [[SDLSetDisplayLayout alloc] initWithPredefinedLayout:SDLPredefinedLayoutNonMedia];
-    [self.sdlManager sendRequest:setDisplayLayout];
+    [self.sdlManager.screenManager changeLayout:[[SDLTemplateConfiguration alloc] initWithPredefinedLayout:SDLPredefinedLayoutNonMedia] withCompletionHandler:nil];
 
     [self sdlex_updateScreen];
     self.sdlManager.screenManager.softButtonObjects = [self.buttonManager allScreenSoftButtons];

--- a/Example Apps/Example Swift/MenuManager.swift
+++ b/Example Apps/Example Swift/MenuManager.swift
@@ -124,9 +124,8 @@ private extension MenuManager {
         /// Non-Media
         let submenuTitleNonMedia = "Non - Media (Default)"
         submenuItems.append(SDLMenuCell(title: submenuTitleNonMedia, icon: nil, voiceCommands: nil, handler: { (triggerSource) in
-            let display = SDLSetDisplayLayout(predefinedLayout: .nonMedia)
-            manager.send(request: display) { (request, response, error) in
-                guard response?.success.boolValue == .some(true) else {
+            manager.screenManager.changeLayout(SDLTemplateConfiguration(predefinedLayout: .nonMedia)) { err in
+                if err != nil {
                     AlertManager.sendAlert(textField1: errorMessage, sdlManager: manager)
                     return
                 }
@@ -136,9 +135,8 @@ private extension MenuManager {
         /// Graphic with Text
         let submenuTitleGraphicText = "Graphic With Text"
         submenuItems.append(SDLMenuCell(title: submenuTitleGraphicText, icon: nil, voiceCommands: nil, handler: { (triggerSource) in
-            let display = SDLSetDisplayLayout(predefinedLayout: .graphicWithText)
-            manager.send(request: display) { (request, response, error) in
-                guard response?.success.boolValue == .some(true) else {
+            manager.screenManager.changeLayout(SDLTemplateConfiguration(predefinedLayout: .graphicWithText)) { err in
+                if err != nil {
                     AlertManager.sendAlert(textField1: errorMessage, sdlManager: manager)
                     return
                 }

--- a/Example Apps/Example Swift/ProxyManager.swift
+++ b/Example Apps/Example Swift/ProxyManager.swift
@@ -250,9 +250,8 @@ private extension ProxyManager {
     /// Set the template and create the UI
     func showInitialData() {
         guard sdlManager.hmiLevel == .full else { return }
-        
-        let setDisplayLayout = SDLSetDisplayLayout(predefinedLayout: .nonMedia)
-        sdlManager.send(setDisplayLayout)
+
+        sdlManager.screenManager.changeLayout(SDLTemplateConfiguration(predefinedLayout: .nonMedia), withCompletionHandler: nil)
 
         updateScreen()
         sdlManager.screenManager.softButtonObjects = buttonManager.allScreenSoftButtons()

--- a/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
+++ b/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
@@ -7527,7 +7527,7 @@
 			attributes = {
 				CLASSPREFIX = SDL;
 				LastSwiftUpdateCheck = 0710;
-				LastUpgradeCheck = 0940;
+				LastUpgradeCheck = 1200;
 				ORGANIZATIONNAME = smartdevicelink;
 				TargetAttributes = {
 					5D4019AE1A76EC350006B0C2 = {
@@ -9096,6 +9096,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 				);
 				INFOPLIST_FILE = SmartDeviceLinkTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -9128,6 +9129,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 				);
 				INFOPLIST_FILE = SmartDeviceLinkTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = (
 					"$(inherited)",

--- a/SmartDeviceLink-iOS.xcodeproj/xcshareddata/xcschemes/SmartDeviceLink-Example-ObjC.xcscheme
+++ b/SmartDeviceLink-iOS.xcodeproj/xcshareddata/xcschemes/SmartDeviceLink-Example-ObjC.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SmartDeviceLink-iOS.xcodeproj/xcshareddata/xcschemes/SmartDeviceLink.xcscheme
+++ b/SmartDeviceLink-iOS.xcodeproj/xcshareddata/xcschemes/SmartDeviceLink.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SmartDeviceLink-iOS.xcodeproj/xcshareddata/xcschemes/SmartDeviceLinkSwift.xcscheme
+++ b/SmartDeviceLink-iOS.xcodeproj/xcshareddata/xcschemes/SmartDeviceLinkSwift.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -29,8 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -51,8 +49,6 @@
             ReferencedContainer = "container:SmartDeviceLink-iOS.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
+++ b/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
@@ -167,7 +167,10 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)sdl_sendSetDisplayLayoutWithTemplateConfiguration:(SDLTemplateConfiguration *)configuration completionHandler:(void (^)(NSError *_Nullable error))handler {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     SDLSetDisplayLayout *setLayout = [[SDLSetDisplayLayout alloc] initWithLayout:configuration.template dayColorScheme:configuration.dayColorScheme nightColorScheme:configuration.nightColorScheme];
+#pragma clang diagnostic pop
 
     __weak typeof(self)weakSelf = self;
     [self.connectionManager sendConnectionRequest:setLayout withResponseHandler:^(__kindof SDLRPCRequest * _Nullable request, __kindof SDLRPCResponse * _Nullable response, NSError * _Nullable error) {
@@ -499,7 +502,10 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (void)sdl_updateCurrentScreenDataFromSetDisplayLayout:(SDLSetDisplayLayout *)setDisplayLayout {
+#pragma clang diagnostic pop
     self.currentScreenData.templateConfig = [[SDLTemplateConfiguration alloc] initWithTemplate:setDisplayLayout.displayLayout dayColorScheme:setDisplayLayout.dayColorScheme nightColorScheme:setDisplayLayout.nightColorScheme];
 
     if (self.currentDataUpdatedHandler != nil) {

--- a/SmartDeviceLink/public/SDLSetDisplayLayout.h
+++ b/SmartDeviceLink/public/SDLSetDisplayLayout.h
@@ -8,15 +8,15 @@
 
 @class SDLTemplateColorScheme;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * Used to set an alternate display layout. If not sent, default screen for
  * given platform will be shown
  *
  * Since SmartDeviceLink 2.0
  */
-
-NS_ASSUME_NONNULL_BEGIN
-
+__deprecated_msg("Use SDLManager.screenManager.changeLayout() instead")
 @interface SDLSetDisplayLayout : SDLRPCRequest
 
 /// Convenience init to set a display layout

--- a/SmartDeviceLink/public/SDLSetDisplayLayout.m
+++ b/SmartDeviceLink/public/SDLSetDisplayLayout.m
@@ -11,7 +11,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation SDLSetDisplayLayout
+#pragma clang diagnostic pop
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"

--- a/SmartDeviceLink/public/SDLSetDisplayLayoutResponse.h
+++ b/SmartDeviceLink/public/SDLSetDisplayLayoutResponse.h
@@ -16,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  Since SmartDeviceLink 2.0
  */
+__deprecated_msg("Use SDLManager.screenManager.changeLayout() instead")
 @interface SDLSetDisplayLayoutResponse : SDLRPCResponse
 
 /**

--- a/SmartDeviceLink/public/SDLSetDisplayLayoutResponse.m
+++ b/SmartDeviceLink/public/SDLSetDisplayLayoutResponse.m
@@ -14,7 +14,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation SDLSetDisplayLayoutResponse
+#pragma clang diagnostic pop
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicUpdateOperationSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicUpdateOperationSpec.m
@@ -1101,8 +1101,11 @@ describe(@"the text and graphic operation", ^{
                 });
 
                 it(@"should send a set display layout, then update the screen data, then send a Show with no data", ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                     SDLSetDisplayLayout *sentRPC = testConnectionManager.receivedRequests.firstObject;
                     expect(sentRPC).to(beAnInstanceOf([SDLSetDisplayLayout class]));
+#pragma clang diagnostic pop
                     expect(sentRPC.displayLayout).to(equal(newConfiguration.template));
 
                     [testConnectionManager respondToLastRequestWithResponse:successSetDisplayLayoutResponse];
@@ -1133,8 +1136,11 @@ describe(@"the text and graphic operation", ^{
 
                 // should send a set display layout, then update the screen data, then send a Show with data and then update the screen data again
                 it(@"should send a set display layout, then update the screen data, then send a Show with data and then update the screen data again", ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                     SDLSetDisplayLayout *sentRPC = testConnectionManager.receivedRequests.firstObject;
                     expect(sentRPC).to(beAnInstanceOf([SDLSetDisplayLayout class]));
+#pragma clang diagnostic pop
                     expect(sentRPC.displayLayout).to(equal(newConfiguration.template));
 
                     [testConnectionManager respondToLastRequestWithResponse:successSetDisplayLayoutResponse];
@@ -1156,8 +1162,11 @@ describe(@"the text and graphic operation", ^{
                 // when cancelled before finishing
                 describe(@"when cancelled before finishing", ^{
                     it(@"should finish the operation with the set display layout data in the current data handler and set an update superseded error in the update completion handler", ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                         SDLSetDisplayLayout *sentRPC = testConnectionManager.receivedRequests.firstObject;
                         expect(sentRPC).to(beAnInstanceOf([SDLSetDisplayLayout class]));
+#pragma clang diagnostic pop
                         expect(sentRPC.displayLayout).to(equal(newConfiguration.template));
 
                         [testOp cancel];
@@ -1174,8 +1183,11 @@ describe(@"the text and graphic operation", ^{
                 // when it receives a set display layout failure
                 describe(@"when it receives a set display layout failure", ^{
                     it(@"should send a set display layout, then reset the screen data, then finish the operation", ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                         SDLSetDisplayLayout *sentRPC = testConnectionManager.receivedRequests.firstObject;
                         expect(sentRPC).to(beAnInstanceOf([SDLSetDisplayLayout class]));
+#pragma clang diagnostic pop
                         expect(sentRPC.displayLayout).to(equal(newConfiguration.template));
 
                         [testConnectionManager respondToLastRequestWithResponse:failSetDisplayLayoutResponse];

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicUpdateOperationSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicUpdateOperationSpec.m
@@ -67,9 +67,12 @@ describe(@"the text and graphic operation", ^{
     __block SDLWindowCapability *allEnabledCapability = [[SDLWindowCapability alloc] init];
 
     __block SDLShowResponse *successShowResponse = [[SDLShowResponse alloc] init];
-    __block SDLSetDisplayLayoutResponse *successSetDisplayLayoutResponse = [[SDLSetDisplayLayoutResponse alloc] init];
     __block SDLShowResponse *failShowResponse = [[SDLShowResponse alloc] init];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    __block SDLSetDisplayLayoutResponse *successSetDisplayLayoutResponse = [[SDLSetDisplayLayoutResponse alloc] init];
     __block SDLSetDisplayLayoutResponse *failSetDisplayLayoutResponse = [[SDLSetDisplayLayoutResponse alloc] init];
+#pragma clang diagnostic pop
     __block SDLTextAndGraphicState *emptyCurrentData = nil;
 
     __block SDLTextAndGraphicState *receivedState = nil;

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSetDisplayLayoutSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSetDisplayLayoutSpec.m
@@ -12,6 +12,8 @@
 
 QuickSpecBegin(SDLSetDisplayLayoutSpec)
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 describe(@"SetDisplayLayout Tests", ^ {
     __block SDLPredefinedLayout predefinedLayout = SDLPredefinedLayoutMedia;
     __block NSString *otherLayout = @"test123";
@@ -77,5 +79,6 @@ describe(@"SetDisplayLayout Tests", ^ {
         });
     });
 });
+#pragma clang diagnostic pop
 
 QuickSpecEnd

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLSetDisplayLayoutResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLSetDisplayLayoutResponseSpec.m
@@ -24,6 +24,8 @@ SDLButtonCapabilities* button = [[SDLButtonCapabilities alloc] init];
 SDLSoftButtonCapabilities* softButton = [[SDLSoftButtonCapabilities alloc] init];
 SDLPresetBankCapabilities* presetBank = [[SDLPresetBankCapabilities alloc] init];
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 describe(@"Getter/Setter Tests", ^ {
     it(@"Should set and get correctly", ^ {
         SDLSetDisplayLayoutResponse* testResponse = [[SDLSetDisplayLayoutResponse alloc] init];
@@ -67,5 +69,6 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testResponse.presetBankCapabilities).to(beNil());
     });
 });
+#pragma clang diagnostic pop
 
 QuickSpecEnd

--- a/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
+++ b/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
@@ -435,10 +435,16 @@ describe(@"System capability manager", ^{
     });
 
     context(@"When notified of a SetDisplayLayout Response", ^ {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         __block SDLSetDisplayLayoutResponse *testSetDisplayLayoutResponse = nil;
+#pragma clang diagnostic pop
 
         beforeEach(^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             testSetDisplayLayoutResponse = [[SDLSetDisplayLayoutResponse alloc] init];
+#pragma clang diagnostic pop
             testSetDisplayLayoutResponse.displayCapabilities = testDisplayCapabilities;
             testSetDisplayLayoutResponse.buttonCapabilities = testButtonCapabilities;
             testSetDisplayLayoutResponse.softButtonCapabilities = testSoftButtonCapabilities;


### PR DESCRIPTION
Fixes #1785 

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Unit tests were run and ensured that no new warnings were created when running unit tests.

#### Core Tests
Basic smoke tests were run using the example swift app.

Core version / branch / commit hash / module tested against: Manticore (Core v6.1.1)
HMI name / version / branch / commit hash / module tested against: Manticore (Generic HMI v0.8.1)

### Summary
This PR deprecates `SDLSetDisplayLayout` and `SDLSetDisplayLayoutResponse`.

### Changelog
##### Enhancements
* The `SDLSetDisplayLayout` RPC is now deprecated in favor of the `SDLScreenManager.changeLayout()` API.

### Tasks Remaining:
None

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
