### PR TITLE
Bugfix/battery drain issue

### DIFF
--- a/SmartDeviceLink/private/SDLIAPDataSession.m
+++ b/SmartDeviceLink/private/SDLIAPDataSession.m
@@ -6,6 +6,8 @@
 //  Copyright © 2019 smartdevicelink. All rights reserved.
 //
 
+#import <UIKit/UIDevice.h>
+
 #import "SDLIAPDataSession.h"
 
 #import "SDLGlobals.h"
@@ -17,6 +19,7 @@
 
 NSString *const IOStreamThreadName = @"com.smartdevicelink.iostream";
 NSTimeInterval const IOStreamThreadCanceledSemaphoreWaitSecs = 1.0;
+NSTimeInterval const IOStreamThreadRetryWaitSecs = 10.0;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -36,14 +39,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithAccessory:(nullable EAAccessory *)accessory delegate:(id<SDLIAPDataSessionDelegate>)delegate forProtocol:(NSString *)protocol; {
     SDLLogV(@"iAP data session init for accessory: %@", accessory);
-
+    
     self = [super initWithAccessory:accessory forProtocol:protocol];
     if (!self) { return nil; }
-
+    
     _delegate = delegate;
     _sendDataQueue = [[SDLMutableDataQueue alloc] init];
     _ioStreamThreadCancelledSemaphore = dispatch_semaphore_create(0);
-
     return self;
 }
 
@@ -57,7 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
         [self.delegate dataSessionShouldRetry];
     } else {
         SDLLogD(@"Starting data session with accessory: %@, using protocol: %@", self.accessory.name, self.protocolString);
-
+        
         if (![super createSession]) {
             SDLLogW(@"Data session failed to setup with accessory: %@. Retrying...", self.accessory);
             __weak typeof(self) weakSelf = self;
@@ -67,7 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
                 [strongSelf.delegate dataSessionShouldRetry];
             }];
         }
-
+        
         if (self.eaSession != nil) {
             self.ioStreamThread = [[NSThread alloc] initWithTarget:self selector:@selector(sdl_accessoryEventLoop) object:nil];
             [self.ioStreamThread setName:IOStreamThreadName];
@@ -83,6 +85,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)destroySessionWithCompletionHandler:(void (^)(void))disconnectCompletionHandler {
     SDLLogD(@"Destroying the data session");
 
+    [self sdl_forceCloseEaSession];
+
     if (self.ioStreamThread == nil) {
         SDLLogV(@"No data session established");
         [super cleanupClosedSession];
@@ -90,23 +94,38 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     // Tell the ioStreamThread to shutdown the I/O streams. The I/O streams must be opened and closed on the same thread; if they are not, random crashes can occur. Dispatch this task to the main queue to ensure that this task is performed on the Main Thread. We are using the Main Thread for ease since we don't want to create a separate thread just to wait on closing the I/O streams. Using the Main Thread ensures that semaphore wait is not called from ioStreamThread, which would block the ioStreamThread and prevent shutdown.
-    __weak typeof(self) weakSelf = self;
     dispatch_async(dispatch_get_main_queue(), ^{
-        __strong typeof(weakSelf) strongSelf = weakSelf;
-
+        
         // Attempt to cancel the ioStreamThread. Once the thread realizes it has been cancelled, it will cleanup the I/O streams. Make sure to wake up the run loop in case there is no current I/O event running on the ioThread.
-        [strongSelf.ioStreamThread cancel];
-        [strongSelf performSelector:@selector(sdl_doNothing) onThread:self.ioStreamThread withObject:nil waitUntilDone:NO];
-
+        [self.ioStreamThread cancel];
+        [self performSelector:@selector(sdl_doNothing) onThread:self.ioStreamThread withObject:nil waitUntilDone:NO];
+        
         // Block the thread until the semaphore has been released by the ioStreamThread (or a timeout has occured).
-        BOOL cancelledSuccessfully = [strongSelf sdl_isIOThreadCancelled];
+        BOOL cancelledSuccessfully = [self sdl_isIOThreadCancelled];
         if (!cancelledSuccessfully) {
             SDLLogE(@"The I/O streams were not shut down successfully. We might not be able to create a new session with an accessory during the same app session. If this happens, only force quitting and restarting the app will allow new sessions.");
+            [self performSelector:@selector(sdl_retryThreadCancel) withObject:nil afterDelay:IOStreamThreadRetryWaitSecs];
+            [self sdl_retryThreadCancel];
+        } else {
+            self.ioStreamThread = nil;
         }
-
-        [strongSelf.sendDataQueue removeAllObjects];
-
+        
+        [self.sendDataQueue removeAllObjects];
+        
         disconnectCompletionHandler();
+    });
+}
+
+- (void)sdl_forceCloseEaSession {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (self.eaSession != nil) {
+            [[self.eaSession inputStream] close];
+            [[self.eaSession inputStream] removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+            [[self.eaSession inputStream] setDelegate:nil];
+            [[self.eaSession outputStream] close];
+            [[self.eaSession outputStream] removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+            [[self.eaSession outputStream] setDelegate:nil];
+        }
     });
 }
 
@@ -114,15 +133,43 @@ NS_ASSUME_NONNULL_BEGIN
 /// @return Whether or not the session's I/O streams were closed successfully.
 - (BOOL)sdl_isIOThreadCancelled {
     NSAssert(![NSThread.currentThread.name isEqualToString:IOStreamThreadName], @"%@ must not be called from the ioStreamThread!", NSStringFromSelector(_cmd));
-
+    
     long lWait = dispatch_semaphore_wait(self.ioStreamThreadCancelledSemaphore, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(IOStreamThreadCanceledSemaphoreWaitSecs * NSEC_PER_SEC)));
     if (lWait == 0) {
         SDLLogD(@"ioStreamThread cancelled successfully");
         return YES;
     }
-
+    
     SDLLogE(@"Failed to cancel ioStreamThread within %.1f seconds", IOStreamThreadCanceledSemaphoreWaitSecs);
     return NO;
+}
+
+- (void)sdl_retryThreadCancel {
+    if (self.ioStreamThread == nil) {
+        SDLLogV(@"No data session established during Retry");
+        [super cleanupClosedSession];
+    }
+    SDLLogE(@"Will retry thread cancel in %.1f seconds", IOStreamThreadRetryWaitSecs);
+    __weak typeof(self) weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        
+        // Attempt to cancel the ioStreamThread. Once the thread realizes it has been cancelled, it will cleanup the I/O streams. Make sure to wake up the run loop in case there is no current I/O event running on the ioThread.
+        [strongSelf.ioStreamThread cancel];
+        [strongSelf performSelector:@selector(sdl_doNothing) onThread:self.ioStreamThread withObject:nil waitUntilDone:NO];
+        
+        // Block the thread until the semaphore has been released by the ioStreamThread (or a timeout has occured).
+        BOOL cancelledSuccessfully = [strongSelf sdl_isIOThreadCancelled];
+        if (!cancelledSuccessfully) {
+            SDLLogE(@"The I/O streams were not shut down successfully.  Will try again.");
+            [strongSelf performSelector:@selector(sdl_retryThreadCancel) withObject:nil afterDelay:IOStreamThreadRetryWaitSecs];
+            [strongSelf sdl_retryThreadCancel];
+        } else {
+            strongSelf.ioStreamThread = nil;
+        }
+        
+        [strongSelf.sendDataQueue removeAllObjects];
+    });
 }
 
 /// Helper method for waking up the ioStreamThread.
@@ -133,7 +180,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)sendData:(NSData *)data {
     // Enqueue the data for transmission on the IO thread
     [self.sendDataQueue enqueueBuffer:data.mutableCopy];
-
+    
     [self performSelector:@selector(sdl_dequeueAndWriteToOutputStream) onThread:self.ioStreamThread withObject:nil waitUntilDone:NO];
 }
 
@@ -145,22 +192,22 @@ NS_ASSUME_NONNULL_BEGIN
         SDLLogW(@"Attempted to send data on I/O thread but the thread is cancelled.");
         return;
     }
-
+    
     NSOutputStream *ostream = self.eaSession.outputStream;
     if (!ostream.hasSpaceAvailable) {
         SDLLogV(@"Attempted to send data with output stream but there is no space available.");
         return;
     }
-
+    
     NSMutableData *remainder = [self.sendDataQueue frontBuffer];
     if (remainder == nil) {
         SDLLogV(@"No more data to write to data session's output stream. Returning");
         return;
     }
-
+    
     NSUInteger bytesRemaining = remainder.length;
     NSInteger bytesWritten = [ostream write:remainder.bytes maxLength:bytesRemaining];
-
+    
     if (bytesWritten < 0) {
         if (ostream.streamError != nil) {
             // Once a stream has reported an error, it cannot be re-used for read or write operations. Shut down the stream and attempt to create a new session.
@@ -228,7 +275,7 @@ NS_ASSUME_NONNULL_BEGIN
         SDLLogD(@"Data session input stream opened");
         self.isInputStreamOpen = YES;
     }
-
+    
     // When both streams are open, session initialization is complete. Let the delegate know.
     if (self.isInputStreamOpen && self.isOutputStreamOpen) {
         SDLLogV(@"Data session I/O streams opened for protocol: %@", self.protocolString);
@@ -242,13 +289,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)sdl_streamDidEnd:(NSStream *)stream {
     NSAssert(!NSThread.isMainThread, @"%@ should only be called on the IO thread", NSStringFromSelector(_cmd));
-
+    
     SDLLogD(@"Data stream ended");
     if (self.accessory == nil) {
         SDLLogD(@"Data session is nil");
         return;
     }
-
+    
     // The handler will be called on the I/O thread, but the session stop method must be called on the main thread
     dispatch_async(dispatch_get_main_queue(), ^{
         __weak typeof(self) weakSelf = self;
@@ -258,7 +305,7 @@ NS_ASSUME_NONNULL_BEGIN
             [strongSelf.delegate dataSessionShouldRetry];
         }];
     });
-
+    
     // To prevent deadlocks the handler must return to the runloop and not block the thread
 }
 
@@ -275,10 +322,10 @@ NS_ASSUME_NONNULL_BEGIN
             SDLLogE(@"Failed to read from data stream");
             break;
         }
-
+        
         NSData *dataIn = [NSData dataWithBytes:buf length:(NSUInteger)bytesRead];
         SDLLogBytes(dataIn, SDLLogBytesDirectionReceive);
-
+        
         if (bytesRead > 0) {
             if (self.delegate == nil) { return; }
             [self.delegate dataSessionDidReceiveData:dataIn];
@@ -300,9 +347,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)sdl_streamDidError:(NSStream *)stream {
     NSAssert(!NSThread.isMainThread, @"%@ should only be called on the IO thread", NSStringFromSelector(_cmd));
-
+    
     SDLLogE(@"Data session %s stream errored", stream == self.eaSession.inputStream ? "input" : "output");
-
+    
     // To prevent deadlocks the handler must return to the runloop and not block the thread
     dispatch_async(dispatch_get_main_queue(), ^{
         __weak typeof(self) weakSelf = self;
@@ -325,23 +372,34 @@ NS_ASSUME_NONNULL_BEGIN
         if (!self.eaSession) {
             return;
         }
-
+        
         [self startStream:self.eaSession.inputStream];
         [self startStream:self.eaSession.outputStream];
-
+        
         SDLLogD(@"Starting the accessory event loop on thread: %@", NSThread.currentThread.name);
-
+        
+        BOOL runModeFailedOnce = NO;
+        
         while (self.ioStreamThread != nil && !self.ioStreamThread.cancelled) {
+            SDLLogD(@"In the Looper!");
             // Enqueued data will be written to and read from the streams in the runloop
-            [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.25f]];
+            BOOL result = [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.25f]];
+            if (!result && !runModeFailedOnce) {
+                // log error once on any iOS version but only break if on iOS 14 or up.
+                runModeFailedOnce = YES;
+                SDLLogE(@"The run loop returned immediately although two streams supposed to be scheduled.\nInput stream: %@\nOutput stream: %@\nAccessory: %@", self.eaSession.inputStream, self.eaSession.outputStream, self.accessory);
+                if (SDL_SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"14")) {
+                    break;
+                }
+            }
         }
-
+        
         SDLLogD(@"Closing the accessory event loop on thread: %@", NSThread.currentThread.name);
-
+        
         // Close I/O streams
         [self sdl_closeSession];
         [super cleanupClosedSession];
-
+        
         // If a thread is blocked waiting on the I/O streams to shutdown, let the thread know that shutdown has completed.
         dispatch_semaphore_signal(self.ioStreamThreadCancelledSemaphore);
     }
@@ -352,9 +410,9 @@ NS_ASSUME_NONNULL_BEGIN
     if (self.eaSession == nil) {
         return;
     }
-
+    
     SDLLogD(@"Closing EASession for accessory connection id: %tu, name: %@", self.connectionID, self.eaSession.accessory.name);
-
+    
     [self stopStream:[self.eaSession inputStream]];
     [self stopStream:[self.eaSession outputStream]];
 }

--- a/SmartDeviceLink/private/SDLIAPTransport.m
+++ b/SmartDeviceLink/private/SDLIAPTransport.m
@@ -19,7 +19,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-double const TimeRequiredBetweenConnectionAttempts = 10.0;
+double const TimeRequiredBetweenConnectionAttempts = 4.0; // Prevent redundant EASessions
 int const CreateSessionRetries = 3;
 
 @interface SDLIAPTransport () <SDLIAPControlSessionDelegate, SDLIAPDataSessionDelegate>

--- a/SmartDeviceLink/private/SDLLifecycleManager.h
+++ b/SmartDeviceLink/private/SDLLifecycleManager.h
@@ -54,6 +54,8 @@ extern SDLLifecycleState *const SDLLifecycleStateSettingUpHMI;
 extern SDLLifecycleState *const SDLLifecycleStateUnregistering;
 extern SDLLifecycleState *const SDLLifecycleStateReady;
 
+extern NSString *const SDLEASessionCompleteNotification;
+
 typedef void (^SDLMultipleRequestCompletionHandler)(BOOL success);
 typedef BOOL (^SDLMultipleSequentialRequestProgressHandler)(__kindof SDLRPCRequest *request, __kindof SDLRPCResponse *__nullable response, NSError *__nullable error, float percentComplete);
 typedef void (^SDLMultipleAsyncRequestProgressHandler)(__kindof SDLRPCRequest *request, __kindof SDLRPCResponse *__nullable response, NSError *__nullable error, float percentComplete);

--- a/SmartDeviceLink/private/SDLLifecycleManager.m
+++ b/SmartDeviceLink/private/SDLLifecycleManager.m
@@ -192,7 +192,27 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
 
     _backgroundTaskManager = [[SDLBackgroundTaskManager alloc] initWithBackgroundTaskName:BackgroundTaskTransportName];
 
+    if (SDL_SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"14")) {
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(sdl_accessoryDisconnected:)
+                                                     name:EAAccessoryDidDisconnectNotification
+                                                   object:nil];
+    }
+    
     return self;
+}
+
+- (void)sdl_accessoryDisconnected:(NSNotification *)notification {
+    if (SDL_SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"14")) {
+        EAAccessory *accessory = [notification.userInfo objectForKey:EAAccessoryKey];
+        SDLLogD(@"Accessory with serial number: %@, and connectionID: %lu disconnecting.", accessory.serialNumber, (unsigned long)accessory.connectionID);
+        if (self.backgroundTaskManager != nil) {
+            [self.backgroundTaskManager endBackgroundTask];
+        }
+        if (self.secondaryTransportManager != nil) {
+            [_secondaryTransportManager endBackgroundTask];
+        }
+    }
 }
 
 - (void)startWithReadyHandler:(SDLManagerReadyBlock)readyHandler {

--- a/SmartDeviceLink/private/SDLLifecycleManager.m
+++ b/SmartDeviceLink/private/SDLLifecycleManager.m
@@ -80,6 +80,7 @@ SDLLifecycleState *const SDLLifecycleStateUnregistering = @"Unregistering";
 SDLLifecycleState *const SDLLifecycleStateReady = @"Ready";
 
 NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask";
+NSString *const SDLEASessionCompleteNotification = @"com.sdl.eaSessionCompleteNotification";
 
 #pragma mark - Protected Class Interfaces
 @interface SDLStreamingMediaManager ()
@@ -195,7 +196,7 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
     if (SDL_SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"14")) {
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(sdl_accessoryDisconnected:)
-                                                     name:EAAccessoryDidDisconnectNotification
+                                                     name:SDLEASessionCompleteNotification
                                                    object:nil];
     }
     

--- a/SmartDeviceLink/private/SDLSecondaryTransportManager.h
+++ b/SmartDeviceLink/private/SDLSecondaryTransportManager.h
@@ -54,6 +54,8 @@ extern SDLSecondaryTransportState *const SDLSecondaryTransportStateReconnecting;
 /// @param completionHandler Handler called when the session has been destroyed
 - (void)disconnectSecondaryTransportWithCompletionHandler:(void (^)(void))completionHandler;
 
+- (void)endBackgroundTask;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/private/SDLSecondaryTransportManager.m
+++ b/SmartDeviceLink/private/SDLSecondaryTransportManager.m
@@ -159,6 +159,12 @@ struct TransportProtocolUpdated {
     return self;
 }
 
+- (void)endBackgroundTask {
+    if (self.backgroundTaskManager != nil) {
+        [self.backgroundTaskManager endBackgroundTask];
+    }
+}
+
 - (void)startWithPrimaryProtocol:(SDLProtocol *)primaryProtocol {
     SDLLogD(@"SDLSecondaryTransportManager start");
 


### PR DESCRIPTION
Fixes #1799 and #1809

### Risk
This PR makes **no** API changes.

### Testing Plan
- [ ] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [ ] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
TBD

Note: Unit tests to simulate the EA streams are planned. Feasibility must be confirmed because lot of mock classes might need to be created.

#### Core Tests
Only tested against various Ford SYNC3 systems.

### Summary
This PR is a mirror of a Ford internal fork. The goal is to improve stability within the SDL library regarding EA session and stream lifecycle. 

### Changelog
##### Bug Fixes
- Adds a force close for EA sessions upon EA disconnect notifications.
- Adds retry mechanism if IO thread could not be cancelled.
- Fixes a possible infinity loop that could cause a 100% load on the IO thread.
- Prevents a spam of EA connect notifications to execute further.
- Ends existing background task identifier upon EA disconnect notifications.

### Tasks Remaining:
- [ ] [Code review]
- [ ] [Write unit tests when applicable]
- [ ] [Test against other EA devices and make sure no regression is introduced]

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
