### PR TITLE
Fix example apps resetting the soft button state when going from HMI BACKGROUND -> FULL

### DIFF
--- a/Example Apps/Example ObjC/ProxyManager.m
+++ b/Example Apps/Example ObjC/ProxyManager.m
@@ -169,7 +169,6 @@ NS_ASSUME_NONNULL_BEGIN
     [self.sdlManager.screenManager changeLayout:[[SDLTemplateConfiguration alloc] initWithPredefinedLayout:SDLPredefinedLayoutNonMedia] withCompletionHandler:nil];
 
     [self sdlex_updateScreen];
-    self.sdlManager.screenManager.softButtonObjects = [self.buttonManager allScreenSoftButtons];
 }
 
 - (nullable RefreshUIHandler)refreshUIHandler {
@@ -244,8 +243,9 @@ NS_ASSUME_NONNULL_BEGIN
         // This is our first time in a non-NONE state
         self.firstHMILevel = newLevel;
         
-        // Send static menu items.
+        // Send static menu items and soft buttons
         [self sdlex_createMenus];
+        self.sdlManager.screenManager.softButtonObjects = [self.buttonManager allScreenSoftButtons];
 
         // Subscribe to vehicle data.
         [self.vehicleDataManager subscribeToVehicleOdometer];

--- a/Example Apps/Example Swift/ProxyManager.swift
+++ b/Example Apps/Example Swift/ProxyManager.swift
@@ -165,8 +165,9 @@ extension ProxyManager: SDLManagerDelegate {
             // This is our first time in a non-NONE state
             firstHMILevelState = newLevel
 
-            // Send static menu items.
+            // Send static menu items and soft buttons
             createMenuAndGlobalVoiceCommands()
+            sdlManager.screenManager.softButtonObjects = buttonManager.allScreenSoftButtons()
 
             // Subscribe to vehicle data.
             vehicleDataManager.subscribeToVehicleOdometer()
@@ -254,7 +255,6 @@ private extension ProxyManager {
         sdlManager.screenManager.changeLayout(SDLTemplateConfiguration(predefinedLayout: .nonMedia), withCompletionHandler: nil)
 
         updateScreen()
-        sdlManager.screenManager.softButtonObjects = buttonManager.allScreenSoftButtons()
     }
 
     /// Update the UI's textfields, images and soft buttons


### PR DESCRIPTION
Fixes #1782 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [ ] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
n/a - no changes to library code

#### Core Tests
Tested reproduction steps in issue with Obj-C example and Swift example

Core version / branch / commit hash / module tested against: Manticore (Core v6.1.1)
HMI name / version / branch / commit hash / module tested against: Manticore (Generic HMI v0.8.1)

### Summary
This PR modifies the Obj-C and Swift example apps to no longer reset the soft buttons whenever moving to HMI FULL. This could lead to a case where the example apps' soft button state and text / image state is out of sync.

### Changelog
##### Bug Fixes
* [Example Apps] Fixed a case where the soft button state and text / image state could get out of sync.

### Tasks Remaining:
none

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
