### PR TITLE
Removed the suppress deprecation warning

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 
 env:
     PROJECT: 'SmartDeviceLink-iOS.xcodeproj'
-    DESTINATION: 'platform=iOS Simulator,name=iPhone 11,OS=14.0'
+    DESTINATION: 'platform=iOS Simulator,name=iPhone 11,OS=14.1'
 
 jobs:
     build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
 
             # Select the Xcode version (the platform/simulator/OS available for testing depend on the Xcode version)
             - name: Select Xcode version
-              run: sudo xcode-select -switch /Applications/Xcode_12.0.1.app
+              run: sudo xcode-select -switch /Applications/Xcode_12.1.app
 
             - name: Build
               run: set -o pipefail && xcodebuild -scheme "${{ matrix.scheme }}" -destination "$DESTINATION" build | xcpretty --color --simple
@@ -46,7 +46,7 @@ jobs:
 
             # Select the Xcode version (the platform/simulator/OS available for testing depend on the Xcode version)
             - name: Select Xcode version
-              run: sudo xcode-select -switch /Applications/Xcode_12.0.0.app
+              run: sudo xcode-select -switch /Applications/Xcode_12.1.app
 
             - name: Checkout repository
               uses: actions/checkout@v2.3.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
 
             # Select the Xcode version (the platform/simulator/OS available for testing depend on the Xcode version)
             - name: Select Xcode version
-              run: sudo xcode-select -switch /Applications/Xcode_12.0.0.app
+              run: sudo xcode-select -switch /Applications/Xcode_12.0.1.app
 
             - name: Build
               run: set -o pipefail && xcodebuild -scheme "${{ matrix.scheme }}" -destination "$DESTINATION" build | xcpretty --color --simple

--- a/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
+++ b/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
@@ -2059,6 +2059,7 @@
 		2BF2F85120ED068200A26EF2 /* SDLAudioStreamingIndicatorSpec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLAudioStreamingIndicatorSpec.m; sourceTree = "<group>"; };
 		4A1B036E24CF484E008C6B13 /* SDLDriverDistractionCapabilitySpec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLDriverDistractionCapabilitySpec.m; sourceTree = "<group>"; };
 		4A1FA09A25114833006B7851 /* SDLErrorConstants.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SDLErrorConstants.m; path = public/SDLErrorConstants.m; sourceTree = "<group>"; };
+		4A316E0A253F316700D4DDC7 /* test.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; name = test.yml; path = .github/workflows/test.yml; sourceTree = SOURCE_ROOT; };
 		4A40253D24FFDA660080E159 /* SDLTextAndGraphicState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SDLTextAndGraphicState.m; path = private/SDLTextAndGraphicState.m; sourceTree = "<group>"; };
 		4A40253E24FFDA660080E159 /* SDLTextAndGraphicUpdateOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SDLTextAndGraphicUpdateOperation.h; path = private/SDLTextAndGraphicUpdateOperation.h; sourceTree = "<group>"; };
 		4A40253F24FFDA660080E159 /* SDLTextAndGraphicUpdateOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SDLTextAndGraphicUpdateOperation.m; path = private/SDLTextAndGraphicUpdateOperation.m; sourceTree = "<group>"; };
@@ -5603,6 +5604,7 @@
 				5D5934EE1A85160900687FB9 /* Protocol */,
 				5D5934F01A85161A00687FB9 /* Transport */,
 				5D1665A01CF5D5DA00CC4CA1 /* .gitignore */,
+				4A316E0A253F316700D4DDC7 /* test.yml */,
 				5D1665A21CF5D5DA00CC4CA1 /* Cartfile.private */,
 				5D1665A31CF5D5DA00CC4CA1 /* CHANGELOG.md */,
 				5D1665A41CF5D5DA00CC4CA1 /* DEPENDENCIES.md */,

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnAppInterfaceUnregisteredSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnAppInterfaceUnregisteredSpec.m
@@ -29,10 +29,7 @@ describe(@"Getter/Setter Tests", ^ {
                                            @{SDLRPCParameterNameParameters:
                                                  @{SDLRPCParameterNameReason:SDLAppInterfaceUnregisteredReasonAppUnauthorized},
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnAppInterfaceUnregistered}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnAppInterfaceUnregistered* testNotification = [[SDLOnAppInterfaceUnregistered alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testNotification.reason).to(equal(SDLAppInterfaceUnregisteredReasonAppUnauthorized));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnAppServiceDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnAppServiceDataSpec.m
@@ -37,10 +37,7 @@ describe(@"Getter/Setter Tests", ^{
                                                SDLRPCParameterNameServiceData:testAppServiceData
                                                },
                                        SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnAppServiceData}};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnAppServiceData *testNotification = [[SDLOnAppServiceData alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testNotification.serviceData).to(equal(testAppServiceData));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnButtonEventSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnButtonEventSpec.m
@@ -37,10 +37,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                    SDLRPCParameterNameButtonEventMode:SDLButtonEventModeButtonDown,
                                                    SDLRPCParameterNameCustomButtonId:@4252},
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnButtonEvent}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnButtonEvent* testNotification = [[SDLOnButtonEvent alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testNotification.buttonName).to(equal(SDLButtonNameCustomButton));
         expect(testNotification.buttonEventMode).to(equal(SDLButtonEventModeButtonDown));

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnButtonPressSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnButtonPressSpec.m
@@ -37,10 +37,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                    SDLRPCParameterNameButtonPressMode:SDLButtonPressModeLong,
                                                    SDLRPCParameterNameCustomButtonId:@5642},
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnButtonPress}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnButtonPress* testNotification = [[SDLOnButtonPress alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testNotification.buttonName).to(equal(SDLButtonNameCustomButton));
         expect(testNotification.buttonPressMode).to(equal(SDLButtonPressModeLong));

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnCommandSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnCommandSpec.m
@@ -32,10 +32,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                  @{SDLRPCParameterNameCommandId:@5676544,
                                                    SDLRPCParameterNameTriggerSource:SDLTriggerSourceKeyboard},
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnCommand}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnCommand* testNotification = [[SDLOnCommand alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testNotification.cmdID).to(equal(@5676544));
         expect(testNotification.triggerSource).to(equal(SDLTriggerSourceKeyboard));

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnDriverDistractionSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnDriverDistractionSpec.m
@@ -35,10 +35,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                  @{SDLRPCParameterNameState:SDLDriverDistractionStateOn,
                                                    SDLRPCParameterNameLockScreenDismissalEnabled: @1},
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnDriverDistraction}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnDriverDistraction* testNotificationOn = [[SDLOnDriverDistraction alloc] initWithDictionary:dictOn];
-#pragma clang diagnostic pop
         
         expect(testNotificationOn.state).to(equal(SDLDriverDistractionStateOn));
         expect(testNotificationOn.lockScreenDismissalEnabled).to(beTrue());
@@ -48,10 +45,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                  @{SDLRPCParameterNameState:SDLDriverDistractionStateOff,
                                                    SDLRPCParameterNameLockScreenDismissalEnabled: @0},
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnDriverDistraction}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnDriverDistraction *testNotificationOff = [[SDLOnDriverDistraction alloc] initWithDictionary:dictOff];
-#pragma clang diagnostic pop
 
         expect(testNotificationOff.state).to(equal(SDLDriverDistractionStateOff));
         expect(testNotificationOff.lockScreenDismissalEnabled).to(beFalse());

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnHMIStatusSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnHMIStatusSpec.m
@@ -58,10 +58,7 @@ describe(@"Getter/Setter Tests", ^ {
                                         SDLRPCParameterNameVideoStreamingState: testVideoState,
                                         SDLRPCParameterNameWindowId: testWindowID},
                                   SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnHMIStatus}};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnHMIStatus* testNotification = [[SDLOnHMIStatus alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testNotification.hmiLevel).to(equal(testLevel));
         expect(testNotification.audioStreamingState).to(equal(testAudioState));

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnHashChangeSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnHashChangeSpec.m
@@ -28,10 +28,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                            @{SDLRPCParameterNameParameters:
                                                                  @{SDLRPCParameterNameHashId:@"hash"},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnHashChange}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnHashChange* testNotification = [[SDLOnHashChange alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testNotification.hashID).to(equal(@"hash"));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnInteriorVehicleDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnInteriorVehicleDataSpec.m
@@ -35,10 +35,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                            @{SDLRPCParameterNameParameters:
                                                                  @{SDLRPCParameterNameModuleData:someModuleData},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnInteriorVehicleData}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnInteriorVehicleData* testNotification = [[SDLOnInteriorVehicleData alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testNotification.moduleData).to(equal(someModuleData));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnKeyboardInputSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnKeyboardInputSpec.m
@@ -32,10 +32,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                  @{SDLRPCParameterNameEvent:SDLKeyboardEventSubmitted,
                                                    SDLRPCParameterNameData:@"qwertyg"},
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnKeyboardInput}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnKeyboardInput* testNotification = [[SDLOnKeyboardInput alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testNotification.event).to(equal(SDLKeyboardEventSubmitted));
         expect(testNotification.data).to(equal(@"qwertyg"));

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnLanguageChangeSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnLanguageChangeSpec.m
@@ -33,10 +33,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                  @{SDLRPCParameterNameLanguage:SDLLanguageEsEs,
                                                    SDLRPCParameterNameHMIDisplayLanguage:SDLLanguageDeDe},
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnLanguageChange}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnLanguageChange* testNotification = [[SDLOnLanguageChange alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testNotification.language).to(equal(SDLLanguageEsEs));
         expect(testNotification.hmiDisplayLanguage).to(equal(SDLLanguageDeDe));

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnPermissionsChangeSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnPermissionsChangeSpec.m
@@ -37,10 +37,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                            @{SDLRPCParameterNameParameters:
                                                                  @{SDLRPCParameterNamePermissionItem:@[testPermissionItem],
                                                                    SDLRPCParameterNameRequireEncryption:@YES}, SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnPermissionsChange}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnPermissionsChange* testNotification = [[SDLOnPermissionsChange alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testNotification.permissionItem).to(equal([@[testPermissionItem] mutableCopy]));
         expect(testNotification.requireEncryption.boolValue).to(beTrue());

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnRCStatusSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnRCStatusSpec.m
@@ -36,10 +36,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                                    SDLRPCParameterNameAllowed:@YES
                                                                    },
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnRCStatus}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnRCStatus* testNotification = [[SDLOnRCStatus alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testNotification.allowed).to(equal(@YES));
         expect(testNotification.allocatedModules).to(equal([@[allocatedModule] copy]));

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnSyncPDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnSyncPDataSpec.m
@@ -38,10 +38,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                      SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnSyncPData}};
 #pragma clang diagnostic pop
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnSyncPData* testNotification = [[SDLOnSyncPData alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testNotification.URL).to(equal(@"https://www.youtube.com/watch?v=ygr5AHufBN4"));
         expect(testNotification.Timeout).to(equal(@8357));

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnSystemCapabilityUpdatedSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnSystemCapabilityUpdatedSpec.m
@@ -38,10 +38,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                SDLRPCParameterNameSystemCapability:testSystemCapability
                                                },
                                        SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnSystemCapabilityUpdated}};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnSystemCapabilityUpdated *testNotification = [[SDLOnSystemCapabilityUpdated alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testNotification.systemCapability).to(equal(testSystemCapability));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnSystemRequestSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnSystemRequestSpec.m
@@ -48,10 +48,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                    SDLRPCParameterNameOffset:@2532678684,
                                                    SDLRPCParameterNameLength:@50000000000},
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnSystemRequest}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnSystemRequest* testNotification = [[SDLOnSystemRequest alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testNotification.requestType).to(equal(SDLRequestTypeFileResume));
         expect(testNotification.requestSubType).to(equal(@"subtype"));

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnTBTClientStateSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnTBTClientStateSpec.m
@@ -30,10 +30,7 @@ describe(@"Getter/Setter Tests", ^ {
                                            @{SDLRPCParameterNameParameters:
                                                  @{SDLRPCParameterNameState:SDLTBTStateETARequest},
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnTBTClientState}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnTBTClientState* testNotification = [[SDLOnTBTClientState alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testNotification.state).to(equal(SDLTBTStateETARequest));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnTouchEventSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnTouchEventSpec.m
@@ -36,10 +36,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                  @{SDLRPCParameterNameType:SDLTouchTypeBegin,
                                                    SDLRPCParameterNameEvent:[@[event] mutableCopy]},
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnTouchEvent}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnTouchEvent* testNotification = [[SDLOnTouchEvent alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testNotification.type).to(equal(SDLTouchTypeBegin));
         expect(testNotification.event).to(equal([@[event] mutableCopy]));

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnVehicleDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnVehicleDataSpec.m
@@ -183,10 +183,7 @@ describe(@"getter/setter tests", ^{
                                         SDLRPCParameterNameWiperStatus:wiperStatus,
                                         },
                                     SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnVehicleData}};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnVehicleData* testResponse = [[SDLOnVehicleData alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         it(@"expect all properties to be set properly", ^{
             expect(testResponse.accPedalPosition).to(equal(@(accPedalPosition)));

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnWaypointChangeSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnWaypointChangeSpec.m
@@ -71,10 +71,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                    },
                                            SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnWayPointChange
                                            };
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 testNotification = [[SDLOnWayPointChange alloc] initWithDictionary:[NSMutableDictionary dictionaryWithDictionary:initDict]];
-#pragma clang diagnostic pop
             });
             
             // Since all the properties are immutable, a copy should be executed as a retain, which means they should be identical
@@ -91,10 +88,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                    SDLRPCParameterNameParameters: @{}
                                                    }
                                            };
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 testNotification = [[SDLOnWayPointChange alloc] initWithDictionary:[NSMutableDictionary dictionaryWithDictionary:initDict]];
-#pragma clang diagnostic pop
             });
             
             it(@"should return nil for waypoints", ^{

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLAddCommandSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLAddCommandSpec.m
@@ -42,10 +42,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                                   SDLRPCParameterNameVRCommands:[@[@"name", @"anotherName"] mutableCopy],
                                                                   SDLRPCParameterNameCommandIcon:image},
                                                             SDLRPCParameterNameOperationName:SDLRPCFunctionNameAddCommand}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLAddCommand* testRequest = [[SDLAddCommand alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testRequest.cmdID).to(equal(@434577));
         expect(testRequest.menuParams).to(equal(menu));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLAlertManeuverSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLAlertManeuverSpec.m
@@ -36,10 +36,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                                  @{SDLRPCParameterNameTTSChunks:[@[tts] mutableCopy],
                                                                    SDLRPCParameterNameSoftButtons:[@[button] mutableCopy]},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameAlertManeuver}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLAlertManeuver* testRequest = [[SDLAlertManeuver alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testRequest.ttsChunks).to(equal([@[tts] mutableCopy]));
         expect(testRequest.softButtons).to(equal([@[button] mutableCopy]));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLCancelInteractionSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLCancelInteractionSpec.m
@@ -50,10 +50,7 @@ describe(@"Getter/Setter Tests", ^{
                                                    SDLRPCParameterNameFunctionID:@(testFunctionID)
                                                    },
                                            SDLRPCParameterNameOperationName:SDLRPCFunctionNameCancelInteraction}};
-            #pragma clang diagnostic push
-            #pragma clang diagnostic ignored "-Wdeprecated-declarations"
             testRequest = [[SDLCancelInteraction alloc] initWithDictionary:dict];
-            #pragma clang diagnostic pop
 
             expect(testRequest.cancelID).to(equal(testCancelID));
             expect(testRequest.functionID).to(equal(testFunctionID));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLChangeRegistrationSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLChangeRegistrationSpec.m
@@ -122,10 +122,7 @@ describe(@"change registration", ^ {
                                                                            SDLRPCParameterNameNGNMediaScreenAppName:someNGNMediaAppName,
                                                                            SDLRPCParameterNameVRSynonyms:someVRSynonyms},
                                                                      SDLRPCParameterNameOperationName:SDLRPCFunctionNameChangeRegistration}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 testRequest = [[SDLChangeRegistration alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
             });
             
             // Since the properties are immutable, a copy should be executed as a retain, so they should be identical
@@ -156,10 +153,7 @@ describe(@"change registration", ^ {
         
         context(@"when no parameters are set", ^{
             beforeEach(^{
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 testRequest = [[SDLChangeRegistration alloc] initWithDictionary:[NSMutableDictionary dictionary]];
-#pragma clang diagnostic pop
             });
             
             it(@"Should return nil if for language", ^ {

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLCloseApplicationSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLCloseApplicationSpec.m
@@ -25,10 +25,7 @@ describe(@"Getter/Setter Tests", ^{
         NSDictionary *dict = @{SDLRPCParameterNameRequest:@{
                                        SDLRPCParameterNameParameters:@{},
                                        SDLRPCParameterNameOperationName:SDLRPCFunctionNameCloseApplication}};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLCloseApplication *testRequest = [[SDLCloseApplication alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testRequest.name).to(equal(SDLRPCFunctionNameCloseApplication));
         expect(testRequest.parameters).to(beEmpty());

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLCreateInteractionChoiceSetSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLCreateInteractionChoiceSetSpec.m
@@ -34,10 +34,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                                  @{SDLRPCParameterNameInteractionChoiceSetId:@141414,
                                                                    SDLRPCParameterNameChoiceSet:[@[choice] mutableCopy]},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameCreateInteractionChoiceSet}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLCreateInteractionChoiceSet* testRequest = [[SDLCreateInteractionChoiceSet alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testRequest.interactionChoiceSetID).to(equal(@141414));
         expect(testRequest.choiceSet).to(equal([@[choice] mutableCopy]));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLDeleteCommandSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLDeleteCommandSpec.m
@@ -28,10 +28,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                            @{SDLRPCParameterNameParameters:
                                                                  @{SDLRPCParameterNameCommandId:@11223344},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameDeleteCommand}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLDeleteCommand* testRequest = [[SDLDeleteCommand alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testRequest.cmdID).to(equal(@11223344));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLDeleteFileSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLDeleteFileSpec.m
@@ -28,10 +28,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                            @{SDLRPCParameterNameParameters:
                                                                  @{SDLRPCParameterNameSyncFileName:@"synchro"},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameDeleteFile}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLDeleteFile* testRequest = [[SDLDeleteFile alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testRequest.syncFileName).to(equal(@"synchro"));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLDeleteInteractionChoiceSetSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLDeleteInteractionChoiceSetSpec.m
@@ -28,10 +28,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                            @{SDLRPCParameterNameParameters:
                                                                  @{SDLRPCParameterNameInteractionChoiceSetId:@20314},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameDeleteInteractionChoiceSet}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLDeleteInteractionChoiceSet* testRequest = [[SDLDeleteInteractionChoiceSet alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testRequest.interactionChoiceSetID).to(equal(@20314));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLDeleteSubMenuSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLDeleteSubMenuSpec.m
@@ -28,10 +28,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                            @{SDLRPCParameterNameParameters:
                                                                  @{SDLRPCParameterNameMenuID:@25614},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameDeleteSubMenu}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLDeleteSubMenu* testRequest = [[SDLDeleteSubMenu alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testRequest.menuID).to(equal(@25614));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLDiagnosticMessageSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLDiagnosticMessageSpec.m
@@ -34,10 +34,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                                    SDLRPCParameterNameMessageLength:@55555,
                                                                    SDLRPCParameterNameMessageData:[@[@1, @4, @16, @64] mutableCopy]},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameDiagnosticMessage}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLDiagnosticMessage* testRequest = [[SDLDiagnosticMessage alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testRequest.targetID).to(equal(@3562));
         expect(testRequest.messageLength).to(equal(@55555));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLDialNumberSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLDialNumberSpec.m
@@ -49,10 +49,7 @@ describe(@"Dial Number RPC", ^{
                                                        }
                                                }
                                        };
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             testRequest = [[SDLDialNumber alloc] initWithDictionary:[initDict mutableCopy]];
-#pragma clang diagnostic pop
         });
         
         it(@"should get 'number' correctly", ^{
@@ -69,10 +66,7 @@ describe(@"Dial Number RPC", ^{
                                                        }
                                                }
                                        };
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             testRequest = [[SDLDialNumber alloc] initWithDictionary:[initDict mutableCopy]];
-#pragma clang diagnostic pop
         });
         
         it(@"should return nil for number", ^{

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetAppServiceDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetAppServiceDataSpec.m
@@ -43,10 +43,7 @@ describe(@"Getter/Setter Tests", ^{
                                                SDLRPCParameterNameSubscribe:@(testSubscribe)
                                                },
                                        SDLRPCParameterNameOperationName:SDLRPCFunctionNameGetAppServiceData}};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLGetAppServiceData *testRequest = [[SDLGetAppServiceData alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testRequest.serviceType).to(equal(testServiceType));
         expect(testRequest.subscribe).to(beTrue());

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetCloudAppPropertiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetCloudAppPropertiesSpec.m
@@ -37,10 +37,7 @@ describe(@"Getter/Setter Tests", ^{
                                                SDLRPCParameterNameAppId:testAppID
                                                },
                                        SDLRPCParameterNameOperationName:SDLRPCFunctionNameGetCloudAppProperties}};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLGetCloudAppProperties *testRequest = [[SDLGetCloudAppProperties alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testRequest.appID).to(equal(testAppID));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetDTCsSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetDTCsSpec.m
@@ -31,10 +31,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                                  @{SDLRPCParameterNameECUName:@4321,
                                                                    SDLRPCParameterNameDTCMask:@22},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameEndAudioPassThru}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLGetDTCs* testRequest = [[SDLGetDTCs alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testRequest.ecuName).to(equal(@4321));
         expect(testRequest.dtcMask).to(equal(@22));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetFileSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetFileSpec.m
@@ -54,10 +54,7 @@ describe(@"Getter/Setter Tests", ^{
                                                SDLRPCParameterNameLength:@(testLength)
                                                },
                                        SDLRPCParameterNameOperationName:SDLRPCFunctionNameGetFile}};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLGetFile *testRequest = [[SDLGetFile alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testRequest.fileName).to(equal(testFileName));
         expect(testRequest.appServiceId).to(equal(testAppServiceId));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetInteriorVehicleDataConsentSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetInteriorVehicleDataConsentSpec.m
@@ -34,10 +34,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                                  @{SDLRPCParameterNameModuleType : SDLModuleTypeRadio,
                                                                    SDLRPCParameterNameModuleIds: @[@"123", @"456"]},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameGetInteriorVehicleData}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLGetInteriorVehicleDataConsent *testRequest = [[SDLGetInteriorVehicleDataConsent alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testRequest.moduleType).to(equal(SDLModuleTypeRadio));
         expect(testRequest.moduleIds).to(equal(@[@"123", @"456"]));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetSystemCapabilitiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetSystemCapabilitiesSpec.m
@@ -28,10 +28,7 @@ describe(@"Initialization tests", ^{
                                                }
                                        }
                                };
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLGetSystemCapability *testRequest = [[SDLGetSystemCapability alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testRequest.systemCapabilityType).to(equal(SDLSystemCapabilityTypePhoneCall));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetSystemCapabilitySpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetSystemCapabilitySpec.m
@@ -49,10 +49,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                    SDLRPCParameterNameSubscribe:@(testSubcribe)
                                                    },
                                            SDLRPCParameterNameOperationName:SDLRPCFunctionNameGetSystemCapability}};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             SDLGetSystemCapability *testRequest = [[SDLGetSystemCapability alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
             expect(testRequest.systemCapabilityType).to(equal(testSystemCapabilityType));
             expect(testRequest.subscribe).to(beFalse());

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetVehicleDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetVehicleDataSpec.m
@@ -144,10 +144,7 @@ describe(@"getter/setter tests", ^{
                                                         SDLRPCParameterNameWiperStatus:@YES,
                                                         },
                                                 SDLRPCParameterNameOperationName:SDLRPCFunctionNameGetVehicleData}};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLGetVehicleData* testRequest = [[SDLGetVehicleData alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         it(@"expect all properties to be set properly", ^{
             expect(testRequest.accPedalPosition).to(equal(@YES));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetWaypointsSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLGetWaypointsSpec.m
@@ -28,10 +28,7 @@ describe(@"Getter/Setter Tests", ^ {
                                            @{SDLRPCParameterNameParameters:
                                                  @{SDLRPCParameterNameWayPointType:SDLWayPointTypeAll},
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameGetWayPoints}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLGetWayPoints* testRequest = [[SDLGetWayPoints alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testRequest.waypointType).to(equal(SDLWayPointTypeAll));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLPerformAppServiceInteractionSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLPerformAppServiceInteractionSpec.m
@@ -50,10 +50,7 @@ describe(@"Getter/Setter Tests", ^{
                                                SDLRPCParameterNameRequestServiceActive:@(testRequestServiceActive)
                                                },
                                        SDLRPCParameterNameOperationName:SDLRPCFunctionNamePerformAppServiceInteraction}};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLPerformAppServiceInteraction *testRequest = [[SDLPerformAppServiceInteraction alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testRequest.serviceUri).to(equal(testServiceUri));
         expect(testRequest.serviceID).to(equal(testServiceID));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLPerformAudioPassThruSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLPerformAudioPassThruSpec.m
@@ -50,10 +50,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                    SDLRPCParameterNameAudioType:SDLAudioTypePCM,
                                                    SDLRPCParameterNameMuteAudio:@NO},
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNamePerformAudioPassThru}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLPerformAudioPassThru* testRequest = [[SDLPerformAudioPassThru alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testRequest.audioPassThruDisplayText1).to(equal(@"passthru#1"));
         expect(testRequest.audioPassThruDisplayText2).to(equal(@"passthru#2"));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLPublishAppServiceSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLPublishAppServiceSpec.m
@@ -43,10 +43,7 @@ describe(@"Getter/Setter Tests", ^{
                                                    SDLRPCParameterNameAppServiceManifest:testAppServiceManifest
                                                    },
                                            SDLRPCParameterNameOperationName:SDLRPCFunctionNamePublishAppService}};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             SDLPublishAppService *testRequest = [[SDLPublishAppService alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
             expect(testRequest.appServiceManifest).to(equal(testAppServiceManifest));
         });

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLReadDIDSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLReadDIDSpec.m
@@ -31,10 +31,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                                  @{SDLRPCParameterNameECUName:@33112,
                                                                    SDLRPCParameterNameDIDLocation:[@[@200, @201, @205] mutableCopy]},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameEndAudioPassThru}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLReadDID* testRequest = [[SDLReadDID alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testRequest.ecuName).to(equal(@33112));
         expect(testRequest.didLocation).to(equal([@[@200, @201, @205] mutableCopy]));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLReleaseInteriorVehicleDataModuleSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLReleaseInteriorVehicleDataModuleSpec.m
@@ -34,10 +34,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                                  @{SDLRPCParameterNameModuleType: SDLModuleTypeRadio,
                                                                    SDLRPCParameterNameModuleId: @"123"},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameGetInteriorVehicleData}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLReleaseInteriorVehicleDataModule *testRequest = [[SDLReleaseInteriorVehicleDataModule alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testRequest.moduleType).to(equal(SDLModuleTypeRadio));
         expect(testRequest.moduleId).to(equal(@"123"));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLResetGlobalPropertiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLResetGlobalPropertiesSpec.m
@@ -29,10 +29,7 @@ describe(@"Getter/Setter Tests", ^ {
                                            @{SDLRPCParameterNameParameters:
                                                  @{SDLRPCParameterNameProperties:[@[SDLGlobalPropertyMenuName, SDLGlobalPropertyVoiceRecognitionHelpTitle] copy]},
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameResetGlobalProperties}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLResetGlobalProperties* testRequest = [[SDLResetGlobalProperties alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testRequest.properties).to(equal([@[SDLGlobalPropertyMenuName, SDLGlobalPropertyVoiceRecognitionHelpTitle] copy]));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSendHapticDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSendHapticDataSpec.m
@@ -41,10 +41,7 @@ describe(@"Initialization Tests", ^ {
                                                @{SDLRPCParameterNameParameters:
                                                      @{SDLRPCParameterNameHapticRectData:@[testStruct]},
                                                  SDLRPCParameterNameOperationName:SDLRPCFunctionNameSendHapticData}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             SDLSendHapticData *testRequest = [[SDLSendHapticData alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
             expect(testRequest.hapticRectData).to(equal(@[testStruct]));
         });

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSendLocationSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSendLocationSpec.m
@@ -164,10 +164,7 @@ describe(@"Send Location RPC", ^{
                                                    SDLRPCParameterNameOperationName:SDLRPCFunctionNameSendLocation
                                                    }
                                            };
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 testRequest = [[SDLSendLocation alloc] initWithDictionary:[NSMutableDictionary dictionaryWithDictionary:initDict]];
-#pragma clang diagnostic pop
             });
             
             // Since all the properties are immutable, a copy should be executed as a retain, which means they should be identical
@@ -192,10 +189,7 @@ describe(@"Send Location RPC", ^{
                                                    SDLRPCParameterNameParameters: @{}
                                                    }
                                            };
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 testRequest = [[SDLSendLocation alloc] initWithDictionary:[NSMutableDictionary dictionaryWithDictionary:initDict]];
-#pragma clang diagnostic pop
             });
             
             it(@"should return nil for parameters", ^{

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSetAppIconSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSetAppIconSpec.m
@@ -28,10 +28,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                            @{SDLRPCParameterNameParameters:
                                                                  @{SDLRPCParameterNameSyncFileName:@"A/File/Name"},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameSetAppIcon}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSetAppIcon* testRequest = [[SDLSetAppIcon alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testRequest.syncFileName).to(equal(@"A/File/Name"));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSetCloudAppPropertiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSetCloudAppPropertiesSpec.m
@@ -36,10 +36,7 @@ describe(@"Getter/Setter Tests", ^{
                                                SDLRPCParameterNameProperties:testProperties
                                                },
                                        SDLRPCParameterNameOperationName:SDLRPCFunctionNameSetCloudAppProperties}};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSetCloudAppProperties *testRequest = [[SDLSetCloudAppProperties alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testRequest.properties).to(equal(testProperties));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSetDisplayLayoutSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSetDisplayLayoutSpec.m
@@ -50,10 +50,7 @@ describe(@"SetDisplayLayout Tests", ^ {
                                                                @{SDLRPCParameterNameParameters:
                                                                      @{SDLRPCParameterNameDisplayLayout:@"wat"},
                                                                  SDLRPCParameterNameOperationName:SDLRPCFunctionNameSetDisplayLayout}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             SDLSetDisplayLayout* testRequest = [[SDLSetDisplayLayout alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
             expect(testRequest.displayLayout).to(equal(@"wat"));
         });

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSetInteriorVehicleDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSetInteriorVehicleDataSpec.m
@@ -31,10 +31,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                            @{SDLRPCParameterNameParameters:
                                                                  @{SDLRPCParameterNameModuleData : someModuleData},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameSetInteriorVehicleData}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSetInteriorVehicleData* testRequest = [[SDLSetInteriorVehicleData alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testRequest.moduleData).to(equal(someModuleData));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLShowAppMenuSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLShowAppMenuSpec.m
@@ -33,10 +33,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                                  @{SDLRPCParameterNameMenuID:@4345645,
                                                                    },
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameShowAppMenu}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLShowAppMenu* testRequest = [[SDLShowAppMenu alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
          expect(testRequest.menuID).to(equal(@(menuId)));
     });
 

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLShowConstantTBTSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLShowConstantTBTSpec.m
@@ -65,10 +65,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                                    SDLRPCParameterNameManeuverComplete:@NO,
                                                                    SDLRPCParameterNameSoftButtons:[@[button] mutableCopy]},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameShowConstantTBT}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLShowConstantTBT* testRequest = [[SDLShowConstantTBT alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testRequest.navigationText1).to(equal(@"nav1"));
         expect(testRequest.navigationText2).to(equal(@"nav2"));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLShowSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLShowSpec.m
@@ -362,10 +362,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                        SDLRPCParameterNameTemplateConfiguration:testTemplateConfig
                                                      },
                                                  SDLRPCParameterNameOperationName:SDLRPCFunctionNameShow}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             SDLShow* testRequest = [[SDLShow alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
             expect(testRequest.mainField1).to(equal(@"field1"));
             expect(testRequest.mainField2).to(equal(@"field2"));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSliderSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSliderSpec.m
@@ -71,10 +71,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                                SDLRPCParameterNameCancelID:@(testCancelID)
                                                                },
                                                          SDLRPCParameterNameOperationName:SDLRPCFunctionNameSlider}};
-            #pragma clang diagnostic push
-            #pragma clang diagnostic ignored "-Wdeprecated-declarations"
             testRequest = [[SDLSlider alloc] initWithDictionary:dict];
-            #pragma clang diagnostic pop
 
             expect(testRequest.numTicks).to(equal(testNumTicks));
             expect(testRequest.position).to(equal(testPosition));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSpeakSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSpeakSpec.m
@@ -31,10 +31,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                            @{SDLRPCParameterNameParameters:
                                                                  @{SDLRPCParameterNameTTSChunks:[@[chunk] mutableCopy]},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameSpeak}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSpeak* testRequest = [[SDLSpeak alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testRequest.ttsChunks).to(equal([@[chunk] mutableCopy]));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSubscribeButtonSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSubscribeButtonSpec.m
@@ -30,10 +30,7 @@ describe(@"Getter/Setter Tests", ^ {
                                            @{SDLRPCParameterNameParameters:
                                                  @{SDLRPCParameterNameButtonName:SDLButtonNamePreset5},
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameSubscribeButton}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSubscribeButton* testRequest = [[SDLSubscribeButton alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testRequest.buttonName).to(equal(SDLButtonNamePreset5));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSubscribeVehicleDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSubscribeVehicleDataSpec.m
@@ -144,10 +144,7 @@ describe(@"getter/setter tests", ^{
                                                             SDLRPCParameterNameWiperStatus:@YES,
                                                          },
                                                      SDLRPCParameterNameOperationName:SDLRPCFunctionNameSubscribeVehicleData}};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSubscribeVehicleData* testRequest = [[SDLSubscribeVehicleData alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         it(@"expect all properties to be set properly", ^{
             expect(testRequest.accPedalPosition).to(equal(@YES));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSystemRequestSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLSystemRequestSpec.m
@@ -28,10 +28,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                        SDLRPCParameterNameRequestSubType: testSubType,
                                                        SDLRPCParameterNameFileName:testFileName},
                                                  SDLRPCParameterNameOperationName:SDLRPCFunctionNameSystemRequest}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             SDLSystemRequest* testRequest = [[SDLSystemRequest alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
             expect(testRequest.requestType).to(equal(testRequestType));
             expect(testRequest.requestSubType).to(equal(testSubType));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLUnpublishAppServiceSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLUnpublishAppServiceSpec.m
@@ -31,10 +31,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                    @{SDLRPCParameterNameParameters:
                                                          @{SDLRPCParameterNameServiceID:@"idToUnpublish"},
                                                      SDLRPCParameterNameOperationName:SDLRPCFunctionNameUnpublishAppService}};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLUnpublishAppService* testRequest = [[SDLUnpublishAppService alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testRequest.serviceID).to(equal(@"idToUnpublish"));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLUnsubscribeButtonSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLUnsubscribeButtonSpec.m
@@ -30,10 +30,7 @@ describe(@"Getter/Setter Tests", ^ {
                                            @{SDLRPCParameterNameParameters:
                                                  @{SDLRPCParameterNameButtonName:SDLButtonNamePreset0},
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameUnsubscribeButton}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLUnsubscribeButton* testRequest = [[SDLUnsubscribeButton alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testRequest.buttonName).to(equal(SDLButtonNamePreset0));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLUnsubscribeVehicleDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLUnsubscribeVehicleDataSpec.m
@@ -143,10 +143,7 @@ describe(@"getter/setter tests", ^{
                                                             SDLRPCParameterNameWiperStatus:@YES,
                                                          },
                                                 SDLRPCParameterNameOperationName:SDLRPCFunctionNameUnsubscribeVehicleData}};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLUnsubscribeVehicleData* testRequest = [[SDLUnsubscribeVehicleData alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         it(@"expect all properties to be set properly", ^{
             expect(testRequest.accPedalPosition).to(equal(@YES));

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLUpdateTurnListSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLUpdateTurnListSpec.m
@@ -36,10 +36,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                                  @{SDLRPCParameterNameTurnList:[@[turn] mutableCopy],
                                                                    SDLRPCParameterNameSoftButtons:[@[button] mutableCopy]},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameUpdateTurnList}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLUpdateTurnList* testRequest = [[SDLUpdateTurnList alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testRequest.turnList).to(equal([@[turn] mutableCopy]));
         expect(testRequest.softButtons).to(equal([@[button] mutableCopy]));

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLCancelInteractionResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLCancelInteractionResponseSpec.m
@@ -26,10 +26,7 @@ describe(@"Getter/Setter Tests", ^{
         NSDictionary *dict = @{SDLRPCParameterNameRequest:@{
                                        SDLRPCParameterNameParameters:@{},
                                        SDLRPCParameterNameOperationName:SDLRPCFunctionNameCancelInteraction}};
-        #pragma clang diagnostic push
-        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
         testResponse = [[SDLCancelInteractionResponse alloc] initWithDictionary:dict];
-        #pragma clang diagnostic pop
     });
 
     afterEach(^{

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLCloseApplicationResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLCloseApplicationResponseSpec.m
@@ -25,10 +25,7 @@ describe(@"Getter/Setter Tests", ^{
         NSDictionary *dict = @{SDLRPCParameterNameRequest:@{
                                        SDLRPCParameterNameParameters:@{},
                                        SDLRPCParameterNameOperationName:SDLRPCFunctionNameCloseApplication}};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLCloseApplicationResponse *testResponse = [[SDLCloseApplicationResponse alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testResponse.name).to(equal(SDLRPCFunctionNameCloseApplication));
         expect(testResponse.parameters).to(beEmpty());

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLDeleteFileResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLDeleteFileResponseSpec.m
@@ -28,10 +28,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                            @{SDLRPCParameterNameParameters:
                                                                  @{SDLRPCParameterNameSpaceAvailable:@0},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameDeleteFile}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLDeleteFileResponse* testResponse = [[SDLDeleteFileResponse alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testResponse.spaceAvailable).to(equal(@0));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLDiagnosticMessageResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLDiagnosticMessageResponseSpec.m
@@ -28,10 +28,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                            @{SDLRPCParameterNameParameters:
                                                                  @{SDLRPCParameterNameMessageDataResult:@[@3, @9, @27, @81]},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameDiagnosticMessage}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLDiagnosticMessageResponse* testResponse = [[SDLDiagnosticMessageResponse alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testResponse.messageDataResult).to(equal(@[@3, @9, @27, @81]));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetAppServiceDataResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetAppServiceDataResponseSpec.m
@@ -38,10 +38,7 @@ describe(@"Getter/Setter Tests", ^{
                                                SDLRPCParameterNameServiceData:testAppServiceData
                                                },
                                        SDLRPCParameterNameOperationName:SDLRPCFunctionNameGetAppServiceData}};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLGetAppServiceDataResponse *testResponse = [[SDLGetAppServiceDataResponse alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testResponse.serviceData).to(equal(testAppServiceData));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetCloudAppPropertiesResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetCloudAppPropertiesResponseSpec.m
@@ -36,10 +36,7 @@ describe(@"Getter/Setter Tests", ^{
                                                SDLRPCParameterNameProperties:testProperties
                                                },
                                        SDLRPCParameterNameOperationName:SDLRPCFunctionNameSetCloudAppProperties}};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLGetCloudAppPropertiesResponse *testResponse = [[SDLGetCloudAppPropertiesResponse alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testResponse.properties).to(equal(testProperties));
         expect(testResponse.name).to(equal(SDLRPCFunctionNameSetCloudAppProperties));

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetDTCsResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetDTCsResponseSpec.m
@@ -31,10 +31,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                                 @{SDLRPCParameterNameECUHeader:@404,
                                                                   SDLRPCParameterNameDTC:[@[@"FFFF", @"FFFE", @"FFFD"] mutableCopy]},
                                                             SDLRPCParameterNameOperationName:SDLRPCFunctionNameGetDTCs}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLGetDTCsResponse* testResponse = [[SDLGetDTCsResponse alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testResponse.ecuHeader).to(equal(@404));
         expect(testResponse.dtc).to(equal([@[@"FFFF", @"FFFE", @"FFFD"] mutableCopy]));

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetFileResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetFileResponseSpec.m
@@ -48,10 +48,7 @@ describe(@"Getter/Setter Tests", ^{
                                                SDLRPCParameterNameCRC:@(testCrc)
                                                },
                                        SDLRPCParameterNameOperationName:SDLRPCFunctionNameGetFile}};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLGetFileResponse *testResponse = [[SDLGetFileResponse alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testResponse.offset).to(equal(testOffset));
         expect(testResponse.length).to(equal(testLength));

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetInteriorVehicleDataConsentResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetInteriorVehicleDataConsentResponseSpec.m
@@ -40,10 +40,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                            @{SDLRPCParameterNameParameters:
                                                                  @{SDLRPCParameterNameAllowed:allowed},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameGetInteriorVehicleData}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLGetInteriorVehicleDataConsentResponse *testResponse = [[SDLGetInteriorVehicleDataConsentResponse alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testResponse.allowed).to(equal(allowed));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetInteriorVehicleDataResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetInteriorVehicleDataResponseSpec.m
@@ -40,10 +40,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                                  @{SDLRPCParameterNameModuleData:someModuleData,
                                                                    SDLRPCParameterNameIsSubscribed:@NO},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameGetInteriorVehicleData}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLGetInteriorVehicleDataResponse* testResponse = [[SDLGetInteriorVehicleDataResponse alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testResponse.moduleData).to(equal(someModuleData));
         expect(testResponse.isSubscribed).to(equal(@NO));

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetSystemCapabilityResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetSystemCapabilityResponseSpec.m
@@ -41,10 +41,7 @@ describe(@"Initialization tests", ^{
                                        SDLRPCParameterNameOperationName:SDLRPCFunctionNameGetSystemCapability
                                        }
                                };
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLGetSystemCapabilityResponse *testResponse = [[SDLGetSystemCapabilityResponse alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testResponse.systemCapability.systemCapabilityType).to(equal(SDLSystemCapabilityTypeNavigation));
         expect(testResponse.systemCapability.navigationCapability.sendLocationEnabled).to(equal(YES));

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetVehicleDataResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetVehicleDataResponseSpec.m
@@ -184,10 +184,7 @@ describe(@"getter/setter tests", ^{
                                             SDLRPCParameterNameWiperStatus:wiperStatus,
                                             },
                                     SDLRPCParameterNameOperationName:SDLRPCFunctionNameGetVehicleData}};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLGetVehicleDataResponse* testResponse = [[SDLGetVehicleDataResponse alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         it(@"expect all properties to be set properly", ^{
             expect(testResponse.accPedalPosition).to(equal(@(accPedalPosition)));

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetWaypointsResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLGetWaypointsResponseSpec.m
@@ -69,10 +69,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                            }
                                                    }
                                            };
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 testResponse = [[SDLGetWayPointsResponse alloc] initWithDictionary:[NSMutableDictionary dictionaryWithDictionary:initDict]];
-#pragma clang diagnostic pop
             });
             
             // Since all the properties are immutable, a copy should be executed as a retain, which means they should be identical
@@ -89,10 +86,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                    SDLRPCParameterNameParameters: @{}
                                                    }
                                            };
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 testResponse = [[SDLGetWayPointsResponse alloc] initWithDictionary:[NSMutableDictionary dictionaryWithDictionary:initDict]];
-#pragma clang diagnostic pop
             });
             
             it(@"should return nil for waypoints", ^{

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLListFilesResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLListFilesResponseSpec.m
@@ -31,10 +31,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                                  @{SDLRPCParameterNameFilenames:[@[@"Music/music.mp3", @"Documents/document.txt", @"Downloads/format.exe"] mutableCopy],
                                                                    SDLRPCParameterNameSpaceAvailable:@500000000},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameListFiles}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLListFilesResponse* testResponse = [[SDLListFilesResponse alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testResponse.filenames).to(equal([@[@"Music/music.mp3", @"Documents/document.txt", @"Downloads/format.exe"] mutableCopy]));
         expect(testResponse.spaceAvailable).to(equal(@500000000));

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLPerformAppServiceInteractionResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLPerformAppServiceInteractionResponseSpec.m
@@ -35,10 +35,7 @@ describe(@"Getter/Setter Tests", ^{
                                                SDLRPCParameterNameServiceSpecificResult:testServiceSpecificResult
                                                },
                                        SDLRPCParameterNameOperationName:SDLRPCFunctionNamePublishAppService}};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLPerformAppServiceInteractionResponse *testResponse = [[SDLPerformAppServiceInteractionResponse alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testResponse.serviceSpecificResult).to(equal(testServiceSpecificResult));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLPerformInteractionResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLPerformInteractionResponseSpec.m
@@ -36,10 +36,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                   SDLRPCParameterNameManualTextEntry:@"entry",
                                                   SDLRPCParameterNameTriggerSource:SDLTriggerSourceKeyboard},
                                             SDLRPCParameterNameOperationName:SDLRPCFunctionNamePerformInteraction}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLPerformInteractionResponse* testResponse = [[SDLPerformInteractionResponse alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testResponse.choiceID).to(equal(@25));
         expect(testResponse.manualTextEntry).to(equal(@"entry"));

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLPublishAppServiceResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLPublishAppServiceResponseSpec.m
@@ -37,10 +37,7 @@ describe(@"Getter/Setter Tests", ^{
                                                SDLRPCParameterNameAppServiceRecord:testAppServiceRecord
                                                },
                                        SDLRPCParameterNameOperationName:SDLRPCFunctionNamePublishAppService}};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLPublishAppServiceResponse *testResponse = [[SDLPublishAppServiceResponse alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testResponse.appServiceRecord).to(equal(testAppServiceRecord));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLPutFileResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLPutFileResponseSpec.m
@@ -29,10 +29,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                                  @{SDLRPCParameterNameSpaceAvailable:@1248,
                                                                    },
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNamePutFile}};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLPutFileResponse* testResponse = [[SDLPutFileResponse alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testResponse.spaceAvailable).to(equal(@1248));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLReadDIDResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLReadDIDResponseSpec.m
@@ -31,10 +31,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                            @{SDLRPCParameterNameParameters:
                                                                  @{SDLRPCParameterNameDIDResult:[@[result] mutableCopy]},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameReadDID}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLReadDIDResponse* testResponse = [[SDLReadDIDResponse alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testResponse.didResult).to(equal([@[result] mutableCopy]));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLSetCloudAppPropertiesResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLSetCloudAppPropertiesResponseSpec.m
@@ -26,10 +26,7 @@ describe(@"Getter/Setter Tests", ^ {
         NSDictionary *dict = @{SDLRPCParameterNameResponse:@{
                                        SDLRPCParameterNameParameters:@{},
                                        SDLRPCParameterNameOperationName:SDLRPCFunctionNameSetCloudAppProperties}};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSetCloudAppPropertiesResponse *testResponse = [[SDLSetCloudAppPropertiesResponse alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testResponse).toNot(beNil());
         expect(testResponse.name).to(equal(SDLRPCFunctionNameSetCloudAppProperties));

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLSetDisplayLayoutResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLSetDisplayLayoutResponseSpec.m
@@ -49,10 +49,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                                    SDLRPCParameterNameSoftButtonCapabilities:[@[softButton] mutableCopy],
                                                                    SDLRPCParameterNamePresetBankCapabilities:presetBank},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameSetDisplayLayout}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSetDisplayLayoutResponse* testResponse = [[SDLSetDisplayLayoutResponse alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testResponse.displayCapabilities).to(equal(info));
         expect(testResponse.buttonCapabilities).to(equal([@[button] mutableCopy]));

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLSetInteriorVehicleDataResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLSetInteriorVehicleDataResponseSpec.m
@@ -36,10 +36,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                            @{SDLRPCParameterNameParameters:
                                                                  @{SDLRPCParameterNameModuleData:someModuleData},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameSetInteriorVehicleData}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSetInteriorVehicleDataResponse* testResponse = [[SDLSetInteriorVehicleDataResponse alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testResponse.moduleData).to(equal(someModuleData));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLSliderResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLSliderResponseSpec.m
@@ -29,10 +29,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                            @{SDLRPCParameterNameParameters:
                                                                  @{SDLRPCParameterNameSliderPosition:@13},
                                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameSlider}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSliderResponse* testResponse = [[SDLSliderResponse alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testResponse.sliderPosition).to(equal(@13));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLSubscribeVehicleDataResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLSubscribeVehicleDataResponseSpec.m
@@ -151,10 +151,7 @@ describe(@"getter/setter tests", ^{
                                                             },
                                                 SDLRPCParameterNameOperationName:SDLRPCFunctionNameSubscribeVehicleData}};
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSubscribeVehicleDataResponse* testResponse = [[SDLSubscribeVehicleDataResponse alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         it(@"expect all properties to be set properly", ^{
             expect(testResponse.accPedalPosition).to(equal(vehicleDataResult));

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLUnpublishAppServiceResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLUnpublishAppServiceResponseSpec.m
@@ -25,10 +25,7 @@ describe(@"Getter/Setter Tests", ^{
         NSDictionary *dict = @{SDLRPCParameterNameRequest:@{
                                        SDLRPCParameterNameParameters:@{},
                                        SDLRPCParameterNameOperationName:SDLRPCFunctionNameUnpublishAppService}};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLUnpublishAppServiceResponse *testResponse = [[SDLUnpublishAppServiceResponse alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testResponse.name).to(equal(SDLRPCFunctionNameUnpublishAppService));
         expect(testResponse.parameters).to(beEmpty());

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLUnsubscribeVehicleDataResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLUnsubscribeVehicleDataResponseSpec.m
@@ -149,10 +149,7 @@ describe(@"getter/setter tests", ^{
                                                             SDLRPCParameterNameWiperStatus:vehicleDataResult,
                                                             },
                                                 SDLRPCParameterNameOperationName:SDLRPCFunctionNameUnsubscribeVehicleData}};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLUnsubscribeVehicleDataResponse* testResponse = [[SDLUnsubscribeVehicleDataResponse alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         it(@"expect all properties to be set properly", ^{
             expect(testResponse.accPedalPosition).to(equal(vehicleDataResult));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLAirbagStatusSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLAirbagStatusSpec.m
@@ -47,10 +47,7 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameDriverKneeAirbagDeployed:SDLVehicleDataEventStatusNo,
                                        SDLRPCParameterNamePassengerSideAirbagDeployed:SDLVehicleDataEventStatusYes,
                                        SDLRPCParameterNamePassengerKneeAirbagDeployed:SDLVehicleDataEventStatusNoEvent} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLAirbagStatus* testStruct = [[SDLAirbagStatus alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.driverAirbagDeployed).to(equal(SDLVehicleDataEventStatusYes));
         expect(testStruct.driverSideAirbagDeployed).to(equal(SDLVehicleDataEventStatusNoEvent));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLAppInfoSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLAppInfoSpec.m
@@ -31,10 +31,7 @@ describe(@"Getter/Setter Tests", ^ {
         NSMutableDictionary<NSString *, id> *dict = [@{SDLRPCParameterNameAppDisplayName:@"display name",
                                                        SDLRPCParameterNameAppVersion:@"1.2.3.4",
                                                        SDLRPCParameterNameAppBundleId:@"com.app.bundle"} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLAppInfo* testStruct = [[SDLAppInfo alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.appDisplayName).to(equal(@"display name"));
         expect(testStruct.appVersion).to(equal(@"1.2.3.4"));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLAppServiceDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLAppServiceDataSpec.m
@@ -57,10 +57,7 @@ describe(@"Getter/Setter Tests", ^{
                                SDLRPCParameterNameWeatherServiceData:testWeatherServiceData,
                                SDLRPCParameterNameNavigationServiceData:testNavigationServiceData
                                };
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLAppServiceData *testStruct = [[SDLAppServiceData alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testStruct.serviceType).to(equal(testServiceType));
         expect(testStruct.serviceId).to(equal(testServiceId));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLAppServiceRecordSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLAppServiceRecordSpec.m
@@ -23,10 +23,7 @@ describe(@"Getter/Setter Tests", ^{
 
     beforeEach(^{
         testServiceID = @"12345";
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         testAppServiceManifest = [[SDLAppServiceManifest alloc] initWithDictionary:@{SDLRPCParameterNameAllowAppConsumers:@NO}];
-#pragma clang diagnostic pop
         testServicePublished = @NO;
         testServiceActive = @YES;
     });
@@ -59,10 +56,7 @@ describe(@"Getter/Setter Tests", ^{
                                SDLRPCParameterNameServicePublished:testServicePublished,
                                SDLRPCParameterNameServiceActive:testServiceActive
                                     };
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLAppServiceRecord *testStruct = [[SDLAppServiceRecord alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testStruct.serviceID).to(match(testServiceID));
         expect(testStruct.serviceManifest).to(equal(testAppServiceManifest));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLAudioControlDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLAudioControlDataSpec.m
@@ -48,10 +48,7 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameVolume:@(NO),
                                        SDLRPCParameterNameEqualizerSettings:[@[someEqualizerSettings] copy]
                                        } mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLAudioControlData* testStruct = [[SDLAudioControlData alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testStruct.source).to(equal(SDLPrimaryAudioSourceCD));
         expect(testStruct.keepContext).to(equal(@(NO)));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLAudioPassThruCapabilitiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLAudioPassThruCapabilitiesSpec.m
@@ -34,10 +34,7 @@ describe(@"Getter/Setter Tests", ^ {
         NSMutableDictionary* dict = [@{SDLRPCParameterNameSamplingRate:SDLSamplingRate22KHZ,
                                        SDLRPCParameterNameBitsPerSample:SDLBitsPerSample8Bit,
                                        SDLRPCParameterNameAudioType:SDLAudioTypePCM} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLAudioPassThruCapabilities* testStruct = [[SDLAudioPassThruCapabilities alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.samplingRate).to(equal(SDLSamplingRate22KHZ));
         expect(testStruct.bitsPerSample).to(equal(SDLBitsPerSample8Bit));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLBeltStatusSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLBeltStatusSpec.m
@@ -68,10 +68,7 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameRightRearInflatableBelted:SDLVehicleDataEventStatusFault,
                                        SDLRPCParameterNameMiddleRow1BeltDeployed:SDLVehicleDataEventStatusNoEvent,
                                        SDLRPCParameterNameMiddleRow1BuckleBelted:SDLVehicleDataEventStatusNotSupported} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLBeltStatus* testStruct = [[SDLBeltStatus alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.driverBeltDeployed).to(equal(SDLVehicleDataEventStatusNoEvent));
         expect(testStruct.passengerBeltDeployed).to(equal(SDLVehicleDataEventStatusYes));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLBodyInformationSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLBodyInformationSpec.m
@@ -44,10 +44,7 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNamePassengerDoorAjar:@NO,
                                        SDLRPCParameterNameRearLeftDoorAjar:@NO,
                                        SDLRPCParameterNameRearRightDoorAjar:@YES} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLBodyInformation* testStruct = [[SDLBodyInformation alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.parkBrakeActive).to(equal(@YES));
         expect(testStruct.ignitionStableStatus).to(equal(SDLIgnitionStableStatusNotStable));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLButtonCapabilitiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLButtonCapabilitiesSpec.m
@@ -54,10 +54,7 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameShortPressAvailable:@YES,
                                        SDLRPCParameterNameLongPressAvailable:@YES,
                                        SDLRPCParameterNameUpDownAvailable:@NO} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLButtonCapabilities* testStruct = [[SDLButtonCapabilities alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.name).to(equal(SDLButtonNameCustomButton));
         expect(testStruct.moduleInfo).to(equal(testModuleInfo));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLChoiceSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLChoiceSpec.m
@@ -47,10 +47,7 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameSecondaryText:@"Arbitrary",
                                        SDLRPCParameterNameTertiaryText:@"qwerty",
                                        SDLRPCParameterNameSecondaryImage:secondaryImage} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLChoice* testStruct = [[SDLChoice alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.choiceID).to(equal(@3));
         expect(testStruct.menuName).to(equal(@"Hello"));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLCloudAppPropertiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLCloudAppPropertiesSpec.m
@@ -63,10 +63,7 @@ describe(@"Getter/Setter Tests", ^{
                                SDLRPCParameterNameHybridAppPreference:testHybridAppPreference,
                                SDLRPCParameterNameEndpoint:testEndpoint
                                };
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLCloudAppProperties *testStruct = [[SDLCloudAppProperties alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testStruct.nicknames).to(equal(testNicknames));
         expect(testStruct.appID).to(equal(testAppID));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLClusterModeStatusSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLClusterModeStatusSpec.m
@@ -36,10 +36,7 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNamePowerModeQualificationStatus:SDLPowerModeQualificationStatusOk,
                                        SDLRPCParameterNameCarModeStatus:SDLCarModeStatusCrash,
                                        SDLRPCParameterNamePowerModeStatus:SDLPowerModeStatusKeyOut} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLClusterModeStatus* testStruct = [[SDLClusterModeStatus alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.powerModeActive).to(equal(@NO));
         expect(testStruct.powerModeQualificationStatus).to(equal(SDLPowerModeQualificationStatusOk));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLDIDResult.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLDIDResult.m
@@ -32,10 +32,7 @@ describe(@"Getter/Setter Tests", ^ {
         NSMutableDictionary* dict = [@{SDLRPCParameterNameResultCode:SDLVehicleDataResultCodeDataNotSubscribed,
                                        SDLRPCParameterNameDIDLocation:@300,
                                        SDLRPCParameterNameData:@"gertwydhty4235tdhedt4tue"} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLDIDResult* testStruct = [[SDLDIDResult alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.resultCode).to(equal(SDLVehicleDataResultCodeDataNotSubscribed));
         expect(testStruct.didLocation).to(equal(@300));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLDateTimeSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLDateTimeSpec.m
@@ -51,10 +51,7 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameYear:@4000,
                                        SDLRPCParameterNameTimezoneMinuteOffset:@0,
                                        SDLRPCParameterNameTimezoneHourOffset:@1000} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLDateTime* testStruct = [[SDLDateTime alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.millisecond).to(equal(@100));
         expect(testStruct.second).to(equal(@4));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLDeviceInfoSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLDeviceInfoSpec.m
@@ -39,10 +39,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                        SDLRPCParameterNameOSVersion:@"9.9",
                                                        SDLRPCParameterNameCarrier:@"ThatOneWirelessCompany",
                                                        SDLRPCParameterNameMaxNumberRFCOMMPorts:@20} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLDeviceInfo* testStruct = [[SDLDeviceInfo alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.hardware).to(equal(@"GDFR34F"));
         expect(testStruct.firmwareRev).to(equal(@"4.2a"));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLDeviceStatusSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLDeviceStatusSpec.m
@@ -57,10 +57,7 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameSignalLevelStatus:SDLDeviceLevelStatusTwoBars,
                                        SDLRPCParameterNamePrimaryAudioSource:SDLPrimaryAudioSourceBluetoothStereo,
                                        SDLRPCParameterNameECallEventActive:@NO} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLDeviceStatus* testStruct = [[SDLDeviceStatus alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.voiceRecOn).to(equal(@NO));
         expect(testStruct.btIconOn).to(equal(@NO));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLECallInfoSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLECallInfoSpec.m
@@ -33,10 +33,7 @@ describe(@"Getter/Setter Tests", ^ {
         NSMutableDictionary* dict = [@{SDLRPCParameterNameECallNotificationStatus:SDLVehicleDataNotificationStatusNormal,
                                        SDLRPCParameterNameAuxECallNotificationStatus:SDLVehicleDataNotificationStatusActive,
                                        SDLRPCParameterNameECallConfirmationStatus:SDLECallConfirmationStatusInProgress} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLECallInfo* testStruct = [[SDLECallInfo alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.eCallNotificationStatus).to(equal(SDLVehicleDataNotificationStatusNormal));
         expect(testStruct.auxECallNotificationStatus).to(equal(SDLVehicleDataNotificationStatusActive));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLEmergencyEventSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLEmergencyEventSpec.m
@@ -40,10 +40,7 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameRolloverEvent:SDLVehicleDataEventStatusYes,
                                        SDLRPCParameterNameMaximumChangeVelocity:@33,
                                        SDLRPCParameterNameMultipleEvents:SDLVehicleDataEventStatusNo} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLEmergencyEvent* testStruct = [[SDLEmergencyEvent alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.emergencyEventType).to(equal(SDLEmergencyEventTypeFrontal));
         expect(testStruct.fuelCutoffStatus).to(equal(SDLFuelCutoffStatusNormalOperation));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLEqualizerSettingsSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLEqualizerSettingsSpec.m
@@ -39,10 +39,7 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameChannelName:@"channel",
                                        SDLRPCParameterNameChannelSetting:@45
                                        } mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLEqualizerSettings* testStruct = [[SDLEqualizerSettings alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testStruct.channelId).to(equal(@2));
         expect(testStruct.channelName).to(equal(@"channel"));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLFuelRangeSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLFuelRangeSpec.m
@@ -50,10 +50,7 @@ describe(@"getter/setter tests", ^{
                             SDLRPCParameterNameCapacity:@(fuelCapacity),
                             SDLRPCParameterNameCapacityUnit:capacityUnit
                                 };
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLFuelRange *testStruct = [[SDLFuelRange alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         it(@"expect all properties to be set properly", ^{
             expect(testStruct.type).to(equal(type));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLGPSDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLGPSDataSpec.m
@@ -83,10 +83,7 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameSpeed:@64,
                                        SDLRPCParameterNameShifted:@(NO)
                                        } mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLGPSData* testStruct = [[SDLGPSData alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.longitudeDegrees).to(equal(@31.41592653589793));
         expect(testStruct.latitudeDegrees).to(equal(@45));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLGearStatusSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLGearStatusSpec.m
@@ -24,10 +24,7 @@ describe(@"getter/setter tests", ^{
         NSDictionary<NSString *, id> *dict = @{SDLRPCParameterNameUserSelectedGear:SDLPRNDLNinth,
                                                 SDLRPCParameterNameActualGear:SDLPRNDLTenth,
                                                 SDLRPCParameterNameTransmissionType:SDLTransmissionTypeAutomatic};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLGearStatus* testStruct = [[SDLGearStatus alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         it(@"should get correctly when initialized", ^{
             expect(testStruct.userSelectedGear).to(equal(SDLPRNDLNinth));
             expect(testStruct.actualGear).to(equal(SDLPRNDLTenth));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLHMIPermissionsSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLHMIPermissionsSpec.m
@@ -28,10 +28,7 @@ describe(@"Getter/Setter Tests", ^ {
     it(@"Should get correctly when initialized", ^ {
         NSMutableDictionary* dict = [@{SDLRPCParameterNameAllowed:[@[SDLHMILevelBackground, SDLHMILevelFull] copy],
                                        SDLRPCParameterNameUserDisallowed:[@[SDLHMILevelNone, SDLHMILevelLimited] copy]} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLHMIPermissions* testStruct = [[SDLHMIPermissions alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.allowed).to(equal([@[SDLHMILevelBackground, SDLHMILevelFull] copy]));
         expect(testStruct.userDisallowed).to(equal([@[SDLHMILevelNone, SDLHMILevelLimited] copy]));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLHMISettingsControlDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLHMISettingsControlDataSpec.m
@@ -37,10 +37,7 @@ describe(@"Getter/Setter Tests", ^ {
             NSMutableDictionary* dict = [@{SDLRPCParameterNameDisplayMode:SDLDisplayModeAuto,
                                            SDLRPCParameterNameTemperatureUnit:SDLTemperatureUnitCelsius,
                                            SDLRPCParameterNameDistanceUnit:SDLDistanceUnitKilometers} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             SDLHMISettingsControlData* testStruct = [[SDLHMISettingsControlData alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
             expect(testStruct.displayMode).to(equal(SDLDisplayModeAuto));
             expect(testStruct.temperatureUnit).to(equal(SDLTemperatureUnitCelsius));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLHapticRectSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLHapticRectSpec.m
@@ -49,10 +49,7 @@ describe(@"Getter/Setter Tests", ^{
                                                SDLRPCParameterNameHeight:@3000
                                                }
                                        } mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLHapticRect *testStruct = [[SDLHapticRect alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testStruct.id).to(equal(@2));
         expect(testStruct.rect.x).to(equal(@20));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLHeadLampStatusSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLHeadLampStatusSpec.m
@@ -32,10 +32,7 @@ describe(@"Getter/Setter Tests", ^ {
         NSMutableDictionary* dict = [@{SDLRPCParameterNameLowBeamsOn:@YES,
                                        SDLRPCParameterNameHighBeamsOn:@NO,
                                        SDLRPCParameterNameAmbientLightSensorStatus:SDLAmbientLightStatusTwilight3} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLHeadLampStatus* testStruct = [[SDLHeadLampStatus alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.lowBeamsOn).to(equal(@YES));
         expect(testStruct.highBeamsOn).to(equal(@NO));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLImageFieldSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLImageFieldSpec.m
@@ -44,10 +44,7 @@ describe(@"Getter/Setter Tests", ^ {
         NSDictionary *dict = @{SDLRPCParameterNameName: testName,
                                SDLRPCParameterNameImageTypeSupported: testFileTypes,
                                SDLRPCParameterNameImageResolution: testResolution};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLImageField* testStruct = [[SDLImageField alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.name).to(equal(testName));
         expect(testStruct.imageTypeSupported).to(equal(testFileTypes));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLImageResolutionSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLImageResolutionSpec.m
@@ -28,10 +28,7 @@ describe(@"Getter/Setter Tests", ^ {
         NSDictionary *dict = @{SDLRPCParameterNameResolutionHeight:@69,
                                        SDLRPCParameterNameResolutionWidth:@869,
                                        };
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLImageResolution *testStruct = [[SDLImageResolution alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testStruct.resolutionWidth).to(equal(@869));
         expect(testStruct.resolutionHeight).to(equal(@69));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLLightCapabilitiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLLightCapabilitiesSpec.m
@@ -42,10 +42,7 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameRGBColorSpaceAvailable:@NO
                                        } mutableCopy];
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLLightCapabilities* testStruct = [[SDLLightCapabilities alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testStruct.name).to(equal(SDLLightNameFogLights));
         expect(testStruct.densityAvailable).to(equal(@YES));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLLightControlDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLLightControlDataSpec.m
@@ -32,10 +32,7 @@ describe(@"Getter/Setter Tests", ^ {
 
     it(@"Should get correctly when initialized", ^ {
         NSMutableDictionary* dict = [@{SDLRPCParameterNameLightState:[@[someLightState] copy]} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLLightControlData* testStruct = [[SDLLightControlData alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testStruct.lightState).to(equal([@[someLightState] copy]));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLLightStateSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLLightStateSpec.m
@@ -68,10 +68,7 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameDensity:@(0.5),
                                        SDLRPCParameterNameColor:someRGBColor} mutableCopy];
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLLightState* testStruct = [[SDLLightState alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testStruct.id).to(equal(SDLLightNameFogLights));
         expect(testStruct.status).to(equal(SDLLightStatusOn));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLLocationCoordinateSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLLocationCoordinateSpec.m
@@ -54,10 +54,7 @@ describe(@"Getter/Setter Tests", ^ {
                                            SDLRPCParameterNameLongitudeDegrees: someLongitude,
                                            SDLRPCParameterNameLatitudeDegrees: someLatitude,
                                            };
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 testStruct = [[SDLLocationCoordinate alloc] initWithDictionary:[NSMutableDictionary dictionaryWithDictionary:initDict]];
-#pragma clang diagnostic pop
             });
             
             // Since all the properties are immutable, a copy should be executed as a retain, which means they should be identical
@@ -87,10 +84,7 @@ describe(@"Getter/Setter Tests", ^ {
             beforeEach(^{
                 NSDictionary *initDict = @{
                                            };
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 testStruct = [[SDLLocationCoordinate alloc] initWithDictionary:[NSMutableDictionary dictionaryWithDictionary:initDict]];
-#pragma clang diagnostic pop
             });
             
             it(@"should return nil for longitude", ^{

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLLocationDetailsSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLLocationDetailsSpec.m
@@ -152,10 +152,7 @@ describe(@"Getter/Setter Tests", ^ {
                                            SDLRPCParameterNameLocationImage: someImage,
                                            SDLRPCParameterNameSearchAddress: someAddress
                                            };
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 testStruct = [[SDLLocationDetails alloc] initWithDictionary:[NSMutableDictionary dictionaryWithDictionary:initDict]];
-#pragma clang diagnostic pop
             });
             
             // Since all the properties are immutable, a copy should be executed as a retain, which means they should be identical
@@ -202,10 +199,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                    SDLRPCParameterNameParameters: @{}
                                                    }
                                            };
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 testStruct = [[SDLLocationDetails alloc] initWithDictionary:[NSMutableDictionary dictionaryWithDictionary:initDict]];
-#pragma clang diagnostic pop
             });
             
             it(@"should return nil for coordinate", ^{

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLMassageCushionFirmnessSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLMassageCushionFirmnessSpec.m
@@ -34,10 +34,7 @@ describe(@"Getter/Setter Tests", ^ {
         NSMutableDictionary* dict = [@{SDLRPCParameterNameCushion:SDLMassageCushionSeatBolsters,
                                        SDLRPCParameterNameFirmness:@12
                                        } mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLMassageCushionFirmness* testStruct = [[SDLMassageCushionFirmness alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testStruct.cushion).to(equal(SDLMassageCushionSeatBolsters));
         expect(testStruct.firmness).to(equal(@12));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLMassageModeDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLMassageModeDataSpec.m
@@ -35,10 +35,7 @@ describe(@"Getter/Setter Tests", ^ {
         NSMutableDictionary* dict = [@{SDLRPCParameterNameMassageMode:SDLMassageModeLow,
                                        SDLRPCParameterNameMassageZone:SDLMassageZoneLumbar
                                        } mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLMassageModeData* testStruct = [[SDLMassageModeData alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testStruct.massageZone).to(equal(SDLMassageZoneLumbar));
         expect(testStruct.massageMode).to(equal(SDLMassageModeLow));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLMediaServiceManifestSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLMediaServiceManifestSpec.m
@@ -23,10 +23,7 @@ describe(@"Getter/Setter Tests", ^{
 
     it(@"Should get correctly when initialized with a dictionary", ^{
         NSDictionary *dict = @{};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLMediaServiceManifest *testStruct = [[SDLMediaServiceManifest alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         // no parameters to test
         expect(testStruct).toNot(beNil());

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLMenuParamsSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLMenuParamsSpec.m
@@ -30,10 +30,7 @@ describe(@"Initialization tests", ^{
         NSDictionary *dict = @{SDLRPCParameterNameParentID:@(testParentId),
                                        SDLRPCParameterNamePosition:@(testPosition),
                                        SDLRPCParameterNameMenuName:testMenuName};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLMenuParams* testStruct = [[SDLMenuParams alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testStruct.parentID).to(equal(@(testParentId)));
         expect(testStruct.position).to(equal(@(testPosition)));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLModuleDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLModuleDataSpec.m
@@ -52,10 +52,7 @@ describe(@"Initialization tests", ^{
                                        SDLRPCParameterNameLightControlData:someLightData,
                                        SDLRPCParameterNameHmiSettingsControlData:someHMISettingsData,
                                        SDLRPCParameterNameModuleId:someModuleId} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLModuleData* testStruct = [[SDLModuleData alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.moduleType).to(equal(SDLModuleTypeRadio));
         expect(testStruct.radioControlData).to(equal(someRadioData));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLMyKeySpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLMyKeySpec.m
@@ -26,10 +26,7 @@ describe(@"Getter/Setter Tests", ^ {
     
     it(@"Should get correctly when initialized", ^ {
         NSMutableDictionary* dict = [@{SDLRPCParameterNameE911Override:SDLVehicleDataStatusOn} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLMyKey* testStruct = [[SDLMyKey alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.e911Override).to(equal(SDLVehicleDataStatusOn));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLNavigationCapabilitySpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLNavigationCapabilitySpec.m
@@ -25,10 +25,7 @@ describe(@"Initialization tests", ^{
     it(@"Should get correctly when initialized with a dictionary", ^ {
         NSDictionary *dict = @{SDLRPCParameterNameGetWayPointsEnabled: @(YES),
                                        SDLRPCParameterNameSendLocationEnabled: @(YES)};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLNavigationCapability* testStruct = [[SDLNavigationCapability alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testStruct.getWayPointsEnabled).to(equal(YES));
         expect(testStruct.sendLocationEnabled).to(equal(YES));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLNavigationInstructionSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLNavigationInstructionSpec.m
@@ -68,10 +68,7 @@ describe(@"Getter/Setter Tests", ^{
                                SDLRPCParameterNameDetails:testDetails,
                                SDLRPCParameterNameImage:testImage
                                };
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLNavigationInstruction *testStruct = [[SDLNavigationInstruction alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testStruct.locationDetails).to(equal(testLocationDetails));
         expect(testStruct.action).to(equal(testAction));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLNavigationServiceDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLNavigationServiceDataSpec.m
@@ -73,10 +73,7 @@ describe(@"Getter/Setter Tests", ^{
                                SDLRPCParameterNameNextInstructionDistanceScale:@(testNextInstructionDistanceScale),
                                SDLRPCParameterNamePrompt:testPrompt
                                };
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLNavigationServiceData *testStruct = [[SDLNavigationServiceData alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testStruct.timestamp).to(equal(testTimestamp));
         expect(testStruct.origin).to(equal(testOrigin));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLNavigationServiceManifestSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLNavigationServiceManifestSpec.m
@@ -30,10 +30,7 @@ describe(@"Getter/Setter Tests", ^{
 
     it(@"Should get correctly when initialized with a dictionary", ^{
         NSDictionary *dict = @{SDLRPCParameterNameAcceptsWayPoints:@(testAcceptsWayPoints)};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLNavigationServiceManifest *testStruct = [[SDLNavigationServiceManifest alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testStruct.acceptsWayPoints).to(equal(testAcceptsWayPoints));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLOasisAddressSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLOasisAddressSpec.m
@@ -47,10 +47,7 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameSubLocality:@"18",
                                        SDLRPCParameterNameThoroughfare:@"Candy Lane",
                                        SDLRPCParameterNameSubThoroughfare:@"123"} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOasisAddress* testStruct = [[SDLOasisAddress alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.countryName).to(equal(@"United States"));
         expect(testStruct.countryCode).to(equal(@"US"));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLParameterPermissionsSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLParameterPermissionsSpec.m
@@ -28,10 +28,7 @@ describe(@"Getter/Setter Tests", ^ {
     it(@"Should get correctly when initialized", ^ {
         NSMutableDictionary* dict = [@{SDLRPCParameterNameAllowed:[@[SDLHMILevelBackground, SDLHMILevelFull] copy],
                                        SDLRPCParameterNameUserDisallowed:[@[SDLHMILevelNone, SDLHMILevelLimited] copy]} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLParameterPermissions* testStruct = [[SDLParameterPermissions alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.allowed).to(equal([@[SDLHMILevelBackground, SDLHMILevelFull] copy]));
         expect(testStruct.userDisallowed).to(equal([@[SDLHMILevelNone, SDLHMILevelLimited] copy]));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLPermissionItemSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLPermissionItemSpec.m
@@ -38,10 +38,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                        SDLRPCParameterNameHMIPermissions:hmiPermissions,
                                                        SDLRPCParameterNameParameterPermissions:parameterPermissions,
                                                        SDLRPCParameterNameRequireEncryption:@YES} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLPermissionItem *testStruct = [[SDLPermissionItem alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.rpcName).to(equal(@"RPCNameThing"));
         expect(testStruct.hmiPermissions).to(equal(hmiPermissions));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLPhoneCapabilitySpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLPhoneCapabilitySpec.m
@@ -21,10 +21,7 @@ describe(@"Getter/Setter Tests", ^ {
 describe(@"Initialization tests", ^{
     it(@"Should get correctly when initialized with a dictionary", ^ {
         NSDictionary *dict = @{SDLRPCParameterNameDialNumberEnabled: @(YES)};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLPhoneCapability *testStruct = [[SDLPhoneCapability alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testStruct.dialNumberEnabled).to(equal(YES));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLPresetBankCapabilitiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLPresetBankCapabilitiesSpec.m
@@ -24,10 +24,7 @@ describe(@"Getter/Setter Tests", ^ {
     
     it(@"Should get correctly when initialized", ^ {
         NSMutableDictionary<NSString *, id> *dict = [@{SDLRPCParameterNameOnScreenPresetsAvailable:@YES} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLPresetBankCapabilities* testStruct = [[SDLPresetBankCapabilities alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.onScreenPresetsAvailable).to(equal(@YES));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLRDSDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLRDSDataSpec.m
@@ -39,10 +39,7 @@ describe(@"Initialization tests", ^{
                                        SDLRPCParameterNameTrafficAnnouncementIdentification : @YES,
                                        SDLRPCParameterNameRegion : @"reg"} mutableCopy];
         
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLRDSData* testStruct = [[SDLRDSData alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testStruct.programService).to(equal(@"ps"));
         expect(testStruct.radioText).to(equal(@"rt"));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLRGBColorSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLRGBColorSpec.m
@@ -41,10 +41,7 @@ describe(@"RGBColor Tests", ^{
         NSDictionary *dict = @{SDLRPCParameterNameRed: @0,
                                SDLRPCParameterNameGreen: @100,
                                SDLRPCParameterNameBlue: @255};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLRGBColor *testStruct = [[SDLRGBColor alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testStruct.red).to(equal(@0));
         expect(testStruct.green).to(equal(@100));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLRectangleSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLRectangleSpec.m
@@ -37,10 +37,7 @@ describe(@"Rectangle Tests", ^{
                                 SDLRPCParameterNameY:@200,
                                 SDLRPCParameterNameWidth:@2000,
                                 SDLRPCParameterNameHeight:@3000};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLRectangle *testStruct = [[SDLRectangle alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testStruct.x).to(equal(@20));
         expect(testStruct.y).to(equal(@200));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLRemoteControlCapabilitiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLRemoteControlCapabilitiesSpec.m
@@ -52,10 +52,7 @@ describe(@"Initialization tests", ^{
                                        SDLRPCParameterNameLightControlCapabilities:someLightControlCapabilities,
                                        SDLRPCParameterNameHmiSettingsControlCapabilities:someHMISettingsControlCapabilities
                                        };
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLRemoteControlCapabilities* testStruct = [[SDLRemoteControlCapabilities alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testStruct.seatControlCapabilities).to(equal([@[someSeatControlCapabilities] copy]));
         expect(testStruct.climateControlCapabilities).to(equal([@[someClimateControlCapabilities] copy]));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLSISDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLSISDataSpec.m
@@ -54,10 +54,7 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameStationIDNumber:someID,
                                        SDLRPCParameterNameStationMessage:@"message"
                                        } mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSISData* testStruct = [[SDLSISData alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testStruct.stationShortName).to(equal(@"short"));
         expect(testStruct.stationIDNumber).to(equal(someID));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLScreenParamsSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLScreenParamsSpec.m
@@ -33,10 +33,7 @@ describe(@"Getter/Setter Tests", ^ {
     it(@"Should get correctly when initialized", ^ {
         NSMutableDictionary<NSString *, id> *dict = [@{SDLRPCParameterNameResolution:resolution,
                                                        SDLRPCParameterNameTouchEventAvailable:capabilities} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLScreenParams* testStruct = [[SDLScreenParams alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.resolution).to(equal(resolution));
         expect(testStruct.touchEventAvailable).to(equal(capabilities));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLSeatControlCapabilitiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLSeatControlCapabilitiesSpec.m
@@ -137,10 +137,7 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameMassageCushionFirmnessAvailable:@NO,
                                        SDLRPCParameterNameMemoryAvailable:@NO
                                        } mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSeatControlCapabilities *testStruct = [[SDLSeatControlCapabilities alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testStruct.moduleName).to(equal(@"moduleName"));
         expect(testStruct.moduleInfo).to(equal(testModuleInfo));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLSeatLocationCapabilitySpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLSeatLocationCapabilitySpec.m
@@ -54,10 +54,7 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameColumns:@3,
                                        SDLRPCParameterNameLevels:@1,
                                        SDLRPCParameterNameSeats:@[driverSeat]} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSeatLocationCapability *testStruct = [[SDLSeatLocationCapability alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.cols).to(equal(@3));
         expect(testStruct.rows).to(equal(@2));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLSeatLocationSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLSeatLocationSpec.m
@@ -40,10 +40,7 @@ describe(@"Getter/Setter Tests", ^ {
     
     it(@"Should get correctly when initialized", ^ {
         NSMutableDictionary* dict = [@{SDLRPCParameterNameGrid:testGird} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSeatLocation *testStruct = [[SDLSeatLocation alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.grid).to(equal(testGird));
     });

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLSeatMemoryActionSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLSeatMemoryActionSpec.m
@@ -41,10 +41,7 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameLabel:@"none",
                                        SDLRPCParameterNameAction: SDLSeatMemoryActionTypeNone
                                        } mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSeatMemoryAction *testStruct = [[SDLSeatMemoryAction alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testStruct.id).to(equal(@54));
         expect(testStruct.action).to(equal(SDLSeatMemoryActionTypeNone));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLSingleTireStatusSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLSingleTireStatusSpec.m
@@ -33,10 +33,7 @@ describe(@"Getter/Setter Tests", ^ {
                                SDLRPCParameterNameTPMS: SDLTPMSLow,
                                SDLRPCParameterNamePressure: @67.78
                                };
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSingleTireStatus* testStruct = [[SDLSingleTireStatus alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.status).to(equal(SDLComponentVolumeStatusLow));
         expect(testStruct.monitoringSystemStatus).to(equal(SDLTPMSLow));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLSoftButtonCapabilitiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLSoftButtonCapabilitiesSpec.m
@@ -33,10 +33,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                        SDLRPCParameterNameLongPressAvailable:@YES,
                                                        SDLRPCParameterNameUpDownAvailable:@NO,
                                                        SDLRPCParameterNameImageSupported:@NO} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSoftButtonCapabilities* testStruct = [[SDLSoftButtonCapabilities alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.shortPressAvailable).to(equal(@NO));
         expect(testStruct.longPressAvailable).to(equal(@YES));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLSoftButtonSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLSoftButtonSpec.m
@@ -45,10 +45,7 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameIsHighlighted:@YES,
                                        SDLRPCParameterNameSoftButtonId:@5423,
                                        SDLRPCParameterNameSystemAction:SDLSystemActionKeepContext} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSoftButton* testStruct = [[SDLSoftButton alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.type).to(equal(SDLSoftButtonTypeImage));
         expect(testStruct.text).to(equal(@"Button"));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLStartTimeSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLStartTimeSpec.m
@@ -33,10 +33,7 @@ describe(@"StartTime Spec", ^ {
             NSDictionary<NSString *, id> *dict = @{SDLRPCParameterNameHours:@(testHours),
                                                    SDLRPCParameterNameMinutes:@(testMinutes),
                                                    SDLRPCParameterNameSeconds:@(testSeconds)};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             SDLStartTime *testStruct = [[SDLStartTime alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
             expect(testStruct.hours).to(equal(@(testHours)));
             expect(testStruct.minutes).to(equal(@(testMinutes)));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLStationIDNumberSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLStationIDNumberSpec.m
@@ -36,10 +36,7 @@ describe(@"Getter/Setter Tests", ^ {
         NSMutableDictionary* dict = [@{SDLRPCParameterNameCountryCode:@91,
                                        SDLRPCParameterNameFCCFacilityId:@23
                                        } mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLStationIDNumber* testStruct = [[SDLStationIDNumber alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testStruct.countryCode).to(equal(@91));
         expect(testStruct.fccFacilityId).to(equal(@23));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLSystemCapabilitySpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLSystemCapabilitySpec.m
@@ -74,10 +74,7 @@ describe(@"Getter/Setter Tests", ^ {
                                SDLRPCParameterNameSeatLocationCapability: testSeatLocationCapability,
                                SDLRPCParameterNameDriverDistractionCapability: testDriverDistractionCapability
                                };
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLSystemCapability *testStruct = [[SDLSystemCapability alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testStruct.systemCapabilityType).to(equal(SDLSystemCapabilityTypeNavigation));
         expect(testStruct.appServicesCapabilities).to(equal(testAppServicesCapabilities));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTTSChunkSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTTSChunkSpec.m
@@ -32,10 +32,7 @@ describe(@"TTS Chunk Tests", ^{
         it(@"should correctly initialize with initWithDictionary", ^{
             NSDictionary* dict = @{SDLRPCParameterNameText: testText,
                                    SDLRPCParameterNameType: testCapabilities};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             testStruct = [[SDLTTSChunk alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
             expect(testStruct.text).to(equal(testText));
             expect(testStruct.type).to(equal(testCapabilities));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTemperatureSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTemperatureSpec.m
@@ -27,10 +27,7 @@ describe(@"Initialization tests", ^{
         
         NSMutableDictionary* dict = [@{SDLRPCParameterNameUnit : SDLTemperatureUnitCelsius ,
                                            SDLRPCParameterNameValue:@30 } mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLTemperature* testStruct = [[SDLTemperature alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.unit).to(equal(SDLTemperatureUnitCelsius));
         expect(testStruct.value).to(equal(@30));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTemplateColorSchemeSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTemplateColorSchemeSpec.m
@@ -54,10 +54,7 @@ describe(@"TemplateColor Tests", ^{
         NSDictionary *dict = @{SDLRPCParameterNameRed: @0,
                                SDLRPCParameterNameGreen: @100,
                                SDLRPCParameterNameBlue: @255};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLRGBColor *testStruct = [[SDLRGBColor alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testStruct.red).to(equal(@0));
         expect(testStruct.green).to(equal(@100));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTextFieldSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTextFieldSpec.m
@@ -41,10 +41,7 @@ describe(@"Getter/Setter Tests", ^ {
                                SDLRPCParameterNameCharacterSet:testCharacterSet,
                                SDLRPCParameterNameWidth:@(testWidth),
                                SDLRPCParameterNameRows:@(testRows)};
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLTextField* testStruct = [[SDLTextField alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.name).to(equal(testName));
         expect(testStruct.characterSet).to(equal(testCharacterSet));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTireStatusSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTireStatusSpec.m
@@ -51,10 +51,7 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameRightRear:tire4,
                                        SDLRPCParameterNameInnerLeftRear:tire5,
                                        SDLRPCParameterNameInnerRightRear:tire6} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLTireStatus* testStruct = [[SDLTireStatus alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.pressureTelltale).to(equal(SDLWarningLightStatusOff));
         expect(testStruct.leftFront).to(equal(tire1));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTouchCoordSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTouchCoordSpec.m
@@ -28,10 +28,7 @@ describe(@"Getter/Setter Tests", ^ {
     it(@"Should get correctly when initialized", ^ {
         NSMutableDictionary<NSString *, id> *dict = [@{SDLRPCParameterNameX:@67,
                                                        SDLRPCParameterNameY:@362} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLTouchCoord* testStruct = [[SDLTouchCoord alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.x).to(equal(@67));
         expect(testStruct.y).to(equal(@362));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTouchEventCapabilitiesSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTouchEventCapabilitiesSpec.m
@@ -30,10 +30,7 @@ describe(@"Getter/Setter Tests", ^ {
         NSMutableDictionary<NSString *, id> *dict = [@{SDLRPCParameterNamePressAvailable:@YES,
                                                        SDLRPCParameterNameMultiTouchAvailable:@NO,
                                                        SDLRPCParameterNameDoublePressAvailable:@NO} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLTouchEventCapabilities* testStruct = [[SDLTouchEventCapabilities alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.pressAvailable).to(equal(@YES));
         expect(testStruct.multiTouchAvailable).to(equal(@NO));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTouchEventSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTouchEventSpec.m
@@ -33,10 +33,7 @@ describe(@"Getter/Setter Tests", ^ {
         NSMutableDictionary<NSString *, id> *dict = [@{SDLRPCParameterNameId:@3,
                                                        SDLRPCParameterNameTS:[@[@23, @52, @41345234] mutableCopy],
                                                        SDLRPCParameterNameCoordinate:[@[coord] mutableCopy]} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLTouchEvent* testStruct = [[SDLTouchEvent alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.touchEventId).to(equal(@3));
         expect(testStruct.timeStamp).to(equal([@[@23, @52, @41345234] mutableCopy]));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTurnSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLTurnSpec.m
@@ -30,10 +30,7 @@ describe(@"Getter/Setter Tests", ^ {
     it(@"Should get correctly when initialized", ^ {
         NSMutableDictionary<NSString *, id> *dict = [@{SDLRPCParameterNameNavigationText:@"NAVTEXT",
                                                        SDLRPCParameterNameTurnIcon:image} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLTurn* testStruct = [[SDLTurn alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.navigationText).to(equal(@"NAVTEXT"));
         expect(testStruct.turnIcon).to(equal(image));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLVehicleDataResultSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLVehicleDataResultSpec.m
@@ -47,10 +47,7 @@ describe(@"Getter/Setter Tests", ^ {
                                        SDLRPCParameterNameResultCode:SDLVehicleDataResultCodeDisallowed,
                                        SDLRPCParameterNameOEMCustomDataType:@"CustomOEMData"
                                        } mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLVehicleDataResult* testStruct = [[SDLVehicleDataResult alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.dataType).to(equal(SDLVehicleDataTypeAirbagStatus));
         expect(testStruct.customOEMDataType).to(equal(@"CustomOEMData"));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLVehicleTypeSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLVehicleTypeSpec.m
@@ -33,10 +33,7 @@ describe(@"Getter/Setter Tests", ^ {
                                                        SDLRPCParameterNameModel:@"Model",
                                                        SDLRPCParameterNameModelYear:@"3.141*10^36",
                                                        SDLRPCParameterNameTrim:@"AE"} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLVehicleType* testStruct = [[SDLVehicleType alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.make).to(equal(@"Make"));
         expect(testStruct.model).to(equal(@"Model"));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLVideoStreamingCapabilitySpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLVideoStreamingCapabilitySpec.m
@@ -52,10 +52,7 @@ describe(@"Initialization tests", ^{
                                SDLRPCParameterNamePixelPerInch: @(testPixelPerInch),
                                SDLRPCParameterNameScale: @(testScale)};
 
-        #pragma clang diagnostic push
-        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLVideoStreamingCapability* testStruct = [[SDLVideoStreamingCapability alloc] initWithDictionary:dict];
-        #pragma clang diagnostic pop
 
         expect(testStruct.preferredResolution).to(equal(testPreferredResolution));
         expect(testStruct.maxBitrate).to(equal(testMaxBitrate));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLVideoStreamingFormatSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLVideoStreamingFormatSpec.m
@@ -22,10 +22,7 @@ describe(@"Initialization tests", ^{
     it(@"Should get correctly when initialized with a dictionary", ^ {
         NSMutableDictionary* dict = [@{SDLRPCParameterNameVideoProtocol: SDLVideoStreamingProtocolRAW,
                                        SDLRPCParameterNameVideoCodec: SDLVideoStreamingCodecH264} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLVideoStreamingFormat* testStruct = [[SDLVideoStreamingFormat alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testStruct.protocol).to(equal(SDLVideoStreamingProtocolRAW));
         expect(testStruct.codec).to(equal(SDLVideoStreamingCodecH264));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLVrHelpItemSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLVrHelpItemSpec.m
@@ -34,10 +34,7 @@ describe(@"Getter/Setter Tests", ^ {
         NSMutableDictionary<NSString *, id> *dict = [@{SDLRPCParameterNameText:@"DON'T PANIC",
                                                        SDLRPCParameterNameImage:image,
                                                        SDLRPCParameterNamePosition:@42} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLVRHelpItem* testStruct = [[SDLVRHelpItem alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testStruct.text).to(equal(@"DON'T PANIC"));
         expect(testStruct.image).to(equal(image));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLWeatherAlertSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLWeatherAlertSpec.m
@@ -57,10 +57,7 @@ describe(@"Getter/Setter Tests", ^{
                                SDLRPCParameterNameSeverity:testSeverity,
                                SDLRPCParameterNameTimeIssued:testTimeIssued
                                };
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLWeatherAlert *testStruct = [[SDLWeatherAlert alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testStruct.title).to(equal(testTitle));
         expect(testStruct.summary).to(equal(testSummary));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLWeatherDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLWeatherDataSpec.m
@@ -127,10 +127,7 @@ describe(@"Getter/Setter Tests", ^{
                                SDLRPCParameterNameVisibility:@(testVisibility),
                                SDLRPCParameterNameWeatherIcon:testWeatherIcon
                                };
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLWeatherData *testStruct = [[SDLWeatherData alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testStruct.currentTemperature).to(equal(testCurrentTemp));
         expect(testStruct.temperatureHigh).to(equal(testTempHigh));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLWeatherServiceDataSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLWeatherServiceDataSpec.m
@@ -29,8 +29,6 @@ describe(@"Getter/Setter Tests", ^{
         testLocation = [[SDLLocationDetails alloc] init];
         testLocation.locationName = @"testLocationName";
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLWeatherData *testWeatherDataA = [[SDLWeatherData alloc] initWithDictionary:@{SDLRPCParameterNameWeatherSummary:@"testWeatherDataA"}];
         SDLWeatherData *testWeatherDataB = [[SDLWeatherData alloc] initWithDictionary:@{SDLRPCParameterNameWeatherSummary:@"testWeatherDataB"}];
         SDLWeatherData *testWeatherDataC = [[SDLWeatherData alloc] initWithDictionary:@{SDLRPCParameterNameWeatherSummary:@"testWeatherDataC"}];
@@ -40,7 +38,6 @@ describe(@"Getter/Setter Tests", ^{
         testMultidayForecast = @[testWeatherDataA, testWeatherDataC];
 
         SDLWeatherAlert *testWeatherAlertA = [[SDLWeatherAlert alloc] initWithDictionary:@{SDLRPCParameterNameTitle:@"testWeatherAlertA"}];
-#pragma clang diagnostic pop
         testAlerts = @[testWeatherAlertA];
     });
 
@@ -69,10 +66,7 @@ describe(@"Getter/Setter Tests", ^{
                                SDLRPCParameterNameMultidayForecast:testMultidayForecast,
                                SDLRPCParameterNameAlerts:testAlerts
                                };
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLWeatherServiceData *testStruct = [[SDLWeatherServiceData alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testStruct.location).to(equal(testLocation));
         expect(testStruct.currentForecast).to(equal(testCurrentForecast));

--- a/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLWeatherServiceManifestSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/StructSpecs/SDLWeatherServiceManifestSpec.m
@@ -48,10 +48,7 @@ describe(@"Getter/Setter Tests", ^{
                                SDLRPCParameterNameMaxMinutelyForecastAmount:@(testMaxMinutelyForecastAmount),
                                SDLRPCParameterNameWeatherForLocationSupported:@(testWeatherForLocationSupported)
                                };
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLWeatherServiceManifest *testStruct = [[SDLWeatherServiceManifest alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
 
         expect(testStruct.currentForecastSupported).to(equal(testCurrentForecastSupported));
         expect(testStruct.maxMultidayForecastAmount).to(equal(testMaxMultidayForecastAmount));

--- a/SmartDeviceLinkTests/RPCSpecs/SuperclassSpecs/SDLRPCResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/SuperclassSpecs/SDLRPCResponseSpec.m
@@ -41,10 +41,7 @@ describe(@"Getter/Setter Tests",  ^ {
                                                    SDLRPCParameterNameInfo:@"Test Info"},
                                              SDLRPCParameterNameCorrelationId:@1004,
                                              SDLRPCParameterNameOperationName:SDLRPCParameterNameResponse}} mutableCopy];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLRPCResponse* testResponse = [[SDLRPCResponse alloc] initWithDictionary:dict];
-#pragma clang diagnostic pop
         
         expect(testResponse.name).to(equal(SDLRPCParameterNameResponse));
         expect(testResponse.correlationID).to(equal(@1004));


### PR DESCRIPTION
Fixes #1819 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [ ] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
N/A

#### Core Tests
N/A

Core version / branch / commit hash / module tested against: [INSERT]
HMI name / version / branch / commit hash / module tested against: [INSERT]

### Summary
Remove the suppress deprecation warnings from the tests.

### Changelog
##### Breaking Changes
* Remove the suppress deprecation warnings from the tests.

##### Enhancements
* N/A

##### Bug Fixes
* N/A

### Tasks Remaining:
N/A

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
