### PR TITLE
Add nullable attribute to lockScreenDismissalEnabled and lockScreenDismissalWarning

### DIFF
--- a/SmartDeviceLink/public/SDLOnDriverDistraction.h
+++ b/SmartDeviceLink/public/SDLOnDriverDistraction.h
@@ -33,14 +33,14 @@ NS_ASSUME_NONNULL_BEGIN
  
  Optional, Boolean
  */
-@property (strong, nonatomic) NSNumber<SDLBool> *lockScreenDismissalEnabled;
+@property (strong, nonatomic, nullable) NSNumber<SDLBool> *lockScreenDismissalEnabled;
 
 /**
  Warning message to be displayed on the lock screen when dismissal is enabled.  This warning should be used to ensure that the user is not the driver of the vehicle, ex. `Swipe up to dismiss, acknowledging that you are not the driver.`.  This parameter must be present if "lockScreenDismissalEnabled" is set to true.
  
  Optional,  String
  */
-@property (strong, nonatomic) NSString *lockScreenDismissalWarning;
+@property (strong, nonatomic, nullable) NSString *lockScreenDismissalWarning;
 
 @end
 

--- a/SmartDeviceLink/public/SDLOnDriverDistraction.m
+++ b/SmartDeviceLink/public/SDLOnDriverDistraction.m
@@ -30,20 +30,20 @@ NS_ASSUME_NONNULL_BEGIN
     return [self.parameters sdl_enumForName:SDLRPCParameterNameState error:&error];
 }
 
-- (void)setLockScreenDismissalEnabled:(NSNumber<SDLBool> *_Nullable)lockScreenDismissalEnabled {
+- (void)setLockScreenDismissalEnabled:(nullable NSNumber<SDLBool> *)lockScreenDismissalEnabled {
     [self.parameters sdl_setObject:lockScreenDismissalEnabled forName:SDLRPCParameterNameLockScreenDismissalEnabled];
 }
 
-- (NSNumber<SDLBool> *_Nullable)lockScreenDismissalEnabled {
+- (nullable NSNumber<SDLBool> *)lockScreenDismissalEnabled {
     NSError *error = nil;
     return [self.parameters sdl_objectForName:SDLRPCParameterNameLockScreenDismissalEnabled ofClass:NSNumber.class error:&error];
 }
 
-- (void)setLockScreenDismissalWarning:(NSString *_Nullable)lockScreenDismissalWarning {
+- (void)setLockScreenDismissalWarning:(nullable NSString *)lockScreenDismissalWarning {
     [self.parameters sdl_setObject:lockScreenDismissalWarning forName:SDLRPCParameterNameLockScreenDismissalWarning];
 }
 
-- (NSString *_Nullable)lockScreenDismissalWarning {
+- (nullable NSString *)lockScreenDismissalWarning {
     NSError *error = nil;
     return [self.parameters sdl_objectForName:SDLRPCParameterNameLockScreenDismissalWarning ofClass:NSString.class error:&error];
 }

--- a/SmartDeviceLink/public/SDLOnDriverDistraction.m
+++ b/SmartDeviceLink/public/SDLOnDriverDistraction.m
@@ -30,20 +30,20 @@ NS_ASSUME_NONNULL_BEGIN
     return [self.parameters sdl_enumForName:SDLRPCParameterNameState error:&error];
 }
 
-- (void)setLockScreenDismissalEnabled:(NSNumber<SDLBool> *)lockScreenDismissalEnabled {
+- (void)setLockScreenDismissalEnabled:(NSNumber<SDLBool> *_Nullable)lockScreenDismissalEnabled {
     [self.parameters sdl_setObject:lockScreenDismissalEnabled forName:SDLRPCParameterNameLockScreenDismissalEnabled];
 }
 
-- (NSNumber<SDLBool> *)lockScreenDismissalEnabled {
+- (NSNumber<SDLBool> *_Nullable)lockScreenDismissalEnabled {
     NSError *error = nil;
     return [self.parameters sdl_objectForName:SDLRPCParameterNameLockScreenDismissalEnabled ofClass:NSNumber.class error:&error];
 }
 
-- (void)setLockScreenDismissalWarning:(NSString *)lockScreenDismissalWarning {
+- (void)setLockScreenDismissalWarning:(NSString *_Nullable)lockScreenDismissalWarning {
     [self.parameters sdl_setObject:lockScreenDismissalWarning forName:SDLRPCParameterNameLockScreenDismissalWarning];
 }
 
-- (NSString *)lockScreenDismissalWarning {
+- (NSString *_Nullable)lockScreenDismissalWarning {
     NSError *error = nil;
     return [self.parameters sdl_objectForName:SDLRPCParameterNameLockScreenDismissalWarning ofClass:NSString.class error:&error];
 }

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnDriverDistractionSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnDriverDistractionSpec.m
@@ -15,25 +15,33 @@
 
 QuickSpecBegin(SDLOnDriverDistractionSpec)
 
+NSString *testDismissalWarning = @"I got an apple.";
+
 describe(@"Getter/Setter Tests", ^ {
     it(@"Should set and get correctly", ^ {
         SDLOnDriverDistraction *testNotification = [[SDLOnDriverDistraction alloc] init];
         
         testNotification.state = SDLDriverDistractionStateOn;
         testNotification.lockScreenDismissalEnabled = @1;
-        
+        testNotification.lockScreenDismissalWarning = testDismissalWarning;
+
         expect(testNotification.state).to(equal(SDLDriverDistractionStateOn));
         expect(testNotification.lockScreenDismissalEnabled).to(beTrue());
+        expect(testNotification.lockScreenDismissalWarning).to(equal(testDismissalWarning));
         
         testNotification.lockScreenDismissalEnabled = @0;
         expect(testNotification.lockScreenDismissalEnabled).to(beFalse());
+
+        testNotification.lockScreenDismissalWarning = nil;
+        expect(testNotification.lockScreenDismissalWarning).to(beNil());
     });
     
     it(@"Should get correctly when initialized", ^ {
         NSMutableDictionary *dictOn = [@{SDLRPCParameterNameNotification:
                                            @{SDLRPCParameterNameParameters:
                                                  @{SDLRPCParameterNameState:SDLDriverDistractionStateOn,
-                                                   SDLRPCParameterNameLockScreenDismissalEnabled: @1},
+                                                   SDLRPCParameterNameLockScreenDismissalEnabled: @1,
+                                                   SDLRPCParameterNameLockScreenDismissalWarning: testDismissalWarning},
                                              SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnDriverDistraction}} mutableCopy];
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -42,6 +50,7 @@ describe(@"Getter/Setter Tests", ^ {
         
         expect(testNotificationOn.state).to(equal(SDLDriverDistractionStateOn));
         expect(testNotificationOn.lockScreenDismissalEnabled).to(beTrue());
+        expect(testNotificationOn.lockScreenDismissalWarning).to(equal(testDismissalWarning));
         
         NSMutableDictionary *dictOff = [@{SDLRPCParameterNameNotification:
                                            @{SDLRPCParameterNameParameters:
@@ -61,6 +70,7 @@ describe(@"Getter/Setter Tests", ^ {
         SDLOnDriverDistraction *testNotification = [[SDLOnDriverDistraction alloc] init];
         
         expect(testNotification.state).to(beNil());
+        expect(testNotification.lockScreenDismissalWarning).to(beNil());
         expect(testNotification.lockScreenDismissalEnabled).to(beNil());
         expect(testNotification.lockScreenDismissalEnabled).to(beFalsy());
     });

--- a/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnDriverDistractionSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/NotificationSpecs/SDLOnDriverDistractionSpec.m
@@ -28,21 +28,15 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testNotification.state).to(equal(SDLDriverDistractionStateOn));
         expect(testNotification.lockScreenDismissalEnabled).to(beTrue());
         expect(testNotification.lockScreenDismissalWarning).to(equal(testDismissalWarning));
-        
-        testNotification.lockScreenDismissalEnabled = @0;
-        expect(testNotification.lockScreenDismissalEnabled).to(beFalse());
-
-        testNotification.lockScreenDismissalWarning = nil;
-        expect(testNotification.lockScreenDismissalWarning).to(beNil());
     });
     
     it(@"Should get correctly when initialized", ^ {
-        NSMutableDictionary *dictOn = [@{SDLRPCParameterNameNotification:
+        NSDictionary *dictOn = @{SDLRPCParameterNameNotification:
                                            @{SDLRPCParameterNameParameters:
                                                  @{SDLRPCParameterNameState:SDLDriverDistractionStateOn,
                                                    SDLRPCParameterNameLockScreenDismissalEnabled: @1,
                                                    SDLRPCParameterNameLockScreenDismissalWarning: testDismissalWarning},
-                                             SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnDriverDistraction}} mutableCopy];
+                                             SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnDriverDistraction}};
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnDriverDistraction* testNotificationOn = [[SDLOnDriverDistraction alloc] initWithDictionary:dictOn];
@@ -52,11 +46,11 @@ describe(@"Getter/Setter Tests", ^ {
         expect(testNotificationOn.lockScreenDismissalEnabled).to(beTrue());
         expect(testNotificationOn.lockScreenDismissalWarning).to(equal(testDismissalWarning));
         
-        NSMutableDictionary *dictOff = [@{SDLRPCParameterNameNotification:
+        NSDictionary *dictOff = @{SDLRPCParameterNameNotification:
                                            @{SDLRPCParameterNameParameters:
                                                  @{SDLRPCParameterNameState:SDLDriverDistractionStateOff,
                                                    SDLRPCParameterNameLockScreenDismissalEnabled: @0},
-                                             SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnDriverDistraction}} mutableCopy];
+                                             SDLRPCParameterNameOperationName:SDLRPCFunctionNameOnDriverDistraction}};
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
         SDLOnDriverDistraction *testNotificationOff = [[SDLOnDriverDistraction alloc] initWithDictionary:dictOff];


### PR DESCRIPTION
Fixes #1813 

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Unit tests added for the lockScreenDismissalWarning property.

#### Core Tests
N/A

Core version / branch / commit hash / module tested against: 7.0
HMI name / version / branch / commit hash / module tested against: N/A

### Summary
Added the nullable attribute to mentioned properties.

### Changelog
##### Breaking Changes
* N/A

##### Enhancements
* N/A

##### Bug Fixes
* Added the nullable attribute to mentioned properties.

### Tasks Remaining:
N/A

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
