### PR TITLE
Start updating RPCs with generated initializers

### DIFF
--- a/SmartDeviceLink/public/SDLAddCommand.h
+++ b/SmartDeviceLink/public/SDLAddCommand.h
@@ -1,4 +1,34 @@
-//  SDLAddCommand.h
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 
 #import "SDLRPCRequest.h"
@@ -8,6 +38,8 @@
 
 @class SDLImage;
 @class SDLMenuParams;
+
+NS_ASSUME_NONNULL_BEGIN
 
 /**
  *  This class will add a command to the application's Command Menu
@@ -25,10 +57,22 @@
  *  @since SDL 1.0
  *  @see SDLDeleteCommand, SDLAddSubMenu, SDLDeleteSubMenu
  */
-
-NS_ASSUME_NONNULL_BEGIN
-
 @interface SDLAddCommand : SDLRPCRequest
+
+/**
+ * @param cmdID - @(cmdID)
+ * @return A SDLAddCommand object
+ */
+- (instancetype)initWithCmdID:(UInt32)cmdID;
+
+/**
+ * @param cmdID - @(cmdID)
+ * @param menuParams - menuParams
+ * @param vrCommands - vrCommands
+ * @param cmdIcon - cmdIcon
+ * @return A SDLAddCommand object
+ */
+- (instancetype)initWithCmdID:(UInt32)cmdID menuParams:(nullable SDLMenuParams *)menuParams vrCommands:(nullable NSArray<NSString *> *)vrCommands cmdIcon:(nullable SDLImage *)cmdIcon;
 
 /**
  *  Constructs a SDLAddCommand with a handler callback when an event occurs.
@@ -37,7 +81,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @return A SDLAddCommand object
  */
-- (instancetype)initWithHandler:(nullable SDLRPCCommandNotificationHandler)handler;
+- (instancetype)initWithHandler:(nullable SDLRPCCommandNotificationHandler)handler __deprecated_msg("Use initWithCmdId: instead");
 
 /**
  *  Convenience init for creating a voice command menu item.
@@ -49,7 +93,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param handler     Called when the VR system recognizes a phrase in `vrCommands`
  *  @return            A SDLAddCommand object
  */
-- (instancetype)initWithId:(UInt32)commandId vrCommands:(nullable NSArray<NSString *> *)vrCommands handler:(nullable SDLRPCCommandNotificationHandler)handler;
+- (instancetype)initWithId:(UInt32)commandId vrCommands:(nullable NSArray<NSString *> *)vrCommands handler:(nullable SDLRPCCommandNotificationHandler)handler __deprecated_msg("Use initWithCmdId: instead");
 
 /**
  *  Convenience init for creating a menu item with text.
@@ -60,7 +104,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param handler     Called when the menu item is selected and/or when the VR system recognizes a phrase in `vrCommands`
  *  @return            A SDLAddCommand object
  */
-- (instancetype)initWithId:(UInt32)commandId vrCommands:(nullable NSArray<NSString *> *)vrCommands menuName:(NSString *)menuName handler:(nullable SDLRPCCommandNotificationHandler)handler;
+- (instancetype)initWithId:(UInt32)commandId vrCommands:(nullable NSArray<NSString *> *)vrCommands menuName:(NSString *)menuName handler:(nullable SDLRPCCommandNotificationHandler)handler __deprecated_msg("Use initWithCmdId: instead");
 
 /**
  *  Convenience init for creating a menu item with text and a custom icon.
@@ -78,7 +122,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param handler         Called when the menu item is selected and/or when the VR system recognizes a phrase in `vrCommands`
  *  @return                A SDLAddCommand object
  */
-- (instancetype)initWithId:(UInt32)commandId vrCommands:(nullable NSArray<NSString *> *)vrCommands menuName:(NSString *)menuName parentId:(UInt32)parentId position:(UInt16)position iconValue:(nullable NSString *)iconValue iconType:(nullable SDLImageType)iconType iconIsTemplate:(BOOL)iconIsTemplate handler:(nullable SDLRPCCommandNotificationHandler)handler;
+- (instancetype)initWithId:(UInt32)commandId vrCommands:(nullable NSArray<NSString *> *)vrCommands menuName:(NSString *)menuName parentId:(UInt32)parentId position:(UInt16)position iconValue:(nullable NSString *)iconValue iconType:(nullable SDLImageType)iconType iconIsTemplate:(BOOL)iconIsTemplate handler:(nullable SDLRPCCommandNotificationHandler)handler __deprecated_msg("Use initWithCmdId: instead");
 
 /**
  *  Convenience init for creating a menu item with text and a custom icon.
@@ -94,7 +138,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param handler     Called when the menu item is selected and/or when the VR system recognizes a phrase in `vrCommands`
  *  @return            A SDLAddCommand object
  */
-- (instancetype)initWithId:(UInt32)commandId vrCommands:(nullable NSArray<NSString *> *)vrCommands menuName:(NSString *)menuName parentId:(UInt32)parentId position:(UInt16)position icon:(nullable SDLImage *)icon handler:(nullable SDLRPCCommandNotificationHandler)handler;
+- (instancetype)initWithId:(UInt32)commandId vrCommands:(nullable NSArray<NSString *> *)vrCommands menuName:(NSString *)menuName parentId:(UInt32)parentId position:(UInt16)position icon:(nullable SDLImage *)icon handler:(nullable SDLRPCCommandNotificationHandler)handler __deprecated_msg("Use initWithCmdId: instead");
 
 /**
  *  A handler that will let you know when the button you created is subscribed.

--- a/SmartDeviceLink/public/SDLAddSubMenu.h
+++ b/SmartDeviceLink/public/SDLAddSubMenu.h
@@ -37,6 +37,8 @@
 
 @class SDLImage;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * Add a SDLSubMenu to the Command Menu
  * <p>
@@ -50,9 +52,6 @@
  * Since <b>SmartDeviceLink 1.0</b><br>
  * see SDLDeleteSubMenu SDLAddCommand SDLDeleteCommand
  */
-
-NS_ASSUME_NONNULL_BEGIN
-
 @interface SDLAddSubMenu : SDLRPCRequest
 
 /**

--- a/SmartDeviceLink/public/SDLAirbagStatus.h
+++ b/SmartDeviceLink/public/SDLAirbagStatus.h
@@ -1,5 +1,34 @@
-//  SDLAirbagStatus.h
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #import "SDLRPCMessage.h"
 
@@ -11,6 +40,19 @@ NS_ASSUME_NONNULL_BEGIN
  A vehicle data status struct for airbags
  */
 @interface SDLAirbagStatus : SDLRPCStruct
+
+/**
+ * @param driverAirbagDeployed - driverAirbagDeployed
+ * @param driverSideAirbagDeployed - driverSideAirbagDeployed
+ * @param driverCurtainAirbagDeployed - driverCurtainAirbagDeployed
+ * @param passengerAirbagDeployed - passengerAirbagDeployed
+ * @param passengerCurtainAirbagDeployed - passengerCurtainAirbagDeployed
+ * @param driverKneeAirbagDeployed - driverKneeAirbagDeployed
+ * @param passengerSideAirbagDeployed - passengerSideAirbagDeployed
+ * @param passengerKneeAirbagDeployed - passengerKneeAirbagDeployed
+ * @return A SDLAirbagStatus object
+ */
+- (instancetype)initWithDriverAirbagDeployed:(SDLVehicleDataEventStatus)driverAirbagDeployed driverSideAirbagDeployed:(SDLVehicleDataEventStatus)driverSideAirbagDeployed driverCurtainAirbagDeployed:(SDLVehicleDataEventStatus)driverCurtainAirbagDeployed passengerAirbagDeployed:(SDLVehicleDataEventStatus)passengerAirbagDeployed passengerCurtainAirbagDeployed:(SDLVehicleDataEventStatus)passengerCurtainAirbagDeployed driverKneeAirbagDeployed:(SDLVehicleDataEventStatus)driverKneeAirbagDeployed passengerSideAirbagDeployed:(SDLVehicleDataEventStatus)passengerSideAirbagDeployed passengerKneeAirbagDeployed:(SDLVehicleDataEventStatus)passengerKneeAirbagDeployed;
 
 /**
  References signal "VedsDrvBag_D_Ltchd". See VehicleDataEventStatus.

--- a/SmartDeviceLink/public/SDLAlert.h
+++ b/SmartDeviceLink/public/SDLAlert.h
@@ -1,6 +1,34 @@
-//  SDLAlert.h
-//
-
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #import "SDLRPCRequest.h"
 
@@ -20,6 +48,21 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SDLAlert : SDLRPCRequest
 
 /**
+ * @param alertText1 - alertText1
+ * @param alertText2 - alertText2
+ * @param alertText3 - alertText3
+ * @param ttsChunks - ttsChunks
+ * @param duration - duration
+ * @param playTone - playTone
+ * @param progressIndicator - progressIndicator
+ * @param softButtons - softButtons
+ * @param alertIcon - alertIcon
+ * @param cancelID - cancelID
+ * @return A SDLAlert object
+ */
+- (instancetype)initWithAlertText1:(nullable NSString *)alertText1 alertText2:(nullable NSString *)alertText2 alertText3:(nullable NSString *)alertText3 ttsChunks:(nullable NSArray<SDLTTSChunk *> *)ttsChunks duration:(nullable NSNumber<SDLUInt> *)duration playTone:(nullable NSNumber<SDLBool> *)playTone progressIndicator:(nullable NSNumber<SDLBool> *)progressIndicator softButtons:(nullable NSArray<SDLSoftButton *> *)softButtons alertIcon:(nullable SDLImage *)alertIcon cancelID:(nullable NSNumber<SDLInt> *)cancelID;
+
+/**
  Convenience init for creating a modal view with text, buttons, and optional sound cues.
 
  @param alertText The string to be displayed in the first field of the display
@@ -30,7 +73,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param icon Image to be displayed in the alert
  @return An SDLAlert object
  */
-- (instancetype)initWithAlertText:(nullable NSString *)alertText softButtons:(nullable NSArray<SDLSoftButton *> *)softButtons playTone:(BOOL)playTone ttsChunks:(nullable NSArray<SDLTTSChunk *> *)ttsChunks alertIcon:(nullable SDLImage *)icon cancelID:(UInt32)cancelID;
+- (instancetype)initWithAlertText:(nullable NSString *)alertText softButtons:(nullable NSArray<SDLSoftButton *> *)softButtons playTone:(BOOL)playTone ttsChunks:(nullable NSArray<SDLTTSChunk *> *)ttsChunks alertIcon:(nullable SDLImage *)icon cancelID:(UInt32)cancelID  __deprecated_msg("Use initWithAlertText1:alertText2:alertText3:ttsChunks:duration:playTone:progressIndicator:softButtons:alertIcon:cancelID: instead");
 
 /**
  Convenience init for creating a sound-only alert.
@@ -39,7 +82,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param playTone Whether the alert tone should be played before the TTS is spoken
  @return An SDLAlert object
  */
-- (instancetype)initWithTTSChunks:(nullable NSArray<SDLTTSChunk *> *)ttsChunks playTone:(BOOL)playTone;
+- (instancetype)initWithTTSChunks:(nullable NSArray<SDLTTSChunk *> *)ttsChunks playTone:(BOOL)playTone  __deprecated_msg("Use initWithAlertText1:alertText2:alertText3:ttsChunks:duration:playTone:progressIndicator:softButtons:alertIcon:cancelID: instead");
 
 /**
  Convenience init for setting all alert parameters.
@@ -56,7 +99,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param icon Image to be displayed in the alert
  @return An SDLAlert object
  */
-- (instancetype)initWithAlertText1:(nullable NSString *)alertText1 alertText2:(nullable NSString *)alertText2 alertText3:(nullable NSString *)alertText3 softButtons:(nullable NSArray<SDLSoftButton *> *)softButtons playTone:(BOOL)playTone ttsChunks:(nullable NSArray<SDLTTSChunk *> *)ttsChunks duration:(UInt16)duration progressIndicator:(BOOL)progressIndicator alertIcon:(nullable SDLImage *)icon cancelID:(UInt32)cancelID;
+- (instancetype)initWithAlertText1:(nullable NSString *)alertText1 alertText2:(nullable NSString *)alertText2 alertText3:(nullable NSString *)alertText3 softButtons:(nullable NSArray<SDLSoftButton *> *)softButtons playTone:(BOOL)playTone ttsChunks:(nullable NSArray<SDLTTSChunk *> *)ttsChunks duration:(UInt16)duration progressIndicator:(BOOL)progressIndicator alertIcon:(nullable SDLImage *)icon cancelID:(UInt32)cancelID  __deprecated_msg("Use initWithAlertText1:alertText2:alertText3:ttsChunks:duration:playTone:progressIndicator:softButtons:alertIcon:cancelID: instead");
 
 /**
  The first line of the alert text field.

--- a/SmartDeviceLink/public/SDLAlertManeuver.h
+++ b/SmartDeviceLink/public/SDLAlertManeuver.h
@@ -1,5 +1,34 @@
-//  SDLAlertManeuver.h
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 
 #import "SDLRPCRequest.h"
@@ -7,24 +36,14 @@
 @class SDLSoftButton;
 @class SDLTTSChunk;
 
+NS_ASSUME_NONNULL_BEGIN
 
 /**
  *  Shows a SDLShowConstantTBT message with an optional voice command. This message is shown as an overlay over the display's base screen.
  *
  *  @since SmartDeviceLink 1.0
  */
-
-NS_ASSUME_NONNULL_BEGIN
-
 @interface SDLAlertManeuver : SDLRPCRequest
-
-/// Convenience init to create an alert maneuver with required parameters
-///
-/// @param ttsText The text to speak
-/// @param softButtons An arry of soft buttons
-///
-/// @return An SDLAlertManeuver object
-- (instancetype)initWithTTS:(nullable NSString *)ttsText softButtons:(nullable NSArray<SDLSoftButton *> *)softButtons;
 
 ///  Convenience init to create an alert maneuver with all parameters
 ///
@@ -32,6 +51,14 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param softButtons An arry of soft buttons
 /// @return An SDLAlertManeuver object
 - (instancetype)initWithTTSChunks:(nullable NSArray<SDLTTSChunk *> *)ttsChunks softButtons:(nullable NSArray<SDLSoftButton *> *)softButtons;
+
+/// Convenience init to create an alert maneuver with required parameters
+///
+/// @param ttsText The text to speak
+/// @param softButtons An arry of soft buttons
+///
+/// @return An SDLAlertManeuver object
+- (instancetype)initWithTTS:(nullable NSString *)ttsText softButtons:(nullable NSArray<SDLSoftButton *> *)softButtons __deprecated_msg("Use initWithTTSChunks:softButtons: instead");
 
 /**
  *  An array of text chunks.

--- a/SmartDeviceLink/public/SDLAlertResponse.h
+++ b/SmartDeviceLink/public/SDLAlertResponse.h
@@ -1,18 +1,52 @@
-//  SDLAlertResponse.h
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 
 #import "SDLRPCResponse.h"
+
+NS_ASSUME_NONNULL_BEGIN
 
 /**
  Response to SDLAlert
 
  @since SDL 1.0
  */
-
-NS_ASSUME_NONNULL_BEGIN
-
 @interface SDLAlertResponse : SDLRPCResponse
+
+/**
+ * @param tryAgainTime - tryAgainTime
+ * @return A SDLAlertResponse object
+ */
+- (instancetype)initWithTryAgainTime:(nullable NSNumber<SDLUInt> *)tryAgainTime;
 
 /// Amount of time (in seconds) that an app must wait before resending an alert.
 ///

--- a/SmartDeviceLink/public/SDLAppInfo.h
+++ b/SmartDeviceLink/public/SDLAppInfo.h
@@ -1,5 +1,34 @@
-//  SDLAppInfo.h
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #import "SDLRPCStruct.h"
 
@@ -9,6 +38,23 @@ NS_ASSUME_NONNULL_BEGIN
  A struct used in register app interface. Contains detailed information about the registered application.
  */
 @interface SDLAppInfo : SDLRPCStruct
+
+/**
+ * @param appDisplayName - appDisplayName
+ * @param appBundleID - appBundleID
+ * @param appVersion - appVersion
+ * @return A SDLAppInfo object
+ */
+- (instancetype)initWithAppDisplayName:(NSString *)appDisplayName appBundleID:(NSString *)appBundleID appVersion:(NSString *)appVersion;
+
+/**
+ * @param appDisplayName - appDisplayName
+ * @param appBundleID - appBundleID
+ * @param appVersion - appVersion
+ * @param appIcon - appIcon
+ * @return A SDLAppInfo object
+ */
+- (instancetype)initWithAppDisplayName:(NSString *)appDisplayName appBundleID:(NSString *)appBundleID appVersion:(NSString *)appVersion appIcon:(nullable NSString *)appIcon;
 
 /// Convenience init with no parameters
 ///

--- a/SmartDeviceLink/public/SDLAppServiceCapability.h
+++ b/SmartDeviceLink/public/SDLAppServiceCapability.h
@@ -29,13 +29,20 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithUpdatedAppServiceRecord:(SDLAppServiceRecord *)updatedAppServiceRecord NS_DESIGNATED_INITIALIZER;
 
 /**
+ * @param updatedAppServiceRecord - updatedAppServiceRecord
+ * @param updateReason - updateReason
+ * @return A SDLAppServiceCapability object
+ */
+- (instancetype)initWithUpdatedAppServiceRecord:(SDLAppServiceRecord *)updatedAppServiceRecord updateReason:(nullable SDLServiceUpdateReason)updateReason;
+
+/**
  *  Convenience init for all parameters.
  *
  *  @param updateReason             Update reason for this service record
  *  @param updatedAppServiceRecord  Service record for a specific app service provider
  *  @return                         A SDLAppServiceCapability object
  */
-- (instancetype)initWithUpdateReason:(nullable SDLServiceUpdateReason)updateReason updatedAppServiceRecord:(SDLAppServiceRecord *)updatedAppServiceRecord;
+- (instancetype)initWithUpdateReason:(nullable SDLServiceUpdateReason)updateReason updatedAppServiceRecord:(SDLAppServiceRecord *)updatedAppServiceRecord __deprecated_msg("Use initWithUpdatedAppServiceRecord: instead");
 
 /**
  *  Only included in `OnSystemCapbilityUpdated`. Update reason for this service record.

--- a/SmartDeviceLink/public/SDLAppServiceData.h
+++ b/SmartDeviceLink/public/SDLAppServiceData.h
@@ -25,6 +25,23 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SDLAppServiceData : SDLRPCStruct
 
 /**
+ * @param serviceType - serviceType
+ * @param serviceID - serviceID
+ * @return A SDLAppServiceData object
+ */
+- (instancetype)initWithServiceType:(NSString *)serviceType serviceID:(NSString *)serviceID;
+
+/**
+ * @param serviceType - serviceType
+ * @param serviceID - serviceID
+ * @param mediaServiceData - mediaServiceData
+ * @param weatherServiceData - weatherServiceData
+ * @param navigationServiceData - navigationServiceData
+ * @return A SDLAppServiceData object
+ */
+- (instancetype)initWithServiceType:(NSString *)serviceType serviceID:(NSString *)serviceID mediaServiceData:(nullable SDLMediaServiceData *)mediaServiceData weatherServiceData:(nullable SDLWeatherServiceData *)weatherServiceData navigationServiceData:(nullable SDLNavigationServiceData *)navigationServiceData;
+
+/**
  *  Convenience init for service type and service id.
  *
  *  @param serviceType              The type of service that is to be offered by this app.
@@ -70,7 +87,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param navigationServiceData    The navigation service data
  *  @return                         A SDLAppServiceData object
  */
-- (instancetype)initWithAppServiceType:(SDLAppServiceType)serviceType serviceId:(NSString *)serviceId mediaServiceData:(nullable SDLMediaServiceData *)mediaServiceData weatherServiceData:(nullable SDLWeatherServiceData *)weatherServiceData navigationServiceData:(nullable SDLNavigationServiceData *)navigationServiceData;
+- (instancetype)initWithAppServiceType:(SDLAppServiceType)serviceType serviceId:(NSString *)serviceId mediaServiceData:(nullable SDLMediaServiceData *)mediaServiceData weatherServiceData:(nullable SDLWeatherServiceData *)weatherServiceData navigationServiceData:(nullable SDLNavigationServiceData *)navigationServiceData __deprecated_msg("Use initWithServiceType:serviceID: instead");
 
 /**
  *  The type of service that is to be offered by this app. See `AppServiceType` for known enum equivalent types. Parameter is a string to allow for new service types to be used by apps on older versions of SDL Core.

--- a/SmartDeviceLink/public/SDLAppServiceManifest.h
+++ b/SmartDeviceLink/public/SDLAppServiceManifest.h
@@ -1,10 +1,34 @@
-//
-//  SDLAppServiceManifest.h
-//  SmartDeviceLink
-//
-//  Created by Nicole on 1/25/19.
-//  Copyright © 2019 smartdevicelink. All rights reserved.
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #import "SDLRPCRequest.h"
 
@@ -24,6 +48,42 @@ NS_ASSUME_NONNULL_BEGIN
  *  This manifest contains all the information necessary for the service to be published, activated, and allow consumers to interact with it
  */
 @interface SDLAppServiceManifest : SDLRPCStruct
+
+/**
+ * @param serviceType - serviceType
+ * @return A SDLAppServiceManifest object
+ */
+- (instancetype)initWithServiceType:(NSString *)serviceType;
+
+/**
+ * @param serviceType - serviceType
+ * @param serviceName - serviceName
+ * @param serviceIcon - serviceIcon
+ * @param allowAppConsumers - allowAppConsumers
+ * @param rpcSpecVersion - rpcSpecVersion
+ * @param handledRPCs - handledRPCs
+ * @param mediaServiceManifest - mediaServiceManifest
+ * @param weatherServiceManifest - weatherServiceManifest
+ * @param navigationServiceManifest - navigationServiceManifest
+ * @return A SDLAppServiceManifest object
+ */
+- (instancetype)initWithServiceType:(NSString *)serviceType serviceName:(nullable NSString *)serviceName serviceIcon:(nullable SDLImage *)serviceIcon allowAppConsumers:(nullable NSNumber<SDLBool> *)allowAppConsumers rpcSpecVersion:(nullable SDLMsgVersion *)rpcSpecVersion handledRPCs:(nullable NSArray<NSNumber<SDLInt> *> *)handledRPCs mediaServiceManifest:(nullable SDLMediaServiceManifest *)mediaServiceManifest weatherServiceManifest:(nullable SDLWeatherServiceManifest *)weatherServiceManifest navigationServiceManifest:(nullable SDLNavigationServiceManifest *)navigationServiceManifest;
+
+/**
+ *  Convenience init for all parameters.
+ *
+ *  @param serviceName                  Unique name of this service
+ *  @param serviceType                  The type of service that is to be offered by this app
+ *  @param serviceIcon                  The file name of the icon to be associated with this service
+ *  @param allowAppConsumers            If true, app service consumers beyond the IVI system will be able to access this service. If false, only the IVI system will be able consume the service. If not provided, it is assumed to be false
+ *  @param maxRPCSpecVersion            This is the max RPC Spec version the app service understands
+ *  @param handledRPCs                  This field contains the Function IDs for the RPCs that this service intends to handle correctly
+ *  @param mediaServiceManifest         A media service manifest
+ *  @param weatherServiceManifest       A weather service manifest
+ *  @param navigationServiceManifest    A navigation service manifest
+ *  @return                             A SDLAppServiceManifest object
+ */
+- (instancetype)initWithServiceName:(nullable NSString *)serviceName serviceType:(SDLAppServiceType)serviceType serviceIcon:(nullable SDLImage *)serviceIcon allowAppConsumers:(BOOL)allowAppConsumers maxRPCSpecVersion:(nullable SDLMsgVersion *)maxRPCSpecVersion handledRPCs:(nullable NSArray<NSNumber<SDLInt> *> *)handledRPCs mediaServiceManifest:(nullable SDLMediaServiceManifest *)mediaServiceManifest weatherServiceManifest:(nullable SDLWeatherServiceManifest *)weatherServiceManifest navigationServiceManifest:(nullable SDLNavigationServiceManifest *)navigationServiceManifest __deprecated_msg("Use initWithServiceType: instead");
 
 /**
  *  Convenience init for serviceType.
@@ -71,22 +131,6 @@ NS_ASSUME_NONNULL_BEGIN
  *  @return                             A SDLAppServiceManifest object
  */
 - (instancetype)initWithNavigationServiceName:(nullable NSString *)serviceName serviceIcon:(nullable SDLImage *)serviceIcon allowAppConsumers:(BOOL)allowAppConsumers maxRPCSpecVersion:(nullable SDLMsgVersion *)maxRPCSpecVersion handledRPCs:(nullable NSArray<NSNumber<SDLInt> *> *)handledRPCs navigationServiceManifest:(nullable SDLNavigationServiceManifest *)navigationServiceManifest;
-
-/**
- *  Convenience init for all parameters.
- *
- *  @param serviceName                  Unique name of this service
- *  @param serviceType                  The type of service that is to be offered by this app
- *  @param serviceIcon                  The file name of the icon to be associated with this service
- *  @param allowAppConsumers            If true, app service consumers beyond the IVI system will be able to access this service. If false, only the IVI system will be able consume the service. If not provided, it is assumed to be false
- *  @param maxRPCSpecVersion            This is the max RPC Spec version the app service understands
- *  @param handledRPCs                  This field contains the Function IDs for the RPCs that this service intends to handle correctly
- *  @param mediaServiceManifest         A media service manifest
- *  @param weatherServiceManifest       A weather service manifest
- *  @param navigationServiceManifest    A navigation service manifest
- *  @return                             A SDLAppServiceManifest object
- */
-- (instancetype)initWithServiceName:(nullable NSString *)serviceName serviceType:(SDLAppServiceType)serviceType serviceIcon:(nullable SDLImage *)serviceIcon allowAppConsumers:(BOOL)allowAppConsumers maxRPCSpecVersion:(nullable SDLMsgVersion *)maxRPCSpecVersion handledRPCs:(nullable NSArray<NSNumber<SDLInt> *> *)handledRPCs mediaServiceManifest:(nullable SDLMediaServiceManifest *)mediaServiceManifest weatherServiceManifest:(nullable SDLWeatherServiceManifest *)weatherServiceManifest navigationServiceManifest:(nullable SDLNavigationServiceManifest *)navigationServiceManifest;
 
 /**
  *  Unique name of this service.

--- a/SmartDeviceLink/public/SDLAppServiceRecord.h
+++ b/SmartDeviceLink/public/SDLAppServiceRecord.h
@@ -1,10 +1,34 @@
-//
-//  SDLAppServiceRecord.h
-//  SmartDeviceLink
-//
-//  Created by Nicole on 1/25/19.
-//  Copyright © 2019 smartdevicelink. All rights reserved.
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #import "SDLRPCRequest.h"
 

--- a/SmartDeviceLink/public/SDLAppServicesCapabilities.h
+++ b/SmartDeviceLink/public/SDLAppServicesCapabilities.h
@@ -1,10 +1,34 @@
-//
-//  SDLAppServicesCapabilities.h
-//  SmartDeviceLink
-//
-//  Created by Nicole on 1/30/19.
-//  Copyright © 2019 smartdevicelink. All rights reserved.
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #import "SDLRPCRequest.h"
 

--- a/SmartDeviceLink/public/SDLAudioControlCapabilities.h
+++ b/SmartDeviceLink/public/SDLAudioControlCapabilities.h
@@ -1,5 +1,34 @@
-//  SDLAudioControlCapabilities.h
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #import "SDLRPCMessage.h"
 #import "SDLModuleInfo.h"
@@ -14,13 +43,31 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SDLAudioControlCapabilities : SDLRPCStruct
 
 /**
+ * @param moduleName - moduleName
+ * @return A SDLAudioControlCapabilities object
+ */
+- (instancetype)initWithModuleName:(NSString *)moduleName;
+
+/**
+ * @param moduleName - moduleName
+ * @param moduleInfo - moduleInfo
+ * @param sourceAvailable - sourceAvailable
+ * @param keepContextAvailable - keepContextAvailable
+ * @param volumeAvailable - volumeAvailable
+ * @param equalizerAvailable - equalizerAvailable
+ * @param equalizerMaxChannelId - equalizerMaxChannelId
+ * @return A SDLAudioControlCapabilities object
+ */
+- (instancetype)initWithModuleName:(NSString *)moduleName moduleInfo:(nullable SDLModuleInfo *)moduleInfo sourceAvailable:(nullable NSNumber<SDLBool> *)sourceAvailable keepContextAvailable:(nullable NSNumber<SDLBool> *)keepContextAvailable volumeAvailable:(nullable NSNumber<SDLBool> *)volumeAvailable equalizerAvailable:(nullable NSNumber<SDLBool> *)equalizerAvailable equalizerMaxChannelId:(nullable NSNumber<SDLUInt> *)equalizerMaxChannelId;
+
+/**
  Constructs a newly allocated SDLAudioControlCapabilities object with audio control module name (max 100 chars)
  
  @param name The short friendly name of the audio control module.
  @param moduleInfo Information about a RC module, including its id.
  @return An instance of the SDLAudioControlCapabilities class.
  */
-- (instancetype)initWithModuleName:(NSString *)name moduleInfo:(nullable SDLModuleInfo *)moduleInfo;
+- (instancetype)initWithModuleName:(NSString *)name moduleInfo:(nullable SDLModuleInfo *)moduleInfo __deprecated_msg("Use initWithModuleName: instead");
 
 /**
  Constructs a newly allocated SDLAudioControlCapabilities object with given parameters
@@ -33,7 +80,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param equalizerMaxChannelID Equalizer channel ID (between 1-100).
  @return An instance of the SDLAudioControlCapabilities class.
  */
-- (instancetype)initWithModuleName:(NSString *)name moduleInfo:(nullable SDLModuleInfo *)moduleInfo sourceAvailable:(nullable NSNumber<SDLBool> *)sourceAvailable keepContextAvailable:(nullable NSNumber<SDLBool> *)keepContextAvailable volumeAvailable:(nullable NSNumber<SDLBool> *)volumeAvailable equalizerAvailable:(nullable NSNumber<SDLBool> *)equalizerAvailable equalizerMaxChannelID:(nullable NSNumber<SDLInt> *)equalizerMaxChannelID;
+- (instancetype)initWithModuleName:(NSString *)name moduleInfo:(nullable SDLModuleInfo *)moduleInfo sourceAvailable:(nullable NSNumber<SDLBool> *)sourceAvailable keepContextAvailable:(nullable NSNumber<SDLBool> *)keepContextAvailable volumeAvailable:(nullable NSNumber<SDLBool> *)volumeAvailable equalizerAvailable:(nullable NSNumber<SDLBool> *)equalizerAvailable equalizerMaxChannelID:(nullable NSNumber<SDLInt> *)equalizerMaxChannelID __deprecated_msg("Use initWithModuleName: instead");
 
 /**
  * @abstract The short friendly name of the audio control module.

--- a/SmartDeviceLink/public/SDLAudioControlData.h
+++ b/SmartDeviceLink/public/SDLAudioControlData.h
@@ -1,5 +1,34 @@
-//  SDLAudioControlData.h
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #import "SDLRPCMessage.h"
 #import "SDLPrimaryAudioSource.h"
@@ -15,7 +44,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface SDLAudioControlData : SDLRPCStruct
 
-
 /**
  Constructs a newly allocated SDLAudioControlData object with given parameters
 
@@ -25,7 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param equalizerSettings list of supported Equalizer channels.
  @return An instance of the SDLAudioControlData class.
  */
-- (instancetype)initWithSource:(nullable SDLPrimaryAudioSource)source keepContext:(nullable NSNumber<SDLBool> *)keepContext volume:(nullable NSNumber<SDLInt> *)volume equalizerSettings:(nullable NSArray<SDLEqualizerSettings *> *)equalizerSettings;
+- (instancetype)initWithSource:(nullable SDLPrimaryAudioSource)source keepContext:(nullable NSNumber<SDLBool> *)keepContext volume:(nullable NSNumber<SDLUInt> *)volume equalizerSettings:(nullable NSArray<SDLEqualizerSettings *> *)equalizerSettings;
 
 /**
  * @abstract   In a getter response or a notification,

--- a/SmartDeviceLink/public/SDLAudioPassThruCapabilities.h
+++ b/SmartDeviceLink/public/SDLAudioPassThruCapabilities.h
@@ -1,5 +1,34 @@
-//  SDLAudioPassThruCapabilities.h
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #import "SDLRPCMessage.h"
 
@@ -17,6 +46,14 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface SDLAudioPassThruCapabilities : SDLRPCStruct
+
+/**
+ * @param samplingRate - samplingRate
+ * @param bitsPerSample - bitsPerSample
+ * @param audioType - audioType
+ * @return A SDLAudioPassThruCapabilities object
+ */
+- (instancetype)initWithSamplingRate:(SDLSamplingRate)samplingRate bitsPerSample:(SDLBitsPerSample)bitsPerSample audioType:(SDLAudioType)audioType;
 
 /**
  The sampling rate for AudioPassThru

--- a/SmartDeviceLink/public/SDLBeltStatus.h
+++ b/SmartDeviceLink/public/SDLBeltStatus.h
@@ -1,5 +1,34 @@
-//  SDLBeltStatus.h
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #import "SDLRPCMessage.h"
 
@@ -11,6 +40,26 @@ NS_ASSUME_NONNULL_BEGIN
  Vehicle data struct for the seat belt status
  */
 @interface SDLBeltStatus : SDLRPCStruct
+
+/**
+ * @param driverBeltDeployed - driverBeltDeployed
+ * @param passengerBeltDeployed - passengerBeltDeployed
+ * @param passengerBuckleBelted - passengerBuckleBelted
+ * @param driverBuckleBelted - driverBuckleBelted
+ * @param leftRow2BuckleBelted - leftRow2BuckleBelted
+ * @param passengerChildDetected - passengerChildDetected
+ * @param rightRow2BuckleBelted - rightRow2BuckleBelted
+ * @param middleRow2BuckleBelted - middleRow2BuckleBelted
+ * @param middleRow3BuckleBelted - middleRow3BuckleBelted
+ * @param leftRow3BuckleBelted - leftRow3BuckleBelted
+ * @param rightRow3BuckleBelted - rightRow3BuckleBelted
+ * @param leftRearInflatableBelted - leftRearInflatableBelted
+ * @param rightRearInflatableBelted - rightRearInflatableBelted
+ * @param middleRow1BeltDeployed - middleRow1BeltDeployed
+ * @param middleRow1BuckleBelted - middleRow1BuckleBelted
+ * @return A SDLBeltStatus object
+ */
+- (instancetype)initWithDriverBeltDeployed:(SDLVehicleDataEventStatus)driverBeltDeployed passengerBeltDeployed:(SDLVehicleDataEventStatus)passengerBeltDeployed passengerBuckleBelted:(SDLVehicleDataEventStatus)passengerBuckleBelted driverBuckleBelted:(SDLVehicleDataEventStatus)driverBuckleBelted leftRow2BuckleBelted:(SDLVehicleDataEventStatus)leftRow2BuckleBelted passengerChildDetected:(SDLVehicleDataEventStatus)passengerChildDetected rightRow2BuckleBelted:(SDLVehicleDataEventStatus)rightRow2BuckleBelted middleRow2BuckleBelted:(SDLVehicleDataEventStatus)middleRow2BuckleBelted middleRow3BuckleBelted:(SDLVehicleDataEventStatus)middleRow3BuckleBelted leftRow3BuckleBelted:(SDLVehicleDataEventStatus)leftRow3BuckleBelted rightRow3BuckleBelted:(SDLVehicleDataEventStatus)rightRow3BuckleBelted leftRearInflatableBelted:(SDLVehicleDataEventStatus)leftRearInflatableBelted rightRearInflatableBelted:(SDLVehicleDataEventStatus)rightRearInflatableBelted middleRow1BeltDeployed:(SDLVehicleDataEventStatus)middleRow1BeltDeployed middleRow1BuckleBelted:(SDLVehicleDataEventStatus)middleRow1BuckleBelted;
 
 /**
  References signal "VedsDrvBelt_D_Ltchd". See VehicleDataEventStatus.

--- a/SmartDeviceLink/public/SDLBodyInformation.h
+++ b/SmartDeviceLink/public/SDLBodyInformation.h
@@ -1,5 +1,34 @@
-//  SDLBodyInformation.h
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #import "SDLRPCMessage.h"
 
@@ -14,6 +43,26 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface SDLBodyInformation : SDLRPCStruct
+
+/**
+ * @param parkBrakeActive - @(parkBrakeActive)
+ * @param ignitionStableStatus - ignitionStableStatus
+ * @param ignitionStatus - ignitionStatus
+ * @return A SDLBodyInformation object
+ */
+- (instancetype)initWithParkBrakeActive:(BOOL)parkBrakeActive ignitionStableStatus:(SDLIgnitionStableStatus)ignitionStableStatus ignitionStatus:(SDLIgnitionStatus)ignitionStatus;
+
+/**
+ * @param parkBrakeActive - @(parkBrakeActive)
+ * @param ignitionStableStatus - ignitionStableStatus
+ * @param ignitionStatus - ignitionStatus
+ * @param driverDoorAjar - driverDoorAjar
+ * @param passengerDoorAjar - passengerDoorAjar
+ * @param rearLeftDoorAjar - rearLeftDoorAjar
+ * @param rearRightDoorAjar - rearRightDoorAjar
+ * @return A SDLBodyInformation object
+ */
+- (instancetype)initWithParkBrakeActive:(BOOL)parkBrakeActive ignitionStableStatus:(SDLIgnitionStableStatus)ignitionStableStatus ignitionStatus:(SDLIgnitionStatus)ignitionStatus driverDoorAjar:(nullable NSNumber<SDLBool> *)driverDoorAjar passengerDoorAjar:(nullable NSNumber<SDLBool> *)passengerDoorAjar rearLeftDoorAjar:(nullable NSNumber<SDLBool> *)rearLeftDoorAjar rearRightDoorAjar:(nullable NSNumber<SDLBool> *)rearRightDoorAjar;
 
 /**
  * References signal "PrkBrkActv_B_Actl".

--- a/SmartDeviceLink/public/SDLButtonCapabilities.h
+++ b/SmartDeviceLink/public/SDLButtonCapabilities.h
@@ -1,5 +1,34 @@
-//  SDLButtonCapabilities.h
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #import "SDLRPCMessage.h"
 
@@ -16,6 +45,25 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface SDLButtonCapabilities : SDLRPCStruct
+
+/**
+ * @param nameParam - nameParam
+ * @param shortPressAvailable - @(shortPressAvailable)
+ * @param longPressAvailable - @(longPressAvailable)
+ * @param upDownAvailable - @(upDownAvailable)
+ * @return A SDLButtonCapabilities object
+ */
+- (instancetype)initWithNameParam:(SDLButtonName)nameParam shortPressAvailable:(BOOL)shortPressAvailable longPressAvailable:(BOOL)longPressAvailable upDownAvailable:(BOOL)upDownAvailable;
+
+/**
+ * @param nameParam - nameParam
+ * @param shortPressAvailable - @(shortPressAvailable)
+ * @param longPressAvailable - @(longPressAvailable)
+ * @param upDownAvailable - @(upDownAvailable)
+ * @param moduleInfo - moduleInfo
+ * @return A SDLButtonCapabilities object
+ */
+- (instancetype)initWithNameParam:(SDLButtonName)nameParam shortPressAvailable:(BOOL)shortPressAvailable longPressAvailable:(BOOL)longPressAvailable upDownAvailable:(BOOL)upDownAvailable moduleInfo:(nullable SDLModuleInfo *)moduleInfo;
 
 /**
  * The name of the SDL HMI button.

--- a/SmartDeviceLink/public/SDLButtonPress.h
+++ b/SmartDeviceLink/public/SDLButtonPress.h
@@ -1,6 +1,34 @@
-//
-//  SDLButtonPress.h
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #import "SDLRPCRequest.h"
 #import "SDLModuleType.h"
@@ -17,6 +45,23 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SDLButtonPress : SDLRPCRequest
 
 /**
+ * @param moduleType - moduleType
+ * @param buttonName - buttonName
+ * @param buttonPressMode - buttonPressMode
+ * @return A SDLButtonPress object
+ */
+- (instancetype)initWithModuleType:(SDLModuleType)moduleType buttonName:(SDLButtonName)buttonName buttonPressMode:(SDLButtonPressMode)buttonPressMode;
+
+/**
+ * @param moduleType - moduleType
+ * @param buttonName - buttonName
+ * @param buttonPressMode - buttonPressMode
+ * @param moduleId - moduleId
+ * @return A SDLButtonPress object
+ */
+- (instancetype)initWithModuleType:(SDLModuleType)moduleType buttonName:(SDLButtonName)buttonName buttonPressMode:(SDLButtonPressMode)buttonPressMode moduleId:(nullable NSString *)moduleId;
+
+/**
 Constructs a newly allocated SDLButtonPress object with the given parameters
 
 @param buttonName the name of the button
@@ -26,7 +71,7 @@ Constructs a newly allocated SDLButtonPress object with the given parameters
 
 @return An instance of the SDLButtonPress class.
 */
-- (instancetype)initWithButtonName:(SDLButtonName)buttonName moduleType:(SDLModuleType)moduleType moduleId:(nullable NSString *)moduleId buttonPressMode:(SDLButtonPressMode)buttonPressMode;
+- (instancetype)initWithButtonName:(SDLButtonName)buttonName moduleType:(SDLModuleType)moduleType moduleId:(nullable NSString *)moduleId buttonPressMode:(SDLButtonPressMode)buttonPressMode __deprecated_msg("Use initWithModuleType:buttonName:buttonPressMode:moduleId instead");
 
 /**
  * The module where the button should be pressed.

--- a/SmartDeviceLink/public/SDLCancelInteraction.h
+++ b/SmartDeviceLink/public/SDLCancelInteraction.h
@@ -42,12 +42,25 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SDLCancelInteraction : SDLRPCRequest
 
 /**
+ * @param functionIDParam - @(functionIDParam)
+ * @return A SDLCancelInteraction object
+ */
+- (instancetype)initWithFunctionIDParam:(UInt32)functionIDParam;
+
+/**
+ * @param functionIDParam - @(functionIDParam)
+ * @param cancelID - cancelID
+ * @return A SDLCancelInteraction object
+ */
+- (instancetype)initWithFunctionIDParam:(UInt32)functionIDParam cancelID:(nullable NSNumber<SDLInt> *)cancelID;
+
+/**
  Convenience init for dismissing the currently presented modal view (either an alert, slider, scrollable message, or perform interation).
 
  @param functionID The ID of the type of modal view to dismiss
  @return A SDLCancelInteraction object
  */
-- (instancetype)initWithFunctionID:(UInt32)functionID;
+- (instancetype)initWithFunctionID:(UInt32)functionID __deprecated_msg("Use initWithFunctionIDParam: instead");
 
 /**
  Convenience init for dismissing a specific view.
@@ -56,7 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param cancelID The ID of the specific interaction to dismiss
  @return A SDLCancelInteraction object
  */
-- (instancetype)initWithFunctionID:(UInt32)functionID cancelID:(UInt32)cancelID;
+- (instancetype)initWithFunctionID:(UInt32)functionID cancelID:(UInt32)cancelID __deprecated_msg("Use initWithFunctionIDParam:cancelID: instead");
 
 /**
  Convenience init for dismissing an alert.

--- a/SmartDeviceLink/public/SDLChangeRegistration.h
+++ b/SmartDeviceLink/public/SDLChangeRegistration.h
@@ -1,11 +1,42 @@
-//  SDLChangeRegistration.h
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 
 #import "SDLRPCRequest.h"
 #import "SDLLanguage.h"
 
 @class SDLTTSChunk;
+
+NS_ASSUME_NONNULL_BEGIN
 
 /**
  * If the app recognizes during the app registration that the SDL HMI language (voice/TTS and/or display) does not match the app language, the app will be able (but does not need) to change this registration with changeRegistration prior to app being brought into focus.
@@ -14,9 +45,6 @@
  *
  * @since SDL 2.0
  */
-
-NS_ASSUME_NONNULL_BEGIN
-
 @interface SDLChangeRegistration : SDLRPCRequest
 
 /**

--- a/SmartDeviceLink/public/SDLChoice.h
+++ b/SmartDeviceLink/public/SDLChoice.h
@@ -1,5 +1,34 @@
-//  SDLChoice.h
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #import "SDLRPCMessage.h"
 
@@ -16,6 +45,25 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SDLChoice : SDLRPCStruct
 
 /**
+ * @param choiceID - @(choiceID)
+ * @param menuName - menuName
+ * @return A SDLChoice object
+ */
+- (instancetype)initWithChoiceID:(UInt16)choiceID menuName:(NSString *)menuName;
+
+/**
+ * @param choiceID - @(choiceID)
+ * @param menuName - menuName
+ * @param vrCommands - vrCommands
+ * @param image - image
+ * @param secondaryText - secondaryText
+ * @param tertiaryText - tertiaryText
+ * @param secondaryImage - secondaryImage
+ * @return A SDLChoice object
+ */
+- (instancetype)initWithChoiceID:(UInt16)choiceID menuName:(NSString *)menuName vrCommands:(nullable NSArray<NSString *> *)vrCommands image:(nullable SDLImage *)image secondaryText:(nullable NSString *)secondaryText tertiaryText:(nullable NSString *)tertiaryText secondaryImage:(nullable SDLImage *)secondaryImage;
+
+/**
 Constructs a newly allocated SDLChangeRegistration object with the required parameters
 
 @param choiceId the application-scoped identifier that uniquely identifies this choice
@@ -24,7 +72,7 @@ Constructs a newly allocated SDLChangeRegistration object with the required para
 
 @return An instance of the SDLChangeRegistration class.
 */
-- (instancetype)initWithId:(UInt16)choiceId menuName:(NSString *)menuName vrCommands:(nullable NSArray<NSString *> *)vrCommands;
+- (instancetype)initWithId:(UInt16)choiceId menuName:(NSString *)menuName vrCommands:(nullable NSArray<NSString *> *)vrCommands __deprecated_msg("Use initWithChoiceID:menuName: instead");
 
 /**
 Constructs a newly allocated SDLChangeRegistration object with all parameters
@@ -39,7 +87,7 @@ Constructs a newly allocated SDLChangeRegistration object with all parameters
 
 @return An instance of the SDLChangeRegistration class.
 */
-- (instancetype)initWithId:(UInt16)choiceId menuName:(NSString *)menuName vrCommands:(nullable NSArray<NSString *> *)vrCommands image:(nullable SDLImage *)image secondaryText:(nullable NSString *)secondaryText secondaryImage:(nullable SDLImage *)secondaryImage tertiaryText:(nullable NSString *)tertiaryText;
+- (instancetype)initWithId:(UInt16)choiceId menuName:(NSString *)menuName vrCommands:(nullable NSArray<NSString *> *)vrCommands image:(nullable SDLImage *)image secondaryText:(nullable NSString *)secondaryText secondaryImage:(nullable SDLImage *)secondaryImage tertiaryText:(nullable NSString *)tertiaryText __deprecated_msg("Use initWithChoiceID:menuName: instead");
 
 /**
  * The application-scoped identifier that uniquely identifies this choice

--- a/SmartDeviceLink/public/SDLClimateControlCapabilities.h
+++ b/SmartDeviceLink/public/SDLClimateControlCapabilities.h
@@ -1,6 +1,34 @@
-//
-//  SDLClimateControlCapabilities.h
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #import "SDLRPCMessage.h"
 #import "SDLDefrostZone.h"
@@ -13,6 +41,36 @@ NS_ASSUME_NONNULL_BEGIN
  * Contains information about a climate control module's capabilities.
  */
 @interface SDLClimateControlCapabilities : SDLRPCStruct
+
+/**
+ * @param moduleName - moduleName
+ * @return A SDLClimateControlCapabilities object
+ */
+- (instancetype)initWithModuleName:(NSString *)moduleName;
+
+/**
+ * @param moduleName - moduleName
+ * @param moduleInfo - moduleInfo
+ * @param currentTemperatureAvailable - currentTemperatureAvailable
+ * @param fanSpeedAvailable - fanSpeedAvailable
+ * @param desiredTemperatureAvailable - desiredTemperatureAvailable
+ * @param acEnableAvailable - acEnableAvailable
+ * @param acMaxEnableAvailable - acMaxEnableAvailable
+ * @param circulateAirEnableAvailable - circulateAirEnableAvailable
+ * @param autoModeEnableAvailable - autoModeEnableAvailable
+ * @param dualModeEnableAvailable - dualModeEnableAvailable
+ * @param defrostZoneAvailable - defrostZoneAvailable
+ * @param defrostZone - defrostZone
+ * @param ventilationModeAvailable - ventilationModeAvailable
+ * @param ventilationMode - ventilationMode
+ * @param heatedSteeringWheelAvailable - heatedSteeringWheelAvailable
+ * @param heatedWindshieldAvailable - heatedWindshieldAvailable
+ * @param heatedRearWindowAvailable - heatedRearWindowAvailable
+ * @param heatedMirrorsAvailable - heatedMirrorsAvailable
+ * @param climateEnableAvailable - climateEnableAvailable
+ * @return A SDLClimateControlCapabilities object
+ */
+- (instancetype)initWithModuleName:(NSString *)moduleName moduleInfo:(nullable SDLModuleInfo *)moduleInfo currentTemperatureAvailable:(nullable NSNumber<SDLBool> *)currentTemperatureAvailable fanSpeedAvailable:(nullable NSNumber<SDLBool> *)fanSpeedAvailable desiredTemperatureAvailable:(nullable NSNumber<SDLBool> *)desiredTemperatureAvailable acEnableAvailable:(nullable NSNumber<SDLBool> *)acEnableAvailable acMaxEnableAvailable:(nullable NSNumber<SDLBool> *)acMaxEnableAvailable circulateAirEnableAvailable:(nullable NSNumber<SDLBool> *)circulateAirEnableAvailable autoModeEnableAvailable:(nullable NSNumber<SDLBool> *)autoModeEnableAvailable dualModeEnableAvailable:(nullable NSNumber<SDLBool> *)dualModeEnableAvailable defrostZoneAvailable:(nullable NSNumber<SDLBool> *)defrostZoneAvailable defrostZone:(nullable NSArray<SDLDefrostZone> *)defrostZone ventilationModeAvailable:(nullable NSNumber<SDLBool> *)ventilationModeAvailable ventilationMode:(nullable NSArray<SDLVentilationMode> *)ventilationMode heatedSteeringWheelAvailable:(nullable NSNumber<SDLBool> *)heatedSteeringWheelAvailable heatedWindshieldAvailable:(nullable NSNumber<SDLBool> *)heatedWindshieldAvailable heatedRearWindowAvailable:(nullable NSNumber<SDLBool> *)heatedRearWindowAvailable heatedMirrorsAvailable:(nullable NSNumber<SDLBool> *)heatedMirrorsAvailable climateEnableAvailable:(nullable NSNumber<SDLBool> *)climateEnableAvailable;
 
 /// Convenience init to describe the climate control capabilities with all properities.
 ///
@@ -33,7 +91,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param heatedMirrorsAvailable Availability of the control (enable/disable) of heated Mirrors
 /// @param climateEnableAvailable Availability of the control of enable/disable climate control
 /// @return An SDLClimateControlCapabilities object
-- (instancetype)initWithModuleName:(NSString *)moduleName moduleInfo:(nullable SDLModuleInfo *)moduleInfo fanSpeedAvailable:(BOOL)fanSpeedAvailable desiredTemperatureAvailable:(BOOL)desiredTemperatureAvailable acEnableAvailable:(BOOL)acEnableAvailable acMaxEnableAvailable:(BOOL)acMaxEnableAvailable circulateAirAvailable:(BOOL)circulateAirEnableAvailable autoModeEnableAvailable:(BOOL)autoModeEnableAvailable dualModeEnableAvailable:(BOOL)dualModeEnableAvailable defrostZoneAvailable:(BOOL)defrostZoneAvailable ventilationModeAvailable:(BOOL)ventilationModeAvailable heatedSteeringWheelAvailable:(BOOL)heatedSteeringWheelAvailable heatedWindshieldAvailable:(BOOL)heatedWindshieldAvailable heatedRearWindowAvailable:(BOOL)heatedRearWindowAvailable heatedMirrorsAvailable:(BOOL)heatedMirrorsAvailable climateEnableAvailable:(BOOL)climateEnableAvailable;
+- (instancetype)initWithModuleName:(NSString *)moduleName moduleInfo:(nullable SDLModuleInfo *)moduleInfo fanSpeedAvailable:(BOOL)fanSpeedAvailable desiredTemperatureAvailable:(BOOL)desiredTemperatureAvailable acEnableAvailable:(BOOL)acEnableAvailable acMaxEnableAvailable:(BOOL)acMaxEnableAvailable circulateAirAvailable:(BOOL)circulateAirEnableAvailable autoModeEnableAvailable:(BOOL)autoModeEnableAvailable dualModeEnableAvailable:(BOOL)dualModeEnableAvailable defrostZoneAvailable:(BOOL)defrostZoneAvailable ventilationModeAvailable:(BOOL)ventilationModeAvailable heatedSteeringWheelAvailable:(BOOL)heatedSteeringWheelAvailable heatedWindshieldAvailable:(BOOL)heatedWindshieldAvailable heatedRearWindowAvailable:(BOOL)heatedRearWindowAvailable heatedMirrorsAvailable:(BOOL)heatedMirrorsAvailable climateEnableAvailable:(BOOL)climateEnableAvailable __deprecated_msg("Use initWithModuleName: instead");
 
 /**
  * The short friendly name of the climate control module.

--- a/SmartDeviceLink/public/SDLClimateControlData.h
+++ b/SmartDeviceLink/public/SDLClimateControlData.h
@@ -1,6 +1,34 @@
-//
-//  SDLClimateControlData.h
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #import "SDLRPCMessage.h"
 #import "SDLDefrostZone.h"
@@ -15,6 +43,26 @@ NS_ASSUME_NONNULL_BEGIN
  The current information for the Climate Remote Control Module
  */
 @interface SDLClimateControlData : SDLRPCStruct
+
+/**
+ * @param fanSpeed - fanSpeed
+ * @param currentTemperature - currentTemperature
+ * @param desiredTemperature - desiredTemperature
+ * @param acEnable - acEnable
+ * @param circulateAirEnable - circulateAirEnable
+ * @param autoModeEnable - autoModeEnable
+ * @param defrostZone - defrostZone
+ * @param dualModeEnable - dualModeEnable
+ * @param acMaxEnable - acMaxEnable
+ * @param ventilationMode - ventilationMode
+ * @param heatedSteeringWheelEnable - heatedSteeringWheelEnable
+ * @param heatedWindshieldEnable - heatedWindshieldEnable
+ * @param heatedRearWindowEnable - heatedRearWindowEnable
+ * @param heatedMirrorsEnable - heatedMirrorsEnable
+ * @param climateEnable - climateEnable
+ * @return A SDLClimateControlData object
+ */
+- (instancetype)initWithFanSpeed:(nullable NSNumber<SDLUInt> *)fanSpeed currentTemperature:(nullable SDLTemperature *)currentTemperature desiredTemperature:(nullable SDLTemperature *)desiredTemperature acEnable:(nullable NSNumber<SDLBool> *)acEnable circulateAirEnable:(nullable NSNumber<SDLBool> *)circulateAirEnable autoModeEnable:(nullable NSNumber<SDLBool> *)autoModeEnable defrostZone:(nullable SDLDefrostZone)defrostZone dualModeEnable:(nullable NSNumber<SDLBool> *)dualModeEnable acMaxEnable:(nullable NSNumber<SDLBool> *)acMaxEnable ventilationMode:(nullable SDLVentilationMode)ventilationMode heatedSteeringWheelEnable:(nullable NSNumber<SDLBool> *)heatedSteeringWheelEnable heatedWindshieldEnable:(nullable NSNumber<SDLBool> *)heatedWindshieldEnable heatedRearWindowEnable:(nullable NSNumber<SDLBool> *)heatedRearWindowEnable heatedMirrorsEnable:(nullable NSNumber<SDLBool> *)heatedMirrorsEnable climateEnable:(nullable NSNumber<SDLBool> *)climateEnable;
 
 /// Convenience init for climate control data with all properties.
 /// @param fanSpeed Speed of Fan in integer
@@ -32,7 +80,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param heatedMirrorsEnable Represents if heated mirrors are enabled
 /// @param climateEnable Represents if climate is enabled
 /// @return An SDLClimateControlData object
-- (instancetype)initWithFanSpeed:(nullable NSNumber<SDLInt> *)fanSpeed desiredTemperature:(nullable SDLTemperature *)desiredTemperature acEnable:(nullable NSNumber<SDLBool> *)acEnable circulateAirEnable:(nullable NSNumber<SDLBool> *)circulateAirEnable autoModeEnable:(nullable NSNumber<SDLBool> *)autoModeEnable defrostZone:(nullable SDLDefrostZone)defrostZone dualModeEnable:(nullable NSNumber<SDLBool> *)dualModeEnable acMaxEnable:(nullable NSNumber<SDLBool> *)acMaxEnable ventilationMode:(nullable SDLVentilationMode)ventilationMode heatedSteeringWheelEnable:(nullable NSNumber<SDLBool> *)heatedSteeringWheelEnable heatedWindshieldEnable:(nullable NSNumber<SDLBool> *)heatedWindshieldEnable heatedRearWindowEnable:(nullable NSNumber<SDLBool> *)heatedRearWindowEnable heatedMirrorsEnable:(nullable NSNumber<SDLBool> *)heatedMirrorsEnable climateEnable:(nullable NSNumber<SDLBool> *)climateEnable;
+- (instancetype)initWithFanSpeed:(nullable NSNumber<SDLInt> *)fanSpeed desiredTemperature:(nullable SDLTemperature *)desiredTemperature acEnable:(nullable NSNumber<SDLBool> *)acEnable circulateAirEnable:(nullable NSNumber<SDLBool> *)circulateAirEnable autoModeEnable:(nullable NSNumber<SDLBool> *)autoModeEnable defrostZone:(nullable SDLDefrostZone)defrostZone dualModeEnable:(nullable NSNumber<SDLBool> *)dualModeEnable acMaxEnable:(nullable NSNumber<SDLBool> *)acMaxEnable ventilationMode:(nullable SDLVentilationMode)ventilationMode heatedSteeringWheelEnable:(nullable NSNumber<SDLBool> *)heatedSteeringWheelEnable heatedWindshieldEnable:(nullable NSNumber<SDLBool> *)heatedWindshieldEnable heatedRearWindowEnable:(nullable NSNumber<SDLBool> *)heatedRearWindowEnable heatedMirrorsEnable:(nullable NSNumber<SDLBool> *)heatedMirrorsEnable climateEnable:(nullable NSNumber<SDLBool> *)climateEnable __deprecated_msg("Use initWithFanSpeed:currentTemperature:desiredTemperature:acEnable:circulateAirEnable:autoModeEnable:defrostZone:dualModeEnable:acMaxEnable:ventilationMode:heatedSteeringWheelEnable:heatedWindshieldEnable:heatedRearWindowEnable:heatedMirrorsEnable:climateEnable:");
 
 /**
  * Speed of Fan in integer

--- a/SmartDeviceLink/public/SDLCloudAppProperties.h
+++ b/SmartDeviceLink/public/SDLCloudAppProperties.h
@@ -1,10 +1,34 @@
-//
-//  SDLCloudAppProperties.h
-//  SmartDeviceLink
-//
-//  Created by Nicole on 2/26/19.
-//  Copyright © 2019 smartdevicelink. All rights reserved.
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #import "SDLRPCStruct.h"
 
@@ -27,6 +51,18 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithAppID:(NSString *)appID NS_DESIGNATED_INITIALIZER;
 
 /**
+ * @param appID - appID
+ * @param nicknames - nicknames
+ * @param enabled - enabled
+ * @param authToken - authToken
+ * @param cloudTransportType - cloudTransportType
+ * @param hybridAppPreference - hybridAppPreference
+ * @param endpoint - endpoint
+ * @return A SDLCloudAppProperties object
+ */
+- (instancetype)initWithAppID:(NSString *)appID nicknames:(nullable NSArray<NSString *> *)nicknames enabledParam:(nullable NSNumber<SDLBool> *)enabled authToken:(nullable NSString *)authToken cloudTransportType:(nullable NSString *)cloudTransportType hybridAppPreference:(nullable SDLHybridAppPreference)hybridAppPreference endpoint:(nullable NSString *)endpoint __deprecated;
+
+/**
  *  Convenience init for all parameters.
  *
  *  @param appID                The id of the cloud app
@@ -38,7 +74,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param endpoint             The websocket endpoint
  *  @return                     A SDLCloudAppProperties object
  */
-- (instancetype)initWithAppID:(NSString *)appID nicknames:(nullable NSArray<NSString *> *)nicknames enabled:(BOOL)enabled authToken:(nullable NSString *)authToken cloudTransportType:(nullable NSString *)cloudTransportType hybridAppPreference:(nullable SDLHybridAppPreference)hybridAppPreference endpoint:(nullable NSString *)endpoint;
+- (instancetype)initWithAppID:(NSString *)appID nicknames:(nullable NSArray<NSString *> *)nicknames enabled:(BOOL)enabled authToken:(nullable NSString *)authToken cloudTransportType:(nullable NSString *)cloudTransportType hybridAppPreference:(nullable SDLHybridAppPreference)hybridAppPreference endpoint:(nullable NSString *)endpoint __deprecated_msg("Use initWithAppID: instead");
 
 /**
  *  An array of app names a cloud app is allowed to register with. If included in a `SetCloudAppProperties` request, this value will overwrite the existing "nicknames" field in the app policies section of the policy table.

--- a/SmartDeviceLink/public/SDLClusterModeStatus.h
+++ b/SmartDeviceLink/public/SDLClusterModeStatus.h
@@ -1,5 +1,34 @@
-//  SDLClusterModeStatus.h
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #import "SDLRPCMessage.h"
 
@@ -13,6 +42,15 @@ NS_ASSUME_NONNULL_BEGIN
  A vehicle data struct for the cluster mode and power status
  */
 @interface SDLClusterModeStatus : SDLRPCStruct
+
+/**
+ * @param powerModeActive - @(powerModeActive)
+ * @param powerModeQualificationStatus - powerModeQualificationStatus
+ * @param carModeStatus - carModeStatus
+ * @param powerModeStatus - powerModeStatus
+ * @return A SDLClusterModeStatus object
+ */
+- (instancetype)initWithPowerModeActive:(BOOL)powerModeActive powerModeQualificationStatus:(SDLPowerModeQualificationStatus)powerModeQualificationStatus carModeStatus:(SDLCarModeStatus)carModeStatus powerModeStatus:(SDLPowerModeStatus)powerModeStatus;
 
 /**
  References signal "PowerMode_UB".

--- a/SmartDeviceLink/public/SDLCreateInteractionChoiceSet.h
+++ b/SmartDeviceLink/public/SDLCreateInteractionChoiceSet.h
@@ -1,5 +1,34 @@
-//  SDLCreateInteractionChoiceSet.h
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 
 #import "SDLRPCRequest.h"
@@ -23,12 +52,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SDLCreateInteractionChoiceSet : SDLRPCRequest
 
+/**
+ * @param interactionChoiceSetID - @(interactionChoiceSetID)
+ * @param choiceSet - choiceSet
+ * @return A SDLCreateInteractionChoiceSet object
+ */
+- (instancetype)initWithInteractionChoiceSetID:(UInt32)interactionChoiceSetID choiceSet:(NSArray<SDLChoice *> *)choiceSet;
+
 /// Convenience init for creating a choice set RPC
 ///
 /// @param choiceId A unique ID that identifies the Choice Set
 /// @param choiceSet Array of choices, which the user can select by menu or voice recognition
 /// @return An SDLCreateInteractionChoiceSet object
-- (instancetype)initWithId:(UInt32)choiceId choiceSet:(NSArray<SDLChoice *> *)choiceSet;
+- (instancetype)initWithId:(UInt32)choiceId choiceSet:(NSArray<SDLChoice *> *)choiceSet __deprecated_msg("Use initWithInteractionChoiceSetID:choiceSet: instead");
 
 /**
  * A unique ID that identifies the Choice Set

--- a/SmartDeviceLink/public/SDLCreateWindow.h
+++ b/SmartDeviceLink/public/SDLCreateWindow.h
@@ -1,7 +1,34 @@
-//
-//  SDLCreateWindow.h
-//  SmartDeviceLink
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #import "SDLRPCRequest.h"
 #import "SDLWindowType.h"
@@ -16,6 +43,23 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface SDLCreateWindow : SDLRPCRequest
 
+/**
+ * @param windowID - @(windowID)
+ * @param windowName - windowName
+ * @param type - type
+ * @return A SDLCreateWindow object
+ */
+- (instancetype)initWithWindowID:(UInt32)windowID windowName:(NSString *)windowName type:(SDLWindowType)type;
+
+/**
+ * @param windowID - @(windowID)
+ * @param windowName - windowName
+ * @param type - type
+ * @param associatedServiceType - associatedServiceType
+ * @param duplicateUpdatesFromWindowID - duplicateUpdatesFromWindowID
+ * @return A SDLCreateWindow object
+ */
+- (instancetype)initWithWindowID:(UInt32)windowID windowName:(NSString *)windowName type:(SDLWindowType)type associatedServiceType:(nullable NSString *)associatedServiceType duplicateUpdatesFromWindowID:(nullable NSNumber<SDLInt> *)duplicateUpdatesFromWindowID;
 
 /**
  Constructor with the required parameters
@@ -24,7 +68,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param windowName The window name to be used by the HMI. @see windowName
  @param windowType The type of the window to be created. Main window or widget.
  */
-- (instancetype)initWithId:(NSUInteger)windowId windowName:(NSString *)windowName windowType:(SDLWindowType)windowType;
+- (instancetype)initWithId:(NSUInteger)windowId windowName:(NSString *)windowName windowType:(SDLWindowType)windowType __deprecated_msg("Use initWithWindowID:windowName:type:");
 
 /**
  Convinience constructor with all the parameters.
@@ -35,7 +79,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param associatedServiceType Allows an app to create a widget related to a specific service type. @see associatedServiceType
  @param duplicateUpdatesFromWindowID  Optional parameter. Specify whether the content sent to an existing window should be duplicated to the created window. If there isn't a window with the ID, the request will be rejected with `INVALID_DATA`.
  */
-- (instancetype)initWithId:(NSUInteger)windowId windowName:(NSString *)windowName windowType:(SDLWindowType)windowType associatedServiceType:(nullable NSString *)associatedServiceType duplicateUpdatesFromWindowID:(NSUInteger)duplicateUpdatesFromWindowID;
+- (instancetype)initWithId:(NSUInteger)windowId windowName:(NSString *)windowName windowType:(SDLWindowType)windowType associatedServiceType:(nullable NSString *)associatedServiceType duplicateUpdatesFromWindowID:(NSUInteger)duplicateUpdatesFromWindowID __deprecated_msg("Use initWithWindowID:windowName:type:");
 
 
 /**

--- a/SmartDeviceLink/public/SDLDIDResult.h
+++ b/SmartDeviceLink/public/SDLDIDResult.h
@@ -13,6 +13,21 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SDLDIDResult : SDLRPCStruct
 
 /**
+ * @param resultCode - resultCode
+ * @param didLocation - @(didLocation)
+ * @return A SDLDIDResult object
+ */
+- (instancetype)initWithResultCode:(SDLVehicleDataResultCode)resultCode didLocation:(UInt16)didLocation;
+
+/**
+ * @param resultCode - resultCode
+ * @param didLocation - @(didLocation)
+ * @param data - data
+ * @return A SDLDIDResult object
+ */
+- (instancetype)initWithResultCode:(SDLVehicleDataResultCode)resultCode didLocation:(UInt16)didLocation data:(nullable NSString *)data;
+
+/**
  Individual DID result code.
 
  Required

--- a/SmartDeviceLink/public/SDLDateTime.h
+++ b/SmartDeviceLink/public/SDLDateTime.h
@@ -1,5 +1,34 @@
-//  SDLDateTime.h
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #import "SDLRPCStruct.h"
 
@@ -10,12 +39,26 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface SDLDateTime : SDLRPCStruct
 
+/**
+ * @param millisecond - millisecond
+ * @param second - second
+ * @param minute - minute
+ * @param hour - hour
+ * @param day - day
+ * @param month - month
+ * @param year - year
+ * @param tz_hour - tz_hour
+ * @param tz_minute - tz_minute
+ * @return A SDLDateTime object
+ */
+- (instancetype)initWithMillisecond:(nullable NSNumber<SDLUInt> *)millisecond second:(nullable NSNumber<SDLUInt> *)second minute:(nullable NSNumber<SDLUInt> *)minute hour:(nullable NSNumber<SDLUInt> *)hour day:(nullable NSNumber<SDLUInt> *)day month:(nullable NSNumber<SDLUInt> *)month year:(nullable NSNumber<SDLInt> *)year tz_hour:(nullable NSNumber<SDLInt> *)tz_hour tz_minute:(nullable NSNumber<SDLUInt> *)tz_minute;
+
 /// Convenience init for creating a date
 ///
 /// @param hour Hour part of time
 /// @param minute Minutes part of time
 /// @return An SDLDateTime object
-- (instancetype)initWithHour:(UInt8)hour minute:(UInt8)minute;
+- (instancetype)initWithHour:(UInt8)hour minute:(UInt8)minute __deprecated_msg("Use initWithMillisecond:second:minute:hour:day:month:year:tz_hour:tz_minute:");
 
 /// Convenience init for creating a date
 ///
@@ -24,7 +67,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param second Seconds part of time
 /// @param millisecond Milliseconds part of time
 /// @return An SDLDateTime object
-- (instancetype)initWithHour:(UInt8)hour minute:(UInt8)minute second:(UInt8)second millisecond:(UInt16)millisecond;
+- (instancetype)initWithHour:(UInt8)hour minute:(UInt8)minute second:(UInt8)second millisecond:(UInt16)millisecond __deprecated_msg("Use initWithMillisecond:second:minute:hour:day:month:year:tz_hour:tz_minute:");
 
 /// Convenience init for creating a date
 ///
@@ -36,7 +79,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param month Month of the year
 /// @param year The year in YYYY format
 /// @return An SDLDateTime object
-- (instancetype)initWithHour:(UInt8)hour minute:(UInt8)minute second:(UInt8)second millisecond:(UInt16)millisecond day:(UInt8)day month:(UInt8)month year:(UInt16)year;
+- (instancetype)initWithHour:(UInt8)hour minute:(UInt8)minute second:(UInt8)second millisecond:(UInt16)millisecond day:(UInt8)day month:(UInt8)month year:(UInt16)year __deprecated_msg("Use initWithMillisecond:second:minute:hour:day:month:year:tz_hour:tz_minute:");
 
 /// Convenience init for creating a date with all properties
 ///
@@ -50,7 +93,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param timezoneMinuteOffset Time zone offset in Min with regard to UTC
 /// @param timezoneHourOffset Time zone offset in Hours with regard to UTC
 /// @return An SDLDateTime object
-- (instancetype)initWithHour:(UInt8)hour minute:(UInt8)minute second:(UInt8)second millisecond:(UInt16)millisecond day:(UInt8)day month:(UInt8)month year:(UInt16)year timezoneMinuteOffset:(UInt8)timezoneMinuteOffset timezoneHourOffset:(int)timezoneHourOffset;
+- (instancetype)initWithHour:(UInt8)hour minute:(UInt8)minute second:(UInt8)second millisecond:(UInt16)millisecond day:(UInt8)day month:(UInt8)month year:(UInt16)year timezoneMinuteOffset:(UInt8)timezoneMinuteOffset timezoneHourOffset:(int)timezoneHourOffset __deprecated_msg("Use initWithMillisecond:second:minute:hour:day:month:year:tz_hour:tz_minute:");
 
 /**
  * Milliseconds part of time

--- a/SmartDeviceLink/public/SDLDeleteCommand.h
+++ b/SmartDeviceLink/public/SDLDeleteCommand.h
@@ -1,5 +1,34 @@
-//  SDLDeleteCommand.h
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 
 #import "SDLRPCRequest.h"
@@ -21,11 +50,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SDLDeleteCommand : SDLRPCRequest
 
+/**
+ * @param cmdID - @(cmdID)
+ * @return A SDLDeleteCommand object
+ */
+- (instancetype)initWithCmdID:(UInt32)cmdID;
+
 /// Convenience init to remove a command from the menu
 ///
 /// @param commandId The Command ID that identifies the Command to be deleted from Command Menu
 /// @return An SDLDeleteCommand object
-- (instancetype)initWithId:(UInt32)commandId;
+- (instancetype)initWithId:(UInt32)commandId __deprecated_msg("Use initWithCmdID: instead");
 
 /**
  * the Command ID that identifies the Command to be deleted from Command Menu

--- a/SmartDeviceLink/public/SDLDeleteFile.h
+++ b/SmartDeviceLink/public/SDLDeleteFile.h
@@ -1,8 +1,40 @@
-//  SDLDeleteFile.h
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 
 #import "SDLRPCRequest.h"
+
+
+NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Used to delete a file resident on the SDL module in the app's local cache.
@@ -12,16 +44,19 @@
  * Since <b>SmartDeviceLink 2.0</b><br>
  * see SDLPutFile SDLListFiles
  */
-
-NS_ASSUME_NONNULL_BEGIN
-
 @interface SDLDeleteFile : SDLRPCRequest
+
+/**
+ * @param sdlFileName - sdlFileName
+ * @return A SDLDeleteFile object
+ */
+- (instancetype)initWithSdlFileName:(NSString *)sdlFileName;
 
 /// Convenience init to delete a file
 ///
 /// @param fileName A file reference name
 /// @return An SDLDeleteFile object
-- (instancetype)initWithFileName:(NSString *)fileName;
+- (instancetype)initWithFileName:(NSString *)fileName __deprecated_msg("Use initWithSdlFileName: instead");
 
 /**
  * a file reference name

--- a/SmartDeviceLink/public/SDLDeleteFileResponse.h
+++ b/SmartDeviceLink/public/SDLDeleteFileResponse.h
@@ -1,5 +1,34 @@
-//  SDLDeleteFileResponse.h
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 
 #import "SDLRPCResponse.h"
@@ -13,6 +42,12 @@ NS_ASSUME_NONNULL_BEGIN
  Since SmartDeviceLink 2.0
  */
 @interface SDLDeleteFileResponse : SDLRPCResponse
+
+/**
+ * @param spaceAvailable - spaceAvailable
+ * @return A SDLDeleteFileResponse object
+ */
+- (instancetype)initWithSpaceAvailable:(nullable NSNumber<SDLUInt> *)spaceAvailable;
 
 /**
  The remaining available space for your application to store data on the remote system.

--- a/SmartDeviceLink/public/SDLDeleteInteractionChoiceSet.h
+++ b/SmartDeviceLink/public/SDLDeleteInteractionChoiceSet.h
@@ -23,11 +23,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SDLDeleteInteractionChoiceSet : SDLRPCRequest
 
+/**
+ * @param interactionChoiceSetID - @(interactionChoiceSetID)
+ * @return A SDLDeleteInteractionChoiceSet object
+ */
+- (instancetype)initWithInteractionChoiceSetID:(UInt32)interactionChoiceSetID;
+
 /// Convenience init to delete a choice set
 ///
 /// @param choiceId A unique ID that identifies the Choice Set
 /// @return An SDLDeleteInteractionChoiceSet object
-- (instancetype)initWithId:(UInt32)choiceId;
+- (instancetype)initWithId:(UInt32)choiceId __deprecated_msg("Use initWithInteractionChoiceSetID: instead");
 
 /**
  * a unique ID that identifies the Choice Set

--- a/SmartDeviceLink/public/SDLDeleteSubMenu.h
+++ b/SmartDeviceLink/public/SDLDeleteSubMenu.h
@@ -1,8 +1,40 @@
-//  SDLDeleteSubMenu.h
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 
 #import "SDLRPCRequest.h"
+
+
+NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Deletes a submenu from the Command Menu
@@ -16,16 +48,19 @@
  * Since <b>SmartDeviceLink 1.0</b><br>
  * see SDLAddCommand SDLAddSubMenu SDLDeleteCommand
  */
-
-NS_ASSUME_NONNULL_BEGIN
-
 @interface SDLDeleteSubMenu : SDLRPCRequest
+
+/**
+ * @param menuID - @(menuID)
+ * @return A SDLDeleteSubMenu object
+ */
+- (instancetype)initWithMenuID:(UInt32)menuID;
 
 /// Convenience init to delete a submenu
 /// 
 /// @param menuId Identifies the SDLSubMenu to be delete
 /// @return An SDLDeleteSubMenu object
-- (instancetype)initWithId:(UInt32)menuId;
+- (instancetype)initWithId:(UInt32)menuId __deprecated_msg("Use initWithMenuID: instead");
 
 /**
  * the MenuID that identifies the SDLSubMenu to be delete

--- a/SmartDeviceLink/public/SDLDeleteWindow.h
+++ b/SmartDeviceLink/public/SDLDeleteWindow.h
@@ -1,6 +1,34 @@
-//
-//  SDLDeleteWindow.h
-//  SmartDeviceLink
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #import "SDLRPCRequest.h"
 
@@ -14,9 +42,15 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SDLDeleteWindow : SDLRPCRequest
 
 /**
+ * @param windowID - @(windowID)
+ * @return A SDLDeleteWindow object
+ */
+- (instancetype)initWithWindowID:(UInt32)windowID;
+
+/**
  @param windowId A unique ID to identify the window. The value of '0' will always be the default main window on the main display and cannot be deleted.
  */
-- (instancetype)initWithId:(NSUInteger)windowId;
+- (instancetype)initWithId:(NSUInteger)windowId __deprecated_msg("Use initWithWindowID: instead");
 
 /**
  A unique ID to identify the window.

--- a/SmartDeviceLink/public/SDLDeviceInfo.h
+++ b/SmartDeviceLink/public/SDLDeviceInfo.h
@@ -1,5 +1,34 @@
-//  SDLDeviceInfo.h
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #import "SDLRPCMessage.h"
 
@@ -9,6 +38,17 @@ NS_ASSUME_NONNULL_BEGIN
  Various information about connecting device. Referenced in RegisterAppInterface
  */
 @interface SDLDeviceInfo : SDLRPCStruct
+
+/**
+ * @param hardware - hardware
+ * @param firmwareRev - firmwareRev
+ * @param os - os
+ * @param osVersion - osVersion
+ * @param carrier - carrier
+ * @param maxNumberRFCOMMPorts - maxNumberRFCOMMPorts
+ * @return A SDLDeviceInfo object
+ */
+- (instancetype)initWithHardware:(nullable NSString *)hardware firmwareRev:(nullable NSString *)firmwareRev os:(nullable NSString *)os osVersion:(nullable NSString *)osVersion carrier:(nullable NSString *)carrier maxNumberRFCOMMPorts:(nullable NSNumber<SDLUInt> *)maxNumberRFCOMMPorts;
 
 /// Convenience init. Object will contain all information about the connected device automatically.
 ///

--- a/SmartDeviceLink/public/SDLDeviceStatus.h
+++ b/SmartDeviceLink/public/SDLDeviceStatus.h
@@ -1,5 +1,34 @@
-//  SDLDeviceStatus.h
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #import "SDLRPCMessage.h"
 
@@ -7,15 +36,30 @@
 #import "SDLPrimaryAudioSource.h"
 
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  Describes the status related to a connected mobile device or SDL and if or how  it is represented in the vehicle.
 
  @since SDL 2.0
  */
-
-NS_ASSUME_NONNULL_BEGIN
-
 @interface SDLDeviceStatus : SDLRPCStruct
+
+/**
+ * @param voiceRecOn - @(voiceRecOn)
+ * @param btIconOn - @(btIconOn)
+ * @param callActive - @(callActive)
+ * @param phoneRoaming - @(phoneRoaming)
+ * @param textMsgAvailable - @(textMsgAvailable)
+ * @param battLevelStatus - battLevelStatus
+ * @param stereoAudioOutputMuted - @(stereoAudioOutputMuted)
+ * @param monoAudioOutputMuted - @(monoAudioOutputMuted)
+ * @param signalLevelStatus - signalLevelStatus
+ * @param primaryAudioSource - primaryAudioSource
+ * @param eCallEventActive - @(eCallEventActive)
+ * @return A SDLDeviceStatus object
+ */
+- (instancetype)initWithVoiceRecOn:(BOOL)voiceRecOn btIconOn:(BOOL)btIconOn callActive:(BOOL)callActive phoneRoaming:(BOOL)phoneRoaming textMsgAvailable:(BOOL)textMsgAvailable battLevelStatus:(SDLDeviceLevelStatus)battLevelStatus stereoAudioOutputMuted:(BOOL)stereoAudioOutputMuted monoAudioOutputMuted:(BOOL)monoAudioOutputMuted signalLevelStatus:(SDLDeviceLevelStatus)signalLevelStatus primaryAudioSource:(SDLPrimaryAudioSource)primaryAudioSource eCallEventActive:(BOOL)eCallEventActive;
 
 /**
  * Indicates whether the voice recognition is on or off

--- a/SmartDeviceLink/public/SDLDiagnosticMessage.h
+++ b/SmartDeviceLink/public/SDLDiagnosticMessage.h
@@ -1,18 +1,55 @@
-//  SDLDiagnosticMessage.h
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 
 #import "SDLRPCRequest.h"
 
-/** 
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
  *  Non periodic vehicle diagnostic request
  *
  *  @since SDL 3.0
  */
-
-NS_ASSUME_NONNULL_BEGIN
-
 @interface SDLDiagnosticMessage : SDLRPCRequest
+
+/**
+ * @param targetID - @(targetID)
+ * @param messageLength - @(messageLength)
+ * @param messageData - messageData
+ * @return A SDLDiagnosticMessage object
+ */
+- (instancetype)initWithTargetID:(UInt16)targetID messageLength:(UInt16)messageLength messageData:(NSArray<NSNumber<SDLUInt> *> *)messageData;
 
 /// Convenience init
 /// 
@@ -20,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param length Length of message (in bytes)
 /// @param data Array of bytes comprising CAN message
 /// @return An SDLDiagnosticMessage object
-- (instancetype)initWithTargetId:(UInt16)targetId length:(UInt16)length data:(NSArray<NSNumber<SDLUInt> *> *)data;
+- (instancetype)initWithTargetId:(UInt16)targetId length:(UInt16)length data:(NSArray<NSNumber<SDLUInt> *> *)data __deprecated_msg("Use initWithTargetID:messageLength:messageData: instead");
 
 /**
  *  Name of target ECU

--- a/SmartDeviceLink/public/SDLDiagnosticMessageResponse.h
+++ b/SmartDeviceLink/public/SDLDiagnosticMessageResponse.h
@@ -1,5 +1,34 @@
-//  SDLDiagnosticMessageResponse.h
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 
 #import "SDLRPCResponse.h"
@@ -12,6 +41,12 @@ NS_ASSUME_NONNULL_BEGIN
  Since SmartDeviceLink 3.0
  */
 @interface SDLDiagnosticMessageResponse : SDLRPCResponse
+
+/**
+ * @param messageDataResult - messageDataResult
+ * @return A SDLDiagnosticMessageResponse object
+ */
+- (instancetype)initWithMessageDataResult:(nullable NSArray<NSNumber<SDLUInt> *> *)messageDataResult;
 
 /**
  Array of bytes comprising CAN message result.

--- a/SmartDeviceLink/public/SDLDialNumber.h
+++ b/SmartDeviceLink/public/SDLDialNumber.h
@@ -1,17 +1,45 @@
-//
-//  SDLDialNumber.h
-//  SmartDeviceLink-iOS
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #import "SDLRPCRequest.h"
 
-/**
- This RPC is used to tell the head unit to use bluetooth to dial a phone number using the phone.
- 
- @since SDL 4.0
- */
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ This RPC is used to tell the head unit to use bluetooth to dial a phone number using the phone.
+
+ @since SDL 4.0
+ */
 @interface SDLDialNumber : SDLRPCRequest
 
 /// Convenience init to initiate a dial number request

--- a/SmartDeviceLink/public/SDLDisplayCapabilities.h
+++ b/SmartDeviceLink/public/SDLDisplayCapabilities.h
@@ -1,5 +1,34 @@
-//  SDLDisplayCapabilities.h
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #import "SDLRPCMessage.h"
 
@@ -19,6 +48,27 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface SDLDisplayCapabilities : SDLRPCStruct
+
+/**
+ * @param textFields - textFields
+ * @param mediaClockFormats - mediaClockFormats
+ * @param graphicSupported - @(graphicSupported)
+ * @return A SDLDisplayCapabilities object
+ */
+- (instancetype)initWithTextFields:(NSArray<SDLTextField *> *)textFields mediaClockFormats:(NSArray<SDLMediaClockFormat> *)mediaClockFormats graphicSupported:(BOOL)graphicSupported;
+
+/**
+ * @param textFields - textFields
+ * @param mediaClockFormats - mediaClockFormats
+ * @param graphicSupported - @(graphicSupported)
+ * @param displayName - displayName
+ * @param imageFields - imageFields
+ * @param templatesAvailable - templatesAvailable
+ * @param screenParams - screenParams
+ * @param numCustomPresetsAvailable - numCustomPresetsAvailable
+ * @return A SDLDisplayCapabilities object
+ */
+- (instancetype)initWithTextFields:(NSArray<SDLTextField *> *)textFields mediaClockFormats:(NSArray<SDLMediaClockFormat> *)mediaClockFormats graphicSupported:(BOOL)graphicSupported displayName:(nullable NSString *)displayName imageFields:(nullable NSArray<SDLImageField *> *)imageFields templatesAvailable:(nullable NSArray<NSString *> *)templatesAvailable screenParams:(nullable SDLScreenParams *)screenParams numCustomPresetsAvailable:(nullable NSNumber<SDLUInt> *)numCustomPresetsAvailable;
 
 /**
  * The type of display

--- a/SmartDeviceLink/public/SDLDisplayCapability.h
+++ b/SmartDeviceLink/public/SDLDisplayCapability.h
@@ -1,6 +1,34 @@
-//
-//  SDLDisplayCapability.h
-//  SmartDeviceLink
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #import "SDLRPCStruct.h"
 
@@ -17,11 +45,19 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SDLDisplayCapability : SDLRPCStruct
 
 /**
+ * @param displayName - displayName
+ * @param windowTypeSupported - windowTypeSupported
+ * @param windowCapabilities - windowCapabilities
+ * @return A SDLDisplayCapability object
+ */
+- (instancetype)initWithDisplayName:(nullable NSString *)displayName windowTypeSupported:(nullable NSArray<SDLWindowTypeCapabilities *> *)windowTypeSupported windowCapabilities:(nullable NSArray<SDLWindowCapability *> *)windowCapabilities;
+
+/**
  Init with required properties
  
  @param displayName Name of the display.
  */
-- (instancetype)initWithDisplayName:(NSString *)displayName;
+- (instancetype)initWithDisplayName:(NSString *)displayName __deprecated_msg("Use initWithDisplayName:windowTypeSupported:windowCapabilities: instead");
 
 /**
  Init with all the properities
@@ -30,7 +66,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param windowCapabilities Contains a list of capabilities of all windows related to the app. @see windowCapabilities
  @param windowTypeSupported Informs the application how many windows the app is allowed to create per type.
  */
-- (instancetype)initWithDisplayName:(NSString *)displayName windowCapabilities:(nullable NSArray<SDLWindowCapability *> *)windowCapabilities windowTypeSupported:(nullable NSArray<SDLWindowTypeCapabilities *> *)windowTypeSupported;
+- (instancetype)initWithDisplayName:(NSString *)displayName windowCapabilities:(nullable NSArray<SDLWindowCapability *> *)windowCapabilities windowTypeSupported:(nullable NSArray<SDLWindowTypeCapabilities *> *)windowTypeSupported __deprecated_msg("Use initWithDisplayName:windowTypeSupported:windowCapabilities: instead");
 
 
 /**

--- a/SmartDeviceLink/public/SDLECallInfo.h
+++ b/SmartDeviceLink/public/SDLECallInfo.h
@@ -1,5 +1,34 @@
-//  SDLECallInfo.h
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #import "SDLRPCMessage.h"
 
@@ -12,6 +41,14 @@ NS_ASSUME_NONNULL_BEGIN
  A vehicle data struct for emergency call information
  */
 @interface SDLECallInfo : SDLRPCStruct
+
+/**
+ * @param eCallNotificationStatus - eCallNotificationStatus
+ * @param auxECallNotificationStatus - auxECallNotificationStatus
+ * @param eCallConfirmationStatus - eCallConfirmationStatus
+ * @return A SDLECallInfo object
+ */
+- (instancetype)initWithECallNotificationStatus:(SDLVehicleDataNotificationStatus)eCallNotificationStatus auxECallNotificationStatus:(SDLVehicleDataNotificationStatus)auxECallNotificationStatus eCallConfirmationStatus:(SDLECallConfirmationStatus)eCallConfirmationStatus;
 
 /**
  References signal "eCallNotification_4A". See VehicleDataNotificationStatus.

--- a/SmartDeviceLink/public/SDLEmergencyEvent.h
+++ b/SmartDeviceLink/public/SDLEmergencyEvent.h
@@ -1,5 +1,34 @@
-//  SDLEmergencyEvent.h
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #import "SDLRPCMessage.h"
 
@@ -13,6 +42,16 @@ NS_ASSUME_NONNULL_BEGIN
  A vehicle data struct for an emergency event
  */
 @interface SDLEmergencyEvent : SDLRPCStruct
+
+/**
+ * @param emergencyEventType - emergencyEventType
+ * @param fuelCutoffStatus - fuelCutoffStatus
+ * @param rolloverEvent - rolloverEvent
+ * @param maximumChangeVelocity - @(maximumChangeVelocity)
+ * @param multipleEvents - multipleEvents
+ * @return A SDLEmergencyEvent object
+ */
+- (instancetype)initWithEmergencyEventType:(SDLEmergencyEventType)emergencyEventType fuelCutoffStatus:(SDLFuelCutoffStatus)fuelCutoffStatus rolloverEvent:(SDLVehicleDataEventStatus)rolloverEvent maximumChangeVelocity:(UInt8)maximumChangeVelocity multipleEvents:(SDLVehicleDataEventStatus)multipleEvents;
 
 /**
  References signal "VedsEvntType_D_Ltchd". See EmergencyEventType.

--- a/SmartDeviceLink/public/SDLEncodedSyncPData.h
+++ b/SmartDeviceLink/public/SDLEncodedSyncPData.h
@@ -16,6 +16,12 @@ __deprecated
 @interface SDLEncodedSyncPData : SDLRPCRequest
 
 /**
+ * @param data - data
+ * @return A SDLEncodedSyncPData object
+ */
+- (instancetype)initWithData:(NSArray<NSString *> *)data;
+
+/**
  *  Contains base64 encoded string of SyncP packets.
  *
  *  Required, Array length 1 - 100, String length 1 - 1,000,000

--- a/SmartDeviceLink/public/SDLEqualizerSettings.h
+++ b/SmartDeviceLink/public/SDLEqualizerSettings.h
@@ -1,5 +1,34 @@
-//  SDLEqualizerSettings.h
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #import "SDLRPCMessage.h"
 
@@ -12,10 +41,18 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SDLEqualizerSettings : SDLRPCStruct
 
 /// Convenience init
-/// 
+///
 /// @param channelId Read-only channel / frequency name
 /// @param channelSetting Reflects the setting, from 0%-100%.
 - (instancetype)initWithChannelId:(UInt8)channelId channelSetting:(UInt8)channelSetting;
+
+/**
+ * @param channelId - @(channelId)
+ * @param channelSetting - @(channelSetting)
+ * @param channelName - channelName
+ * @return A SDLEqualizerSettings object
+ */
+- (instancetype)initWithChannelId:(UInt8)channelId channelSetting:(UInt8)channelSetting channelName:(nullable NSString *)channelName;
 
 /**
  * @abstract Read-only channel / frequency name

--- a/SmartDeviceLink/public/SDLFuelRange.h
+++ b/SmartDeviceLink/public/SDLFuelRange.h
@@ -1,10 +1,34 @@
-//
-//  SDLFuelRange.h
-//  SmartDeviceLink
-//
-//  Created by Nicole on 6/20/18.
-//  Copyright © 2018 smartdevicelink. All rights reserved.
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #import "SDLCapacityUnit.h"
 #import "SDLComponentVolumeStatus.h"
@@ -19,6 +43,17 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SDLFuelRange : SDLRPCStruct
 
 /**
+ * @param type - type
+ * @param range - range
+ * @param level - level
+ * @param levelState - levelState
+ * @param capacity - capacity
+ * @param capacityUnit - capacityUnit
+ * @return A SDLFuelRange object
+ */
+- (instancetype)initWithTypeParam:(nullable SDLFuelType)type range:(nullable NSNumber<SDLFloat> *)range level:(nullable NSNumber<SDLFloat> *)level levelState:(nullable SDLComponentVolumeStatus)levelState capacity:(nullable NSNumber<SDLFloat> *)capacity capacityUnit:(nullable SDLCapacityUnit)capacityUnit __deprecated;
+
+/**
  *  @param  type - type
  *  @param  range - @(range)
  *  @param  level - @(level)
@@ -27,7 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param  capacityUnit - capacityUnit
  *  @return A SDLFuelRange object
  */
-- (instancetype)initWithType:(nullable SDLFuelType)type range:(float)range level:(float)level levelState:(nullable SDLComponentVolumeStatus)levelState capacity:(float)capacity capacityUnit:(nullable SDLCapacityUnit)capacityUnit;
+- (instancetype)initWithType:(nullable SDLFuelType)type range:(float)range level:(float)level levelState:(nullable SDLComponentVolumeStatus)levelState capacity:(float)capacity capacityUnit:(nullable SDLCapacityUnit)capacityUnit __deprecated;
 
 /**
  * The absolute capacity of this fuel type.

--- a/SmartDeviceLink/public/SDLGetAppServiceData.h
+++ b/SmartDeviceLink/public/SDLGetAppServiceData.h
@@ -19,6 +19,19 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SDLGetAppServiceData : SDLRPCRequest
 
 /**
+ * @param serviceType - serviceType
+ * @return A SDLGetAppServiceData object
+ */
+- (instancetype)initWithServiceType:(NSString *)serviceType;
+
+/**
+ * @param serviceType - serviceType
+ * @param subscribe - subscribe
+ * @return A SDLGetAppServiceData object
+ */
+- (instancetype)initWithServiceType:(NSString *)serviceType subscribe:(nullable NSNumber<SDLBool> *)subscribe;
+
+/**
  *  Convenience init for service type.
  *
  *  @param serviceType      The app service type

--- a/SmartDeviceLink/public/SDLGetAppServiceDataResponse.h
+++ b/SmartDeviceLink/public/SDLGetAppServiceDataResponse.h
@@ -1,10 +1,34 @@
-//
-//  SDLGetAppServiceDataResponse.h
-//  SmartDeviceLink
-//
-//  Created by Nicole on 2/6/19.
-//  Copyright © 2019 smartdevicelink. All rights reserved.
-//
+/*
+ * Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #import "SDLRPCResponse.h"
 
@@ -18,12 +42,18 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SDLGetAppServiceDataResponse : SDLRPCResponse
 
 /**
+ * @param serviceData - serviceData
+ * @return A SDLGetAppServiceDataResponse object
+ */
+- (instancetype)initWithServiceData:(nullable SDLAppServiceData *)serviceData;
+
+/**
  *  Convenience init.
  *
  *  @param serviceData  Contains all the current data of the app service
  *  @return             A SDLGetAppServiceDataResponse object
  */
-- (instancetype)initWithAppServiceData:(SDLAppServiceData *)serviceData;
+- (instancetype)initWithAppServiceData:(SDLAppServiceData *)serviceData __deprecated_msg("Use initWithServiceData: instead");
 
 /**
  *  Contains all the current data of the app service.


### PR DESCRIPTION
Fixes #1821 

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [ ] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [ ] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Unit tests updated for new and deprecated initializers

#### Core Tests
Example apps run

Core version / branch / commit hash / module tested against: Manticore (Core 6.1.1)
HMI name / version / branch / commit hash / module tested against: Manticore (Generic HMI v0.8.1)

### Summary
This PR adds all generated initializers and deprecates many older initializers.

### Changelog
##### Enhancements
* Added RPC initializers generated by the RPC generator and deprecated old initializers.

### Tasks Remaining:
- [ ] Finish adding / deprecating all initializers
- [ ] Fix deprecations in unit tests
- [ ] Add new unit tests for new initializers

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
