### PR TITLE
Bugfix/issue 1751 rpc spec generator does not add parameter descriptors for the enum data type

### DIFF
--- a/generator/transformers/common_producer.py
+++ b/generator/transformers/common_producer.py
@@ -205,7 +205,6 @@ class InterfaceProducerCommon(ABC):
         :param item: named tuple with initiator (constructor) parameter
         :return: wrapped parameter
         """
-        # print('Item: ' + str(item))
         if re.match(r'\w*Int\d+|BOOL|float|double', item.type_native) or \
                 any(map(lambda n: item.type_native.lower() in n.lower(), self.struct_names)):
             return '@({})'.format(item.constructor_argument)
@@ -358,32 +357,32 @@ class InterfaceProducerCommon(ABC):
         :param param: Param from initial Model
         :return: self.param_named with prepared params
         """
-        param.name = self.replace_keywords(param.name)
-        # print('Default value is: ' + str(param.default_value))
+        print('The defaultValue: ' + str(param.default_value))
+        print('The paramName is', item_name)
         if isinstance(param.param_type, (Enum)) and param.default_value:
-            print('Default value is: ' + str(param.default_value.name))
-            print('Default value is: ' + str(param.default_value.internal_name))
-            print('Name is: ', str(param.name))
-        
+            print('The defaultValueName: ' + str(param.default_value.name))
+        param.name = self.replace_keywords(param.name)
         data = {'constructor_argument_override': None,
                 'description': self.extract_description(param.description),
                 'since': param.since,
                 'mandatory': param.is_mandatory,
                 'deprecated': json.loads(param.deprecated.lower()) if param.deprecated else False,
                 'modifier': 'strong',
-                # 'default_value': param.default_value,
                 'history' : param.history }
         if isinstance(param.param_type, (Integer, Float, String, Array)):
-            data['description'].append(self.create_param_descriptor(param.param_type, OrderedDict(), param.name))
+            data['description'].append(self.create_param_descriptor(param.param_type, OrderedDict()))
 
         if isinstance(param.param_type, (Enum)) and param.default_value:
-            data['description'].append(param.default_value.value)
+            defaultDict = OrderedDict()
+            defaultDict['default_value'] = param.default_value.name
+            defaultString = json.dumps(defaultDict)
+            data['description'].append(defaultString)
 
         data.update(self.extract_type(param))
         data.update(self.param_origin_change(param.name))
         return self.param_named(**data)
 
-    def create_param_descriptor(self, param_type, parameterItems, paramName):
+    def create_param_descriptor(self, param_type, parameterItems):
         """
         Recursively creates a documentation string of all the descriptors for a parameter (e.g. {"string_min_length": 1, string_max_length": 500}). The parameters should be returned in the same order they were added to the parameterItems dictionary
         :param param_type: param_type from the initial Model
@@ -398,12 +397,9 @@ class InterfaceProducerCommon(ABC):
                     # Skip adding documentation for the data type if it is a struct or enum. This is unnecessary as each enum or struct has its own documentation
                     continue
                 else:
-                    self.create_param_descriptor(value, parameterItems, paramName)
+                    self.create_param_descriptor(value, parameterItems)
             else:
-                if key == 'default_value' and paramName == 'systemAction':
-                    parameterDescriptor = self.update_param_descriptor(key)
-                    parameterItems[parameterDescriptor] = value
-                elif key == 'default_value' and value is None:
+                if key == 'default_value' and value is None:
                     # Do not add the default_value key/value pair unless it has been explicitly set in the RPC Spec
                     continue
                 else:

--- a/generator/transformers/enums_producer.py
+++ b/generator/transformers/enums_producer.py
@@ -60,7 +60,6 @@ class EnumsProducer(InterfaceProducerCommon):
                 'description': self.extract_description(param.description),
                 'since': param.since,
                 'history': param.history,
-                # 'default_value': param.default_value,
                 'deprecated': json.loads(param.deprecated.lower()) if param.deprecated else False}
         name = None
         if re.match(r'^[A-Z]{1,2}\d|\d[A-Z]{1,2}$', param.name):
@@ -81,11 +80,4 @@ class EnumsProducer(InterfaceProducerCommon):
         if any(re.search(r'^(sdl)?({}){}$'.format(item_name.casefold(), name.casefold()), k) for k in self.key_words):
             name = self._replace_keywords(name)
         data['name'] = name
-        # try:
-        #     param.default_value
-        # except NameError:
-        #     data['default_value'] = None
-        # else:
-        #     data['default_value'] = param.default_value
-
         return self.param_named(**data)

--- a/generator/transformers/enums_producer.py
+++ b/generator/transformers/enums_producer.py
@@ -60,6 +60,7 @@ class EnumsProducer(InterfaceProducerCommon):
                 'description': self.extract_description(param.description),
                 'since': param.since,
                 'history': param.history,
+                # 'default_value': param.default_value,
                 'deprecated': json.loads(param.deprecated.lower()) if param.deprecated else False}
         name = None
         if re.match(r'^[A-Z]{1,2}\d|\d[A-Z]{1,2}$', param.name):
@@ -80,4 +81,11 @@ class EnumsProducer(InterfaceProducerCommon):
         if any(re.search(r'^(sdl)?({}){}$'.format(item_name.casefold(), name.casefold()), k) for k in self.key_words):
             name = self._replace_keywords(name)
         data['name'] = name
+        # try:
+        #     param.default_value
+        # except NameError:
+        #     data['default_value'] = None
+        # else:
+        #     data['default_value'] = param.default_value
+
         return self.param_named(**data)


### PR DESCRIPTION
Fixes #1751 

### Risk
This PR makes **[no / minor / major]** API changes.

### Testing Plan
- [ ] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [ ] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
[Describe the unit tests and behaviors added in this PR]

#### Core Tests
[List of tests performed against Core and behaviors verified]

Core version / branch / commit hash / module tested against: [INSERT]
HMI name / version / branch / commit hash / module tested against: [INSERT]

### Summary
[Summary of PR changes]

### Changelog
##### Breaking Changes
* [Breaking change info]

##### Enhancements
* [Enhancement info]

##### Bug Fixes
* [Bug Fix Info]

### Tasks Remaining:
- [ ] [Task 1]
- [ ] [Task 2]

### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
