### PR TITLE
Fix for template change

### DIFF
--- a/Example Apps/Example ObjC/MenuManager.h
+++ b/Example Apps/Example ObjC/MenuManager.h
@@ -16,12 +16,14 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef void(^RefreshTemplateHandler)(SDLPredefinedLayout);
+
 @interface MenuManager : NSObject
 
-+ (SDLPredefinedLayout)getCurrentTemplate;
-+ (void)setCurrentTemplate:(SDLPredefinedLayout)var;
-+ (NSArray<SDLMenuCell *> *)allMenuItemsWithManager:(SDLManager *)manager performManager:(PerformInteractionManager *)performManager;
-+ (NSArray<SDLVoiceCommand *> *)allVoiceMenuItemsWithManager:(SDLManager *)manager;
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithRefreshTemplateHandler:(RefreshTemplateHandler)updateTemplate;
+- (NSArray<SDLMenuCell *> *)allMenuItemsWithManager:(SDLManager *)manager performManager:(PerformInteractionManager *)performManager;
+- (NSArray<SDLVoiceCommand *> *)allVoiceMenuItemsWithManager:(SDLManager *)manager;
 
 @end
 

--- a/Example Apps/Example ObjC/MenuManager.h
+++ b/Example Apps/Example ObjC/MenuManager.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "SDLPredefinedLayout.h"
 
 @class PerformInteractionManager;
 @class SDLManager;
@@ -17,6 +18,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MenuManager : NSObject
 
++ (SDLPredefinedLayout)getCurrentTemplate;
++ (void)setCurrentTemplate:(SDLPredefinedLayout)var;
 + (NSArray<SDLMenuCell *> *)allMenuItemsWithManager:(SDLManager *)manager performManager:(PerformInteractionManager *)performManager;
 + (NSArray<SDLVoiceCommand *> *)allVoiceMenuItemsWithManager:(SDLManager *)manager;
 

--- a/Example Apps/Example ObjC/MenuManager.m
+++ b/Example Apps/Example ObjC/MenuManager.m
@@ -121,13 +121,15 @@ NS_ASSUME_NONNULL_BEGIN
     
     // Non - Media
     SDLMenuCell *cell = [[SDLMenuCell alloc] initWithTitle:@"Non - Media (Default)" icon:nil voiceCommands:nil handler:^(SDLTriggerSource  _Nonnull triggerSource) {
-        [self setCurrentTemplate:SDLPredefinedLayoutNonMedia];
+        __weak typeof (self) weakSelf = self;
+        [weakSelf setCurrentTemplate:SDLPredefinedLayoutNonMedia];
     }];
     [submenuItems addObject:cell];
     
     // Graphic With Text
     SDLMenuCell *cell2 = [[SDLMenuCell alloc] initWithTitle:@"Graphic With Text" icon:nil voiceCommands:nil handler:^(SDLTriggerSource  _Nonnull triggerSource) {
-        [self setCurrentTemplate:SDLPredefinedLayoutGraphicWithText];
+        __weak typeof (self) weakSelf = self;
+        [weakSelf setCurrentTemplate:SDLPredefinedLayoutGraphicWithText];
     }];
     [submenuItems addObject:cell2];
     

--- a/Example Apps/Example ObjC/MenuManager.m
+++ b/Example Apps/Example ObjC/MenuManager.m
@@ -14,10 +14,21 @@
 #import "RPCPermissionsManager.h"
 #import "SmartDeviceLink.h"
 #import "VehicleDataManager.h"
+#import "SDLPredefinedLayout.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
+static SDLPredefinedLayout currentTemplate;
+
 @implementation MenuManager
+
++ (SDLPredefinedLayout)getCurrentTemplate {
+    return currentTemplate;
+}
+
++ (void)setCurrentTemplate:(SDLPredefinedLayout)var {
+    currentTemplate = var;
+}
 
 + (NSArray<SDLMenuCell *> *)allMenuItemsWithManager:(SDLManager *)manager performManager:(PerformInteractionManager *)performManager {
     return @[[self sdlex_menuCellSpeakNameWithManager:manager],
@@ -97,7 +108,8 @@ NS_ASSUME_NONNULL_BEGIN
     
     // Non - Media
     SDLMenuCell *cell = [[SDLMenuCell alloc] initWithTitle:@"Non - Media (Default)" icon:nil voiceCommands:nil handler:^(SDLTriggerSource  _Nonnull triggerSource) {
-        [manager.screenManager changeLayout:[[SDLTemplateConfiguration alloc] initWithPredefinedLayout:SDLPredefinedLayoutNonMedia] withCompletionHandler:^(NSError * _Nullable error) {
+        currentTemplate = SDLPredefinedLayoutNonMedia;
+        [manager.screenManager changeLayout:[[SDLTemplateConfiguration alloc] initWithPredefinedLayout: [self getCurrentTemplate]] withCompletionHandler:^(NSError * _Nullable error) {
             if (error != nil) {
                 [AlertManager sendAlertWithManager:manager image:nil textField1:errorMessage textField2:nil];
             }
@@ -107,7 +119,8 @@ NS_ASSUME_NONNULL_BEGIN
     
     // Graphic With Text
     SDLMenuCell *cell2 = [[SDLMenuCell alloc] initWithTitle:@"Graphic With Text" icon:nil voiceCommands:nil handler:^(SDLTriggerSource  _Nonnull triggerSource) {
-        [manager.screenManager changeLayout:[[SDLTemplateConfiguration alloc] initWithPredefinedLayout:SDLPredefinedLayoutGraphicWithText] withCompletionHandler:^(NSError * _Nullable error) {
+        currentTemplate = SDLPredefinedLayoutGraphicWithText;
+        [manager.screenManager changeLayout:[[SDLTemplateConfiguration alloc] initWithPredefinedLayout: [self getCurrentTemplate]] withCompletionHandler:^(NSError * _Nullable error) {
             if (error != nil) {
                 [AlertManager sendAlertWithManager:manager image:nil textField1:errorMessage textField2:nil];
             }

--- a/Example Apps/Example ObjC/ProxyManager.m
+++ b/Example Apps/Example ObjC/ProxyManager.m
@@ -166,7 +166,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)sdlex_showInitialData {
     if (![self.sdlManager.hmiLevel isEqualToEnum:SDLHMILevelFull]) { return; }
 
-    [self.sdlManager.screenManager changeLayout:[[SDLTemplateConfiguration alloc] initWithPredefinedLayout:SDLPredefinedLayoutNonMedia] withCompletionHandler:nil];
+    [self.sdlManager.screenManager changeLayout:[[SDLTemplateConfiguration alloc] initWithPredefinedLayout:[MenuManager getCurrentTemplate]] withCompletionHandler:nil];
 
     [self sdlex_updateScreen];
 }

--- a/Example Apps/Example ObjC/ProxyManager.m
+++ b/Example Apps/Example ObjC/ProxyManager.m
@@ -60,25 +60,6 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (nullable RefreshTemplateHandler)refreshTemplateHandler {
-    if(!_refreshTemplateHandler) {
-        __weak typeof(self) weakSelf = self;
-        self.refreshTemplateHandler = ^(SDLPredefinedLayout template) {
-            NSString *errorMessage = @"Changing the template failed";
-            weakSelf.currentTemplate = template;
-            [weakSelf.sdlManager.screenManager changeLayout:[[SDLTemplateConfiguration alloc] initWithPredefinedLayout:weakSelf.currentTemplate] withCompletionHandler:nil];
-
-            [weakSelf.sdlManager.screenManager changeLayout:[[SDLTemplateConfiguration alloc] initWithPredefinedLayout: weakSelf.currentTemplate] withCompletionHandler:^(NSError * _Nullable error) {
-                if (error != nil) {
-                    [AlertManager sendAlertWithManager:weakSelf.sdlManager image:nil textField1:errorMessage textField2:nil];
-                }
-            }];
-        };
-    }
-
-    return _refreshTemplateHandler;
-}
-
 - (void)sdlex_startManager {
     __weak typeof (self) weakSelf = self;
     [self.sdlManager startWithReadyHandler:^(BOOL success, NSError * _Nullable error) {
@@ -204,6 +185,25 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     return _refreshUIHandler;
+}
+
+- (nullable RefreshTemplateHandler)refreshTemplateHandler {
+    if(!_refreshTemplateHandler) {
+        __weak typeof(self) weakSelf = self;
+        weakSelf.refreshTemplateHandler = ^(SDLPredefinedLayout template) {
+            NSString *errorMessage = @"Changing the template failed";
+            weakSelf.currentTemplate = template;
+            [weakSelf.sdlManager.screenManager changeLayout:[[SDLTemplateConfiguration alloc] initWithPredefinedLayout:weakSelf.currentTemplate] withCompletionHandler:nil];
+
+            [weakSelf.sdlManager.screenManager changeLayout:[[SDLTemplateConfiguration alloc] initWithPredefinedLayout: weakSelf.currentTemplate] withCompletionHandler:^(NSError * _Nullable error) {
+                if (error != nil) {
+                    [AlertManager sendAlertWithManager:weakSelf.sdlManager image:nil textField1:errorMessage textField2:nil];
+                }
+            }];
+        };
+    }
+
+    return _refreshTemplateHandler;
 }
 
 - (void)sdlex_updateScreen {

--- a/Example Apps/Example Swift/MenuManager.swift
+++ b/Example Apps/Example Swift/MenuManager.swift
@@ -15,6 +15,7 @@ typealias RefreshTemplateHandler = ((SDLPredefinedLayout) -> Void)
 class MenuManager: NSObject {
     fileprivate var refreshTemplateHandler: RefreshTemplateHandler?
 
+    /// Setting current selected template
     public fileprivate(set) var currentTemplate: SDLPredefinedLayout {
         didSet {
             guard let refreshTemplateHandler = refreshTemplateHandler else { return }

--- a/Example Apps/Example Swift/MenuManager.swift
+++ b/Example Apps/Example Swift/MenuManager.swift
@@ -11,6 +11,9 @@ import SmartDeviceLink
 import SmartDeviceLinkSwift
 
 class MenuManager: NSObject {
+
+    static var currentTemplate : SDLPredefinedLayout = .nonMedia
+
     /// Creates and returns the menu items
     ///
     /// - Parameter manager: The SDL Manager
@@ -124,7 +127,8 @@ private extension MenuManager {
         /// Non-Media
         let submenuTitleNonMedia = "Non - Media (Default)"
         submenuItems.append(SDLMenuCell(title: submenuTitleNonMedia, icon: nil, voiceCommands: nil, handler: { (triggerSource) in
-            manager.screenManager.changeLayout(SDLTemplateConfiguration(predefinedLayout: .nonMedia)) { err in
+            currentTemplate = .nonMedia
+            manager.screenManager.changeLayout(SDLTemplateConfiguration(predefinedLayout: currentTemplate)) { err in
                 if err != nil {
                     AlertManager.sendAlert(textField1: errorMessage, sdlManager: manager)
                     return
@@ -135,7 +139,8 @@ private extension MenuManager {
         /// Graphic with Text
         let submenuTitleGraphicText = "Graphic With Text"
         submenuItems.append(SDLMenuCell(title: submenuTitleGraphicText, icon: nil, voiceCommands: nil, handler: { (triggerSource) in
-            manager.screenManager.changeLayout(SDLTemplateConfiguration(predefinedLayout: .graphicWithText)) { err in
+            currentTemplate = .graphicWithText
+            manager.screenManager.changeLayout(SDLTemplateConfiguration(predefinedLayout: currentTemplate)) { err in
                 if err != nil {
                     AlertManager.sendAlert(textField1: errorMessage, sdlManager: manager)
                     return

--- a/Example Apps/Example Swift/ProxyManager.swift
+++ b/Example Apps/Example Swift/ProxyManager.swift
@@ -252,7 +252,7 @@ private extension ProxyManager {
     func showInitialData() {
         guard sdlManager.hmiLevel == .full else { return }
 
-        sdlManager.screenManager.changeLayout(SDLTemplateConfiguration(predefinedLayout: .nonMedia), withCompletionHandler: nil)
+        sdlManager.screenManager.changeLayout(SDLTemplateConfiguration(predefinedLayout: MenuManager.currentTemplate), withCompletionHandler: nil)
 
         updateScreen()
     }

--- a/Example Apps/Example Swift/ProxyManager.swift
+++ b/Example Apps/Example Swift/ProxyManager.swift
@@ -39,19 +39,6 @@ class ProxyManager: NSObject {
         currentTemplate = .nonMedia
         super.init()
     }
-
-    var refreshTemplateHandler: RefreshTemplateHandler {
-        return { [weak self] template in
-            let errorMessage = "Changing the template failed"
-            self?.currentTemplate = template
-            self?.sdlManager.screenManager.changeLayout(SDLTemplateConfiguration(predefinedLayout: template)) { err in
-                if err != nil {
-                    AlertManager.sendAlert(textField1: errorMessage, sdlManager: (self?.sdlManager)!)
-                    return
-                }
-            }
-        }
-    }
 }
 
 // MARK: - SDL Configuration
@@ -262,6 +249,20 @@ private extension ProxyManager {
     var refreshUIHandler: RefreshUIHandler? {
         return { [unowned self] () in
             self.updateScreen()
+        }
+    }
+
+    /// Handler for refreshing the template
+    var refreshTemplateHandler: RefreshTemplateHandler {
+        return { [weak self] template in
+            let errorMessage = "Changing the template failed"
+            self?.currentTemplate = template
+            self?.sdlManager.screenManager.changeLayout(SDLTemplateConfiguration(predefinedLayout: template)) { err in
+                if err != nil {
+                    AlertManager.sendAlert(textField1: errorMessage, sdlManager: (self?.sdlManager)!)
+                    return
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #1827 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [ ] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
N/A

#### Core Tests
N/A

Core version / branch / commit hash / module tested against: N/A
HMI name / version / branch / commit hash / module tested against: N/A

### Summary
Fixed template issue, when the user switched HMI level from full to background and the back to full, the template was being reset to the default one(nonMedia)

### Changelog
##### Breaking Changes
* N/A

##### Enhancements
* N/A

##### Bug Fixes
* Fixed template issue, when the user switched HMI level from full to background and the back to full, the template was being reset to the default one(nonMedia)

### Tasks Remaining:
N/A

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
