### PR TITLE
RPC spec generator now adds the default_value to the documentation for enum and bool parameters

### DIFF
--- a/generator/transformers/common_producer.py
+++ b/generator/transformers/common_producer.py
@@ -368,20 +368,37 @@ class InterfaceProducerCommon(ABC):
         if isinstance(param.param_type, (Integer, Float, String, Array)):
             data['description'].append(self.create_param_type_descriptor(param.param_type, OrderedDict()))
 
-        if isinstance(param.param_type, (Enum)) and param.default_value:
-            print('\nEnum default value whoo ' + param.default_value.name)
-            for key, value in param.__dict__.items():
-                print('key ' + key + ', value ' + str(value))
-            for key, value in param.param_type.__dict__.items():
-                print('\tparam_type key ' + key + ', value ' + str(value))
+        if isinstance(param.param_type, (Integer, Float, Boolean, Enum)):
+            param_descriptor = self.create_param_default_value_descriptor(param, OrderedDict())
+            if param_descriptor:
+                data['description'].append(param_descriptor)
 
         data.update(self.extract_type(param))
         data.update(self.param_origin_change(param.name))
         return self.param_named(**data)
 
+    def create_param_default_value_descriptor(self, param, parameterItems):
+        """
+        Creates a documentation string of the default value for a parameter.
+        :param param: param from the initial Model
+        :param parameterItems: Ordered dictionary that stores each of the parameter's descriptors
+        :return: All the descriptor params from param_type concatenated into one string
+        """
+        if param.default_value is None:
+            return ""
+
+        if isinstance(param.param_type, Enum):
+            print('adding Enum default_value ' + str(param.default_value) + ' for: ' + param.name)
+            parameterItems['default_value'] = param.default_value.name
+        else:
+            print('adding Non-Enum default_value ' + str(param.default_value) + ' for: ' + param.name)
+            parameterItems['default_value'] = param.default_value
+
+        return json.dumps(parameterItems, sort_keys=False)
+
     def create_param_type_descriptor(self, param_type, parameterItems):
         """
-        Recursively creates a documentation string of all the descriptors for a parameter (e.g. {"string_min_length": 1, string_max_length": 500}). The parameters should be returned in the same order they were added to the parameterItems dictionary
+        Recursively creates a documentation string of all the descriptors for a parameter type (e.g. {"string_min_length": 1, string_max_length": 500}). The parameters should be returned in the same order they were added to the parameterItems dictionary
         :param param_type: param_type from the initial Model
         :param parameterItems: Ordered dictionary that stores each of the parameter's descriptors
         :return: All the descriptor params from param_type concatenated into one string

--- a/generator/transformers/common_producer.py
+++ b/generator/transformers/common_producer.py
@@ -366,15 +366,15 @@ class InterfaceProducerCommon(ABC):
                 'modifier': 'strong',
                 'history' : param.history }
 
-        parameter_docs = OrderedDict()
+        parameterItems = OrderedDict()
         if isinstance(param.param_type, (Integer, Float, String, Array)):
-            self.create_param_type_descriptor(param.param_type, parameter_docs)
+            self.create_param_type_descriptor(param.param_type, parameterItems)
 
         if isinstance(param.param_type, (Boolean, Enum)):
-            self.create_param_default_value_descriptor(param, parameter_docs)
+            self.create_param_default_value_descriptor(param, parameterItems)
 
-        if len(parameter_docs) > 0:
-            data['description'].append(json.dumps(parameter_docs, sort_keys=False))
+        if len(parameterItems) > 0:
+            data['description'].append(json.dumps(parameterItems, sort_keys=False))
 
         data.update(self.extract_type(param))
         data.update(self.param_origin_change(param.name))

--- a/generator/transformers/common_producer.py
+++ b/generator/transformers/common_producer.py
@@ -366,13 +366,20 @@ class InterfaceProducerCommon(ABC):
                 'modifier': 'strong',
                 'history' : param.history }
         if isinstance(param.param_type, (Integer, Float, String, Array)):
-            data['description'].append(self.create_param_descriptor(param.param_type, OrderedDict()))
+            data['description'].append(self.create_param_type_descriptor(param.param_type, OrderedDict()))
+
+        if isinstance(param.param_type, (Enum)) and param.default_value:
+            print('\nEnum default value whoo ' + param.default_value.name)
+            for key, value in param.__dict__.items():
+                print('key ' + key + ', value ' + str(value))
+            for key, value in param.param_type.__dict__.items():
+                print('\tparam_type key ' + key + ', value ' + str(value))
 
         data.update(self.extract_type(param))
         data.update(self.param_origin_change(param.name))
         return self.param_named(**data)
 
-    def create_param_descriptor(self, param_type, parameterItems):
+    def create_param_type_descriptor(self, param_type, parameterItems):
         """
         Recursively creates a documentation string of all the descriptors for a parameter (e.g. {"string_min_length": 1, string_max_length": 500}). The parameters should be returned in the same order they were added to the parameterItems dictionary
         :param param_type: param_type from the initial Model
@@ -387,7 +394,7 @@ class InterfaceProducerCommon(ABC):
                     # Skip adding documentation for the data type if it is a struct or enum. This is unnecessary as each enum or struct has its own documentation
                     continue
                 else:
-                    self.create_param_descriptor(value, parameterItems)
+                    self.create_param_type_descriptor(value, parameterItems)
             else:
                 if key == 'default_value' and value is None:
                     # Do not add the default_value key/value pair unless it has been explicitly set in the RPC Spec

--- a/generator/transformers/common_producer.py
+++ b/generator/transformers/common_producer.py
@@ -365,6 +365,8 @@ class InterfaceProducerCommon(ABC):
                 'deprecated': json.loads(param.deprecated.lower()) if param.deprecated else False,
                 'modifier': 'strong',
                 'history': param.history}
+
+        parameterItems = OrderedDict()
         if isinstance(param.param_type, (Integer, Float, String, Array)):
             self.create_param_type_descriptor(param.param_type, parameterItems)
 

--- a/generator/transformers/common_producer.py
+++ b/generator/transformers/common_producer.py
@@ -382,7 +382,7 @@ class InterfaceProducerCommon(ABC):
 
     def create_param_type_descriptor(self, param_type, parameterItems):
         """
-        Gets all the descriptors for a parameter (e.g. {"string_min_length": 1, string_max_length": 500}). The parameters should be returned in the same order they were added to the parameterItems dictionary
+        Gets all the descriptors for a parameter to be used in parameter's documentation (e.g. {"string_min_length": 1, string_max_length": 500}). The parameters should be returned in the same order they were added to the parameterItems dictionary
         :param param_type: param_type from the initial Model
         :param parameterItems: Ordered dictionary that stores each of the parameter's descriptors
         :return: All the descriptor params
@@ -408,7 +408,7 @@ class InterfaceProducerCommon(ABC):
 
     def create_param_default_value_descriptor(self, param, parameterItems):
         """
-        Creates a documentation string of the default value for a parameter from the param. (HAX: The default_value for Enums and Bools are not saved to the param's param_type model for some reason)
+        Extracts the default value for a parameter to be used in parameter's documentation (HAX: The default_value for Ints and Floats is save to both the param and param_type but is only saved to the param_type for Enums and Bools for some reason)
         :param param: param from the initial Model
         :param parameterItems: Ordered dictionary that stores each of the parameter's descriptors
         :return: All the descriptor params

--- a/generator/transformers/common_producer.py
+++ b/generator/transformers/common_producer.py
@@ -385,7 +385,7 @@ class InterfaceProducerCommon(ABC):
         Gets all the descriptors for a parameter (e.g. {"string_min_length": 1, string_max_length": 500}). The parameters should be returned in the same order they were added to the parameterItems dictionary
         :param param_type: param_type from the initial Model
         :param parameterItems: Ordered dictionary that stores each of the parameter's descriptors
-        :return: All the descriptor params from param_type concatenated into one string
+        :return: All the descriptor params
         """
         # The key is a descriptor (i.e. max_value) and value is the associated value (i.e. 100). Some values will be dictionaries that have to be parsed to get additional descriptors (e.g. the value for an array of strings' data type will be sub-dictionary describing the min_length, max_length, and default value for the strings used in the array)
         for key, value in param_type.__dict__.items():
@@ -411,7 +411,7 @@ class InterfaceProducerCommon(ABC):
         Creates a documentation string of the default value for a parameter from the param. (HAX: The default_value for Enums and Bools are not saved to the param's param_type model for some reason)
         :param param: param from the initial Model
         :param parameterItems: Ordered dictionary that stores each of the parameter's descriptors
-        :return: All the descriptor params from param_type concatenated into one string
+        :return: All the descriptor params
         """
         if param.default_value is None:
             return parameterItems


### PR DESCRIPTION
Fixes #1751.

This PR is dependent on RPC_Spec issue [no.285](https://github.com/smartdevicelink/rpc_spec/issues/285) being fixed.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Unit tests were run.

#### Core Tests
The library was not modified. Only the RPC Spec generator was modified.

Core version / branch / commit hash / module tested against: N/A
HMI name / version / branch / commit hash / module tested against: N/A

### Summary
The RPC spec generator now adds the `default_value` to the documentation for `enum` and `bool` parameters. 

### Changelog
##### Bug Fixes
* The RPC spec generator now adds the `default_value` to the documentation for all types of parameters.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
