### PR TITLE
Put SDL queues at the highest priority

### DIFF
--- a/SmartDeviceLink/private/SDLChoiceSetManager.m
+++ b/SmartDeviceLink/private/SDLChoiceSetManager.m
@@ -147,6 +147,7 @@ UInt16 const ChoiceCellCancelIdMin = 1;
     NSOperationQueue *queue = [[NSOperationQueue alloc] init];
     queue.name = @"com.sdl.screenManager.choiceSetManager.transactionQueue";
     queue.maxConcurrentOperationCount = 1;
+    queue.qualityOfService = NSQualityOfServiceUserInteractive;
     queue.underlyingQueue = [SDLGlobals sharedGlobals].sdlConcurrentQueue;
     queue.suspended = YES;
 

--- a/SmartDeviceLink/private/SDLGlobals.m
+++ b/SmartDeviceLink/private/SDLGlobals.m
@@ -60,8 +60,8 @@ typedef NSNumber *MTUBox;
     _rpcVersion = [[SDLVersion alloc] initWithString:@"1.0.0"];
     _dynamicMTUDict = [NSMutableDictionary dictionary];
 
-    dispatch_queue_attr_t qosSerial = dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL, QOS_CLASS_USER_INITIATED, 0);
-    dispatch_queue_attr_t qosConcurrent = dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_CONCURRENT, QOS_CLASS_USER_INITIATED, 0);
+    dispatch_queue_attr_t qosSerial = dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL, QOS_CLASS_USER_INTERACTIVE, 0);
+    dispatch_queue_attr_t qosConcurrent = dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_CONCURRENT, QOS_CLASS_USER_INTERACTIVE, 0);
 
     _sdlProcessingQueue = dispatch_queue_create(SDLProcessingQueueName, qosSerial);
     dispatch_queue_set_specific(_sdlProcessingQueue, SDLProcessingQueueName, SDLProcessingQueueName, NULL);

--- a/SmartDeviceLink/private/SDLLifecycleManager.m
+++ b/SmartDeviceLink/private/SDLLifecycleManager.m
@@ -157,6 +157,7 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
 
     _rpcOperationQueue = [[NSOperationQueue alloc] init];
     _rpcOperationQueue.name = @"com.sdl.lifecycle.rpcOperation.concurrent";
+    _rpcOperationQueue.qualityOfService = NSQualityOfServiceUserInteractive;
     _rpcOperationQueue.underlyingQueue = [SDLGlobals sharedGlobals].sdlConcurrentQueue;
     _lifecycleQueue = dispatch_queue_create_with_target("com.sdl.lifecycle", DISPATCH_QUEUE_SERIAL, [SDLGlobals sharedGlobals].sdlProcessingQueue);
 

--- a/SmartDeviceLink/private/SDLSoftButtonManager.m
+++ b/SmartDeviceLink/private/SDLSoftButtonManager.m
@@ -11,6 +11,7 @@
 #import "SDLConnectionManagerType.h"
 #import "SDLError.h"
 #import "SDLFileManager.h"
+#import "SDLGlobals.h"
 #import "SDLLogMacros.h"
 #import "SDLOnHMIStatus.h"
 #import "SDLPredefinedWindows.h"
@@ -94,7 +95,8 @@ NS_ASSUME_NONNULL_BEGIN
     NSOperationQueue *queue = [[NSOperationQueue alloc] init];
     queue.name = @"SDLSoftButtonManager Transaction Queue";
     queue.maxConcurrentOperationCount = 1;
-    queue.qualityOfService = NSQualityOfServiceUserInitiated;
+    queue.qualityOfService = NSQualityOfServiceUserInteractive;
+    queue.underlyingQueue = [SDLGlobals sharedGlobals].sdlConcurrentQueue;
     queue.suspended = YES;
 
     return queue;

--- a/SmartDeviceLink/private/SDLSoftButtonReplaceOperation.m
+++ b/SmartDeviceLink/private/SDLSoftButtonReplaceOperation.m
@@ -175,7 +175,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     SDLShow *show = [[SDLShow alloc] init];
-    show.mainField1 = self.mainField1;
+    show.mainField1 = self.mainField1 ?: @"";
     show.softButtons = [softButtons copy];
 
     [self.connectionManager sendConnectionRequest:show withResponseHandler:^(__kindof SDLRPCRequest * _Nullable request, __kindof SDLRPCResponse * _Nullable response, NSError * _Nullable error) {

--- a/SmartDeviceLink/private/SDLSoftButtonReplaceOperation.m
+++ b/SmartDeviceLink/private/SDLSoftButtonReplaceOperation.m
@@ -174,6 +174,7 @@ NS_ASSUME_NONNULL_BEGIN
         [softButtons addObject:buttonObject.currentStateSoftButton];
     }
 
+    // HAX: Work around a bug in Sync where not sending a main field when sending soft buttons will lock up the head unit for 10-15 seconds.
     SDLShow *show = [[SDLShow alloc] init];
     show.mainField1 = self.mainField1 ?: @"";
     show.softButtons = [softButtons copy];

--- a/SmartDeviceLink/private/SDLSoftButtonTransitionOperation.m
+++ b/SmartDeviceLink/private/SDLSoftButtonTransitionOperation.m
@@ -50,6 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)sdl_sendNewSoftButtons {
+    // HAX: Work around a bug in Sync where not sending a main field when sending soft buttons will lock up the head unit for 10-15 seconds.
     SDLShow *newShow = [[SDLShow alloc] init];
     newShow.mainField1 = self.mainField1 ?: @"";
     newShow.softButtons = [self sdl_currentStateSoftButtonsForObjects:self.softButtons];

--- a/SmartDeviceLink/private/SDLSoftButtonTransitionOperation.m
+++ b/SmartDeviceLink/private/SDLSoftButtonTransitionOperation.m
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)sdl_sendNewSoftButtons {
     SDLShow *newShow = [[SDLShow alloc] init];
-    newShow.mainField1 = self.mainField1;
+    newShow.mainField1 = self.mainField1 ?: @"";
     newShow.softButtons = [self sdl_currentStateSoftButtonsForObjects:self.softButtons];
 
     [self.connectionManager sendConnectionRequest:newShow withResponseHandler:^(__kindof SDLRPCRequest * _Nullable request, __kindof SDLRPCResponse * _Nullable response, NSError * _Nullable error) {

--- a/SmartDeviceLink/private/SDLTextAndGraphicManager.m
+++ b/SmartDeviceLink/private/SDLTextAndGraphicManager.m
@@ -13,6 +13,7 @@
 #import "SDLDisplayCapability.h"
 #import "SDLError.h"
 #import "SDLFileManager.h"
+#import "SDLGlobals.h"
 #import "SDLImage.h"
 #import "SDLLogMacros.h"
 #import "SDLMetadataTags.h"
@@ -127,7 +128,8 @@ NS_ASSUME_NONNULL_BEGIN
     NSOperationQueue *queue = [[NSOperationQueue alloc] init];
     queue.name = @"SDLTextAndGraphicManager Transaction Queue";
     queue.maxConcurrentOperationCount = 1;
-    queue.qualityOfService = NSQualityOfServiceUserInitiated;
+    queue.qualityOfService = NSQualityOfServiceUserInteractive;
+    queue.underlyingQueue = [SDLGlobals sharedGlobals].sdlConcurrentQueue;
     queue.suspended = YES;
 
     return queue;


### PR DESCRIPTION
Fixes #1778

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
No unit tests were needed

#### Core Tests
Verified lots of screen manager behavior with SDL Core. Slight improvements are possible, but it's not super easy to tell, especially if testing against Sync.

Core version / branch / commit hash / module tested against: Sync Gen 3.4
HMI name / version / branch / commit hash / module tested against: Sync Gen 3.4

### Summary
This update moves SDL queues to be at the highest priority level instead of the second-highest priority level, and additionally changes the soft button operations to always send `Show.mainField1` even if it should be blank.

### Changelog
##### Bug Fixes
* SDL code now runs at the highest priority level. Note that this may delay calls to the main thread, which may impact UI performance. However, because SDL code only runs when an SDL app is connected, this should be okay and should improve SDL performance and lag.
* SDL soft button operations now always send `Show.mainField1`, which works around a bug on Ford Sync head units.

### Tasks Remaining:
- [x] Additional testing with video streaming apps
- [x] See if any metrics can be generated

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
