### PR TITLE
WIP:Fix Soft Buttons handlers are never removed

### DIFF
--- a/SmartDeviceLink/private/SDLResponseDispatcher.h
+++ b/SmartDeviceLink/private/SDLResponseDispatcher.h
@@ -46,9 +46,19 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic, readonly) NSMapTable<SDLSubscribeButtonName *, SDLRPCButtonNotificationHandler> *buttonHandlerMap;
 
 /**
- *  Holds a map of soft button ids and their corresponding blocks.
+ *  Holds a map of SDLShow soft button ids and their corresponding blocks.
  */
-@property (strong, nonatomic, readonly) NSMapTable<SDLSoftButtonId *, SDLRPCButtonNotificationHandler> *customButtonHandlerMap;
+@property (strong, nonatomic, readonly) NSMapTable<SDLSoftButtonId *, SDLRPCButtonNotificationHandler> *showButtonHandlerMap;
+
+/**
+*  Holds a map of SDLAlert soft button ids and their corresponding blocks.
+*/
+@property (strong, nonatomic, readonly) NSMapTable<SDLSoftButtonId *, SDLRPCButtonNotificationHandler> *alertButtonHandlerMap;
+
+/**
+*  Holds a map of SDLScrollableMessage soft button ids and their corresponding blocks.
+*/
+@property (strong, nonatomic, readonly) NSMapTable<SDLSoftButtonId *, SDLRPCButtonNotificationHandler> *scrollMsgButtonHandlerMap;
 
 /**
  *  Holds an audio pass thru block.

--- a/SmartDeviceLink/private/SDLResponseDispatcher.m
+++ b/SmartDeviceLink/private/SDLResponseDispatcher.m
@@ -72,7 +72,9 @@ NS_ASSUME_NONNULL_BEGIN
     _rpcRequestDictionary = [NSMutableDictionary dictionary];
     _commandHandlerMap = [NSMapTable mapTableWithKeyOptions:NSMapTableCopyIn valueOptions:NSMapTableCopyIn];
     _buttonHandlerMap = [NSMapTable mapTableWithKeyOptions:NSMapTableCopyIn valueOptions:NSMapTableCopyIn];
-    _customButtonHandlerMap = [NSMapTable mapTableWithKeyOptions:NSMapTableCopyIn valueOptions:NSMapTableCopyIn];
+    _showButtonHandlerMap = [NSMapTable mapTableWithKeyOptions:NSMapTableCopyIn valueOptions:NSMapTableCopyIn];
+    _alertButtonHandlerMap = [NSMapTable mapTableWithKeyOptions:NSMapTableCopyIn valueOptions:NSMapTableCopyIn];
+    _scrollMsgButtonHandlerMap = [NSMapTable mapTableWithKeyOptions:NSMapTableCopyIn valueOptions:NSMapTableCopyIn];
 
     // Responses
     for (SDLNotificationName responseName in [SDLNotificationConstants allResponseNames]) {
@@ -127,7 +129,8 @@ NS_ASSUME_NONNULL_BEGIN
         }
     } else if ([request isKindOfClass:[SDLAlert class]]) {
         SDLAlert *alert = (SDLAlert *)request;
-        [self sdl_addToCustomButtonHandlerMap:alert.softButtons];
+        [self sdl_clearCustomButtonHandlerMap:self.alertButtonHandlerMap softButtons:alert.softButtons];
+        [self sdl_addToCustomButtonHandlerMap:self.alertButtonHandlerMap softButtons:alert.softButtons];
     } else if ([request isKindOfClass:[SDLAlertManeuver class]]) {
         SDLAlertManeuver *alertManeuver = (SDLAlertManeuver *)request;
         [self sdl_addToCustomButtonHandlerMap:alertManeuver.softButtons];
@@ -136,10 +139,12 @@ NS_ASSUME_NONNULL_BEGIN
         [self sdl_addToCustomButtonHandlerMap:subtleAlert.softButtons];
     } else if ([request isKindOfClass:[SDLScrollableMessage class]]) {
         SDLScrollableMessage *scrollableMessage = (SDLScrollableMessage *)request;
-        [self sdl_addToCustomButtonHandlerMap:scrollableMessage.softButtons];
+        [self sdl_clearCustomButtonHandlerMap:self.scrollMsgButtonHandlerMap softButtons:scrollableMessage.softButtons];
+        [self sdl_addToCustomButtonHandlerMap:self.scrollMsgButtonHandlerMap softButtons:scrollableMessage.softButtons];
     } else if ([request isKindOfClass:[SDLShow class]]) {
         SDLShow *show = (SDLShow *)request;
-        [self sdl_addToCustomButtonHandlerMap:show.softButtons];
+       [self sdl_clearCustomButtonHandlerMap:self.showButtonHandlerMap softButtons:show.softButtons];
+        [self sdl_addToCustomButtonHandlerMap:self.showButtonHandlerMap softButtons:show.softButtons];
     } else if ([request isKindOfClass:[SDLShowConstantTBT class]]) {
         SDLShowConstantTBT *showConstantTBT = (SDLShowConstantTBT *)request;
         [self sdl_addToCustomButtonHandlerMap:showConstantTBT.softButtons];
@@ -202,13 +207,27 @@ NS_ASSUME_NONNULL_BEGIN
         [strongself->_rpcResponseHandlerMap removeAllObjects];
         [strongself->_commandHandlerMap removeAllObjects];
         [strongself->_buttonHandlerMap removeAllObjects];
-        [strongself->_customButtonHandlerMap removeAllObjects];
+        [strongself->_showButtonHandlerMap removeAllObjects];
+        [strongself->_alertButtonHandlerMap removeAllObjects];
+        [strongself->_scrollMsgButtonHandlerMap removeAllObjects];
         strongself->_audioPassThruHandler = nil;
     }];
 }
 
-- (void)sdl_addToCustomButtonHandlerMap:(NSArray<SDLSoftButton *> *)softButtons {
-    __weak typeof(self) weakself = self;
+- (void)sdl_clearCustomButtonHandlerMap:(NSMapTable<SDLSoftButtonId *, SDLRPCButtonNotificationHandler> *)customButtonHandlerMap softButtons:(NSArray<SDLSoftButton *> *)softButtons {
+    NSLog(@"SDLResponseDispatcher sdl_clearCustomButtonHandlerMap");
+    if (softButtons.count) {
+        [self sdl_runAsyncOnQueue:^{
+            [customButtonHandlerMap removeAllObjects];
+        }];
+    }
+    else {
+        // App defined SoftButtons. If omitted on supported displays, the currently displayed SoftButton values will not change.
+        NSLog(@"SDLResponseDispatcher sdl_clearCustomButtonHandlerMap SoftButton values will not change");
+    }
+}
+
+- (void)sdl_addToCustomButtonHandlerMap:(NSMapTable<SDLSoftButtonId *, SDLRPCButtonNotificationHandler> *)customButtonHandlerMap softButtons:(NSArray<SDLSoftButton *> *)softButtons {
     for (SDLSoftButton *sb in softButtons) {
         if (sb.softButtonID == nil) {
             @throw [NSException sdl_missingIdException];
@@ -216,8 +235,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         if (sb.handler != nil) {
             [self sdl_runAsyncOnQueue:^{
-                __strong typeof(weakself) strongself = weakself;
-                strongself->_customButtonHandlerMap[sb.softButtonID] = sb.handler;
+                customButtonHandlerMap[sb.softButtonID] = sb.handler;
             }];
         }
     }
@@ -312,7 +330,7 @@ NS_ASSUME_NONNULL_BEGIN
     SDLRPCButtonNotificationHandler handler = nil;
     if ([name isEqualToEnum:SDLButtonNameCustomButton]) {
         // Custom buttons
-        handler = self.customButtonHandlerMap[customID];
+        handler = [self sdl_getCustomButtonHandler:customID];
     } else {
         // Static buttons
         handler = self.buttonHandlerMap[name];
@@ -329,6 +347,33 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
     
+- (SDLRPCButtonNotificationHandler)sdl_getCustomButtonHandler:(NSNumber *)customID {
+    NSLog(@"SDLResponseDispatcher sdl_getCustomButtonHandler customID = %@", customID);
+    SDLRPCButtonNotificationHandler handler = nil;
+    NSArray<NSNumber *>* showBtnkeys = [self.showButtonHandlerMap keyEnumerator].allObjects;
+    for (NSUInteger i = 0; i < showBtnkeys.count; i++) {
+        if (customID == [showBtnkeys objectAtIndex:i]) {
+            handler = self.showButtonHandlerMap[customID];
+            return handler;
+        }
+    }
+    NSArray<NSNumber *>* alertkeys = [self.alertButtonHandlerMap keyEnumerator].allObjects;
+    for (NSUInteger i = 0; i < alertkeys.count; i++) {
+        if (customID == [alertkeys objectAtIndex:i]) {
+            handler = self.alertButtonHandlerMap[customID];
+            return handler;
+        }
+    }
+    NSArray<NSNumber *>* scrollMsgkeys = [self.scrollMsgButtonHandlerMap keyEnumerator].allObjects;
+    for (NSUInteger i = 0; i < scrollMsgkeys.count; i++) {
+        if (customID == [scrollMsgkeys objectAtIndex:i]) {
+            handler = self.scrollMsgButtonHandlerMap[customID];
+            return handler;
+        }
+    }
+    return handler;
+}
+
 #pragma mark Audio Pass Thru
     
 - (void)sdl_runHandlerForAudioPassThru:(SDLRPCNotificationNotification *)notification {

--- a/SmartDeviceLinkTests/Notifications/SDLResponseDispatcherSpec.m
+++ b/SmartDeviceLinkTests/Notifications/SDLResponseDispatcherSpec.m
@@ -46,14 +46,18 @@ describe(@"a response dispatcher", ^{
         expect(testDispatcher.rpcRequestDictionary).toNot(beNil());
         expect(testDispatcher.commandHandlerMap).toNot(beNil());
         expect(testDispatcher.buttonHandlerMap).toNot(beNil());
-        expect(testDispatcher.customButtonHandlerMap).toNot(beNil());
+        expect(testDispatcher.showButtonHandlerMap).toNot(beNil());
+        expect(testDispatcher.alertButtonHandlerMap).toNot(beNil());
+        expect(testDispatcher.scrollMsgButtonHandlerMap).toNot(beNil());
 //        expect(testDispatcher.audioPassThruHandler).to(beNil());
 
         expect(testDispatcher.rpcResponseHandlerMap).to(haveCount(@0));
         expect(testDispatcher.rpcRequestDictionary).to(haveCount(@0));
         expect(testDispatcher.commandHandlerMap).to(haveCount(@0));
         expect(testDispatcher.buttonHandlerMap).to(haveCount(@0));
-        expect(testDispatcher.customButtonHandlerMap).to(haveCount(@0));
+        expect(testDispatcher.showButtonHandlerMap).to(haveCount(@0));
+        expect(testDispatcher.alertButtonHandlerMap).to(haveCount(@0));
+        expect(testDispatcher.scrollMsgButtonHandlerMap).to(haveCount(@0));
     });
     
     context(@"storing a request without a handler", ^{
@@ -73,7 +77,9 @@ describe(@"a response dispatcher", ^{
             expect(testDispatcher.rpcRequestDictionary).to(haveCount(@1));
             expect(testDispatcher.commandHandlerMap).to(haveCount(@0));
             expect(testDispatcher.buttonHandlerMap).to(haveCount(@0));
-            expect(testDispatcher.customButtonHandlerMap).to(haveCount(@0));
+            expect(testDispatcher.showButtonHandlerMap).to(haveCount(@0));
+            expect(testDispatcher.alertButtonHandlerMap).to(haveCount(@0));
+            expect(testDispatcher.scrollMsgButtonHandlerMap).to(haveCount(@0));
         });
     });
     
@@ -142,8 +148,8 @@ describe(@"a response dispatcher", ^{
             });
             
             it(@"should add the soft button to the map", ^{
-                expect(testDispatcher.customButtonHandlerMap[testSoftButton1.softButtonID]).toNot(beNil());
-                expect(testDispatcher.customButtonHandlerMap).to(haveCount(@1));
+                expect(testDispatcher.showButtonHandlerMap[testSoftButton1.softButtonID]).toNot(beNil());
+                expect(testDispatcher.showButtonHandlerMap).to(haveCount(@1));
             });
             
             describe(@"when button press and button event notifications arrive", ^{
@@ -200,7 +206,7 @@ describe(@"a response dispatcher", ^{
             });
             
             it(@"should not add the soft button", ^{
-                expect(testDispatcher.customButtonHandlerMap).to(haveCount(@0));
+                expect(testDispatcher.showButtonHandlerMap).to(haveCount(@0));
             });
         });
         
@@ -224,7 +230,7 @@ describe(@"a response dispatcher", ^{
             it(@"should not store the request", ^{
                 [testDispatcher storeRequest:testShow handler:nil];
                 
-                expect(testDispatcher.customButtonHandlerMap).to(haveCount(@0));
+                expect(testDispatcher.showButtonHandlerMap).to(haveCount(@0));
             });
         });
     });
@@ -505,8 +511,8 @@ describe(@"a response dispatcher", ^{
             });
             
             it(@"should add the soft button to the map", ^{
-                expect(testDispatcher.customButtonHandlerMap[testSoftButton1.softButtonID]).toNot(beNil());
-                expect(testDispatcher.customButtonHandlerMap).to(haveCount(@1));
+                expect(testDispatcher.alertButtonHandlerMap[testSoftButton1.softButtonID]).toNot(beNil());
+                expect(testDispatcher.alertButtonHandlerMap).to(haveCount(@1));
             });
             
             describe(@"when button press and button event notifications arrive", ^{
@@ -563,7 +569,7 @@ describe(@"a response dispatcher", ^{
             });
             
             it(@"should not add the soft button", ^{
-                expect(testDispatcher.customButtonHandlerMap).to(haveCount(@0));
+                expect(testDispatcher.alertButtonHandlerMap).to(haveCount(@0));
             });
         });
         
@@ -587,7 +593,7 @@ describe(@"a response dispatcher", ^{
             it(@"should not store the request", ^{
                 [testDispatcher storeRequest:testAlert handler:nil];
                 
-                expect(testDispatcher.customButtonHandlerMap).to(haveCount(@0));
+                expect(testDispatcher.alertButtonHandlerMap).to(haveCount(@0));
             });
         });
     });
@@ -949,8 +955,8 @@ describe(@"a response dispatcher", ^{
             });
             
             it(@"should add the soft button to the map", ^{
-                expect(testDispatcher.customButtonHandlerMap[testSoftButton1.softButtonID]).toNot(beNil());
-                expect(testDispatcher.customButtonHandlerMap).to(haveCount(@1));
+                expect(testDispatcher.scrollMsgButtonHandlerMap[testSoftButton1.softButtonID]).toNot(beNil());
+                expect(testDispatcher.scrollMsgButtonHandlerMap).to(haveCount(@1));
             });
             
             describe(@"when button press and button event notifications arrive", ^{
@@ -1007,7 +1013,7 @@ describe(@"a response dispatcher", ^{
             });
             
             it(@"should not add the soft button", ^{
-                expect(testDispatcher.customButtonHandlerMap).to(haveCount(@0));
+                expect(testDispatcher.scrollMsgButtonHandlerMap).to(haveCount(@0));
             });
         });
         
@@ -1031,7 +1037,7 @@ describe(@"a response dispatcher", ^{
             it(@"should not store the request", ^{
                 [testDispatcher storeRequest:testScrollableMessage handler:nil];
                 
-                expect(testDispatcher.customButtonHandlerMap).to(haveCount(@0));
+                expect(testDispatcher.scrollMsgButtonHandlerMap).to(haveCount(@0));
             });
         });
     });


### PR DESCRIPTION
Fixes #515 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
unit tests were run

#### Core Tests
Tested the old SoftButton handlers are removed from memory.

Core version / branch / commit hash / module tested against: 6.0.1
HMI name / version / branch / commit hash / module tested against: N/A

### Summary
1.  Add containers (`showButtonHandlerMap`、`alertButtonHandlerMap`、`scrollMsgButtonHandlerMap`) to restore `softButtonHandlers` of RPC(`SDLShow`、`SDLAlert`、`SDLScrollableMessage`).
2. Every time you want to save a new handler object, first delete the old handler in the corresponding container. If there is no `softbuttonhandler` currently, the container does not need to be emptied.
3. When `softbutton` is clicked, the corresponding handler is found from three containers according to the button ID. If the handler object is found, it will be sent to the app.
![image](https://user-images.githubusercontent.com/35795928/84655649-4a786180-af4c-11ea-99b4-4288e545bf15.png)

### Changelog
##### Breaking Changes
* N/A

##### Enhancements
* N/A

##### Bug Fixes
* N/A

### Tasks Remaining:
* N/A

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)