### PR TITLE
Bugfix 1847 library stops working if startservice times out

### DIFF
--- a/SmartDeviceLink/private/SDLIAPTransport.m
+++ b/SmartDeviceLink/private/SDLIAPTransport.m
@@ -57,6 +57,10 @@ int const CreateSessionRetries = 3;
     return self;
 }
 
+- (void)dealloc {
+    [self sdl_stopEventListening];
+}
+
 #pragma mark - Notifications
 
 /**
@@ -217,8 +221,6 @@ int const CreateSessionRetries = 3;
  */
 - (void)disconnectWithCompletionHandler:(void (^)(void))disconnectCompletionHandler {
     SDLLogD(@"Disconnecting IAP transport");
-    // Stop event listening here so that even if the transport is disconnected by `SDLProxy` when there is a start session timeout, the class unregisters for accessory notifications
-    [self sdl_stopEventListening];
 
     self.retryCounter = 0;
     self.sessionSetupInProgress = NO;


### PR DESCRIPTION
Fixes #1847 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [ ] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

### Summary
Changes the moment when a transport object removes observers to EA(dis)connect.

### Tasks Remaining:
- [ ] [Perform unit tests]
- [ ] [Test with and without secondary transport]
- [ ] [Verify the transport is deallocated properly when a new one is created]

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
