### PR TITLE
[SDL 0297] Add function to transmit audio data of AudioStream in time division

### DIFF
--- a/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
+++ b/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		000DD57622EF0971005AB7A7 /* SDLReleaseInteriorVehicleDataModuleResponseSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 000DD57522EF0971005AB7A7 /* SDLReleaseInteriorVehicleDataModuleResponseSpec.m */; };
 		00EADD3322DFE54B0088B608 /* SDLEncryptionLifecycleManagerSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 00EADD3222DFE54B0088B608 /* SDLEncryptionLifecycleManagerSpec.m */; };
 		00EADD3522DFE5670088B608 /* SDLEncryptionConfigurationSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 00EADD3422DFE5670088B608 /* SDLEncryptionConfigurationSpec.m */; };
+		040C7934255A589300AAB8EB /* dispatch_timer.h in Headers */ = {isa = PBXBuildFile; fileRef = 040C7932255A589300AAB8EB /* dispatch_timer.h */; };
+		040C7935255A589300AAB8EB /* dispatch_timer.m in Sources */ = {isa = PBXBuildFile; fileRef = 040C7933255A589300AAB8EB /* dispatch_timer.m */; };
 		106187B924AA75540045C4EC /* SDLRPCPermissionStatusSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 106187B824AA75540045C4EC /* SDLRPCPermissionStatusSpec.m */; };
 		109566F6242986F300E24F66 /* SDLCacheFileManagerSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 109566F5242986F300E24F66 /* SDLCacheFileManagerSpec.m */; };
 		1098F03824A39699004F53CC /* SDLPermissionElementSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 1098F03724A39699004F53CC /* SDLPermissionElementSpec.m */; };
@@ -1789,6 +1791,8 @@
 		000DD57522EF0971005AB7A7 /* SDLReleaseInteriorVehicleDataModuleResponseSpec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLReleaseInteriorVehicleDataModuleResponseSpec.m; sourceTree = "<group>"; };
 		00EADD3222DFE54B0088B608 /* SDLEncryptionLifecycleManagerSpec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLEncryptionLifecycleManagerSpec.m; sourceTree = "<group>"; };
 		00EADD3422DFE5670088B608 /* SDLEncryptionConfigurationSpec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLEncryptionConfigurationSpec.m; sourceTree = "<group>"; };
+		040C7932255A589300AAB8EB /* dispatch_timer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = dispatch_timer.h; path = SmartDeviceLink/public/dispatch_timer.h; sourceTree = SOURCE_ROOT; };
+		040C7933255A589300AAB8EB /* dispatch_timer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = dispatch_timer.m; path = SmartDeviceLink/public/dispatch_timer.m; sourceTree = SOURCE_ROOT; };
 		106187B824AA75540045C4EC /* SDLRPCPermissionStatusSpec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLRPCPermissionStatusSpec.m; sourceTree = "<group>"; };
 		109566F5242986F300E24F66 /* SDLCacheFileManagerSpec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLCacheFileManagerSpec.m; sourceTree = "<group>"; };
 		1098F03724A39699004F53CC /* SDLPermissionElementSpec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLPermissionElementSpec.m; sourceTree = "<group>"; };
@@ -4371,6 +4375,8 @@
 		5D23C9471FCF59F400002CA5 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				040C7932255A589300AAB8EB /* dispatch_timer.h */,
+				040C7933255A589300AAB8EB /* dispatch_timer.m */,
 				4ABB260F24F7F3520061BF55 /* SDLPCMAudioConverter.h */,
 				4ABB260E24F7F3520061BF55 /* SDLPCMAudioConverter.m */,
 				4ABB260B24F7F33F0061BF55 /* SDLAudioFile.h */,
@@ -7360,6 +7366,7 @@
 				4ABB276A24F7FE480061BF55 /* SDLHybridAppPreference.h in Headers */,
 				4A8BD37A24F9468B000945E3 /* SDLProtocolConstants.h in Headers */,
 				4ABB2B0F24F84D950061BF55 /* SDLAppInfo.h in Headers */,
+				040C7934255A589300AAB8EB /* dispatch_timer.h in Headers */,
 				4ABB2AB124F847F40061BF55 /* SDLSetDisplayLayoutResponse.h in Headers */,
 				4ABB2A5E24F847B10061BF55 /* SDLGetDTCsResponse.h in Headers */,
 				4A8BD39A24F94741000945E3 /* SDLIAPControlSessionDelegate.h in Headers */,
@@ -7768,6 +7775,7 @@
 				4ABB291724F842160061BF55 /* SDLCancelInteraction.m in Sources */,
 				4ABB279424F7FF0B0061BF55 /* SDLKeypressMode.m in Sources */,
 				4A8BD34324F945CC000945E3 /* SDLControlFramePayloadEndService.m in Sources */,
+				040C7935255A589300AAB8EB /* dispatch_timer.m in Sources */,
 				4A8BD26A24F933C7000945E3 /* SDLParameterPermissions.m in Sources */,
 				4ABB25EB24F7E7C20061BF55 /* SDLCarWindowViewController.m in Sources */,
 				4ABB284D24F828630061BF55 /* SDLTransmissionType.m in Sources */,

--- a/SmartDeviceLink/public/SDLAudioStreamManager.h
+++ b/SmartDeviceLink/public/SDLAudioStreamManager.h
@@ -59,8 +59,9 @@ NS_ASSUME_NONNULL_BEGIN
  @note This happens on a serial background thread and will provide an error callback using the delegate if the conversion fails.
 
  @param fileURL File URL to convert
+ @param forceInterrupt force Audio Stream Interrupt
  */
-- (void)pushWithFileURL:(NSURL *)fileURL;
+- (void)pushWithFileURL:(NSURL *)fileURL forceInterrupt:(BOOL)forceInterrupt;
 
 /**
  Push a new audio buffer onto the queue. Call `playNextWhenReady` to start playing the pushed audio buffer.

--- a/SmartDeviceLink/public/dispatch_timer.h
+++ b/SmartDeviceLink/public/dispatch_timer.h
@@ -1,0 +1,18 @@
+//
+//  dispatch_timer.h
+//  MobileNav
+//
+//  Created by Muller, Alexander (A.) on 5/12/16.
+//  Copyright © 2016 Alex Muller. All rights reserved.
+//
+
+#ifndef dispatch_timer_h
+#define dispatch_timer_h
+
+#include <dispatch/dispatch.h>
+#include <stdio.h>
+
+dispatch_source_t dispatch_create_timer(double afterInterval, bool repeating, dispatch_block_t block);
+void dispatch_stop_timer(dispatch_source_t timer);
+
+#endif /* dispatch_timer_h */

--- a/SmartDeviceLink/public/dispatch_timer.m
+++ b/SmartDeviceLink/public/dispatch_timer.m
@@ -1,0 +1,38 @@
+//
+//  dispatch_timer.c
+//  MobileNav
+//
+//  Created by Muller, Alexander (A.) on 5/12/16.
+//  Copyright © 2016 Alex Muller. All rights reserved.
+//
+
+#include "dispatch_timer.h"
+
+dispatch_source_t dispatch_create_timer(double afterInterval, bool repeating, dispatch_block_t block) {
+    dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT,
+                                                       0);
+    dispatch_source_t timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER,
+                                                     0,
+                                                     0,
+                                                     queue);
+    dispatch_source_set_timer(timer,
+                              dispatch_time(DISPATCH_TIME_NOW, (int64_t)(afterInterval * NSEC_PER_SEC)),
+                              (uint64_t)(afterInterval * NSEC_PER_SEC),
+                              (1ull * NSEC_PER_SEC) / 10);
+    dispatch_source_set_event_handler(timer, ^{
+        if (!repeating) {
+            dispatch_stop_timer(timer);
+        }
+        if (block) {
+            block();
+        }
+    });
+    dispatch_resume(timer);
+
+    return timer;
+}
+
+void dispatch_stop_timer(dispatch_source_t timer) {
+    dispatch_source_set_event_handler(timer, NULL);
+    dispatch_source_cancel(timer);
+}


### PR DESCRIPTION
Fixes #1808 

This PR is **not ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Updated Unit tests for pushWithFileURL

#### Core Tests
I have run my test app to make sure audiostream runs.
Test app: https://github.com/zx5656/sdl_video_streaming_iOS_sample
Core version / branch / commit hash / module tested against: Core 6.1
HMI name / version / branch / commit hash / module tested against: our own HMI

### Summary
This implements [SDL 0297] Add function to transmit audio data of AudioStream in time division

### Changelog
##### Breaking Changes
* N/A

##### Enhancements
* This PR adds a function that transmits time-divided audio data via AudioStreaming.

##### Bug Fixes
* issue #1808 

### Tasks Remaining:
* N/A

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
