### PR TITLE
Fix for overwriting SDLArtwork

### DIFF
--- a/SmartDeviceLink/private/SDLMenuManager.m
+++ b/SmartDeviceLink/private/SDLMenuManager.m
@@ -552,22 +552,18 @@ UInt32 const MenuCellIdMin = 1;
 }
 
 - (BOOL)sdl_artworkNeedsUpload:(SDLArtwork *)artwork {
-    if (artwork != nil) {
-        if (artwork.isStaticIcon) {
-            return NO;
-        } else {
-            return (artwork.overwrite || (self.fileManager != nil && ![self.fileManager hasUploadedFile:artwork]));
-        }
+    if (artwork != nil && !artwork.isStaticIcon) {
+        return (artwork.overwrite || (self.fileManager != nil && ![self.fileManager hasUploadedFile:artwork]));
     }
+
     return NO;
 }
 
-- (BOOL) sdl_allArtworksUploaded:(NSArray<SDLMenuCell *> *)cells {
+- (BOOL) sdl_areAllCellArtworksUploaded:(NSArray<SDLMenuCell *> *)cells {
     for (SDLMenuCell *cell in cells) {
         if (![self sdl_artworkUploaded:cell.icon]) {
             return NO;
-        }
-        if (cell.subCells != nil && (cell.subCells.count) > 0) {
+        } else if (cell.subCells != nil && (cell.subCells.count) > 0) {
             return [self sdl_allArtworksUploaded:cell.subCells];
         }
     }
@@ -575,7 +571,7 @@ UInt32 const MenuCellIdMin = 1;
     return YES;
 }
 
-- (BOOL) sdl_artworkUploaded:(SDLArtwork *)artwork {
+- (BOOL) sdl_isArtworkUploaded:(nullable SDLArtwork *)artwork {
     if (artwork != nil) {
         return artwork.isStaticIcon || (self.fileManager != nil && [self.fileManager hasUploadedFile:artwork]);
     }

--- a/SmartDeviceLink/private/SDLMenuManager.m
+++ b/SmartDeviceLink/private/SDLMenuManager.m
@@ -472,7 +472,7 @@ UInt32 const MenuCellIdMin = 1;
     NSArray<SDLRPCRequest *> *mainMenuCommands = nil;
     NSArray<SDLRPCRequest *> *subMenuCommands = nil;
 
-    if ([self sdl_findAllArtworksToBeUploadedFromCells:self.menuCells].count > 0 || ![self.windowCapability hasImageFieldOfName:SDLImageFieldNameCommandIcon]) {
+    if ([self sdl_allArtworksUploaded:self.menuCells] || ![self.windowCapability hasImageFieldOfName:SDLImageFieldNameCommandIcon]) {
         // Send artwork-less menu
         mainMenuCommands = [self sdl_mainMenuCommandsForCells:updatedMenu withArtwork:NO usingIndexesFrom:menu];
         subMenuCommands =  [self sdl_subMenuCommandsForCells:updatedMenu withArtwork:NO];
@@ -552,7 +552,34 @@ UInt32 const MenuCellIdMin = 1;
 }
 
 - (BOOL)sdl_artworkNeedsUpload:(SDLArtwork *)artwork {
-    return (artwork != nil && ![self.fileManager hasUploadedFile:artwork] && !artwork.isStaticIcon);
+    if (artwork != nil) {
+        if (artwork.isStaticIcon) {
+            return false;
+        } else {
+            return artwork.overwrite || (self.fileManager != nil && ![self.fileManager hasUploadedFile:artwork]);
+        }
+    }
+    return false;
+}
+
+- (BOOL) sdl_allArtworksUploaded:(NSArray<SDLMenuCell *> *)cells {
+    for (SDLMenuCell *cell in cells) {
+        if (![self sdl_artworkUploaded:cell.icon]) {
+            return false;
+        }
+        if (cell.subCells != nil && [cell.subCells count]> 0) {
+            return [self sdl_allArtworksUploaded:cell.subCells];
+        }
+    }
+
+    return true;
+}
+
+- (BOOL) sdl_artworkUploaded:(SDLArtwork *)artwork {
+    if (artwork != nil) {
+        return artwork.isStaticIcon || (self.fileManager != nil && [self.fileManager hasUploadedFile:artwork]);
+    }
+    return true;
 }
 
 #pragma mark IDs

--- a/SmartDeviceLink/private/SDLMenuManager.m
+++ b/SmartDeviceLink/private/SDLMenuManager.m
@@ -472,7 +472,7 @@ UInt32 const MenuCellIdMin = 1;
     NSArray<SDLRPCRequest *> *mainMenuCommands = nil;
     NSArray<SDLRPCRequest *> *subMenuCommands = nil;
 
-    if (![self sdl_areAllCellArtworksUploaded:self.menuCells] || ![self.windowCapability hasImageFieldOfName:SDLImageFieldNameCommandIcon]) {
+    if (![self sdl_shouldRPCsIncludeImages:self.menuCells] || ![self.windowCapability hasImageFieldOfName:SDLImageFieldNameCommandIcon]) {
         // Send artwork-less menu
         mainMenuCommands = [self sdl_mainMenuCommandsForCells:updatedMenu withArtwork:NO usingIndexesFrom:menu];
         subMenuCommands =  [self sdl_subMenuCommandsForCells:updatedMenu withArtwork:NO];
@@ -551,13 +551,13 @@ UInt32 const MenuCellIdMin = 1;
     return [mutableArtworks allObjects];
 }
 
-- (BOOL)sdl_areAllCellArtworksUploaded:(NSArray<SDLMenuCell *> *)cells {
+- (BOOL)sdl_shouldRPCsIncludeImages:(NSArray<SDLMenuCell *> *)cells {
     for (SDLMenuCell *cell in cells) {
         SDLArtwork *artwork = cell.icon;
         if (artwork != nil && !artwork.isStaticIcon && ![self.fileManager hasUploadedFile:artwork]) {
             return NO;
         } else if (cell.subCells.count > 0) {
-            return [self sdl_areAllCellArtworksUploaded:cell.subCells];
+            return [self sdl_shouldRPCsIncludeImages:cell.subCells];
         }
     }
 

--- a/SmartDeviceLink/private/SDLMenuManager.m
+++ b/SmartDeviceLink/private/SDLMenuManager.m
@@ -539,7 +539,7 @@ UInt32 const MenuCellIdMin = 1;
 
     NSMutableSet<SDLArtwork *> *mutableArtworks = [NSMutableSet set];
     for (SDLMenuCell *cell in cells) {
-        if (self.fileManager != nil && [self.fileManager sdl_artworkNeedsUpload:cell.icon]) {
+        if (self.fileManager != nil && [self.fileManager fileNeedsUpload:cell.icon]) {
             [mutableArtworks addObject:cell.icon];
         }
 
@@ -553,19 +553,12 @@ UInt32 const MenuCellIdMin = 1;
 
 - (BOOL)sdl_areAllCellArtworksUploaded:(NSArray<SDLMenuCell *> *)cells {
     for (SDLMenuCell *cell in cells) {
-        if (![self sdl_isArtworkUploaded:cell.icon]) {
+        SDLArtwork *artwork = cell.icon;
+        if (artwork != nil && !artwork.isStaticIcon && self.fileManager != nil && ![self.fileManager hasUploadedFile:(artwork)]) {
             return NO;
         } else if (cell.subCells != nil && (cell.subCells.count) > 0) {
             return [self sdl_areAllCellArtworksUploaded:cell.subCells];
         }
-    }
-
-    return YES;
-}
-
-- (BOOL)sdl_isArtworkUploaded:(nullable SDLArtwork *)artwork {
-    if (artwork != nil) {
-        return artwork.isStaticIcon || (self.fileManager != nil && [self.fileManager hasUploadedFile:artwork]);
     }
 
     return YES;

--- a/SmartDeviceLink/private/SDLMenuManager.m
+++ b/SmartDeviceLink/private/SDLMenuManager.m
@@ -539,7 +539,7 @@ UInt32 const MenuCellIdMin = 1;
 
     NSMutableSet<SDLArtwork *> *mutableArtworks = [NSMutableSet set];
     for (SDLMenuCell *cell in cells) {
-        if ([self sdl_artworkNeedsUpload:cell.icon]) {
+        if (self.fileManager != nil && [self.fileManager sdl_artworkNeedsUpload:cell.icon]) {
             [mutableArtworks addObject:cell.icon];
         }
 
@@ -549,14 +549,6 @@ UInt32 const MenuCellIdMin = 1;
     }
 
     return [mutableArtworks allObjects];
-}
-
-- (BOOL)sdl_artworkNeedsUpload:(SDLArtwork *)artwork {
-    if (artwork != nil && !artwork.isStaticIcon) {
-        return (artwork.overwrite || (self.fileManager != nil && ![self.fileManager hasUploadedFile:artwork]));
-    }
-
-    return NO;
 }
 
 - (BOOL)sdl_areAllCellArtworksUploaded:(NSArray<SDLMenuCell *> *)cells {

--- a/SmartDeviceLink/private/SDLMenuManager.m
+++ b/SmartDeviceLink/private/SDLMenuManager.m
@@ -472,7 +472,7 @@ UInt32 const MenuCellIdMin = 1;
     NSArray<SDLRPCRequest *> *mainMenuCommands = nil;
     NSArray<SDLRPCRequest *> *subMenuCommands = nil;
 
-    if ([self sdl_allArtworksUploaded:self.menuCells] || ![self.windowCapability hasImageFieldOfName:SDLImageFieldNameCommandIcon]) {
+    if (![self sdl_allArtworksUploaded:self.menuCells] || ![self.windowCapability hasImageFieldOfName:SDLImageFieldNameCommandIcon]) {
         // Send artwork-less menu
         mainMenuCommands = [self sdl_mainMenuCommandsForCells:updatedMenu withArtwork:NO usingIndexesFrom:menu];
         subMenuCommands =  [self sdl_subMenuCommandsForCells:updatedMenu withArtwork:NO];
@@ -554,32 +554,32 @@ UInt32 const MenuCellIdMin = 1;
 - (BOOL)sdl_artworkNeedsUpload:(SDLArtwork *)artwork {
     if (artwork != nil) {
         if (artwork.isStaticIcon) {
-            return false;
+            return NO;
         } else {
-            return artwork.overwrite || (self.fileManager != nil && ![self.fileManager hasUploadedFile:artwork]);
+            return (artwork.overwrite || (self.fileManager != nil && ![self.fileManager hasUploadedFile:artwork]));
         }
     }
-    return false;
+    return NO;
 }
 
 - (BOOL) sdl_allArtworksUploaded:(NSArray<SDLMenuCell *> *)cells {
     for (SDLMenuCell *cell in cells) {
         if (![self sdl_artworkUploaded:cell.icon]) {
-            return false;
+            return NO;
         }
-        if (cell.subCells != nil && [cell.subCells count]> 0) {
+        if (cell.subCells != nil && (cell.subCells.count) > 0) {
             return [self sdl_allArtworksUploaded:cell.subCells];
         }
     }
 
-    return true;
+    return YES;
 }
 
 - (BOOL) sdl_artworkUploaded:(SDLArtwork *)artwork {
     if (artwork != nil) {
         return artwork.isStaticIcon || (self.fileManager != nil && [self.fileManager hasUploadedFile:artwork]);
     }
-    return true;
+    return YES;
 }
 
 #pragma mark IDs

--- a/SmartDeviceLink/private/SDLMenuManager.m
+++ b/SmartDeviceLink/private/SDLMenuManager.m
@@ -472,7 +472,7 @@ UInt32 const MenuCellIdMin = 1;
     NSArray<SDLRPCRequest *> *mainMenuCommands = nil;
     NSArray<SDLRPCRequest *> *subMenuCommands = nil;
 
-    if (![self sdl_allArtworksUploaded:self.menuCells] || ![self.windowCapability hasImageFieldOfName:SDLImageFieldNameCommandIcon]) {
+    if (![self sdl_areAllCellArtworksUploaded:self.menuCells] || ![self.windowCapability hasImageFieldOfName:SDLImageFieldNameCommandIcon]) {
         // Send artwork-less menu
         mainMenuCommands = [self sdl_mainMenuCommandsForCells:updatedMenu withArtwork:NO usingIndexesFrom:menu];
         subMenuCommands =  [self sdl_subMenuCommandsForCells:updatedMenu withArtwork:NO];
@@ -559,22 +559,23 @@ UInt32 const MenuCellIdMin = 1;
     return NO;
 }
 
-- (BOOL) sdl_areAllCellArtworksUploaded:(NSArray<SDLMenuCell *> *)cells {
+- (BOOL)sdl_areAllCellArtworksUploaded:(NSArray<SDLMenuCell *> *)cells {
     for (SDLMenuCell *cell in cells) {
-        if (![self sdl_artworkUploaded:cell.icon]) {
+        if (![self sdl_isArtworkUploaded:cell.icon]) {
             return NO;
         } else if (cell.subCells != nil && (cell.subCells.count) > 0) {
-            return [self sdl_allArtworksUploaded:cell.subCells];
+            return [self sdl_areAllCellArtworksUploaded:cell.subCells];
         }
     }
 
     return YES;
 }
 
-- (BOOL) sdl_isArtworkUploaded:(nullable SDLArtwork *)artwork {
+- (BOOL)sdl_isArtworkUploaded:(nullable SDLArtwork *)artwork {
     if (artwork != nil) {
         return artwork.isStaticIcon || (self.fileManager != nil && [self.fileManager hasUploadedFile:artwork]);
     }
+
     return YES;
 }
 

--- a/SmartDeviceLink/private/SDLMenuManager.m
+++ b/SmartDeviceLink/private/SDLMenuManager.m
@@ -539,7 +539,7 @@ UInt32 const MenuCellIdMin = 1;
 
     NSMutableSet<SDLArtwork *> *mutableArtworks = [NSMutableSet set];
     for (SDLMenuCell *cell in cells) {
-        if (self.fileManager != nil && [self.fileManager fileNeedsUpload:cell.icon]) {
+        if ([self.fileManager fileNeedsUpload:cell.icon]) {
             [mutableArtworks addObject:cell.icon];
         }
 
@@ -554,9 +554,9 @@ UInt32 const MenuCellIdMin = 1;
 - (BOOL)sdl_areAllCellArtworksUploaded:(NSArray<SDLMenuCell *> *)cells {
     for (SDLMenuCell *cell in cells) {
         SDLArtwork *artwork = cell.icon;
-        if (artwork != nil && !artwork.isStaticIcon && self.fileManager != nil && ![self.fileManager hasUploadedFile:(artwork)]) {
+        if (artwork != nil && !artwork.isStaticIcon && ![self.fileManager hasUploadedFile:artwork]) {
             return NO;
-        } else if (cell.subCells != nil && (cell.subCells.count) > 0) {
+        } else if (cell.subCells.count > 0) {
             return [self sdl_areAllCellArtworksUploaded:cell.subCells];
         }
     }

--- a/SmartDeviceLink/private/SDLPreloadChoicesOperation.m
+++ b/SmartDeviceLink/private/SDLPreloadChoicesOperation.m
@@ -87,10 +87,10 @@ NS_ASSUME_NONNULL_BEGIN
 
     NSMutableArray<SDLArtwork *> *artworksToUpload = [NSMutableArray arrayWithCapacity:self.cellsToUpload.count];
     for (SDLChoiceCell *cell in self.cellsToUpload) {
-        if ([self sdl_shouldSendChoicePrimaryImage] && ([self.fileManager fileNeedsUpload:cell.artwork])) {
+        if ([self sdl_shouldSendChoicePrimaryImage] && [self.fileManager fileNeedsUpload:cell.artwork]) {
             [artworksToUpload addObject:cell.artwork];
         }
-        if ([self sdl_shouldSendChoiceSecondaryImage] && ([self.fileManager fileNeedsUpload:cell.secondaryArtwork])) {
+        if ([self sdl_shouldSendChoiceSecondaryImage] && [self.fileManager fileNeedsUpload:cell.secondaryArtwork]) {
             [artworksToUpload addObject:cell.secondaryArtwork];
         }
     }

--- a/SmartDeviceLink/private/SDLPreloadChoicesOperation.m
+++ b/SmartDeviceLink/private/SDLPreloadChoicesOperation.m
@@ -115,10 +115,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)sdl_artworkNeedsUpload:(SDLArtwork *)artwork {
     if (artwork != nil) {
-        if (artwork.isStaticIcon) {
-            return NO;
-        } else {
-            return artwork.overwrite || (self.fileManager != nil && ![self.fileManager hasUploadedFile:artwork]);
+        if (artwork != nil && !artwork.isStaticIcon) {
+            return (artwork.overwrite || (self.fileManager != nil && ![self.fileManager hasUploadedFile:artwork]));
         }
     }
     return NO;

--- a/SmartDeviceLink/private/SDLPreloadChoicesOperation.m
+++ b/SmartDeviceLink/private/SDLPreloadChoicesOperation.m
@@ -114,7 +114,14 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (BOOL)sdl_artworkNeedsUpload:(SDLArtwork *)artwork {
-    return (artwork != nil && ![self.fileManager hasUploadedFile:artwork] && !artwork.isStaticIcon);
+    if (artwork != nil) {
+        if (artwork.isStaticIcon) {
+            return false;
+        } else {
+            return artwork.overwrite || (self.fileManager != nil && ![self.fileManager hasUploadedFile:artwork]);
+        }
+    }
+    return false;
 }
 
 - (void)sdl_preloadCells {

--- a/SmartDeviceLink/private/SDLPreloadChoicesOperation.m
+++ b/SmartDeviceLink/private/SDLPreloadChoicesOperation.m
@@ -116,12 +116,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)sdl_artworkNeedsUpload:(SDLArtwork *)artwork {
     if (artwork != nil) {
         if (artwork.isStaticIcon) {
-            return false;
+            return NO;
         } else {
             return artwork.overwrite || (self.fileManager != nil && ![self.fileManager hasUploadedFile:artwork]);
         }
     }
-    return false;
+    return NO;
 }
 
 - (void)sdl_preloadCells {

--- a/SmartDeviceLink/private/SDLPreloadChoicesOperation.m
+++ b/SmartDeviceLink/private/SDLPreloadChoicesOperation.m
@@ -87,10 +87,10 @@ NS_ASSUME_NONNULL_BEGIN
 
     NSMutableArray<SDLArtwork *> *artworksToUpload = [NSMutableArray arrayWithCapacity:self.cellsToUpload.count];
     for (SDLChoiceCell *cell in self.cellsToUpload) {
-        if ([self sdl_shouldSendChoicePrimaryImage] && (self.fileManager != nil && [self.fileManager sdl_artworkNeedsUpload:cell.artwork])) {
+        if ([self sdl_shouldSendChoicePrimaryImage] && self.fileManager != nil && ([self.fileManager fileNeedsUpload:cell.artwork])) {
             [artworksToUpload addObject:cell.artwork];
         }
-        if ([self sdl_shouldSendChoiceSecondaryImage] && (self.fileManager != nil && [self.fileManager sdl_artworkNeedsUpload:cell.secondaryArtwork])) {
+        if ([self sdl_shouldSendChoiceSecondaryImage] && self.fileManager != nil && ([self.fileManager fileNeedsUpload:cell.secondaryArtwork])) {
             [artworksToUpload addObject:cell.secondaryArtwork];
         }
     }

--- a/SmartDeviceLink/private/SDLPreloadChoicesOperation.m
+++ b/SmartDeviceLink/private/SDLPreloadChoicesOperation.m
@@ -87,10 +87,10 @@ NS_ASSUME_NONNULL_BEGIN
 
     NSMutableArray<SDLArtwork *> *artworksToUpload = [NSMutableArray arrayWithCapacity:self.cellsToUpload.count];
     for (SDLChoiceCell *cell in self.cellsToUpload) {
-        if ([self sdl_shouldSendChoicePrimaryImage] && self.fileManager != nil && ([self.fileManager fileNeedsUpload:cell.artwork])) {
+        if ([self sdl_shouldSendChoicePrimaryImage] && ([self.fileManager fileNeedsUpload:cell.artwork])) {
             [artworksToUpload addObject:cell.artwork];
         }
-        if ([self sdl_shouldSendChoiceSecondaryImage] && self.fileManager != nil && ([self.fileManager fileNeedsUpload:cell.secondaryArtwork])) {
+        if ([self sdl_shouldSendChoiceSecondaryImage] && ([self.fileManager fileNeedsUpload:cell.secondaryArtwork])) {
             [artworksToUpload addObject:cell.secondaryArtwork];
         }
     }

--- a/SmartDeviceLink/private/SDLPreloadChoicesOperation.m
+++ b/SmartDeviceLink/private/SDLPreloadChoicesOperation.m
@@ -87,10 +87,10 @@ NS_ASSUME_NONNULL_BEGIN
 
     NSMutableArray<SDLArtwork *> *artworksToUpload = [NSMutableArray arrayWithCapacity:self.cellsToUpload.count];
     for (SDLChoiceCell *cell in self.cellsToUpload) {
-        if ([self sdl_shouldSendChoicePrimaryImage] && [self sdl_artworkNeedsUpload:cell.artwork]) {
+        if ([self sdl_shouldSendChoicePrimaryImage] && (self.fileManager != nil && [self.fileManager sdl_artworkNeedsUpload:cell.artwork])) {
             [artworksToUpload addObject:cell.artwork];
         }
-        if ([self sdl_shouldSendChoiceSecondaryImage] && [self sdl_artworkNeedsUpload:cell.secondaryArtwork]) {
+        if ([self sdl_shouldSendChoiceSecondaryImage] && (self.fileManager != nil && [self.fileManager sdl_artworkNeedsUpload:cell.secondaryArtwork])) {
             [artworksToUpload addObject:cell.secondaryArtwork];
         }
     }
@@ -111,15 +111,6 @@ NS_ASSUME_NONNULL_BEGIN
 
         completionHandler(error);
     }];
-}
-
-- (BOOL)sdl_artworkNeedsUpload:(SDLArtwork *)artwork {
-    if (artwork != nil) {
-        if (artwork != nil && !artwork.isStaticIcon) {
-            return (artwork.overwrite || (self.fileManager != nil && ![self.fileManager hasUploadedFile:artwork]));
-        }
-    }
-    return NO;
 }
 
 - (void)sdl_preloadCells {

--- a/SmartDeviceLink/private/SDLSoftButtonReplaceOperation.m
+++ b/SmartDeviceLink/private/SDLSoftButtonReplaceOperation.m
@@ -228,13 +228,10 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Images
 
 - (BOOL)sdl_artworkNeedsUpload:(SDLArtwork *)artwork {
-    if (artwork != nil && self.softButtonCapabilities.imageSupported) {
-        if (artwork.isStaticIcon) {
-            return NO;
-        } else {
-            return artwork.overwrite || (self.fileManager != nil && ![self.fileManager hasUploadedFile:artwork]);
-        }
+    if (artwork != nil && !artwork.isStaticIcon) {
+        return (artwork.overwrite || (self.fileManager != nil && ![self.fileManager hasUploadedFile:artwork]));
     }
+
     return NO;
 }
 

--- a/SmartDeviceLink/private/SDLSoftButtonReplaceOperation.m
+++ b/SmartDeviceLink/private/SDLSoftButtonReplaceOperation.m
@@ -228,7 +228,14 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Images
 
 - (BOOL)sdl_artworkNeedsUpload:(SDLArtwork *)artwork {
-    return (artwork != nil && ![self.fileManager hasUploadedFile:artwork] && self.softButtonCapabilities.imageSupported.boolValue && !artwork.isStaticIcon);
+    if (artwork != nil && self.softButtonCapabilities.imageSupported) {
+        if (artwork.isStaticIcon) {
+            return false;
+        } else {
+            return artwork.overwrite || (self.fileManager != nil && ![self.fileManager hasUploadedFile:artwork]);
+        }
+    }
+    return false;
 }
 
 /// Checks all the button states for images that need to be uploaded.

--- a/SmartDeviceLink/private/SDLSoftButtonReplaceOperation.m
+++ b/SmartDeviceLink/private/SDLSoftButtonReplaceOperation.m
@@ -103,7 +103,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)sdl_uploadInitialStateImagesWithCompletionHandler:(void (^)(void))handler {
     NSMutableArray<SDLArtwork *> *initialStatesToBeUploaded = [NSMutableArray array];
     for (SDLSoftButtonObject *object in self.softButtonObjects) {
-        if ([self sdl_artworkNeedsUpload:object.currentState.artwork]) {
+        if (self.fileManager != nil && [self.fileManager sdl_artworkNeedsUpload:object.currentState.artwork]) {
             [initialStatesToBeUploaded addObject:object.currentState.artwork];
         }
     }
@@ -118,7 +118,7 @@ NS_ASSUME_NONNULL_BEGIN
     for (SDLSoftButtonObject *object in self.softButtonObjects) {
         for (SDLSoftButtonState *state in object.states) {
             if ([state.name isEqualToString:object.currentState.name]) { continue; }
-            if ([self sdl_artworkNeedsUpload:state.artwork]) {
+            if (self.fileManager != nil && [self.fileManager sdl_artworkNeedsUpload:state.artwork]) {
                 [otherStatesToBeUploaded addObject:state.artwork];
             }
         }
@@ -227,21 +227,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Images
 
-- (BOOL)sdl_artworkNeedsUpload:(SDLArtwork *)artwork {
-    if (artwork != nil && !artwork.isStaticIcon) {
-        return (artwork.overwrite || (self.fileManager != nil && ![self.fileManager hasUploadedFile:artwork]));
-    }
-
-    return NO;
-}
-
 /// Checks all the button states for images that need to be uploaded.
 /// @return True if all images have been uploaded; false at least one image needs to be uploaded
 - (BOOL)sdl_allStateImagesAreUploaded {
     for (SDLSoftButtonObject *button in self.softButtonObjects) {
         for (SDLSoftButtonState *state in button.states) {
             SDLArtwork *artwork = state.artwork;
-            if (![self sdl_artworkNeedsUpload:artwork]) { continue; }
+            if (self.fileManager != nil && ![self.fileManager sdl_artworkNeedsUpload:artwork]) { continue; }
             return NO;
         }
     }

--- a/SmartDeviceLink/private/SDLSoftButtonReplaceOperation.m
+++ b/SmartDeviceLink/private/SDLSoftButtonReplaceOperation.m
@@ -103,7 +103,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)sdl_uploadInitialStateImagesWithCompletionHandler:(void (^)(void))handler {
     NSMutableArray<SDLArtwork *> *initialStatesToBeUploaded = [NSMutableArray array];
     for (SDLSoftButtonObject *object in self.softButtonObjects) {
-        if (self.fileManager != nil && [self.fileManager sdl_artworkNeedsUpload:object.currentState.artwork]) {
+        if (self.fileManager != nil && [self.fileManager fileNeedsUpload:object.currentState.artwork] && self.softButtonCapabilities.imageSupported.boolValue) {
             [initialStatesToBeUploaded addObject:object.currentState.artwork];
         }
     }
@@ -118,7 +118,7 @@ NS_ASSUME_NONNULL_BEGIN
     for (SDLSoftButtonObject *object in self.softButtonObjects) {
         for (SDLSoftButtonState *state in object.states) {
             if ([state.name isEqualToString:object.currentState.name]) { continue; }
-            if (self.fileManager != nil && [self.fileManager sdl_artworkNeedsUpload:state.artwork]) {
+            if (self.fileManager != nil && [self.fileManager fileNeedsUpload:state.artwork] && self.softButtonCapabilities.imageSupported.boolValue) {
                 [otherStatesToBeUploaded addObject:state.artwork];
             }
         }
@@ -233,7 +233,7 @@ NS_ASSUME_NONNULL_BEGIN
     for (SDLSoftButtonObject *button in self.softButtonObjects) {
         for (SDLSoftButtonState *state in button.states) {
             SDLArtwork *artwork = state.artwork;
-            if (self.fileManager != nil && ![self.fileManager sdl_artworkNeedsUpload:artwork]) { continue; }
+            if (self.fileManager != nil && ![self.fileManager fileNeedsUpload:artwork] && self.softButtonCapabilities.imageSupported.boolValue) { continue; }
             return NO;
         }
     }

--- a/SmartDeviceLink/private/SDLSoftButtonReplaceOperation.m
+++ b/SmartDeviceLink/private/SDLSoftButtonReplaceOperation.m
@@ -103,7 +103,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)sdl_uploadInitialStateImagesWithCompletionHandler:(void (^)(void))handler {
     NSMutableArray<SDLArtwork *> *initialStatesToBeUploaded = [NSMutableArray array];
     for (SDLSoftButtonObject *object in self.softButtonObjects) {
-        if (self.fileManager != nil && [self.fileManager fileNeedsUpload:object.currentState.artwork] && self.softButtonCapabilities.imageSupported.boolValue) {
+        if ([self.fileManager fileNeedsUpload:object.currentState.artwork]) {
             [initialStatesToBeUploaded addObject:object.currentState.artwork];
         }
     }
@@ -118,7 +118,7 @@ NS_ASSUME_NONNULL_BEGIN
     for (SDLSoftButtonObject *object in self.softButtonObjects) {
         for (SDLSoftButtonState *state in object.states) {
             if ([state.name isEqualToString:object.currentState.name]) { continue; }
-            if (self.fileManager != nil && [self.fileManager fileNeedsUpload:state.artwork] && self.softButtonCapabilities.imageSupported.boolValue) {
+            if ([self.fileManager fileNeedsUpload:state.artwork]) {
                 [otherStatesToBeUploaded addObject:state.artwork];
             }
         }
@@ -233,7 +233,7 @@ NS_ASSUME_NONNULL_BEGIN
     for (SDLSoftButtonObject *button in self.softButtonObjects) {
         for (SDLSoftButtonState *state in button.states) {
             SDLArtwork *artwork = state.artwork;
-            if (self.fileManager != nil && ![self.fileManager fileNeedsUpload:artwork] && self.softButtonCapabilities.imageSupported.boolValue) { continue; }
+            if (![self.fileManager fileNeedsUpload:artwork]) { continue; }
             return NO;
         }
     }

--- a/SmartDeviceLink/private/SDLSoftButtonReplaceOperation.m
+++ b/SmartDeviceLink/private/SDLSoftButtonReplaceOperation.m
@@ -230,12 +230,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)sdl_artworkNeedsUpload:(SDLArtwork *)artwork {
     if (artwork != nil && self.softButtonCapabilities.imageSupported) {
         if (artwork.isStaticIcon) {
-            return false;
+            return NO;
         } else {
             return artwork.overwrite || (self.fileManager != nil && ![self.fileManager hasUploadedFile:artwork]);
         }
     }
-    return false;
+    return NO;
 }
 
 /// Checks all the button states for images that need to be uploaded.

--- a/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
+++ b/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
@@ -263,8 +263,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable SDLShow *)sdl_createImageOnlyShowWithPrimaryArtwork:(nullable SDLArtwork *)primaryArtwork secondaryArtwork:(nullable SDLArtwork *)secondaryArtwork  {
     SDLShow *newShow = [[SDLShow alloc] init];
-    newShow.graphic = [self sdl_isArtworkUploaded:primaryArtwork] ? primaryArtwork.imageRPC : nil;
-    newShow.secondaryGraphic = [self sdl_isArtworkUploaded:secondaryArtwork] ? secondaryArtwork.imageRPC : nil;
+    newShow.graphic = [self sdl_shouldRPCIncludeImage:primaryArtwork] ? primaryArtwork.imageRPC : nil;
+    newShow.secondaryGraphic = [self sdl_shouldRPCIncludeImage:secondaryArtwork] ? secondaryArtwork.imageRPC : nil;
 
     if (newShow.graphic == nil && newShow.secondaryGraphic == nil) {
         SDLLogV(@"No graphics to upload");
@@ -515,7 +515,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Should Update
 
-- (BOOL)sdl_isArtworkUploaded:(nullable SDLArtwork *)artwork {
+- (BOOL)sdl_shouldRPCIncludeImage:(nullable SDLArtwork *)artwork {
     if (artwork == nil) { return NO; }
 
     return (artwork.isStaticIcon || [self.fileManager hasUploadedFile:artwork]);

--- a/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
+++ b/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
@@ -516,20 +516,18 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Should Update
 
 - (BOOL)sdl_artworkNeedsUpload:(SDLArtwork *)artwork {
-    if (artwork != nil) {
-        if (artwork.isStaticIcon) {
-            return NO;
-        } else {
-            return (artwork.overwrite || (![self.fileManager hasUploadedFile:artwork]));
-        }
+    if (artwork != nil && !artwork.isStaticIcon) {
+        return (artwork.overwrite || (self.fileManager != nil && ![self.fileManager hasUploadedFile:artwork]));
     }
+
     return NO;
 }
 
-- (BOOL) sdl_artworkUploaded:(SDLArtwork *)artwork {
+- (BOOL)sdl_artworkIsUploaded:(nullable SDLArtwork *)artwork {
     if (artwork != nil) {
         return artwork.isStaticIcon || (self.fileManager != nil && [self.fileManager hasUploadedFile:artwork]);
     }
+
     return YES;
 }
 
@@ -537,7 +535,7 @@ NS_ASSUME_NONNULL_BEGIN
     // If the template is updating, we don't yet know it's capabilities. Just assume the template supports the primary image. 
     BOOL templateSupportsPrimaryArtwork = [self.currentCapabilities hasImageFieldOfName:SDLImageFieldNameGraphic] || [self sdl_shouldUpdateTemplateConfig];
     BOOL graphicNameMatchesExisting = [self.currentScreenData.primaryGraphic.name isEqualToString:self.updatedState.primaryGraphic.name];
-    BOOL shouldOverwriteGraphic = self.updatedState.primaryGraphic != nil && self.updatedState.primaryGraphic.overwrite;
+    BOOL shouldOverwriteGraphic = self.updatedState.primaryGraphic.overwrite;
     BOOL graphicExists = (self.updatedState.primaryGraphic != nil);
 
     return (templateSupportsPrimaryArtwork && (shouldOverwriteGraphic || !graphicNameMatchesExisting) && graphicExists);

--- a/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
+++ b/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
@@ -530,7 +530,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (artwork != nil) {
         return artwork.isStaticIcon || (self.fileManager != nil && [self.fileManager hasUploadedFile:artwork]);
     }
-    return NO;
+    return YES;
 }
 
 - (BOOL)sdl_shouldUpdatePrimaryImage {

--- a/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
+++ b/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
@@ -263,8 +263,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable SDLShow *)sdl_createImageOnlyShowWithPrimaryArtwork:(nullable SDLArtwork *)primaryArtwork secondaryArtwork:(nullable SDLArtwork *)secondaryArtwork  {
     SDLShow *newShow = [[SDLShow alloc] init];
-    newShow.graphic = ![self sdl_artworkNeedsUpload:primaryArtwork] ? primaryArtwork.imageRPC : nil;
-    newShow.secondaryGraphic = ![self sdl_artworkNeedsUpload:secondaryArtwork] ? secondaryArtwork.imageRPC : nil;
+    newShow.graphic = [self sdl_artworkUploaded:primaryArtwork] ? primaryArtwork.imageRPC : nil;
+    newShow.secondaryGraphic = [self sdl_artworkUploaded:secondaryArtwork] ? secondaryArtwork.imageRPC : nil;
 
     if (newShow.graphic == nil && newShow.secondaryGraphic == nil) {
         SDLLogV(@"No graphics to upload");
@@ -516,29 +516,45 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Should Update
 
 - (BOOL)sdl_artworkNeedsUpload:(SDLArtwork *)artwork {
-    return (artwork != nil && ![self.fileManager hasUploadedFile:artwork] && !artwork.isStaticIcon);
+    if (artwork != nil) {
+        if (artwork.isStaticIcon) {
+            return false;
+        } else {
+            return (artwork.overwrite || (![self.fileManager hasUploadedFile:artwork]));
+        }
+    }
+    return true;
+}
+
+- (BOOL) sdl_artworkUploaded:(SDLArtwork *)artwork {
+    if (artwork != nil) {
+        return artwork.isStaticIcon || (self.fileManager != nil && [self.fileManager hasUploadedFile:artwork]);
+    }
+    return true;
 }
 
 - (BOOL)sdl_shouldUpdatePrimaryImage {
     // If the template is updating, we don't yet know it's capabilities. Just assume the template supports the primary image. 
     BOOL templateSupportsPrimaryArtwork = [self.currentCapabilities hasImageFieldOfName:SDLImageFieldNameGraphic] || [self sdl_shouldUpdateTemplateConfig];
-    BOOL graphicMatchesExisting = [self.currentScreenData.primaryGraphic.name isEqualToString:self.updatedState.primaryGraphic.name];
+    BOOL graphicNameMatchesExisting = [self.currentScreenData.primaryGraphic.name isEqualToString:self.updatedState.primaryGraphic.name];
+    BOOL shouldOverwriteGraphic = self.updatedState.primaryGraphic != nil && self.updatedState.primaryGraphic.overwrite;
     BOOL graphicExists = (self.updatedState.primaryGraphic != nil);
 
-    return (templateSupportsPrimaryArtwork && !graphicMatchesExisting && graphicExists);
+    return (templateSupportsPrimaryArtwork && (shouldOverwriteGraphic || !graphicNameMatchesExisting) && graphicExists);
 }
 
 - (BOOL)sdl_shouldUpdateSecondaryImage {
     // If the template is updating, we don't yet know it's capabilities. Just assume the template supports the secondary image. 
     BOOL templateSupportsSecondaryArtwork = [self.currentCapabilities hasImageFieldOfName:SDLImageFieldNameSecondaryGraphic] || [self sdl_shouldUpdateTemplateConfig];
-    BOOL graphicMatchesExisting = [self.currentScreenData.secondaryGraphic.name isEqualToString:self.updatedState.secondaryGraphic.name];
+    BOOL graphicNameMatchesExisting = [self.currentScreenData.secondaryGraphic.name isEqualToString:self.updatedState.secondaryGraphic.name];
+    BOOL shouldOverwriteGraphic = self.updatedState.secondaryGraphic != nil && self.updatedState.secondaryGraphic.overwrite;
     BOOL graphicExists = (self.updatedState.secondaryGraphic != nil);
 
     // Cannot detect if there is a secondary image below v5.0, so we'll just try to detect if the primary image is allowed and allow the secondary image if it is.
     if ([[SDLGlobals sharedGlobals].rpcVersion isGreaterThanOrEqualToVersion:[SDLVersion versionWithMajor:5 minor:0 patch:0]]) {
-        return (templateSupportsSecondaryArtwork && !graphicMatchesExisting && graphicExists);
+        return (templateSupportsSecondaryArtwork && (shouldOverwriteGraphic || !graphicNameMatchesExisting) && graphicExists);
     } else {
-        return ([self.currentCapabilities hasImageFieldOfName:SDLImageFieldNameGraphic] && !graphicMatchesExisting && graphicExists);
+        return ([self.currentCapabilities hasImageFieldOfName:SDLImageFieldNameGraphic] && (shouldOverwriteGraphic || !graphicNameMatchesExisting) && graphicExists);
     }
 }
 

--- a/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
+++ b/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
@@ -518,19 +518,19 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)sdl_artworkNeedsUpload:(SDLArtwork *)artwork {
     if (artwork != nil) {
         if (artwork.isStaticIcon) {
-            return false;
+            return NO;
         } else {
             return (artwork.overwrite || (![self.fileManager hasUploadedFile:artwork]));
         }
     }
-    return true;
+    return NO;
 }
 
 - (BOOL) sdl_artworkUploaded:(SDLArtwork *)artwork {
     if (artwork != nil) {
         return artwork.isStaticIcon || (self.fileManager != nil && [self.fileManager hasUploadedFile:artwork]);
     }
-    return true;
+    return NO;
 }
 
 - (BOOL)sdl_shouldUpdatePrimaryImage {

--- a/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
+++ b/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
@@ -263,8 +263,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable SDLShow *)sdl_createImageOnlyShowWithPrimaryArtwork:(nullable SDLArtwork *)primaryArtwork secondaryArtwork:(nullable SDLArtwork *)secondaryArtwork  {
     SDLShow *newShow = [[SDLShow alloc] init];
-    newShow.graphic = [self sdl_artworkUploaded:primaryArtwork] ? primaryArtwork.imageRPC : nil;
-    newShow.secondaryGraphic = [self sdl_artworkUploaded:secondaryArtwork] ? secondaryArtwork.imageRPC : nil;
+    newShow.graphic = [self sdl_isArtworkUploaded:primaryArtwork] ? primaryArtwork.imageRPC : nil;
+    newShow.secondaryGraphic = [self sdl_isArtworkUploaded:secondaryArtwork] ? secondaryArtwork.imageRPC : nil;
 
     if (newShow.graphic == nil && newShow.secondaryGraphic == nil) {
         SDLLogV(@"No graphics to upload");
@@ -523,7 +523,7 @@ NS_ASSUME_NONNULL_BEGIN
     return NO;
 }
 
-- (BOOL)sdl_artworkIsUploaded:(nullable SDLArtwork *)artwork {
+- (BOOL)sdl_isArtworkUploaded:(nullable SDLArtwork *)artwork {
     if (artwork != nil) {
         return artwork.isStaticIcon || (self.fileManager != nil && [self.fileManager hasUploadedFile:artwork]);
     }

--- a/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
+++ b/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
@@ -111,7 +111,7 @@ NS_ASSUME_NONNULL_BEGIN
             }
             [strongSelf finishOperation];
         }];
-    } else if (![self sdl_artworkNeedsUpload:self.updatedState.primaryGraphic] && ![self sdl_artworkNeedsUpload:self.updatedState.secondaryGraphic]) {
+    } else if (self.fileManager != nil && ![self.fileManager sdl_artworkNeedsUpload:self.updatedState.primaryGraphic] && ![self.fileManager sdl_artworkNeedsUpload:self.updatedState.secondaryGraphic]) {
         SDLLogV(@"Images already uploaded, sending full update");
         // The files to be updated are already uploaded, send the full show immediately
         [self sdl_sendShow:show withHandler:^(NSError * _Nullable error) {
@@ -514,14 +514,6 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 #pragma mark - Should Update
-
-- (BOOL)sdl_artworkNeedsUpload:(SDLArtwork *)artwork {
-    if (artwork != nil && !artwork.isStaticIcon) {
-        return (artwork.overwrite || (self.fileManager != nil && ![self.fileManager hasUploadedFile:artwork]));
-    }
-
-    return NO;
-}
 
 - (BOOL)sdl_isArtworkUploaded:(nullable SDLArtwork *)artwork {
     if (artwork != nil) {

--- a/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
+++ b/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
@@ -111,7 +111,7 @@ NS_ASSUME_NONNULL_BEGIN
             }
             [strongSelf finishOperation];
         }];
-    } else if (self.fileManager != nil && ![self.fileManager sdl_artworkNeedsUpload:self.updatedState.primaryGraphic] && ![self.fileManager sdl_artworkNeedsUpload:self.updatedState.secondaryGraphic]) {
+    } else if (self.fileManager != nil && ![self.fileManager fileNeedsUpload:self.updatedState.primaryGraphic] && ![self.fileManager fileNeedsUpload:self.updatedState.secondaryGraphic]) {
         SDLLogV(@"Images already uploaded, sending full update");
         // The files to be updated are already uploaded, send the full show immediately
         [self sdl_sendShow:show withHandler:^(NSError * _Nullable error) {
@@ -520,7 +520,7 @@ NS_ASSUME_NONNULL_BEGIN
         return artwork.isStaticIcon || (self.fileManager != nil && [self.fileManager hasUploadedFile:artwork]);
     }
 
-    return YES;
+    return NO;
 }
 
 - (BOOL)sdl_shouldUpdatePrimaryImage {

--- a/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
+++ b/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
@@ -111,7 +111,7 @@ NS_ASSUME_NONNULL_BEGIN
             }
             [strongSelf finishOperation];
         }];
-    } else if (self.fileManager != nil && ![self.fileManager fileNeedsUpload:self.updatedState.primaryGraphic] && ![self.fileManager fileNeedsUpload:self.updatedState.secondaryGraphic]) {
+    } else if (![self.fileManager fileNeedsUpload:self.updatedState.primaryGraphic] && ![self.fileManager fileNeedsUpload:self.updatedState.secondaryGraphic]) {
         SDLLogV(@"Images already uploaded, sending full update");
         // The files to be updated are already uploaded, send the full show immediately
         [self sdl_sendShow:show withHandler:^(NSError * _Nullable error) {
@@ -516,11 +516,9 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Should Update
 
 - (BOOL)sdl_isArtworkUploaded:(nullable SDLArtwork *)artwork {
-    if (artwork != nil) {
-        return artwork.isStaticIcon || (self.fileManager != nil && [self.fileManager hasUploadedFile:artwork]);
-    }
+    if (artwork == nil) { return NO; }
 
-    return NO;
+    return (artwork.isStaticIcon || [self.fileManager hasUploadedFile:artwork]);
 }
 
 - (BOOL)sdl_shouldUpdatePrimaryImage {

--- a/SmartDeviceLink/public/SDLFileManager.h
+++ b/SmartDeviceLink/public/SDLFileManager.h
@@ -137,6 +137,13 @@ typedef void (^SDLFileManagerStartupCompletionHandler)(BOOL success, NSError *__
 - (void)uploadFiles:(NSArray<SDLFile *> *)files completionHandler:(nullable SDLFileManagerMultiUploadCompletionHandler)completionHandler NS_SWIFT_NAME(upload(files:completionHandler:));
 
 /**
+ *  Check if artwork needs to be uploaded.
+ *
+ *  @param artwork      A SDLArwork containing an image to be sent
+ */
+- (BOOL)sdl_artworkNeedsUpload:(SDLArtwork *)artwork;
+
+/**
  *  Uploads an artwork file to the remote file system and returns the name of the uploaded artwork once completed. If an artwork with the same name is already on the remote system, the artwork is not uploaded and the artwork name is simply returned.
  *
  *  @param artwork      A SDLArwork containing an image to be sent

--- a/SmartDeviceLink/public/SDLFileManager.h
+++ b/SmartDeviceLink/public/SDLFileManager.h
@@ -137,17 +137,16 @@ typedef void (^SDLFileManagerStartupCompletionHandler)(BOOL success, NSError *__
 - (void)uploadFiles:(NSArray<SDLFile *> *)files completionHandler:(nullable SDLFileManagerMultiUploadCompletionHandler)completionHandler NS_SWIFT_NAME(upload(files:completionHandler:));
 
 /**
- * Check if an SdlFile needs to be uploaded to Core or not.
- * It is different from hasUploadedFile() because it takes isStaticIcon and overwrite properties into consideration.
- * ie, if the file is static icon, the method always returns false.
- * If the file is dynamic, it returns true in one of these situations:
- * 1) the file has the overwrite property set to true
- * 2) the file hasn't been uploaded to Core before.
+ * Check if an SDLFile needs to be uploaded to Core or not. This method differs from hasUploadedFile() because it takes the `isStaticIcon` and `overwrite` properties into consideration.
  *
- * @param file the SdlFile that needs to be checked
- * @return boolean that tells whether file needs to be uploaded to Core or not
+ * For example, if the file is static icon, the method always returns false.
+ *
+ * If the file is dynamic, it returns true in one of these situations: 1) the file has the overwrite property set to true, 2) the file hasn't been uploaded to Core before.
+ *
+ * @param file the SDLFile that needs to be checked
+ * @return BOOL that tells whether file needs to be uploaded to Core or not
  */
-- (BOOL)fileNeedsUpload:(SDLArtwork *)file;
+- (BOOL)fileNeedsUpload:(SDLFile *)file;
 
 /**
  *  Uploads an artwork file to the remote file system and returns the name of the uploaded artwork once completed. If an artwork with the same name is already on the remote system, the artwork is not uploaded and the artwork name is simply returned.

--- a/SmartDeviceLink/public/SDLFileManager.h
+++ b/SmartDeviceLink/public/SDLFileManager.h
@@ -137,11 +137,17 @@ typedef void (^SDLFileManagerStartupCompletionHandler)(BOOL success, NSError *__
 - (void)uploadFiles:(NSArray<SDLFile *> *)files completionHandler:(nullable SDLFileManagerMultiUploadCompletionHandler)completionHandler NS_SWIFT_NAME(upload(files:completionHandler:));
 
 /**
- *  Check if artwork needs to be uploaded.
+ * Check if an SdlFile needs to be uploaded to Core or not.
+ * It is different from hasUploadedFile() because it takes isStaticIcon and overwrite properties into consideration.
+ * ie, if the file is static icon, the method always returns false.
+ * If the file is dynamic, it returns true in one of these situations:
+ * 1) the file has the overwrite property set to true
+ * 2) the file hasn't been uploaded to Core before.
  *
- *  @param artwork      A SDLArwork containing an image to be sent
+ * @param file the SdlFile that needs to be checked
+ * @return boolean that tells whether file needs to be uploaded to Core or not
  */
-- (BOOL)sdl_artworkNeedsUpload:(SDLArtwork *)artwork;
+- (BOOL)fileNeedsUpload:(SDLArtwork *)file;
 
 /**
  *  Uploads an artwork file to the remote file system and returns the name of the uploaded artwork once completed. If an artwork with the same name is already on the remote system, the artwork is not uploaded and the artwork name is simply returned.

--- a/SmartDeviceLink/public/SDLFileManager.m
+++ b/SmartDeviceLink/public/SDLFileManager.m
@@ -426,6 +426,14 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
 
 #pragma mark Artworks
 
+- (BOOL)sdl_artworkNeedsUpload:(SDLArtwork *)artwork {
+    if (artwork != nil && !artwork.isStaticIcon) {
+        return (artwork.overwrite || ![self hasUploadedFile:artwork]);
+    }
+
+    return NO;
+}
+
 - (void)uploadArtwork:(SDLArtwork *)artwork completionHandler:(nullable SDLFileManagerUploadArtworkCompletionHandler)completion {
     __weak typeof(self) weakself = self;
     [self uploadFile:artwork completionHandler:^(BOOL success, NSUInteger bytesAvailable, NSError * _Nullable error) {

--- a/SmartDeviceLink/public/SDLFileManager.m
+++ b/SmartDeviceLink/public/SDLFileManager.m
@@ -426,9 +426,9 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
 
 #pragma mark Artworks
 
-- (BOOL)sdl_artworkNeedsUpload:(SDLArtwork *)artwork {
-    if (artwork != nil && !artwork.isStaticIcon) {
-        return (artwork.overwrite || ![self hasUploadedFile:artwork]);
+- (BOOL)fileNeedsUpload:(SDLFile *)file {
+    if (file != nil && !file.isStaticIcon) {
+        return (file.overwrite || ![self hasUploadedFile:file]);
     }
 
     return NO;

--- a/SmartDeviceLink/public/SDLFileManager.m
+++ b/SmartDeviceLink/public/SDLFileManager.m
@@ -284,13 +284,13 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
     // HAX: [#827](https://github.com/smartdevicelink/sdl_ios/issues/827) Older versions of Core had a bug where list files would cache incorrectly.
     if (file.persistent && [self.remoteFileNames containsObject:file.name]) {
         // If it's a persistant file, the bug won't present itself; just check if it's on the remote system
-        return true;
+        return YES;
     } else if (!file.persistent && [self.remoteFileNames containsObject:file.name] && [self.uploadedEphemeralFileNames containsObject:file.name]) {
         // If it's an ephemeral file, the bug will present itself; check that it's a remote file AND that we've uploaded it this session
-        return true;
+        return YES;
     }
 
-    return false;
+    return NO;
 }
 
 - (void)uploadFiles:(NSArray<SDLFile *> *)files completionHandler:(nullable SDLFileManagerMultiUploadCompletionHandler)completionHandler {
@@ -427,11 +427,9 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
 #pragma mark Artworks
 
 - (BOOL)fileNeedsUpload:(SDLFile *)file {
-    if (file != nil && !file.isStaticIcon) {
-        return (file.overwrite || ![self hasUploadedFile:file]);
-    }
+    if (file == nil || file.isStaticIcon) { return NO; }
 
-    return NO;
+    return (file.overwrite || ![self hasUploadedFile:file]);
 }
 
 - (void)uploadArtwork:(SDLArtwork *)artwork completionHandler:(nullable SDLFileManagerUploadArtworkCompletionHandler)completion {

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLFileManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLFileManagerSpec.m
@@ -517,7 +517,7 @@ describe(@"uploading / deleting single files with the file manager", ^{
                     expect(testFileNeedsUpload).to(beFalse());
                 });
 
-                it(@"should not allow file to be uploaded when overwrite is set to true", ^{
+                it(@"should allow file to be uploaded when overwrite is set to true", ^{
                     artwork.overwrite = YES;
 
                     BOOL testFileNeedsUpload = [testFileManager fileNeedsUpload:artwork];

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLFileManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLFileManagerSpec.m
@@ -491,8 +491,8 @@ describe(@"uploading / deleting single files with the file manager", ^{
 
         context(@"when artwork is dynamic", ^{
             beforeEach(^{
+                testUIImage = [FileManagerSpecHelper imagesForCount:1].firstObject;
                 expectedArtworkName = testInitialFileNames.firstObject;
-
                 artwork = [SDLArtwork artworkWithImage:testUIImage name:expectedArtworkName asImageFormat:SDLArtworkImageFormatPNG];
             });
 
@@ -505,8 +505,6 @@ describe(@"uploading / deleting single files with the file manager", ^{
 
             context(@"when artwork is previously uploaded", ^{
                 beforeEach(^{
-                    testUIImage = [FileManagerSpecHelper imagesForCount:1].firstObject;
-
                     testFileManager.uploadedEphemeralFileNames = [NSMutableSet setWithArray:testInitialFileNames];
                     testFileManager.mutableRemoteFileNames = [NSMutableSet setWithArray:testInitialFileNames];
                     [testFileManager.stateMachine setToState:SDLFileManagerStateReady fromOldState:SDLFileManagerStateShutdown callEnterTransition:NO];

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLMenuManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLMenuManagerSpec.m
@@ -62,7 +62,7 @@ describe(@"menu manager", ^{
         testArtwork = [[SDLArtwork alloc] initWithData:[@"Test data" dataUsingEncoding:NSUTF8StringEncoding] name:@"some artwork name" fileExtension:@"png" persistent:NO];
         testArtwork2 = [[SDLArtwork alloc] initWithData:[@"Test data 2" dataUsingEncoding:NSUTF8StringEncoding] name:@"some artwork name 2" fileExtension:@"png" persistent:NO];
         testArtwork3 = [[SDLArtwork alloc] initWithData:[@"Test data 3" dataUsingEncoding:NSUTF8StringEncoding] name:@"some artwork name" fileExtension:@"png" persistent:NO];
-        testArtwork3.overwrite = true;
+        testArtwork3.overwrite = YES;
 
         textOnlyCell = [[SDLMenuCell alloc] initWithTitle:@"Test 1" icon:nil voiceCommands:nil handler:^(SDLTriggerSource  _Nonnull triggerSource) {}];
         textAndImageCell = [[SDLMenuCell alloc] initWithTitle:@"Test 2" icon:testArtwork voiceCommands:nil handler:^(SDLTriggerSource  _Nonnull triggerSource) {}];

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLMenuManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLMenuManagerSpec.m
@@ -235,6 +235,7 @@ describe(@"menu manager", ^{
                 });
 
                 it(@"should properly overwrite an image cell", ^{
+                    OCMStub([mockFileManager fileNeedsUpload:[OCMArg isNotNil]]).andReturn(YES);
                     textAndImageCell = [[SDLMenuCell alloc] initWithTitle:@"Test 2" icon:testArtwork3 voiceCommands:nil handler:^(SDLTriggerSource  _Nonnull triggerSource) {}];
                     testManager.menuCells = @[textAndImageCell, submenuImageCell];
                     OCMVerify([mockFileManager uploadArtworks:[OCMArg any] completionHandler:[OCMArg any]]);

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLMenuManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLMenuManagerSpec.m
@@ -46,6 +46,7 @@ describe(@"menu manager", ^{
     __block SDLSystemCapabilityManager *mockSystemCapabilityManager = nil;
     __block SDLArtwork *testArtwork = nil;
     __block SDLArtwork *testArtwork2 = nil;
+    __block SDLArtwork *testArtwork3 = nil;
 
     __block SDLMenuCell *textOnlyCell = nil;
     __block SDLMenuCell *textOnlyCell2 = nil;
@@ -58,6 +59,8 @@ describe(@"menu manager", ^{
     beforeEach(^{
         testArtwork = [[SDLArtwork alloc] initWithData:[@"Test data" dataUsingEncoding:NSUTF8StringEncoding] name:@"some artwork name" fileExtension:@"png" persistent:NO];
         testArtwork2 = [[SDLArtwork alloc] initWithData:[@"Test data 2" dataUsingEncoding:NSUTF8StringEncoding] name:@"some artwork name 2" fileExtension:@"png" persistent:NO];
+        testArtwork3 = [[SDLArtwork alloc] initWithData:[@"Test data 3" dataUsingEncoding:NSUTF8StringEncoding] name:@"some artwork name" fileExtension:@"png" persistent:NO];
+        testArtwork3.overwrite = true;
 
         textOnlyCell = [[SDLMenuCell alloc] initWithTitle:@"Test 1" icon:nil voiceCommands:nil handler:^(SDLTriggerSource  _Nonnull triggerSource) {}];
         textAndImageCell = [[SDLMenuCell alloc] initWithTitle:@"Test 2" icon:testArtwork voiceCommands:nil handler:^(SDLTriggerSource  _Nonnull triggerSource) {}];
@@ -211,6 +214,8 @@ describe(@"menu manager", ^{
             context(@"when the image is already on the head unit", ^{
                 beforeEach(^{
                     OCMStub([mockFileManager hasUploadedFile:[OCMArg isNotNil]]).andReturn(YES);
+                    OCMExpect([mockFileManager hasUploadedFile:testArtwork3]);
+                    OCMExpect([mockFileManager uploadArtwork:testArtwork3 completionHandler:nil]);
                 });
 
                 it(@"should properly update an image cell", ^{
@@ -228,6 +233,25 @@ describe(@"menu manager", ^{
                     expect(submenu).to(haveCount(1));
                     expect(sentCommand.cmdIcon.value).to(equal(testArtwork.name));
                     expect(sentSubmenu.menuIcon.value).to(equal(testArtwork2.name));
+                });
+
+                fit(@"should properly override an image cell", ^{
+                    testManager.menuCells = @[textAndImageCell, submenuImageCell];
+
+                    NSPredicate *addCommandPredicate = [NSPredicate predicateWithFormat:@"self isMemberOfClass: %@", [SDLAddCommand class]];
+                    NSArray *add = [[mockConnectionManager.receivedRequests copy] filteredArrayUsingPredicate:addCommandPredicate];
+                    SDLAddCommand *sentCommand = add.firstObject;
+
+                    NSPredicate *addSubmenuPredicate = [NSPredicate predicateWithFormat:@"self isMemberOfClass: %@", [SDLAddSubMenu class]];
+                    NSArray *submenu = [[mockConnectionManager.receivedRequests copy] filteredArrayUsingPredicate:addSubmenuPredicate];
+                    SDLAddSubMenu *sentSubmenu = submenu.firstObject;
+//                    sentSubmenu.menuIcon = testArtwork3.imageRPC;
+                    sentCommand.cmdIcon = testArtwork3.imageRPC;
+                    expect(add).to(haveCount(1));
+                    expect(submenu).to(haveCount(1));
+                    expect(sentCommand.cmdIcon.value).to(equal(testArtwork.name));
+                    expect(sentSubmenu.menuIcon.value).to(equal(testArtwork2.name));
+                    OCMVerifyAll(mockFileManager);
                 });
             });
 

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLMenuManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLMenuManagerSpec.m
@@ -234,7 +234,7 @@ describe(@"menu manager", ^{
                     OCMReject([mockFileManager uploadArtworks:[OCMArg any] completionHandler:[OCMArg any]]);
                 });
 
-                it(@"should properly override an image cell", ^{
+                it(@"should properly overwrite an image cell", ^{
                     textAndImageCell = [[SDLMenuCell alloc] initWithTitle:@"Test 2" icon:testArtwork3 voiceCommands:nil handler:^(SDLTriggerSource  _Nonnull triggerSource) {}];
                     testManager.menuCells = @[textAndImageCell, submenuImageCell];
                     OCMVerify([mockFileManager uploadArtworks:[OCMArg any] completionHandler:[OCMArg any]]);

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLMenuManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLMenuManagerSpec.m
@@ -35,7 +35,7 @@
 @property (assign, nonatomic) UInt32 lastMenuId;
 @property (copy, nonatomic) NSArray<SDLMenuCell *> *oldMenuCells;
 
-- (BOOL)sdl_areAllCellArtworksUploaded:(NSArray<SDLMenuCell *> *)cells;
+- (BOOL)sdl_shouldRPCsIncludeImages:(NSArray<SDLMenuCell *> *)cells;
 
 @end
 
@@ -188,8 +188,8 @@ describe(@"menu manager", ^{
         it(@"should check if all artworks are uploaded and return NO", ^{
             textAndImageCell = [[SDLMenuCell alloc] initWithTitle:@"Test 2" icon:testArtwork3 voiceCommands:nil handler:^(SDLTriggerSource  _Nonnull triggerSource) {}];
             testManager.menuCells = @[textAndImageCell, textOnlyCell];
-            OCMVerify([testManager sdl_areAllCellArtworksUploaded:testManager.menuCells]);
-            expect([testManager sdl_areAllCellArtworksUploaded:testManager.menuCells]).to(beFalse());
+            OCMVerify([testManager sdl_shouldRPCsIncludeImages:testManager.menuCells]);
+            expect([testManager sdl_shouldRPCsIncludeImages:testManager.menuCells]).to(beFalse());
         });
 
         it(@"should properly update a text cell", ^{
@@ -228,8 +228,8 @@ describe(@"menu manager", ^{
                 it(@"should check if all artworks are uploaded", ^{
                     textAndImageCell = [[SDLMenuCell alloc] initWithTitle:@"Test 2" icon:testArtwork3 voiceCommands:nil handler:^(SDLTriggerSource  _Nonnull triggerSource) {}];
                     testManager.menuCells = @[textAndImageCell, textOnlyCell];
-                    OCMVerify([testManager sdl_areAllCellArtworksUploaded:testManager.menuCells]);
-                    expect([testManager sdl_areAllCellArtworksUploaded:testManager.menuCells]).to(beTrue());
+                    OCMVerify([testManager sdl_shouldRPCsIncludeImages:testManager.menuCells]);
+                    expect([testManager sdl_shouldRPCsIncludeImages:testManager.menuCells]).to(beTrue());
                 });
 
                 it(@"should properly update an image cell", ^{

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLMenuManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLMenuManagerSpec.m
@@ -214,8 +214,6 @@ describe(@"menu manager", ^{
             context(@"when the image is already on the head unit", ^{
                 beforeEach(^{
                     OCMStub([mockFileManager hasUploadedFile:[OCMArg isNotNil]]).andReturn(YES);
-                    OCMExpect([mockFileManager hasUploadedFile:testArtwork3]);
-                    OCMExpect([mockFileManager uploadArtwork:testArtwork3 completionHandler:nil]);
                 });
 
                 it(@"should properly update an image cell", ^{
@@ -233,6 +231,7 @@ describe(@"menu manager", ^{
                     expect(submenu).to(haveCount(1));
                     expect(sentCommand.cmdIcon.value).to(equal(testArtwork.name));
                     expect(sentSubmenu.menuIcon.value).to(equal(testArtwork2.name));
+                    OCMReject([mockFileManager uploadFile:[OCMArg any] completionHandler:[OCMArg any]]);
                 });
 
                 fit(@"should properly override an image cell", ^{
@@ -251,7 +250,7 @@ describe(@"menu manager", ^{
                     expect(submenu).to(haveCount(1));
                     expect(sentCommand.cmdIcon.value).to(equal(testArtwork.name));
                     expect(sentSubmenu.menuIcon.value).to(equal(testArtwork2.name));
-                    OCMVerifyAll(mockFileManager);
+                    OCMVerify([mockFileManager uploadFile:[OCMArg any] completionHandler:[OCMArg any]]);
                 });
             });
 

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLMenuManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLMenuManagerSpec.m
@@ -35,6 +35,8 @@
 @property (assign, nonatomic) UInt32 lastMenuId;
 @property (copy, nonatomic) NSArray<SDLMenuCell *> *oldMenuCells;
 
+- (BOOL)sdl_areAllCellArtworksUploaded:(NSArray<SDLMenuCell *> *)cells;
+
 @end
 
 QuickSpecBegin(SDLMenuManagerSpec)
@@ -183,6 +185,13 @@ describe(@"menu manager", ^{
             });
         });
 
+        it(@"should check if all artworks are uploaded and return NO", ^{
+            textAndImageCell = [[SDLMenuCell alloc] initWithTitle:@"Test 2" icon:testArtwork3 voiceCommands:nil handler:^(SDLTriggerSource  _Nonnull triggerSource) {}];
+            testManager.menuCells = @[textAndImageCell, textOnlyCell];
+            OCMVerify([testManager sdl_areAllCellArtworksUploaded:testManager.menuCells]);
+            expect([testManager sdl_areAllCellArtworksUploaded:testManager.menuCells]).to(beFalse());
+        });
+
         it(@"should properly update a text cell", ^{
             testManager.menuCells = @[textOnlyCell];
 
@@ -214,6 +223,13 @@ describe(@"menu manager", ^{
             context(@"when the image is already on the head unit", ^{
                 beforeEach(^{
                     OCMStub([mockFileManager hasUploadedFile:[OCMArg isNotNil]]).andReturn(YES);
+                });
+
+                it(@"should check if all artworks are uploaded", ^{
+                    textAndImageCell = [[SDLMenuCell alloc] initWithTitle:@"Test 2" icon:testArtwork3 voiceCommands:nil handler:^(SDLTriggerSource  _Nonnull triggerSource) {}];
+                    testManager.menuCells = @[textAndImageCell, textOnlyCell];
+                    OCMVerify([testManager sdl_areAllCellArtworksUploaded:testManager.menuCells]);
+                    expect([testManager sdl_areAllCellArtworksUploaded:testManager.menuCells]).to(beTrue());
                 });
 
                 it(@"should properly update an image cell", ^{

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLMenuManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLMenuManagerSpec.m
@@ -231,26 +231,13 @@ describe(@"menu manager", ^{
                     expect(submenu).to(haveCount(1));
                     expect(sentCommand.cmdIcon.value).to(equal(testArtwork.name));
                     expect(sentSubmenu.menuIcon.value).to(equal(testArtwork2.name));
-                    OCMReject([mockFileManager uploadFile:[OCMArg any] completionHandler:[OCMArg any]]);
+                    OCMReject([mockFileManager uploadArtworks:[OCMArg any] completionHandler:[OCMArg any]]);
                 });
 
-                fit(@"should properly override an image cell", ^{
+                it(@"should properly override an image cell", ^{
+                    textAndImageCell = [[SDLMenuCell alloc] initWithTitle:@"Test 2" icon:testArtwork3 voiceCommands:nil handler:^(SDLTriggerSource  _Nonnull triggerSource) {}];
                     testManager.menuCells = @[textAndImageCell, submenuImageCell];
-
-                    NSPredicate *addCommandPredicate = [NSPredicate predicateWithFormat:@"self isMemberOfClass: %@", [SDLAddCommand class]];
-                    NSArray *add = [[mockConnectionManager.receivedRequests copy] filteredArrayUsingPredicate:addCommandPredicate];
-                    SDLAddCommand *sentCommand = add.firstObject;
-
-                    NSPredicate *addSubmenuPredicate = [NSPredicate predicateWithFormat:@"self isMemberOfClass: %@", [SDLAddSubMenu class]];
-                    NSArray *submenu = [[mockConnectionManager.receivedRequests copy] filteredArrayUsingPredicate:addSubmenuPredicate];
-                    SDLAddSubMenu *sentSubmenu = submenu.firstObject;
-//                    sentSubmenu.menuIcon = testArtwork3.imageRPC;
-                    sentCommand.cmdIcon = testArtwork3.imageRPC;
-                    expect(add).to(haveCount(1));
-                    expect(submenu).to(haveCount(1));
-                    expect(sentCommand.cmdIcon.value).to(equal(testArtwork.name));
-                    expect(sentSubmenu.menuIcon.value).to(equal(testArtwork2.name));
-                    OCMVerify([mockFileManager uploadFile:[OCMArg any] completionHandler:[OCMArg any]]);
+                    OCMVerify([mockFileManager uploadArtworks:[OCMArg any] completionHandler:[OCMArg any]]);
                 });
             });
 

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLPreloadChoicesOperationSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLPreloadChoicesOperationSpec.m
@@ -54,6 +54,7 @@ describe(@"a preload choices operation", ^{
             windowCapability.textFields = @[primaryTextField];
 
             OCMStub([testFileManager uploadArtworks:[OCMArg any] completionHandler:[OCMArg invokeBlock]]);
+            OCMStub([testFileManager fileNeedsUpload:[OCMArg isNotNil]]).andReturn(YES);
         });
 
         context(@"with artworks", ^{

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLPreloadChoicesOperationSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLPreloadChoicesOperationSpec.m
@@ -25,6 +25,7 @@ describe(@"a preload choices operation", ^{
     __block NSString *testDisplayName = @"SDL_GENERIC";
 
     __block NSData *cellArtData = [@"testart" dataUsingEncoding:NSUTF8StringEncoding];
+    __block NSData *cellArtData2 = [@"testart2" dataUsingEncoding:NSUTF8StringEncoding];
 
     __block BOOL hasCalledOperationCompletionHandler = NO;
     __block NSError *resultError = nil;
@@ -60,6 +61,7 @@ describe(@"a preload choices operation", ^{
             __block NSSet<SDLChoiceCell *> *cellsWithStaticIcon = nil;
             __block NSString *art1Name = @"Art1Name";
             __block NSString *art2Name = @"Art2Name";
+            __block SDLArtwork *cell1Art2 = [[SDLArtwork alloc] initWithData:cellArtData2 name:art1Name fileExtension:@"png" persistent:NO];
 
             beforeEach(^{
                 SDLArtwork *cell1Art = [[SDLArtwork alloc] initWithData:cellArtData name:art1Name fileExtension:@"png" persistent:NO];
@@ -144,6 +146,25 @@ describe(@"a preload choices operation", ^{
                             return (artworks.count == 2);
                         }] completionHandler:[OCMArg any]]);
                         expect(@(testOp.currentState)).to(equal(SDLPreloadChoicesOperationStatePreloadingChoices));
+                    });
+
+                    it(@"should properly override artwork", ^{
+                        cell1Art2.overwrite = YES;
+                        SDLChoiceCell *cell1WithArt = [[SDLChoiceCell alloc] initWithText:@"Cell1" artwork:cell1Art2 voiceCommands:nil];
+
+                        SDLArtwork *cell2Art = [[SDLArtwork alloc] initWithData:cellArtData name:art2Name fileExtension:@"png" persistent:NO];
+                        SDLChoiceCell *cell2WithArtAndSecondary = [[SDLChoiceCell alloc] initWithText:@"Cell2" secondaryText:nil tertiaryText:nil voiceCommands:nil artwork:cell2Art secondaryArtwork:cell2Art];
+
+                        SDLArtwork *staticIconArt = [SDLArtwork artworkWithStaticIcon:SDLStaticIconNameDate];
+                        SDLChoiceCell *cellWithStaticIcon = [[SDLChoiceCell alloc] initWithText:@"Static Icon" secondaryText:nil tertiaryText:nil voiceCommands:nil artwork:staticIconArt secondaryArtwork:nil];
+
+                        cellsWithArtwork = [NSSet setWithArray:@[cell1WithArt, cell2WithArtAndSecondary]];
+                        cellsWithStaticIcon = [NSSet setWithArray:@[cellWithStaticIcon]];
+                        testOp = [[SDLPreloadChoicesOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager displayName:testDisplayName windowCapability:windowCapability isVROptional:NO cellsToPreload:cellsWithArtwork];
+                        [testOp start];
+
+                        OCMExpect([testFileManager uploadArtworks:[OCMArg any] completionHandler:[OCMArg any]]);
+                        OCMVerify([testFileManager uploadArtworks:[OCMArg any] completionHandler:[OCMArg any]]);
                     });
                 });
 

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLPreloadChoicesOperationSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLPreloadChoicesOperationSpec.m
@@ -148,7 +148,7 @@ describe(@"a preload choices operation", ^{
                         expect(@(testOp.currentState)).to(equal(SDLPreloadChoicesOperationStatePreloadingChoices));
                     });
 
-                    it(@"should properly override artwork", ^{
+                    it(@"should properly overwrite artwork", ^{
                         cell1Art2.overwrite = YES;
                         SDLChoiceCell *cell1WithArt = [[SDLChoiceCell alloc] initWithText:@"Cell1" artwork:cell1Art2 voiceCommands:nil];
 

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicUpdateOperationSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicUpdateOperationSpec.m
@@ -835,7 +835,7 @@ describe(@"the text and graphic operation", ^{
                     OCMReject([mockFileManager uploadArtworks:[OCMArg any] progressHandler:[OCMArg any] completionHandler:[OCMArg any]]);
                 });
 
-                it(@"should properly override artwork", ^{
+                it(@"should properly overwrite artwork", ^{
                     SDLArtwork *testArtwork3 = [[SDLArtwork alloc] initWithData:[@"Test data 3" dataUsingEncoding:NSUTF8StringEncoding] name:testArtworkName fileExtension:@"png" persistent:NO];
                     testArtwork3.overwrite = YES;
 

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicUpdateOperationSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicUpdateOperationSpec.m
@@ -53,6 +53,7 @@ NSString *testArtworkName = @"some artwork name";
 SDLArtwork *testArtwork = [[SDLArtwork alloc] initWithData:[@"Test data" dataUsingEncoding:NSUTF8StringEncoding] name:testArtworkName fileExtension:@"png" persistent:NO];
 NSString *testArtworkName2 = @"some other artwork name";
 SDLArtwork *testArtwork2 = [[SDLArtwork alloc] initWithData:[@"Test data 2" dataUsingEncoding:NSUTF8StringEncoding] name:testArtworkName2 fileExtension:@"png" persistent:NO];
+SDLArtwork *testArtwork3 = [[SDLArtwork alloc] initWithData:[@"Test data 3" dataUsingEncoding:NSUTF8StringEncoding] name:testArtworkName fileExtension:@"png" persistent:NO];
 SDLArtwork *testStaticIcon = [SDLArtwork artworkWithStaticIcon:SDLStaticIconNameDate];
 
 SDLTemplateConfiguration *newConfiguration = [[SDLTemplateConfiguration alloc] initWithPredefinedLayout:SDLPredefinedLayoutTilesOnly];
@@ -99,6 +100,7 @@ describe(@"the text and graphic operation", ^{
         emptyCurrentData = [[SDLTextAndGraphicState alloc] init];
         receivedState = nil;
         receivedError = nil;
+        testArtwork3.overwrite = YES;
 
         // Default to the max version
         [SDLGlobals sharedGlobals].rpcVersion = [SDLVersion versionWithString:SDLMaxProxyRPCVersion];
@@ -832,6 +834,18 @@ describe(@"the text and graphic operation", ^{
                     expect(firstSentRequest.mainField2).to(beEmpty());
                     expect(firstSentRequest.graphic).toNot(beNil());
                     expect(firstSentRequest.secondaryGraphic).to(beNil());
+                });
+
+                it(@"should properly override artwork", ^{
+                    SDLTextAndGraphicState *updatedState2 = [[SDLTextAndGraphicState alloc] init];
+                    updatedState2.textField1 = field1String;
+                    updatedState2.primaryGraphic = testArtwork3;
+                    updatedState2.secondaryGraphic = testArtwork2;
+
+                    SDLTextAndGraphicUpdateOperation *testOp2 = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:updatedState newState:updatedState2 currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
+                    [testOp2 start];
+
+                    OCMVerify([mockFileManager uploadArtworks:[OCMArg any] completionHandler:[OCMArg any]]);
                 });
             });
 

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicUpdateOperationSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicUpdateOperationSpec.m
@@ -832,6 +832,7 @@ describe(@"the text and graphic operation", ^{
                     expect(firstSentRequest.mainField2).to(beEmpty());
                     expect(firstSentRequest.graphic).toNot(beNil());
                     expect(firstSentRequest.secondaryGraphic).to(beNil());
+                    OCMReject([mockFileManager uploadArtworks:[OCMArg any] progressHandler:[OCMArg any] completionHandler:[OCMArg any]]);
                 });
 
                 it(@"should properly override artwork", ^{

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicUpdateOperationSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicUpdateOperationSpec.m
@@ -836,6 +836,7 @@ describe(@"the text and graphic operation", ^{
                 });
 
                 it(@"should properly overwrite artwork", ^{
+                    OCMStub([mockFileManager fileNeedsUpload:[OCMArg isNotNil]]).andReturn(YES);
                     SDLArtwork *testArtwork3 = [[SDLArtwork alloc] initWithData:[@"Test data 3" dataUsingEncoding:NSUTF8StringEncoding] name:testArtworkName fileExtension:@"png" persistent:NO];
                     testArtwork3.overwrite = YES;
 
@@ -886,6 +887,7 @@ describe(@"the text and graphic operation", ^{
             // when there is text to update as well
             context(@"when there is text to update as well", ^{
                 beforeEach(^{
+                    OCMStub([mockFileManager fileNeedsUpload:[OCMArg isNotNil]]).andReturn(YES);
                     updatedState = [[SDLTextAndGraphicState alloc] init];
                     updatedState.textField1 = field1String;
                     updatedState.primaryGraphic = testArtwork;
@@ -961,6 +963,7 @@ describe(@"the text and graphic operation", ^{
             // when there is no text to update
             context(@"when there is no text to update", ^{
                 beforeEach(^{
+                    OCMStub([mockFileManager fileNeedsUpload:[OCMArg isNotNil]]).andReturn(YES);
                     updatedState = [[SDLTextAndGraphicState alloc] init];
                     updatedState.primaryGraphic = testArtwork;
 
@@ -990,6 +993,7 @@ describe(@"the text and graphic operation", ^{
             // when the image is a static icon
             context(@"when the image is a static icon", ^{
                 beforeEach(^{
+                    OCMStub([mockFileManager fileNeedsUpload:[OCMArg isNotNil]]).andReturn(NO);
                     updatedState = [[SDLTextAndGraphicState alloc] init];
                     updatedState.primaryGraphic = testStaticIcon;
 
@@ -1016,6 +1020,7 @@ describe(@"the text and graphic operation", ^{
             context(@"if the images for the primary and secondary graphics fail the upload process", ^{
                 beforeEach(^{
                     OCMStub([mockFileManager hasUploadedFile:[OCMArg isNotNil]]).andReturn(NO);
+                    OCMStub([mockFileManager fileNeedsUpload:[OCMArg isNotNil]]).andReturn(YES);
                     NSArray<NSString *> *testSuccessfulArtworks = @[];
                     NSError *testError = [NSError errorWithDomain:@"errorDomain"
                                                              code:9
@@ -1048,6 +1053,7 @@ describe(@"the text and graphic operation", ^{
                     NSArray<NSString *> *testSuccessfulArtworks = @[testArtwork.name];
                     NSError *testError = [NSError errorWithDomain:@"errorDomain" code:9 userInfo:@{testArtwork2.name:@"error 2"}];
                     OCMStub([mockFileManager uploadArtworks:[OCMArg isNotNil] progressHandler:[OCMArg isNotNil] completionHandler:([OCMArg invokeBlockWithArgs:testSuccessfulArtworks, testError, nil])]);
+                    OCMStub([mockFileManager fileNeedsUpload:[OCMArg isNotNil]]).andReturn(YES);
                     updatedState = [[SDLTextAndGraphicState alloc] init];
                     updatedState.textField1 = field1String;
                     updatedState.primaryGraphic = testArtwork;
@@ -1076,6 +1082,7 @@ describe(@"the text and graphic operation", ^{
                     NSArray<NSString *> *testSuccessfulArtworks = @[testArtwork2.name];
                     NSError *testError = [NSError errorWithDomain:@"errorDomain" code:9 userInfo:@{testArtwork.name:@"error 2"}];
                     OCMStub([mockFileManager uploadArtworks:[OCMArg isNotNil] progressHandler:[OCMArg isNotNil] completionHandler:([OCMArg invokeBlockWithArgs:testSuccessfulArtworks, testError, nil])]);
+                    OCMStub([mockFileManager fileNeedsUpload:[OCMArg isNotNil]]).andReturn(YES);
                     updatedState = [[SDLTextAndGraphicState alloc] init];
                     updatedState.textField1 = field1String;
                     updatedState.primaryGraphic = testArtwork;

--- a/SmartDeviceLinkTests/SDLSoftButtonReplaceOperationSpec.m
+++ b/SmartDeviceLinkTests/SDLSoftButtonReplaceOperationSpec.m
@@ -165,6 +165,7 @@ describe(@"a soft button replace operation", ^{
 
             context(@"When a response is received to the upload", ^{
                 beforeEach(^{
+                    OCMExpect([testFileManager fileNeedsUpload:[OCMArg any]]);
                     [testOp start];
                 });
 
@@ -269,6 +270,8 @@ describe(@"a soft button replace operation", ^{
                 beforeEach(^{
                     capabilities = [[SDLSoftButtonCapabilities alloc] init];
                     capabilities.imageSupported = @YES;
+//                    OCMExpect([testFileManager fileNeedsUpload:[OCMArg any]]);
+//                    OCMStub([testFileManager fileNeedsUpload:[OCMArg isNotNil]]);
                 });
 
                 context(@"when artworks are already on the system", ^{
@@ -277,11 +280,12 @@ describe(@"a soft button replace operation", ^{
 
                         testSoftButtonObjects = @[buttonWithText, buttonWithTextAndImage];
                         testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
+//                        OCMExpect([testFileManager fileNeedsUpload:[OCMArg any]]).andReturn(YES);
                     });
 
                     it(@"should not upload artworks", ^{
                         OCMReject([testFileManager uploadArtworks:[OCMArg any] progressHandler:nil completionHandler:nil]);
-
+                        OCMStub([testFileManager fileNeedsUpload:[OCMArg any]]).andReturn(NO);
                         [testOp start];
 
                         OCMVerifyAllWithDelay(testFileManager, 0.5);
@@ -300,20 +304,24 @@ describe(@"a soft button replace operation", ^{
                     });
 
                     it(@"should properly overwrite artwork", ^{
+//                        OCMExpect([testFileManager fileNeedsUpload:[OCMArg any]]);
+                        OCMStub([testFileManager fileNeedsUpload:[OCMArg isNotNil]]).andReturn(YES);
                         OCMExpect([testFileManager uploadArtworks:[OCMArg any] progressHandler:[OCMArg any] completionHandler:[OCMArg any]]);
 
                         object2State1 = [[SDLSoftButtonState alloc] initWithStateName:object2State1Name text:object2State1Text artwork:object2State11Art];
                         buttonWithTextAndImage = [[SDLSoftButtonObject alloc] initWithName:object2Name states:@[object2State1, object2State2] initialStateName:object2State1.name handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {}];
                         testSoftButtonObjects = @[buttonWithText, buttonWithTextAndImage];
                         testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
-
+//                        OCMExpect([testFileManager fileNeedsUpload:[OCMArg isNil]]).andReturn(YES);
                         [testOp start];
-
+//                        OCMStub([testFileManager fileNeedsUpload:[OCMArg isNotNil]]).andReturn(YES);
                         OCMVerify([testFileManager uploadArtworks:[OCMArg any] progressHandler:[OCMArg any] completionHandler:[OCMArg any]]);
                     });
 
                     context(@"When a response is received to the upload", ^{
                         beforeEach(^{
+//                            OCMExpect([testFileManager fileNeedsUpload:[OCMArg isNotNil]]);
+//                            OCMStub([testFileManager fileNeedsUpload:[OCMArg isNotNil]]).andReturn(YES);
                             [testOp start];
                         });
 
@@ -336,10 +344,12 @@ describe(@"a soft button replace operation", ^{
                 context(@"when the artworks need uploading", ^{
                     beforeEach(^{
                         OCMStub([testFileManager hasUploadedFile:[OCMArg isNotNil]]).andReturn(NO);
+//                        OCMStub([testFileManager fileNeedsUpload:[OCMArg isNotNil]]).andReturn(YES);
                     });
 
                     context(@"when artworks are static icons", ^{
                         beforeEach(^{
+                            OCMStub([testFileManager fileNeedsUpload:[OCMArg isNotNil]]).andReturn(NO);
                             testSoftButtonObjects = @[buttonWithTextAndStaticImage];
 
                             testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
@@ -384,11 +394,18 @@ describe(@"a soft button replace operation", ^{
                     });
 
                     context(@"when artworks are dynamic icons", ^{
+//                        beforeEach(^{
+//                            OCMStub([testFileManager fileNeedsUpload:[OCMArg any]]);
+//                        });
+
                         it(@"should upload all artworks", ^{
                             // Check that the artworks in the initial button states are uploaded
                             OCMExpect([testFileManager uploadArtworks:@[buttonWithTextAndImage.states[0].artwork] progressHandler:[OCMArg invokeBlock] completionHandler:[OCMArg invokeBlock]]);
+//                            OCMExpect([testFileManager fileNeedsUpload:[OCMArg any]]);
+//                            OCMStub([testFileManager fileNeedsUpload:[OCMArg isNotNil]]).andReturn(YES);
                             testSoftButtonObjects = @[buttonWithText, buttonWithTextAndImage];
                             testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
+//                            OCMStub([testFileManager fileNeedsUpload:[OCMArg any]]).andReturn(YES);
                             [testOp start];
                             OCMVerifyAllWithDelay(testFileManager, 0.5);
 
@@ -423,15 +440,19 @@ describe(@"a soft button replace operation", ^{
 
                         it(@"should upload all artworks even if the initial state does not have artworks", ^{
                             OCMReject([testFileManager uploadFiles:[OCMArg any] progressHandler:[OCMArg invokeBlock] completionHandler:[OCMArg invokeBlock]]);
+//                            OCMStub([testFileManager fileNeedsUpload:[OCMArg any]]).andReturn(NO);
 
                             // buttonWithTextAndImage2 has text in the first state and an text and image in the second & third states
                             testSoftButtonObjects = @[buttonWithTextAndStaticImage, buttonWithTextAndImage2];
                             testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
+//                            OCMStub([testFileManager fileNeedsUpload:[OCMArg any]]);
                             [testOp start];
+//                            OCMStub([testFileManager fileNeedsUpload:[OCMArg any]]).andReturn(YES);
                             OCMVerifyAllWithDelay(testFileManager, 0.5);
 
                             NSArray<SDLArtwork *> *testArtworkUploads = @[buttonWithTextAndImage2.states[1].artwork, buttonWithTextAndImage2.states[2].artwork];
                             OCMExpect([testFileManager uploadArtworks:testArtworkUploads progressHandler:[OCMArg invokeBlock] completionHandler:[OCMArg invokeBlock]]);
+//                            OCMExpect([testFileManager fileNeedsUpload:[OCMArg any]]);
                             [testConnectionManager respondToLastRequestWithResponse:successResponse];
                             OCMVerifyAllWithDelay(testFileManager, 0.5);
 
@@ -461,6 +482,7 @@ describe(@"a soft button replace operation", ^{
 
                         context(@"When a response is received to the upload", ^{
                             beforeEach(^{
+                                OCMStub([testFileManager fileNeedsUpload:[OCMArg isNotNil]]).andReturn(YES);
                                 OCMExpect([testFileManager uploadArtworks:[OCMArg isNotNil] progressHandler:[OCMArg invokeBlock] completionHandler:[OCMArg invokeBlock]]);
 
                                 testSoftButtonObjects = @[buttonWithTextAndImage];

--- a/SmartDeviceLinkTests/SDLSoftButtonReplaceOperationSpec.m
+++ b/SmartDeviceLinkTests/SDLSoftButtonReplaceOperationSpec.m
@@ -274,6 +274,8 @@ describe(@"a soft button replace operation", ^{
 
                 context(@"when artworks are already on the system", ^{
                     beforeEach(^{
+                        OCMStub([testFileManager hasUploadedFile:[OCMArg isNotNil]]).andReturn(YES);
+
                         testSoftButtonObjects = @[buttonWithText, buttonWithTextAndImage];
                         testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
                     });
@@ -427,19 +429,20 @@ describe(@"a soft button replace operation", ^{
 
                         it(@"should upload all artworks even if the initial state does not have artworks", ^{
                             OCMReject([testFileManager uploadFiles:[OCMArg any] progressHandler:[OCMArg invokeBlock] completionHandler:[OCMArg invokeBlock]]);
-//                            OCMStub([testFileManager fileNeedsUpload:[OCMArg any]]).andReturn(NO);
+                            OCMExpect([testFileManager fileNeedsUpload:[OCMArg isNotNil]]).andReturn(YES);
+                            OCMExpect([testFileManager fileNeedsUpload:[OCMArg isNotNil]]).andReturn(NO);
+                            OCMExpect([testFileManager fileNeedsUpload:[OCMArg isNil]]).andReturn(NO);
 
                             // buttonWithTextAndImage2 has text in the first state and an text and image in the second & third states
                             testSoftButtonObjects = @[buttonWithTextAndStaticImage, buttonWithTextAndImage2];
                             testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
-//                            OCMStub([testFileManager fileNeedsUpload:[OCMArg any]]);
+
                             [testOp start];
-//                            OCMStub([testFileManager fileNeedsUpload:[OCMArg any]]).andReturn(YES);
                             OCMVerifyAllWithDelay(testFileManager, 0.5);
 
                             NSArray<SDLArtwork *> *testArtworkUploads = @[buttonWithTextAndImage2.states[1].artwork, buttonWithTextAndImage2.states[2].artwork];
+                            OCMStub([testFileManager fileNeedsUpload:[OCMArg isNotNil]]).andReturn(YES);
                             OCMExpect([testFileManager uploadArtworks:testArtworkUploads progressHandler:[OCMArg invokeBlock] completionHandler:[OCMArg invokeBlock]]);
-//                            OCMExpect([testFileManager fileNeedsUpload:[OCMArg any]]);
                             [testConnectionManager respondToLastRequestWithResponse:successResponse];
                             OCMVerifyAllWithDelay(testFileManager, 0.5);
 

--- a/SmartDeviceLinkTests/SDLSoftButtonReplaceOperationSpec.m
+++ b/SmartDeviceLinkTests/SDLSoftButtonReplaceOperationSpec.m
@@ -270,17 +270,12 @@ describe(@"a soft button replace operation", ^{
                 beforeEach(^{
                     capabilities = [[SDLSoftButtonCapabilities alloc] init];
                     capabilities.imageSupported = @YES;
-//                    OCMExpect([testFileManager fileNeedsUpload:[OCMArg any]]);
-//                    OCMStub([testFileManager fileNeedsUpload:[OCMArg isNotNil]]);
                 });
 
                 context(@"when artworks are already on the system", ^{
                     beforeEach(^{
-                        OCMStub([testFileManager hasUploadedFile:[OCMArg isNotNil]]).andReturn(YES);
-
                         testSoftButtonObjects = @[buttonWithText, buttonWithTextAndImage];
                         testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
-//                        OCMExpect([testFileManager fileNeedsUpload:[OCMArg any]]).andReturn(YES);
                     });
 
                     it(@"should not upload artworks", ^{
@@ -304,24 +299,21 @@ describe(@"a soft button replace operation", ^{
                     });
 
                     it(@"should properly overwrite artwork", ^{
-//                        OCMExpect([testFileManager fileNeedsUpload:[OCMArg any]]);
-                        OCMStub([testFileManager fileNeedsUpload:[OCMArg isNotNil]]).andReturn(YES);
                         OCMExpect([testFileManager uploadArtworks:[OCMArg any] progressHandler:[OCMArg any] completionHandler:[OCMArg any]]);
-
+                        OCMExpect([testFileManager fileNeedsUpload:[OCMArg any]]);
+                        OCMStub([testFileManager fileNeedsUpload:[OCMArg isNotNil]]).andReturn(YES);
                         object2State1 = [[SDLSoftButtonState alloc] initWithStateName:object2State1Name text:object2State1Text artwork:object2State11Art];
                         buttonWithTextAndImage = [[SDLSoftButtonObject alloc] initWithName:object2Name states:@[object2State1, object2State2] initialStateName:object2State1.name handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {}];
                         testSoftButtonObjects = @[buttonWithText, buttonWithTextAndImage];
                         testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
-//                        OCMExpect([testFileManager fileNeedsUpload:[OCMArg isNil]]).andReturn(YES);
+                        OCMExpect([testFileManager fileNeedsUpload:[OCMArg any]]);
                         [testOp start];
-//                        OCMStub([testFileManager fileNeedsUpload:[OCMArg isNotNil]]).andReturn(YES);
                         OCMVerify([testFileManager uploadArtworks:[OCMArg any] progressHandler:[OCMArg any] completionHandler:[OCMArg any]]);
                     });
 
                     context(@"When a response is received to the upload", ^{
                         beforeEach(^{
-//                            OCMExpect([testFileManager fileNeedsUpload:[OCMArg isNotNil]]);
-//                            OCMStub([testFileManager fileNeedsUpload:[OCMArg isNotNil]]).andReturn(YES);
+                            OCMStub([testFileManager fileNeedsUpload:[OCMArg any]]).andReturn(NO);
                             [testOp start];
                         });
 
@@ -344,7 +336,6 @@ describe(@"a soft button replace operation", ^{
                 context(@"when the artworks need uploading", ^{
                     beforeEach(^{
                         OCMStub([testFileManager hasUploadedFile:[OCMArg isNotNil]]).andReturn(NO);
-//                        OCMStub([testFileManager fileNeedsUpload:[OCMArg isNotNil]]).andReturn(YES);
                     });
 
                     context(@"when artworks are static icons", ^{
@@ -394,18 +385,14 @@ describe(@"a soft button replace operation", ^{
                     });
 
                     context(@"when artworks are dynamic icons", ^{
-//                        beforeEach(^{
-//                            OCMStub([testFileManager fileNeedsUpload:[OCMArg any]]);
-//                        });
-
                         it(@"should upload all artworks", ^{
                             // Check that the artworks in the initial button states are uploaded
                             OCMExpect([testFileManager uploadArtworks:@[buttonWithTextAndImage.states[0].artwork] progressHandler:[OCMArg invokeBlock] completionHandler:[OCMArg invokeBlock]]);
-//                            OCMExpect([testFileManager fileNeedsUpload:[OCMArg any]]);
-//                            OCMStub([testFileManager fileNeedsUpload:[OCMArg isNotNil]]).andReturn(YES);
+                            OCMExpect([testFileManager fileNeedsUpload:[OCMArg any]]);
+                            OCMStub([testFileManager fileNeedsUpload:[OCMArg isNotNil]]).andReturn(YES);
                             testSoftButtonObjects = @[buttonWithText, buttonWithTextAndImage];
                             testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
-//                            OCMStub([testFileManager fileNeedsUpload:[OCMArg any]]).andReturn(YES);
+                            OCMExpect([testFileManager fileNeedsUpload:[OCMArg any]]);
                             [testOp start];
                             OCMVerifyAllWithDelay(testFileManager, 0.5);
 

--- a/SmartDeviceLinkTests/SDLSoftButtonReplaceOperationSpec.m
+++ b/SmartDeviceLinkTests/SDLSoftButtonReplaceOperationSpec.m
@@ -44,6 +44,7 @@ describe(@"a soft button replace operation", ^{
     __block NSString *object2State2ArtworkName = @"O2S2 Artwork";
     __block SDLArtwork *object2State1Art = nil;
     __block SDLArtwork *object2State2Art = nil;
+    __block SDLArtwork *object2State11Art = nil;
     __block SDLSoftButtonState *object2State1 = nil;
     __block SDLSoftButtonState *object2State2 = nil;
     __block SDLSoftButtonObject *buttonWithTextAndImage = nil;
@@ -97,6 +98,8 @@ describe(@"a soft button replace operation", ^{
 
         object2State1Art = [[SDLArtwork alloc] initWithData:[@"TestData" dataUsingEncoding:NSUTF8StringEncoding] name:object2State1ArtworkName fileExtension:@"png" persistent:YES];
         object2State2Art = [[SDLArtwork alloc] initWithData:[@"TestData2" dataUsingEncoding:NSUTF8StringEncoding] name:object2State2ArtworkName fileExtension:@"png" persistent:YES];
+        object2State11Art = [[SDLArtwork alloc] initWithData:[@"TestData11" dataUsingEncoding:NSUTF8StringEncoding] name:object2State1ArtworkName fileExtension:@"png" persistent:YES];
+        object2State11Art.overwrite = YES;
         object2State1 = [[SDLSoftButtonState alloc] initWithStateName:object2State1Name text:object2State1Text artwork:object2State1Art];
         object2State2 = [[SDLSoftButtonState alloc] initWithStateName:object2State2Name text:object2State2Text artwork:object2State2Art];
         buttonWithTextAndImage = [[SDLSoftButtonObject alloc] initWithName:object2Name states:@[object2State1, object2State2] initialStateName:object2State1.name handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {}];
@@ -294,6 +297,19 @@ describe(@"a soft button replace operation", ^{
                         expect(sentRequests.firstObject.softButtons.lastObject.text).to(equal(object2State1Text));
                         expect(sentRequests.firstObject.softButtons.lastObject.image).toNot(beNil());
                         expect(sentRequests.firstObject.softButtons.lastObject.type).to(equal(SDLSoftButtonTypeBoth));
+                    });
+
+                    it(@"should properly override artwork", ^{
+                        OCMExpect([testFileManager uploadArtworks:[OCMArg any] progressHandler:[OCMArg any] completionHandler:[OCMArg any]]);
+
+                        object2State1 = [[SDLSoftButtonState alloc] initWithStateName:object2State1Name text:object2State1Text artwork:object2State11Art];
+                        buttonWithTextAndImage = [[SDLSoftButtonObject alloc] initWithName:object2Name states:@[object2State1, object2State2] initialStateName:object2State1.name handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {}];
+                        testSoftButtonObjects = @[buttonWithText, buttonWithTextAndImage];
+                        testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
+
+                        [testOp start];
+
+                        OCMVerify([testFileManager uploadArtworks:[OCMArg any] progressHandler:[OCMArg any] completionHandler:[OCMArg any]]);
                     });
 
                     context(@"When a response is received to the upload", ^{

--- a/SmartDeviceLinkTests/SDLSoftButtonReplaceOperationSpec.m
+++ b/SmartDeviceLinkTests/SDLSoftButtonReplaceOperationSpec.m
@@ -299,7 +299,7 @@ describe(@"a soft button replace operation", ^{
                         expect(sentRequests.firstObject.softButtons.lastObject.type).to(equal(SDLSoftButtonTypeBoth));
                     });
 
-                    it(@"should properly override artwork", ^{
+                    it(@"should properly overwrite artwork", ^{
                         OCMExpect([testFileManager uploadArtworks:[OCMArg any] progressHandler:[OCMArg any] completionHandler:[OCMArg any]]);
 
                         object2State1 = [[SDLSoftButtonState alloc] initWithStateName:object2State1Name text:object2State1Text artwork:object2State11Art];


### PR DESCRIPTION
Fixes #1117 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Unit tests added for their respective Spec files. Checks when the overwrite property is set to true for a new SDLArtwork if it gets uploaded or not.

#### Core Tests
N/A

Core version / branch / commit hash / module tested against: N/A
HMI name / version / branch / commit hash / module tested against: N/A

### Summary
Fix for overwriting a previously uploaded SDLArtwork with the same name.

### Changelog
##### Breaking Changes
* N/A

##### Enhancements
* N/A

##### Bug Fixes
Fix for overwriting a previously uploaded SDLArtwork with the same name.

### Tasks Remaining:
N/A

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
