### PR TITLE
Fix for template reset on hmi level changes in example apps

### DIFF
--- a/Example Apps/Example ObjC/ProxyManager.m
+++ b/Example Apps/Example ObjC/ProxyManager.m
@@ -249,11 +249,13 @@ NS_ASSUME_NONNULL_BEGIN
 
         // Subscribe to vehicle data.
         [self.vehicleDataManager subscribeToVehicleOdometer];
+
+        //Handle initial launch
+        [self sdlex_showInitialData];
     }
 
     if ([newLevel isEqualToEnum:SDLHMILevelFull]) {
         // The SDL app is in the foreground. Always try to show the initial state to guard against some possible weird states. Duplicates will be ignored by Core.
-        [self sdlex_showInitialData];
         [self.subscribeButtonManager subscribeToAllPresetButtons];
     } else if ([newLevel isEqualToEnum:SDLHMILevelLimited]) {
         // An active NAV or MEDIA SDL app is in the background

--- a/Example Apps/Example ObjC/ProxyManager.m
+++ b/Example Apps/Example ObjC/ProxyManager.m
@@ -164,6 +164,10 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)sdlex_showInitialData {
+    // Send static menu items and soft buttons
+    [self sdlex_createMenus];
+    self.sdlManager.screenManager.softButtonObjects = [self.buttonManager allScreenSoftButtons];
+
     if (![self.sdlManager.hmiLevel isEqualToEnum:SDLHMILevelFull]) { return; }
 
     [self.sdlManager.screenManager changeLayout:[[SDLTemplateConfiguration alloc] initWithPredefinedLayout:SDLPredefinedLayoutNonMedia] withCompletionHandler:nil];
@@ -243,10 +247,6 @@ NS_ASSUME_NONNULL_BEGIN
         // This is our first time in a non-NONE state
         self.firstHMILevel = newLevel;
         
-        // Send static menu items and soft buttons
-        [self sdlex_createMenus];
-        self.sdlManager.screenManager.softButtonObjects = [self.buttonManager allScreenSoftButtons];
-
         // Subscribe to vehicle data.
         [self.vehicleDataManager subscribeToVehicleOdometer];
 

--- a/Example Apps/Example Swift/ProxyManager.swift
+++ b/Example Apps/Example Swift/ProxyManager.swift
@@ -165,10 +165,6 @@ extension ProxyManager: SDLManagerDelegate {
             // This is our first time in a non-NONE state
             firstHMILevelState = newLevel
 
-            // Send static menu items and soft buttons
-            createMenuAndGlobalVoiceCommands()
-            sdlManager.screenManager.softButtonObjects = buttonManager.allScreenSoftButtons()
-
             // Subscribe to vehicle data.
             vehicleDataManager.subscribeToVehicleOdometer()
 
@@ -252,6 +248,10 @@ private extension ProxyManager {
 
     /// Set the template and create the UI
     func showInitialData() {
+        // Send static menu items and soft buttons
+        createMenuAndGlobalVoiceCommands()
+        sdlManager.screenManager.softButtonObjects = buttonManager.allScreenSoftButtons()
+
         guard sdlManager.hmiLevel == .full else { return }
 
         sdlManager.screenManager.changeLayout(SDLTemplateConfiguration(predefinedLayout: .nonMedia), withCompletionHandler: nil)

--- a/Example Apps/Example Swift/ProxyManager.swift
+++ b/Example Apps/Example Swift/ProxyManager.swift
@@ -171,12 +171,14 @@ extension ProxyManager: SDLManagerDelegate {
 
             // Subscribe to vehicle data.
             vehicleDataManager.subscribeToVehicleOdometer()
+
+            //Handle initial launch
+            showInitialData()
         }
 
         switch newLevel {
         case .full:
             // The SDL app is in the foreground. Always try to show the initial state to guard against some possible weird states. Duplicates will be ignored by Core.
-            showInitialData()
             subscribeButtonManager.subscribeToPresetButtons()
         case .limited: break // An active NAV or MEDIA SDL app is in the background
         case .background: break // The SDL app is not in the foreground


### PR DESCRIPTION
Fixes #1827 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [ ] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
N/A

#### Core Tests
N/A

Core version / branch / commit hash / module tested against: N/A
HMI name / version / branch / commit hash / module tested against: N/A

### Summary
Fixed template issue, when the user switched HMI level from full to background and the back to full, the template was being reset to the default one(nonMedia)

### Changelog
##### Breaking Changes
* N/A

##### Enhancements
* N/A

##### Bug Fixes
* Fixed template issue, when the user switched HMI level from full to background and the back to full, the template was being reset to the default one(nonMedia)

### Tasks Remaining:
N/A

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
