### PR TITLE
Fix for using NS_TYPED_ENUM instead of SDL_SWIFT_ENUM

### DIFF
--- a/generator/templates/SDLRPCFunctionNames.h.jinja2
+++ b/generator/templates/SDLRPCFunctionNames.h.jinja2
@@ -6,7 +6,7 @@
 /**
  *  All RPC request / response / notification names
  */
-typedef SDLEnum SDLRPCFunctionName SDL_SWIFT_ENUM;
+typedef SDLEnum SDLRPCFunctionName NS_TYPED_ENUM;
 {% for param in params %}
 {#- description if exist in source xml, will be putted here
     since if exist in source xml, will be putted here -#}

--- a/generator/templates/SDLRPCParameterNames.h.jinja2
+++ b/generator/templates/SDLRPCParameterNames.h.jinja2
@@ -6,7 +6,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef NSString* SDLRPCParameterName SDL_SWIFT_ENUM;
+typedef NSString* SDLRPCParameterName NS_TYPED_ENUM;
 {% for param in params %}
 extern SDLRPCParameterName const SDLRPCParameterName{{ param.name }};
 {%- endfor %}

--- a/generator/templates/enums/template.h.jinja2
+++ b/generator/templates/enums/template.h.jinja2
@@ -7,7 +7,7 @@
 {%- endblock -%}
 {%- block body %}
 {% include 'description.jinja2' %}
-typedef SDLEnum {{ name }} SDL_SWIFT_ENUM{{ending}};
+typedef SDLEnum {{ name }} NS_TYPED_ENUM{{ending}};
 {%- for param in params %}
 {%- include 'description_param.jinja2' %}
 extern {{ name }} const {{ name }}{{param.name}}{{ " __deprecated" if param.deprecated and param.deprecated }};

--- a/generator/templates/enums/template.m.jinja2
+++ b/generator/templates/enums/template.m.jinja2
@@ -3,7 +3,7 @@
 #import "{{name}}.h"
 {%- block body %}
 {% if add_typedef %}
-typedef SDLEnum {{name}} SDL_SWIFT_ENUM;
+typedef SDLEnum {{name}} NS_TYPED_ENUM;
 {% endif -%}
 {%- for param in params %}
 {{ name }} const {{ name }}{{param.name}} = @"{{param.origin}}";


### PR DESCRIPTION
Fixes #1834 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [ ] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
N/A

#### Core Tests
N/A

Core version / branch / commit hash / module tested against: N/A
HMI name / version / branch / commit hash / module tested against: N/A

### Summary
Replace SDL_SWIFT_ENUM with NS_TYPED_ENUM.

### Changelog
##### Breaking Changes
* N/A

##### Enhancements
* N/A

##### Bug Fixes
* Replace SDL_SWIFT_ENUM with NS_TYPED_ENUM.

### Tasks Remaining:
N/A

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
