### PR TITLE
Fix to deprecate SDLDisplayCapabilities

### DIFF
--- a/SmartDeviceLink/public/SDLDisplayCapabilities.h
+++ b/SmartDeviceLink/public/SDLDisplayCapabilities.h
@@ -17,7 +17,7 @@
  */
 
 NS_ASSUME_NONNULL_BEGIN
-__deprecated_msg("Use the displayCapabilities property in SDLSystemCapabilityManager instead.")
+__deprecated_msg("Use SDLSystemCapabilityManager.defaultMainWindowCapability instead")
 @interface SDLDisplayCapabilities : SDLRPCStruct
 
 /**

--- a/SmartDeviceLink/public/SDLDisplayCapabilities.h
+++ b/SmartDeviceLink/public/SDLDisplayCapabilities.h
@@ -17,7 +17,7 @@
  */
 
 NS_ASSUME_NONNULL_BEGIN
-
+__deprecated_msg("Use the displayCapabilities property in SDLSystemCapabilityManager instead.")
 @interface SDLDisplayCapabilities : SDLRPCStruct
 
 /**

--- a/SmartDeviceLink/public/SDLDisplayCapabilities.m
+++ b/SmartDeviceLink/public/SDLDisplayCapabilities.m
@@ -11,6 +11,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation SDLDisplayCapabilities
 
 - (void)setDisplayType:(SDLDisplayType)displayType {
@@ -90,5 +92,6 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 @end
+#pragma clang diagnostic pop
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/public/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/public/SDLSystemCapabilityManager.m
@@ -53,7 +53,10 @@ typedef NSString * SDLServiceID;
 @property (weak, nonatomic) id<SDLConnectionManagerType> connectionManager;
 
 @property (nullable, strong, nonatomic, readwrite) NSArray<SDLDisplayCapability *> *displays;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 @property (nullable, strong, nonatomic, readwrite) SDLDisplayCapabilities *displayCapabilities;
+#pragma clang diagnostic pop
 @property (nullable, strong, nonatomic, readwrite) SDLHMICapabilities *hmiCapabilities;
 @property (nullable, copy, nonatomic, readwrite) NSArray<SDLSoftButtonCapabilities *> *softButtonCapabilities;
 @property (nullable, copy, nonatomic, readwrite) NSArray<SDLButtonCapabilities *> *buttonCapabilities;
@@ -200,6 +203,8 @@ typedef NSString * SDLServiceID;
 /// @param display The old-style `SDLDisplayCapabilities` object to convert
 /// @param buttons The old-style `SDLButtonCapabilities` object to convert
 /// @param softButtons The old-style `SDLSoftButtonCapabilities` to convert
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (NSArray<SDLDisplayCapability *> *)sdl_createDisplayCapabilityListFromDeprecatedDisplayCapabilities:(SDLDisplayCapabilities *)display buttons:(NSArray<SDLButtonCapabilities *> *)buttons softButtons:(NSArray<SDLSoftButtonCapabilities *> *)softButtons {
     SDLLogV(@"Creating display capability from deprecated display capabilities");
     // Based on deprecated Display capabilities we don't know if widgets are supported. The default MAIN window is the only window we know is supported, so it's the only one we will expose.
@@ -245,6 +250,7 @@ typedef NSString * SDLServiceID;
     displayCapability.windowCapabilities = @[defaultWindowCapability];
     return @[displayCapability];
 }
+#pragma clang diagnostic pop
 
 #pragma mark Convert New to Deprecated
 
@@ -257,7 +263,10 @@ typedef NSString * SDLServiceID;
     }
     
     // Create the deprecated capabilities for backward compatibility if developers try to access them
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     SDLDisplayCapabilities *convertedCapabilities = [[SDLDisplayCapabilities alloc] init];
+#pragma clang diagnostic pop
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
     convertedCapabilities.displayType = SDLDisplayTypeGeneric; // deprecated but it is mandatory

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingVideoLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingVideoLifecycleManagerSpec.m
@@ -151,7 +151,10 @@ describe(@"the streaming video manager", ^{
 
         describe(@"after receiving a register app interface response", ^{
             __block SDLRegisterAppInterfaceResponse *someRegisterAppInterfaceResponse = nil;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             __block SDLDisplayCapabilities *someDisplayCapabilities = nil;
+#pragma clang diagnostic pop
             __block SDLScreenParams *someScreenParams = nil;
             __block SDLImageResolution *someImageResolution = nil;
             __block SDLHMICapabilities *someHMICapabilities = nil;
@@ -194,7 +197,10 @@ describe(@"the streaming video manager", ^{
                     someHMICapabilities = [[SDLHMICapabilities alloc] init];
                     someHMICapabilities.videoStreaming = @YES;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                     someDisplayCapabilities = [[SDLDisplayCapabilities alloc] init];
+#pragma clang diagnostic pop
                     someDisplayCapabilities.screenParams = someScreenParams;
 
                     someRegisterAppInterfaceResponse = [[SDLRegisterAppInterfaceResponse alloc] init];

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLRegisterAppInterfaceResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLRegisterAppInterfaceResponseSpec.m
@@ -16,7 +16,10 @@
 QuickSpecBegin(SDLRegisterAppInterfaceResponseSpec)
 
 __block SDLMsgVersion *sdlVersion = [[SDLMsgVersion alloc] initWithMajorVersion:0 minorVersion:0 patchVersion:0];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 __block SDLDisplayCapabilities* info = [[SDLDisplayCapabilities alloc] init];
+#pragma clang diagnostic pop
 __block SDLButtonCapabilities* button = [[SDLButtonCapabilities alloc] init];
 __block SDLSoftButtonCapabilities* softButton = [[SDLSoftButtonCapabilities alloc] init];
 __block SDLPresetBankCapabilities* presetBank = [[SDLPresetBankCapabilities alloc] init];__block

--- a/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLSetDisplayLayoutResponseSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/ResponseSpecs/SDLSetDisplayLayoutResponseSpec.m
@@ -19,7 +19,10 @@
 
 QuickSpecBegin(SDLSetDisplayLayoutResponseSpec)
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 SDLDisplayCapabilities* info = [[SDLDisplayCapabilities alloc] init];
+#pragma clang diagnostic pop
 SDLButtonCapabilities* button = [[SDLButtonCapabilities alloc] init];
 SDLSoftButtonCapabilities* softButton = [[SDLSoftButtonCapabilities alloc] init];
 SDLPresetBankCapabilities* presetBank = [[SDLPresetBankCapabilities alloc] init];

--- a/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
+++ b/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
@@ -48,7 +48,10 @@ typedef NSString * SDLServiceID;
 @property (weak, nonatomic) id<SDLConnectionManagerType> connectionManager;
 
 @property (nullable, strong, nonatomic, readwrite) NSArray<SDLDisplayCapability *> *displays;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 @property (nullable, strong, nonatomic, readwrite) SDLDisplayCapabilities *displayCapabilities;
+#pragma clang diagnostic pop
 @property (nullable, strong, nonatomic, readwrite) SDLHMICapabilities *hmiCapabilities;
 @property (nullable, copy, nonatomic, readwrite) NSArray<SDLSoftButtonCapabilities *> *softButtonCapabilities;
 @property (nullable, copy, nonatomic, readwrite) NSArray<SDLButtonCapabilities *> *buttonCapabilities;
@@ -87,7 +90,10 @@ describe(@"System capability manager", ^{
     __block TestConnectionManager *testConnectionManager = nil;
 
     __block NSArray<SDLDisplayCapability *> *testDisplayCapabilityList = nil;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     __block SDLDisplayCapabilities *testDisplayCapabilities = nil;
+#pragma clang diagnostic pop
     __block NSArray<SDLSoftButtonCapabilities *> *testSoftButtonCapabilities = nil;
     __block NSArray<SDLButtonCapabilities *> *testButtonCapabilities = nil;
     __block SDLPresetBankCapabilities *testPresetBankCapabilities = nil;
@@ -95,8 +101,10 @@ describe(@"System capability manager", ^{
     beforeEach(^{
         testConnectionManager = [[TestConnectionManager alloc] init];
         testSystemCapabilityManager = [[SDLSystemCapabilityManager alloc] initWithConnectionManager:testConnectionManager];
-        
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         testDisplayCapabilities = [[SDLDisplayCapabilities alloc] init];
+#pragma clang diagnostic pop
         testDisplayCapabilities.graphicSupported = @NO;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
@@ -267,7 +275,10 @@ describe(@"System capability manager", ^{
 
                     context(@"when displayCapabilities.graphicSupported is true", ^{
                         beforeEach(^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                             testSystemCapabilityManager.displayCapabilities = [[SDLDisplayCapabilities alloc] init];
+#pragma clang diagnostic pop
                             testSystemCapabilityManager.displayCapabilities.graphicSupported = @YES;
                         });
 


### PR DESCRIPTION
Fixes #1857 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
N/A

#### Core Tests
N/A

Core version / branch / commit hash / module tested against: N/A
HMI name / version / branch / commit hash / module tested against: N/A

### Summary
Deprecate DisplayCapabilities and point users to using the SystemCapabilityManager and suppress warnings.

### Changelog
##### Breaking Changes
* N/A

##### Enhancements
* N/A

##### Bug Fixes
* Deprecate DisplayCapabilities and point users to using the SystemCapabilityManager and suppress warnings.

### Tasks Remaining:
N/A

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
