### PR TITLE
Fix for SDL protocol message version

### DIFF
--- a/SmartDeviceLink/private/SDLGlobals.h
+++ b/SmartDeviceLink/private/SDLGlobals.h
@@ -48,7 +48,7 @@ extern void *const SDLConcurrentQueueName;
 /// @param block The block to run on the serial sub-queue.
 + (void)runSyncOnSerialSubQueue:(dispatch_queue_t)queue block:(void (^)(void))block;
 
-- (void)sdl_resetProtocolVersion;
+- (void)reset;
 
 @end
 

--- a/SmartDeviceLink/private/SDLGlobals.h
+++ b/SmartDeviceLink/private/SDLGlobals.h
@@ -48,6 +48,8 @@ extern void *const SDLConcurrentQueueName;
 /// @param block The block to run on the serial sub-queue.
 + (void)runSyncOnSerialSubQueue:(dispatch_queue_t)queue block:(void (^)(void))block;
 
+- (void)sdl_resetProtocolVersion;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/private/SDLGlobals.m
+++ b/SmartDeviceLink/private/SDLGlobals.m
@@ -131,7 +131,7 @@ typedef NSNumber *MTUBox;
     }
 }
 
-- (void)sdl_resetProtocolVersion {
+- (void)reset {
     _protocolVersion = [[SDLVersion alloc] initWithString:@"1.0.0"];
     _maxHeadUnitProtocolVersion = [[SDLVersion alloc] initWithString:@"0.0.0"];
     _rpcVersion = [[SDLVersion alloc] initWithString:@"1.0.0"];

--- a/SmartDeviceLink/private/SDLGlobals.m
+++ b/SmartDeviceLink/private/SDLGlobals.m
@@ -131,6 +131,12 @@ typedef NSNumber *MTUBox;
     }
 }
 
+- (void)sdl_resetProtocolVersion {
+    _protocolVersion = [[SDLVersion alloc] initWithString:@"1.0.0"];
+    _maxHeadUnitProtocolVersion = [[SDLVersion alloc] initWithString:@"0.0.0"];
+    _rpcVersion = [[SDLVersion alloc] initWithString:@"1.0.0"];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/private/SDLLifecycleProtocolHandler.m
+++ b/SmartDeviceLink/private/SDLLifecycleProtocolHandler.m
@@ -92,6 +92,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Called when the transport is closed.
 - (void)protocolDidClose:(SDLProtocol *)protocol {
     if (self.protocol != protocol) { return; }
+    [[SDLGlobals sharedGlobals] sdl_resetProtocolVersion];
 
     SDLLogW(@"Transport disconnected");
     [self.notificationDispatcher postNotificationName:SDLTransportDidDisconnect infoObject:nil];

--- a/SmartDeviceLink/private/SDLLifecycleProtocolHandler.m
+++ b/SmartDeviceLink/private/SDLLifecycleProtocolHandler.m
@@ -92,7 +92,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Called when the transport is closed.
 - (void)protocolDidClose:(SDLProtocol *)protocol {
     if (self.protocol != protocol) { return; }
-    [[SDLGlobals sharedGlobals] sdl_resetProtocolVersion];
+    [[SDLGlobals sharedGlobals] reset];
 
     SDLLogW(@"Transport disconnected");
     [self.notificationDispatcher postNotificationName:SDLTransportDidDisconnect infoObject:nil];

--- a/SmartDeviceLinkTests/UtilitiesSpecs/SDLGlobalsSpec.m
+++ b/SmartDeviceLinkTests/UtilitiesSpecs/SDLGlobalsSpec.m
@@ -43,7 +43,7 @@ describe(@"The SDLGlobals class", ^{
 
     describe(@"test values after calling sdl_resetProtocolVersion", ^{
         beforeEach(^{
-            [testGlobals sdl_resetProtocolVersion];
+            [testGlobals reset];
         });
 
         it(@"should return should properly set values", ^{

--- a/SmartDeviceLinkTests/UtilitiesSpecs/SDLGlobalsSpec.m
+++ b/SmartDeviceLinkTests/UtilitiesSpecs/SDLGlobalsSpec.m
@@ -40,6 +40,19 @@ describe(@"The SDLGlobals class", ^{
             expect(testGlobals.maxHeadUnitProtocolVersion).to(equal(someVersionHigherThanMaxProxyVersion));
         });
     });
+
+    describe(@"test values after calling sdl_resetProtocolVersion", ^{
+        beforeEach(^{
+            [testGlobals sdl_resetProtocolVersion];
+        });
+
+        it(@"should return should properly set values", ^{
+            expect(testGlobals.protocolVersion.stringVersion).to(equal(@"1.0.0"));
+            expect(testGlobals.protocolVersion.major).to(equal(1));
+            expect(testGlobals.maxHeadUnitProtocolVersion.stringVersion).to(equal(@"0.0.0"));
+            expect(testGlobals.rpcVersion).to(equal([[SDLVersion alloc] initWithMajor:1 minor:0 patch:0]));
+        });
+    });
     
     describe(@"getting the max MTU version", ^{
         context(@"when protocol version is 1 - 2", ^{


### PR DESCRIPTION
Fixes #1837 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
New test added to handle property resets

#### Core Tests
N/A

Core version / branch / commit hash / module tested against: N/A
HMI name / version / branch / commit hash / module tested against: N/A

### Summary
Fix for initial protocol version after subsequent iAP connects. 

### Changelog
##### Breaking Changes
* N/A

##### Enhancements
* N/A

##### Bug Fixes
* Fix for initial protocol version after subsequent iAP connects. 

### Tasks Remaining:
N/A

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
