### PR TITLE
Fix SDLArtwork copy with static icon / overwrite

### DIFF
--- a/SmartDeviceLink/public/SDLArtwork.m
+++ b/SmartDeviceLink/public/SDLArtwork.m
@@ -156,9 +156,17 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - NSObject overrides
 
 - (id)copyWithZone:(nullable NSZone *)zone {
-    SDLArtworkImageFormat imageFormat = self.fileType == SDLFileTypePNG ? SDLArtworkImageFormatPNG : SDLArtworkImageFormatJPG;
+    SDLArtwork *artwork = nil;
+    if (self.isStaticIcon) {
+        artwork = [[SDLArtwork allocWithZone:zone] initWithStaticIcon:[[NSString alloc] initWithData:self.data encoding:NSASCIIStringEncoding]];
+    } else {
+        SDLArtworkImageFormat imageFormat = self.fileType == SDLFileTypePNG ? SDLArtworkImageFormatPNG : SDLArtworkImageFormatJPG;
+        artwork = [[SDLArtwork allocWithZone:zone] initWithImage:[self.image copy] name:[self.name copy] persistent:self.isPersistent asImageFormat:imageFormat];
+    }
 
-    return [[SDLArtwork allocWithZone:zone] initWithImage:[self.image copy] name:[self.name copy] persistent:self.isPersistent asImageFormat:imageFormat];
+    artwork.overwrite = self.overwrite;
+
+    return artwork;
 }
 
 - (NSUInteger)hash {
@@ -184,7 +192,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"SDLArtwork name: %@, image: %@, isTemplate: %@, isStaticIcon: %@", self.name, self.image, (self.isTemplate ? @"YES" : @"NO"), (self.isStaticIcon ? @"YES" : @"NO")];
+    return [NSString stringWithFormat:@"SDLArtwork name: %@, image: %@, isTemplate: %@, isStaticIcon: %@, isOverwrite: %@", self.name, self.image, (self.isTemplate ? @"YES" : @"NO"), (self.isStaticIcon ? @"YES" : @"NO"), (self.overwrite ? @"YES" : @"NO")];
 }
 
 @end

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLArtworkSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLArtworkSpec.m
@@ -162,6 +162,39 @@ describe(@"SDLArtwork Tests", ^{
             expect(expectedName1).toNot(equal(expectedName2));
         });
     });
+
+    describe(@"copying the image", ^{
+        context(@"a dynamic image", ^{
+            beforeEach(^{
+                expectedArtwork = [[SDLArtwork alloc] initWithImage:testImagePNGTemplate persistent:YES asImageFormat:SDLArtworkImageFormatPNG];
+                expectedArtwork.overwrite = YES;
+            });
+
+            it(@"should copy correctly", ^{
+                SDLArtwork *copiedArtwork = [expectedArtwork copy];
+                expect(copiedArtwork.isTemplate).to(equal(expectedArtwork.isTemplate));
+                expect(copiedArtwork.data).to(equal(expectedArtwork.data));
+                expect(copiedArtwork.imageRPC).to(equal(expectedArtwork.imageRPC));
+                expect(copiedArtwork.overwrite).to(equal(expectedArtwork.overwrite));
+                expect(copiedArtwork.isStaticIcon).to(equal(expectedArtwork.isStaticIcon));
+            });
+        });
+
+        context(@"a static image", ^{
+            beforeEach(^{
+                expectedArtwork = [[SDLArtwork alloc] initWithStaticIcon:SDLStaticIconNameKey];
+            });
+
+            it(@"should copy correctly", ^{
+                SDLArtwork *copiedArtwork = [expectedArtwork copy];
+                expect(copiedArtwork.isTemplate).to(equal(expectedArtwork.isTemplate));
+                expect(copiedArtwork.data).to(equal(expectedArtwork.data));
+                expect(copiedArtwork.imageRPC).to(equal(expectedArtwork.imageRPC));
+                expect(copiedArtwork.overwrite).to(equal(expectedArtwork.overwrite));
+                expect(copiedArtwork.isStaticIcon).to(equal(expectedArtwork.isStaticIcon));
+            });
+        });
+    });
 });
 
 QuickSpecEnd


### PR DESCRIPTION
Fixes #1846 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Added unit tests for copying artwork both static or dynamic artwork

#### Core Tests
Tested displaying a copied artwork

Core version / branch / commit hash / module tested against: Manticore (Core v6.1.1)
HMI name / version / branch / commit hash / module tested against: Manticore (Generic HMI v0.8.1)

### Summary
This PR fixes copying an artwork that contains a static icon or is set to overwrite.

### Changelog
##### Bug Fixes
* Fixes copying an artwork that contains a static icon or is set to overwrite.

### Tasks Remaining:
n/a

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
