### PR TITLE
Update to only overwrite non-persistent files on RPC v4.3.1 or less

### DIFF
--- a/SmartDeviceLink/private/SDLLifecycleManager.m
+++ b/SmartDeviceLink/private/SDLLifecycleManager.m
@@ -395,7 +395,7 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
 
         weakSelf.registerResponse = (SDLRegisterAppInterfaceResponse *)response;
         [SDLGlobals sharedGlobals].rpcVersion = [SDLVersion versionWithSDLMsgVersion:weakSelf.registerResponse.sdlMsgVersion];
-        SDLLogD(@"Did register app; RPC version: %@, SDL version: %@, starting languages: (VR) %@, (HMI) %@, vehicle type: %@", weakSelf.registerResponse.sdlMsgVersion, weakSelf.registerResponse.sdlVersion, weakSelf.registerResponse.language, weakSelf.registerResponse.hmiDisplayLanguage, weakSelf.registerResponse.vehicleType);
+        SDLLogD(@"Did register app; RPC version: %@, SDL version: %@, starting languages: (VR) %@, (HMI) %@, vehicle type: %@", weakSelf.registerResponse.sdlMsgVersion, (weakSelf.registerResponse.sdlVersion ?: @"unavailable"), weakSelf.registerResponse.language, weakSelf.registerResponse.hmiDisplayLanguage, weakSelf.registerResponse.vehicleType);
 
         [weakSelf sdl_transitionToState:SDLLifecycleStateRegistered];
     }];

--- a/SmartDeviceLink/private/SDLLifecycleManager.m
+++ b/SmartDeviceLink/private/SDLLifecycleManager.m
@@ -395,6 +395,8 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
 
         weakSelf.registerResponse = (SDLRegisterAppInterfaceResponse *)response;
         [SDLGlobals sharedGlobals].rpcVersion = [SDLVersion versionWithSDLMsgVersion:weakSelf.registerResponse.sdlMsgVersion];
+        SDLLogD(@"Did register app; RPC version: %@, SDL version: %@, starting languages: (VR) %@, (HMI) %@, vehicle type: %@", weakSelf.registerResponse.sdlMsgVersion, weakSelf.registerResponse.sdlVersion, weakSelf.registerResponse.language, weakSelf.registerResponse.hmiDisplayLanguage, weakSelf.registerResponse.vehicleType);
+
         [weakSelf sdl_transitionToState:SDLLifecycleStateRegistered];
     }];
 }

--- a/SmartDeviceLink/public/SDLFileManager.m
+++ b/SmartDeviceLink/public/SDLFileManager.m
@@ -22,6 +22,7 @@
 #import "SDLPutFile.h"
 #import "SDLStateMachine.h"
 #import "SDLUploadFileOperation.h"
+#import "SDLVersion.h"
 
 
 NS_ASSUME_NONNULL_BEGIN
@@ -377,9 +378,9 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
         return;
     }
 
-    // HAX: [#827](https://github.com/smartdevicelink/sdl_ios/issues/827) Older versions of Core had a bug where list files would cache incorrectly. This led to attempted uploads failing due to the system thinking they were already there when they were not.
-    if (!file.persistent && ![self hasUploadedFile:file]) {
-        file.overwrite = true;
+    // HAX: [#827](https://github.com/smartdevicelink/sdl_ios/issues/827) Older versions of Core had a bug where list files would cache incorrectly. This led to attempted uploads failing due to the system thinking they were already there when they were not. This is only needed if connecting to Core v4.3.1 or less which corresponds to RPC v4.3.1 or less
+    if (!file.persistent && ![self hasUploadedFile:file] && ![[SDLGlobals sharedGlobals].rpcVersion isGreaterThanOrEqualToVersion:[SDLVersion versionWithMajor:4 minor:4 patch:0]]) {
+        file.overwrite = YES;
     }
 
     // Check our overwrite settings and error out if it would overwrite

--- a/SmartDeviceLink/public/SDLFileManager.m
+++ b/SmartDeviceLink/public/SDLFileManager.m
@@ -379,7 +379,7 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
     }
 
     // HAX: [#827](https://github.com/smartdevicelink/sdl_ios/issues/827) Older versions of Core had a bug where list files would cache incorrectly. This led to attempted uploads failing due to the system thinking they were already there when they were not. This is only needed if connecting to Core v4.3.1 or less which corresponds to RPC v4.3.1 or less
-    if (!file.persistent && ![self hasUploadedFile:file] && ![[SDLGlobals sharedGlobals].rpcVersion isGreaterThanOrEqualToVersion:[SDLVersion versionWithMajor:4 minor:4 patch:0]]) {
+    if (!file.persistent && ![self hasUploadedFile:file] && [[SDLGlobals sharedGlobals].rpcVersion isLessThanVersion:[SDLVersion versionWithMajor:4 minor:4 patch:0]]) {
         file.overwrite = YES;
     }
 

--- a/SmartDeviceLink/public/SDLMsgVersion.m
+++ b/SmartDeviceLink/public/SDLMsgVersion.m
@@ -52,7 +52,7 @@
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"%@.%@.%@", self.majorVersion, self.minorVersion, self.patchVersion];
+    return [NSString stringWithFormat:@"%@.%@.%@", self.majorVersion, self.minorVersion, (self.patchVersion ?: @"0")];
 }
 
 @end


### PR DESCRIPTION
Fixes #827 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Unit tests were run, but no new tests were added.

#### Core Tests
Tested displaying a non-persistent artwork on a v4.2 head unit and a v6.0 head unit

Core version / branch / commit hash / module tested against: Manticore (6.0), Sync 3.4 (4.2)
HMI name / version / branch / commit hash / module tested against: Manticore (Generic HMI 0.8.2), Sync 3.4

### Summary
This PR alters a check that was added in SDL iOS v5.2 which changes non-persistent files to always overwrite existing data. This check was added due to a bug in Core v4.3 and below that doesn't properly check the cache for a list files, causing these files to not update properly unless they attempt an overwrite. Because this bug was fixed in SDL Core v4.3.1, we can add a version check to only apply the check on RPC versions v4.3.0 and below (which corresponds to Core v4.3.1 and below).

### Changelog
##### Bug Fixes
* Don't auto-overwrite non-persistent files when not necessary on newer SDL Core versions.

### Tasks Remaining:
- [x] Test against newer Core versions to ensure that no longer overwriting non-persistent files works properly.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
