### PR TITLE
Change T&G BlankArtwork to persistent artwork

### DIFF
--- a/SmartDeviceLink/private/SDLTextAndGraphicManager.m
+++ b/SmartDeviceLink/private/SDLTextAndGraphicManager.m
@@ -366,7 +366,7 @@ NS_ASSUME_NONNULL_BEGIN
     UIImage *blankImage = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();
 
-    _blankArtwork = [SDLArtwork artworkWithImage:blankImage name:@"sdl_BlankArt" asImageFormat:SDLArtworkImageFormatPNG];
+    _blankArtwork = [SDLArtwork persistentArtworkWithImage:blankImage name:@"sdl_BlankArt" asImageFormat:SDLArtworkImageFormatPNG];
 
     return _blankArtwork;
 }


### PR DESCRIPTION
Fixes #1864 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
No unit tests changed

#### Core Tests
Tested on Core v4.2 (Sync 3.4) and Core v6.1 / Generic HMI v0.8.1 (Manticore)

Core version / branch / commit hash / module tested against: See above
HMI name / version / branch / commit hash / module tested against: See above

### Summary
This PR changes the blank artwork used to show no artwork to be persistent rather than ephemeral.

### Changelog
##### Bug Fixes
* Blank artwork will not be uploaded after every connection.

### Tasks Remaining:
n/a

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
