### PR TITLE
Fixed throw an exception in the soft button manager if two buttons have the same name

### DIFF
--- a/SmartDeviceLink/private/SDLError.h
+++ b/SmartDeviceLink/private/SDLError.h
@@ -95,7 +95,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface NSException (SDLExceptions)
 
-+ (NSException *)sdl_duplicateSoftButtonsTitleException;
++ (NSException *)sdl_duplicateSoftButtonsNameException;
 + (NSException *)sdl_missingHandlerException;
 + (NSException *)sdl_missingIdException;
 + (NSException *)sdl_missingFilesException;

--- a/SmartDeviceLink/private/SDLError.h
+++ b/SmartDeviceLink/private/SDLError.h
@@ -95,6 +95,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface NSException (SDLExceptions)
 
++ (NSException *)sdl_duplicateSoftButtonsTitleException;
 + (NSException *)sdl_missingHandlerException;
 + (NSException *)sdl_missingIdException;
 + (NSException *)sdl_missingFilesException;

--- a/SmartDeviceLink/private/SDLError.m
+++ b/SmartDeviceLink/private/SDLError.m
@@ -407,8 +407,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation NSException (SDLExceptions)
 
-+ (NSException *)sdl_duplicateSoftButtonsTitleException {
-    return [NSException exceptionWithName:@"InvalidSoftButtonsInitialization" reason:@"Attempting to create soft buttons with the same title" userInfo:nil];
++ (NSException *)sdl_duplicateSoftButtonsNameException {
+    return [NSException exceptionWithName:@"InvalidSoftButtonsInitialization" reason:@"Attempting to create soft buttons with the same name" userInfo:nil];
 }
 
 + (NSException *)sdl_missingHandlerException {

--- a/SmartDeviceLink/private/SDLError.m
+++ b/SmartDeviceLink/private/SDLError.m
@@ -407,6 +407,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation NSException (SDLExceptions)
 
++ (NSException *)sdl_duplicateSoftButtonsTitleException {
+    return [NSException exceptionWithName:@"InvalidSoftButtonsInitialization" reason:@"Attempting to create soft buttons with the same title" userInfo:nil];
+}
+
 + (NSException *)sdl_missingHandlerException {
     return [NSException
             exceptionWithName:@"MissingHandlerException"

--- a/SmartDeviceLink/private/SDLSoftButtonManager.m
+++ b/SmartDeviceLink/private/SDLSoftButtonManager.m
@@ -133,7 +133,7 @@ NS_ASSUME_NONNULL_BEGIN
             if ([softButtonObjects[j].name isEqualToString:buttonName]) {
                 _softButtonObjects = @[];
                 SDLLogE(@"Attempted to set soft button objects, but two buttons had the same name: %@", softButtonObjects);
-                @throw [NSException sdl_duplicateSoftButtonsTitleException];
+                @throw [NSException sdl_duplicateSoftButtonsNameException];
             }
         }
     }

--- a/SmartDeviceLink/private/SDLSoftButtonManager.m
+++ b/SmartDeviceLink/private/SDLSoftButtonManager.m
@@ -133,7 +133,7 @@ NS_ASSUME_NONNULL_BEGIN
             if ([softButtonObjects[j].name isEqualToString:buttonName]) {
                 _softButtonObjects = @[];
                 SDLLogE(@"Attempted to set soft button objects, but two buttons had the same name: %@", softButtonObjects);
-                return;
+                @throw [NSException sdl_duplicateSoftButtonsTitleException];
             }
         }
     }

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLSoftButtonManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLSoftButtonManagerSpec.m
@@ -153,7 +153,8 @@ describe(@"a soft button manager", ^{
             testObject1 = [[SDLSoftButtonObject alloc] initWithName:sameName states:@[object1State1, object1State2] initialStateName:object1State1Name handler:nil];
             testObject2 = [[SDLSoftButtonObject alloc] initWithName:sameName state:object2State1 handler:nil];
 
-            testManager.softButtonObjects = @[testObject1, testObject2];
+            expectAction((^{ testManager.softButtonObjects = @[testObject1, testObject2];
+            })).to(raiseException().named(@"InvalidSoftButtonsInitialization"));
         });
 
         it(@"should fail to set the buttons", ^{

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLRegisterAppInterfaceSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLRegisterAppInterfaceSpec.m
@@ -42,7 +42,7 @@ describe(@"RegisterAppInterface Tests", ^{
     __block SDLDeviceInfo *info = nil;
     __block SDLAppInfo *appInfo = nil;
     __block SDLTemplateColorScheme *colorScheme = nil;
-    __block SDLMsgVersion * currentSDLMsgVersion = [[SDLMsgVersion alloc] initWithMajorVersion:7 minorVersion:0 patchVersion:0];
+    __block SDLMsgVersion * currentSDLMsgVersion = [[SDLMsgVersion alloc] initWithMajorVersion:7 minorVersion:1 patchVersion:0];
 
     beforeEach(^{
         testRegisterAppInterface = nil;

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLRegisterAppInterfaceSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLRegisterAppInterfaceSpec.m
@@ -91,14 +91,10 @@ describe(@"RegisterAppInterface Tests", ^{
     });
 
  describe(@"Setting With Dictionary", ^{
-     beforeEach( ^{
+     it(@"initWithDictionary", ^{
          NSDictionary *dict = @{SDLRPCParameterNameRequest:
                       @{SDLRPCParameterNameParameters:
-                            @{SDLRPCParameterNameSyncMessageVersion:@{
-                                      SDLRPCParameterNameMajorVersion: @7,
-                                      SDLRPCParameterNameMinorVersion: @0,
-                                      SDLRPCParameterNamePatchVersion: @0
-                                      },
+                            @{SDLRPCParameterNameSyncMessageVersion:currentSDLMsgVersion,
                               SDLRPCParameterNameAppName:appName,
                               SDLRPCParameterNameTTSName:[@[chunk] mutableCopy],
                               SDLRPCParameterNameNGNMediaScreenAppName:shortAppName,

--- a/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLRegisterAppInterfaceSpec.m
+++ b/SmartDeviceLinkTests/RPCSpecs/RequestSpecs/SDLRegisterAppInterfaceSpec.m
@@ -90,48 +90,48 @@ describe(@"RegisterAppInterface Tests", ^{
         expect(testRegisterAppInterface.sdlMsgVersion).to(equal(msgVersion));
     });
 
- describe(@"Setting With Dictionary", ^{
-     it(@"initWithDictionary", ^{
-         NSDictionary *dict = @{SDLRPCParameterNameRequest:
-                      @{SDLRPCParameterNameParameters:
-                            @{SDLRPCParameterNameSyncMessageVersion:currentSDLMsgVersion,
-                              SDLRPCParameterNameAppName:appName,
-                              SDLRPCParameterNameTTSName:[@[chunk] mutableCopy],
-                              SDLRPCParameterNameNGNMediaScreenAppName:shortAppName,
-                              SDLRPCParameterNameVRSynonyms:@[vrSynonyms],
-                              SDLRPCParameterNameIsMediaApplication:isMediaApp,
-                              SDLRPCParameterNameLanguageDesired:SDLLanguageNoNo,
-                              SDLRPCParameterNameHMIDisplayLanguageDesired:SDLLanguagePtPt,
-                              SDLRPCParameterNameAppHMIType:appTypes,
-                              SDLRPCParameterNameHashId:resumeHash,
-                              SDLRPCParameterNameDeviceInfo:info,
-                              SDLRPCParameterNameFullAppID:fullAppId,
-                              SDLRPCParameterNameAppId:appId,
-                              SDLRPCParameterNameAppInfo:appInfo,
-                              SDLRPCParameterNameDayColorScheme: colorScheme,
-                              SDLRPCParameterNameNightColorScheme: colorScheme,
-                              },
-                        SDLRPCParameterNameOperationName:SDLRPCFunctionNameRegisterAppInterface}};
-         SDLRegisterAppInterface *testRegisterAppInterface = [[SDLRegisterAppInterface alloc] initWithDictionary:dict];
+    describe(@"Setting With Dictionary", ^{
+        it(@"initWithDictionary", ^{
+            NSDictionary *dict = @{SDLRPCParameterNameRequest:
+                                       @{SDLRPCParameterNameParameters:
+                                             @{SDLRPCParameterNameSyncMessageVersion:currentSDLMsgVersion,
+                                               SDLRPCParameterNameAppName:appName,
+                                               SDLRPCParameterNameTTSName:[@[chunk] mutableCopy],
+                                               SDLRPCParameterNameNGNMediaScreenAppName:shortAppName,
+                                               SDLRPCParameterNameVRSynonyms:@[vrSynonyms],
+                                               SDLRPCParameterNameIsMediaApplication:isMediaApp,
+                                               SDLRPCParameterNameLanguageDesired:SDLLanguageNoNo,
+                                               SDLRPCParameterNameHMIDisplayLanguageDesired:SDLLanguagePtPt,
+                                               SDLRPCParameterNameAppHMIType:appTypes,
+                                               SDLRPCParameterNameHashId:resumeHash,
+                                               SDLRPCParameterNameDeviceInfo:info,
+                                               SDLRPCParameterNameFullAppID:fullAppId,
+                                               SDLRPCParameterNameAppId:appId,
+                                               SDLRPCParameterNameAppInfo:appInfo,
+                                               SDLRPCParameterNameDayColorScheme: colorScheme,
+                                               SDLRPCParameterNameNightColorScheme: colorScheme,
+                                             },
+                                         SDLRPCParameterNameOperationName:SDLRPCFunctionNameRegisterAppInterface}};
+            SDLRegisterAppInterface *testRegisterAppInterface = [[SDLRegisterAppInterface alloc] initWithDictionary:dict];
 
-         expect(testRegisterAppInterface.sdlMsgVersion).to(equal(currentSDLMsgVersion));
-         expect(testRegisterAppInterface.appName).to(match(appName));
-         expect(testRegisterAppInterface.ttsName).to(equal([@[chunk] mutableCopy]));
-         expect(testRegisterAppInterface.ngnMediaScreenAppName).to(match(shortAppName));
-         expect(testRegisterAppInterface.vrSynonyms).to(equal(@[vrSynonyms]));
-         expect(testRegisterAppInterface.isMediaApplication).to(equal(isMediaApp));
-         expect(testRegisterAppInterface.languageDesired).to(equal(SDLLanguageNoNo));
-         expect(testRegisterAppInterface.hmiDisplayLanguageDesired).to(equal(SDLLanguagePtPt));
-         expect(testRegisterAppInterface.appHMIType).to(equal(appTypes));
-         expect(testRegisterAppInterface.hashID).to(match(resumeHash));
-         expect(testRegisterAppInterface.deviceInfo).to(equal(info));
-         expect(testRegisterAppInterface.fullAppID).to(match(fullAppId));
-         expect(testRegisterAppInterface.appID).to(match(appId));
-         expect(testRegisterAppInterface.appInfo).to(equal(appInfo));
-         expect(testRegisterAppInterface.dayColorScheme).to(equal(colorScheme));
-         expect(testRegisterAppInterface.nightColorScheme).to(equal(colorScheme));
-     });
- });
+            expect(testRegisterAppInterface.sdlMsgVersion).to(equal(currentSDLMsgVersion));
+            expect(testRegisterAppInterface.appName).to(match(appName));
+            expect(testRegisterAppInterface.ttsName).to(equal([@[chunk] mutableCopy]));
+            expect(testRegisterAppInterface.ngnMediaScreenAppName).to(match(shortAppName));
+            expect(testRegisterAppInterface.vrSynonyms).to(equal(@[vrSynonyms]));
+            expect(testRegisterAppInterface.isMediaApplication).to(equal(isMediaApp));
+            expect(testRegisterAppInterface.languageDesired).to(equal(SDLLanguageNoNo));
+            expect(testRegisterAppInterface.hmiDisplayLanguageDesired).to(equal(SDLLanguagePtPt));
+            expect(testRegisterAppInterface.appHMIType).to(equal(appTypes));
+            expect(testRegisterAppInterface.hashID).to(match(resumeHash));
+            expect(testRegisterAppInterface.deviceInfo).to(equal(info));
+            expect(testRegisterAppInterface.fullAppID).to(match(fullAppId));
+            expect(testRegisterAppInterface.appID).to(match(appId));
+            expect(testRegisterAppInterface.appInfo).to(equal(appInfo));
+            expect(testRegisterAppInterface.dayColorScheme).to(equal(colorScheme));
+            expect(testRegisterAppInterface.nightColorScheme).to(equal(colorScheme));
+        });
+    });
 
     describe(@"initializers", ^{
         it(@"init", ^{


### PR DESCRIPTION
Fixes #1897 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Unit test handled to expect exception in case of softButtons do not have unique titles.

#### Core Tests
N/A

Core version / branch / commit hash / module tested against: 7.1
HMI name / version / branch / commit hash / module tested against: N/A

### Summary
Exception is thrown in case multiple softButtons are being and do not have unique titles.

### Changelog
##### Breaking Changes
* N/A

##### Enhancements
* N/A

##### Bug Fixes
* N/A

### Tasks Remaining:
N/A

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
