### PR TITLE
Prevent incorrect background processing

### DIFF
--- a/SmartDeviceLink/private/SDLLifecycleManager.m
+++ b/SmartDeviceLink/private/SDLLifecycleManager.m
@@ -14,7 +14,6 @@
 #import "SDLLifecycleRPCAdapter.h"
 #import "SDLAsynchronousRPCOperation.h"
 #import "SDLAsynchronousRPCRequestOperation.h"
-#import "SDLBackgroundTaskManager.h"
 #import "SDLChangeRegistration.h"
 #import "SDLConfiguration.h"
 #import "SDLConnectionManagerType.h"
@@ -107,7 +106,6 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
 @property (copy, nonatomic) SDLManagerReadyBlock readyHandler;
 @property (copy, nonatomic) dispatch_queue_t lifecycleQueue;
 @property (assign, nonatomic) int32_t lastCorrelationId;
-@property (copy, nonatomic) SDLBackgroundTaskManager *backgroundTaskManager;
 @property (strong, nonatomic) SDLLanguage currentVRLanguage;
 
 // RPC Handlers
@@ -189,8 +187,6 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_transportDidDisconnect) name:SDLTransportDidDisconnect object:_notificationDispatcher];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(hmiStatusDidChange:) name:SDLDidChangeHMIStatusNotification object:_notificationDispatcher];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(remoteHardwareDidUnregister:) name:SDLDidReceiveAppUnregisteredNotification object:_notificationDispatcher];
-
-    _backgroundTaskManager = [[SDLBackgroundTaskManager alloc] initWithBackgroundTaskName:BackgroundTaskTransportName];
 
     return self;
 }
@@ -354,9 +350,6 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
 
         if (shouldRestart) {
             [strongSelf sdl_transitionToState:SDLLifecycleStateStarted];
-        } else {
-            // End the background task because a session will not be established
-            [strongSelf.backgroundTaskManager endBackgroundTask];
         }
     });
 }
@@ -583,9 +576,6 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
     if ([self.delegate respondsToSelector:@selector(videoStreamingState:didChangetoState:)]) {
         [self.delegate videoStreamingState:SDLVideoStreamingStateNotStreamable didChangetoState:self.videoStreamingState];
     }
-
-    // Stop the background task now that setup has completed
-    [self.backgroundTaskManager endBackgroundTask];
 }
 
 - (void)didEnterStateUnregistering {

--- a/SmartDeviceLink/private/SDLLifecycleManager.m
+++ b/SmartDeviceLink/private/SDLLifecycleManager.m
@@ -254,9 +254,6 @@ NSString *const BackgroundTaskTransportName = @"com.sdl.transport.backgroundTask
 }
 
 - (void)didEnterStateStarted {
-    // Start a background task so a session can be established even when the app is backgrounded.
-    [self.backgroundTaskManager startBackgroundTask];
-
     // Start up the internal protocol, transport, and other internal managers
     self.secondaryTransportManager = nil;
     SDLLifecycleConfiguration *lifecycleConfig = self.configuration.lifecycleConfig;


### PR DESCRIPTION
Fixes #1799  (when used in conjunction with EASession left open PR #https://github.com/kmicha19-ford/sdl_ios/pull/1)

This PR is ready for review.

### Risk

This PR makes no  API changes.

### Testing Plan

- I have verified that I have not introduced new warnings in this PR (or explain why below)
- I have tested this PR against Core and verified behavior.

#### Unit Tests

- Does not affect any unit tests.

#### Core Tests

- Built the Obj-C example app and verified that all interactions work
   - iAP disconnect / reconnect
   - LockScreen on/off rapidly
- Built the Swift example app and verified that all interactions work
   - iAP disconnect / reconnect
   - LockScreen on/off rapidly

### Summary

This fixes the bug where an app could run on and on unnecessarily even when backgrounded and disconnected. 

### Changelog

##### Breaking Changes
* None

##### Enhancements

* SDLifeCycleManager no longer uses the SDLBackgroundTaskManager.
* SDLBackgroundTaskManager uses the iOS instance method beginBackgroundTask(withName taskName: String?, 
    expirationHandler handler: (() -> Void)? = nil) -> UIBackgroundTaskIdentifier
* beginBackgroundTask is for requesting additional processing time when an app is backgrounded and before being suspended so an app can finish tasks, such as saving data, before being suspended.  This method is not meant to keep an app running in the background.  After 30 seconds iOS may or may not terminate the app
* Using beginBackgroundTask in this manner may conflict with EAAccessory Connect / Disconnect app management and keep the app running in the background when it should be suspended. This may cause undo battery drain. 
* It should be noted that SDLSecondaryTransportManager correctly uses SDLBackgroundTaskManager.

### Tasks Remaining:
- None

### CLA
- I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
