### PR TITLE
Fix for issue 1913 observer mock is deprecated

### DIFF
--- a/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleSystemRequestHandlerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleSystemRequestHandlerSpec.m
@@ -123,7 +123,7 @@ describe(@"SDLLifecycleSystemRequestHandler tests", ^{
         });
 
         context(@"of type LOCK_SCREEN_URL", ^{
-            __block id lockScreenIconObserver = nil;
+            __block XCTNSNotificationExpectation *lockScreenIconExpectation;
 
             beforeEach(^{
                 receivedSystemRequest.requestType = SDLRequestTypeLockScreenIconURL;
@@ -131,20 +131,19 @@ describe(@"SDLLifecycleSystemRequestHandler tests", ^{
                 UIImage *testImage = [UIImage imageNamed:@"testImagePNG" inBundle:[NSBundle bundleForClass:self.class] compatibleWithTraitCollection:nil];
                 OCMStub([mockCacheManager retrieveImageForRequest:[OCMArg any] withCompletionHandler:([OCMArg invokeBlockWithArgs:testImage, [NSNull null], nil])]);
 
-                lockScreenIconObserver = OCMObserverMock();
-                [[NSNotificationCenter defaultCenter] addMockObserver:lockScreenIconObserver name:SDLDidReceiveLockScreenIcon object:nil];
-                [[lockScreenIconObserver expect] notificationWithName:SDLDidReceiveLockScreenIcon object:[OCMArg any] userInfo:[OCMArg any]];
+                lockScreenIconExpectation = [[XCTNSNotificationExpectation alloc] initWithName:SDLDidReceiveLockScreenIcon object:nil];
 
                 SDLRPCNotificationNotification *notification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidReceiveSystemRequestNotification object:nil rpcNotification:receivedSystemRequest];
                 [[NSNotificationCenter defaultCenter] postNotification:notification];
             });
 
             it(@"should pass the url to the cache manager and then send a notification", ^{
-                OCMVerifyAll(lockScreenIconObserver);
+                XCTWaiterResult waiter = [XCTWaiter waitForExpectations:@[lockScreenIconExpectation] timeout:4];
+                XCTAssertEqual(waiter, XCTWaiterResultCompleted);
             });
 
             afterEach(^{
-                lockScreenIconObserver = nil;
+                lockScreenIconExpectation = nil;
             });
         });
 


### PR DESCRIPTION
Fixes #1913 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Replaced the use of OCMObserverMock with XCTNSNotificationExpectation since it will be deprecated as of OCMock 3.8

#### Core Tests
N/A

Core version / branch / commit hash / module tested against: N/A
HMI name / version / branch / commit hash / module tested against: N/A

### Summary
Changes related to SDLLifecycleSystemRequestHandlerSpec file

### Changelog
##### Breaking Changes
* N/A

##### Enhancements
* N/A

##### Bug Fixes
* N/A

### Tasks Remaining:
N/A

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
