### PR TITLE
Fixed empty string bug in Menu Cell texts

### DIFF
--- a/SmartDeviceLink/private/SDLMenuManager.m
+++ b/SmartDeviceLink/private/SDLMenuManager.m
@@ -673,8 +673,8 @@ UInt32 const MenuCellIdMin = 1;
     params.menuName = cell.title;
     params.parentID = cell.parentCellId != UINT32_MAX ? @(cell.parentCellId) : nil;
     params.position = @(position);
-    params.secondaryText = ([cell.secondaryText isEqualToString:@""]) ? nil : cell.secondaryText;
-    params.tertiaryText = ([cell.tertiaryText isEqualToString:@""]) ? nil : cell.tertiaryText;
+    params.secondaryText = (cell.secondaryText.length == 0) ? nil : cell.secondaryText;
+    params.tertiaryText = (cell.tertiaryText.length == 0) ? nil : cell.tertiaryText;
 
     command.menuParams = params;
     command.vrCommands = (cell.voiceCommands.count == 0) ? nil : cell.voiceCommands;
@@ -696,8 +696,8 @@ UInt32 const MenuCellIdMin = 1;
         submenuLayout = self.menuConfiguration.defaultSubmenuLayout;
     }
     
-    NSString *secondaryText = ([cell.secondaryText isEqualToString:@""]) ? nil : cell.secondaryText;
-    NSString *tertiaryText = ([cell.tertiaryText isEqualToString:@""]) ? nil : cell.tertiaryText;
+    NSString *secondaryText = (cell.secondaryText.length == 0) ? nil : cell.secondaryText;
+    NSString *tertiaryText = (cell.tertiaryText.length == 0) ? nil : cell.tertiaryText;
 
     return [[SDLAddSubMenu alloc] initWithMenuID:cell.cellId menuName:cell.title position:@(position) menuIcon:icon menuLayout:submenuLayout parentID:nil secondaryText:secondaryText tertiaryText:tertiaryText secondaryImage:secondaryImage];
 }

--- a/SmartDeviceLink/private/SDLMenuManager.m
+++ b/SmartDeviceLink/private/SDLMenuManager.m
@@ -673,8 +673,8 @@ UInt32 const MenuCellIdMin = 1;
     params.menuName = cell.title;
     params.parentID = cell.parentCellId != UINT32_MAX ? @(cell.parentCellId) : nil;
     params.position = @(position);
-    params.tertiaryText = cell.tertiaryText;
-    params.secondaryText = cell.secondaryText;
+    params.secondaryText = ([cell.secondaryText isEqualToString:@""]) ? nil : cell.secondaryText;
+    params.tertiaryText = ([cell.tertiaryText isEqualToString:@""]) ? nil : cell.tertiaryText;
 
     command.menuParams = params;
     command.vrCommands = (cell.voiceCommands.count == 0) ? nil : cell.voiceCommands;
@@ -695,7 +695,11 @@ UInt32 const MenuCellIdMin = 1;
     } else {
         submenuLayout = self.menuConfiguration.defaultSubmenuLayout;
     }
-    return [[SDLAddSubMenu alloc] initWithMenuID:cell.cellId menuName:cell.title position:@(position) menuIcon:icon menuLayout:submenuLayout parentID:nil secondaryText:cell.secondaryText tertiaryText:cell.tertiaryText secondaryImage:secondaryImage];
+    
+    NSString *secondaryText = ([cell.secondaryText isEqualToString:@""]) ? nil : cell.secondaryText;
+    NSString *tertiaryText = ([cell.tertiaryText isEqualToString:@""]) ? nil : cell.tertiaryText;
+
+    return [[SDLAddSubMenu alloc] initWithMenuID:cell.cellId menuName:cell.title position:@(position) menuIcon:icon menuLayout:submenuLayout parentID:nil secondaryText:secondaryText tertiaryText:tertiaryText secondaryImage:secondaryImage];
 }
 
 #pragma mark - Calling handlers


### PR DESCRIPTION
Fixes #1923 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
N/A

#### Core Tests
N/A

Core version / branch / commit hash / module tested against: Branch develop
HMI name / version / branch / commit hash / module tested against: Generic/ branch develop

### Summary
In case the secondaryText or tertiaryText are being set with an empty string, replace it with nil instead.

### Changelog
##### Breaking Changes
* In case the secondaryText or tertiaryText are being set with an empty string, replace it with nil instead.

##### Enhancements
* N/A

##### Bug Fixes
* N/A

### Tasks Remaining:
N/A

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
