### PR TITLE
Fix for lock screen not dismissible bug

### DIFF
--- a/SmartDeviceLink/private/SDLLockScreenManager.m
+++ b/SmartDeviceLink/private/SDLLockScreenManager.m
@@ -167,7 +167,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
     // currentDriverDistraction variable is introduced to insure that unless the lockScreenDismissalEnabled value changes, it should stay what it was last set to
     SDLOnDriverDistraction *currentDriverDistraction = notification.notification;
-    if (currentDriver.lockScreenDismissalEnabled == nil && self.lastDriverDistractionNotification.lockScreenDismissalEnabled != nil){
+    if (currentDriverDistraction.lockScreenDismissalEnabled == nil && self.lastDriverDistractionNotification.lockScreenDismissalEnabled != nil){
         currentDriverDistraction.lockScreenDismissalEnabled = self.lastDriverDistractionNotification.lockScreenDismissalEnabled;
         currentDriverDistraction.lockScreenDismissalWarning = self.lastDriverDistractionNotification.lockScreenDismissalWarning;
     }

--- a/SmartDeviceLink/private/SDLLockScreenManager.m
+++ b/SmartDeviceLink/private/SDLLockScreenManager.m
@@ -165,8 +165,13 @@ NS_ASSUME_NONNULL_BEGIN
     if (![notification isNotificationMemberOfClass:[SDLOnDriverDistraction class]]) {
         return;
     }
-
-    self.lastDriverDistractionNotification = notification.notification;
+    // currentDriverDistraction variable is introduced to insure that unless the lockScreenDismissalEnabled value changes, it should stay what it was last set to
+    SDLOnDriverDistraction *currentDriverDistraction = notification.notification;
+    if (currentDriver.lockScreenDismissalEnabled == nil && self.lastDriverDistractionNotification.lockScreenDismissalEnabled != nil){
+        currentDriverDistraction.lockScreenDismissalEnabled = self.lastDriverDistractionNotification.lockScreenDismissalEnabled;
+        currentDriverDistraction.lockScreenDismissalWarning = self.lastDriverDistractionNotification.lockScreenDismissalWarning;
+    }
+    self.lastDriverDistractionNotification = currentDriverDistraction;
     [self sdl_updateLockScreenDismissable];
 }
 

--- a/SmartDeviceLink/private/SDLLockScreenManager.m
+++ b/SmartDeviceLink/private/SDLLockScreenManager.m
@@ -190,7 +190,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)sdl_updatePresentation {
     if (self.config.displayMode == SDLLockScreenConfigurationDisplayModeAlways) {
-        if (self.canPresent && !self.lockScreenDismissedByUser) {
+        if (self.canPresent && !self.lockScreenDismissedByUser && !self.lockScreenDismissable) {
             [self.presenter updateLockScreenToShow:YES withCompletionHandler:nil];
         }
     } else if (self.lastLockNotification.lockScreenStatus == SDLLockScreenStatusRequired) {

--- a/SmartDeviceLink/private/SDLLockScreenManager.m
+++ b/SmartDeviceLink/private/SDLLockScreenManager.m
@@ -165,7 +165,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (![notification isNotificationMemberOfClass:[SDLOnDriverDistraction class]]) {
         return;
     }
-    // currentDriverDistraction variable is introduced to insure that unless the lockScreenDismissalEnabled value changes, it should stay what it was last set to
+    // When an `OnDriverDistraction` notification is sent with a `lockScreenDismissalEnabled` value, keep track of said value if subsequent `OnDriverDistraction`s are missing the `lockScreenDismissalEnabled` value. This is done because the `lockScreenDismissalEnabled` state is assumed to be the same value until a new `lockScreenDismissalEnabled` value is received.
     SDLOnDriverDistraction *currentDriverDistraction = notification.notification;
     if (currentDriverDistraction.lockScreenDismissalEnabled == nil && self.lastDriverDistractionNotification.lockScreenDismissalEnabled != nil){
         currentDriverDistraction.lockScreenDismissalEnabled = self.lastDriverDistractionNotification.lockScreenDismissalEnabled;
@@ -190,7 +190,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)sdl_updatePresentation {
     if (self.config.displayMode == SDLLockScreenConfigurationDisplayModeAlways) {
-        if (self.canPresent) {
+        if (self.canPresent && !self.lockScreenDismissedByUser) {
             [self.presenter updateLockScreenToShow:YES withCompletionHandler:nil];
         }
     } else if (self.lastLockNotification.lockScreenStatus == SDLLockScreenStatusRequired) {


### PR DESCRIPTION
Fixes #1948 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
N/A

#### Core Tests
N/A

Core version / branch / commit hash / module tested against: N/A
HMI name / version / branch / commit hash / module tested against: Manticore

### Summary
Added currentDriverDistraction variable that holds the `lockScreenDismissalEnabled` and `lockScreenDismissalWarning` in case they were not changes in the new notification received

### Changelog
##### Breaking Changes
* N/A

##### Enhancements
* N/A

##### Bug Fixes
* Added currentDriverDistraction variable that holds the `lockScreenDismissalEnabled` and `lockScreenDismissalWarning` in case they were not changes in the new notification received

### Tasks Remaining:
N/A

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
