### PR TITLE
Let developer override the default custom video encoder settings when not set by the video streaming capability 

### DIFF
--- a/SmartDeviceLink/private/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/private/SDLStreamingVideoLifecycleManager.m
@@ -796,10 +796,10 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
     if (!matchedVideoCapability.supportedFormats) {
         matchedVideoCapability.supportedFormats = videoCapabilityUpdated.supportedFormats;
     }
-    if (!matchedVideoCapability.maxBitrate) {
+    if (matchedVideoCapability.maxBitrate == nil) {
         matchedVideoCapability.maxBitrate = videoCapabilityUpdated.maxBitrate;
     }
-    if (!matchedVideoCapability.preferredFPS) {
+    if (matchedVideoCapability.preferredFPS == nil) {
         matchedVideoCapability.preferredFPS = videoCapabilityUpdated.preferredFPS;
     }
 

--- a/SmartDeviceLink/private/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/private/SDLStreamingVideoLifecycleManager.m
@@ -1131,12 +1131,12 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
     // Apply customEncoderSettings here. Note that value from HMI (such as maxBitrate) will be overwritten by custom settings
     // (Exception: ExpectedFrameRate, AverageBitRate)
     for (id key in self.customEncoderSettings.keyEnumerator) {
-        // do NOT override framerate or average bitrate if custom setting is higher than current setting.
+        // Do *not* override framerate or average bitrate if custom setting is higher than current setting.
         // See SDL 0323 (https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0323-align-VideoStreamingParameter-with-capability.md) for details.
         if (([(NSString *)key isEqualToString:(__bridge NSString *)kVTCompressionPropertyKey_ExpectedFrameRate] && capability.preferredFPS != nil) ||
             ([(NSString *)key isEqualToString:(__bridge NSString *)kVTCompressionPropertyKey_AverageBitRate] && capability.maxBitrate != nil)) {
-            NSNumber *customEncoderSettings = (NSNumber *)[self.customEncoderSettings valueForKey:key];
-            NSNumber *videoEncoderSettings = (NSNumber *)[self.videoEncoderSettings valueForKey:key];
+            NSNumber *customEncoderSettings = (NSNumber *)self.customEncoderSettings[key];
+            NSNumber *videoEncoderSettings = (NSNumber *)self.videoEncoderSettings[key];
             if (customEncoderSettings.doubleValue < videoEncoderSettings.doubleValue) {
                 self.videoEncoderSettings[key] = customEncoderSettings;
             }

--- a/SmartDeviceLink/private/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/private/SDLStreamingVideoLifecycleManager.m
@@ -1109,7 +1109,7 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
     assert(capability != nil);
 
     self.videoStreamingCapability = capability;
-    self.focusableItemManager.enableHapticDataRequests = capability.hapticSpatialDataSupported.boolValue; // nil capability makes NO
+    self.focusableItemManager.enableHapticDataRequests = capability.hapticSpatialDataSupported.boolValue;
     self.videoScaleManager.scale = capability.scale.floatValue;
     self.videoScaleManager.displayViewportResolution = capability.preferredResolution.makeSize;
 
@@ -1124,10 +1124,10 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
     // Apply customEncoderSettings here. Note that value from HMI (such as maxBitrate) will be overwritten by custom settings
     // (Exception: ExpectedFrameRate, AverageBitRate)
     for (id key in self.customEncoderSettings.keyEnumerator) {
-        // do NOT override framerate or average bitreate if custom setting is higher than current setting.
+        // do NOT override framerate or average bitrate if custom setting is higher than current setting.
         // See SDL 0323 (https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0323-align-VideoStreamingParameter-with-capability.md) for details.
-        if ([(NSString *)key isEqualToString:(__bridge NSString *)kVTCompressionPropertyKey_ExpectedFrameRate] ||
-            [(NSString *)key isEqualToString:(__bridge NSString *)kVTCompressionPropertyKey_AverageBitRate]) {
+        if (([(NSString *)key isEqualToString:(__bridge NSString *)kVTCompressionPropertyKey_ExpectedFrameRate] && capability.preferredFPS != nil) ||
+            ([(NSString *)key isEqualToString:(__bridge NSString *)kVTCompressionPropertyKey_AverageBitRate] && capability.maxBitrate != nil)) {
             NSNumber *customEncoderSettings = (NSNumber *)[self.customEncoderSettings valueForKey:key];
             NSNumber *videoEncoderSettings = (NSNumber *)[self.videoEncoderSettings valueForKey:key];
             if (customEncoderSettings.doubleValue < videoEncoderSettings.doubleValue) {

--- a/SmartDeviceLink/private/SDLStreamingVideoLifecycleManager.m
+++ b/SmartDeviceLink/private/SDLStreamingVideoLifecycleManager.m
@@ -796,6 +796,13 @@ typedef void(^SDLVideoCapabilityResponseHandler)(SDLVideoStreamingCapability *_N
     if (!matchedVideoCapability.supportedFormats) {
         matchedVideoCapability.supportedFormats = videoCapabilityUpdated.supportedFormats;
     }
+    if (!matchedVideoCapability.maxBitrate) {
+        matchedVideoCapability.maxBitrate = videoCapabilityUpdated.maxBitrate;
+    }
+    if (!matchedVideoCapability.preferredFPS) {
+        matchedVideoCapability.preferredFPS = videoCapabilityUpdated.preferredFPS;
+    }
+
     [self sdl_applyVideoCapability:matchedVideoCapability];
     self.shouldUpdateDelegateOnSizeChange = YES;
 

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingVideoLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingVideoLifecycleManagerSpec.m
@@ -1134,7 +1134,7 @@ describe(@"runtime tests", ^{
                 [streamingLifecycleManager sdl_videoStreamingCapabilityDidUpdate:testNilVideoStreamingCapability];
             });
 
-            it(@"should use the library's default values in lieu of a VideoStreamingCapability", ^{
+            it(@"should use the library's default values", ^{
                 expect(streamingLifecycleManager.videoStreamingCapability.maxBitrate).to(beNil());
                 expect(streamingLifecycleManager.videoStreamingCapability.preferredFPS).to(beNil());
 
@@ -1156,7 +1156,7 @@ describe(@"runtime tests", ^{
             __block SDLSystemCapability *testSystemCapability = nil;
             __block SDLVideoStreamingCapability *testVideoStreamingCapability = nil;
 
-            context(@"The module does not support VideoStreamingCapability.additionalVideoStreamingCapabilities", ^{
+            context(@"the module does not support VideoStreamingCapability.additionalVideoStreamingCapabilities", ^{
                 beforeEach(^{
                     SDLImageResolution *resolution = [[SDLImageResolution alloc] initWithWidth:44 height:99];
                     SDLVideoStreamingFormat *format1 = [[SDLVideoStreamingFormat alloc] initWithCodec:SDLVideoStreamingCodecH265 protocol:SDLVideoStreamingProtocolRTMP];
@@ -1190,7 +1190,7 @@ describe(@"runtime tests", ^{
                 });
             });
 
-            context(@"The module supports VideoStreamingCapability.additionalVideoStreamingCapabilities", ^{
+            context(@"the module supports VideoStreamingCapability.additionalVideoStreamingCapabilities", ^{
                 __block SDLVideoStreamingCapability *testAdditionalVideoStreamingCapability = nil;
 
                 beforeEach(^{
@@ -1237,15 +1237,15 @@ describe(@"runtime tests", ^{
         });
     });
 
-    describe(@"Setting the video encoder properties", ^{
+    describe(@"setting the video encoder properties", ^{
         __block SDLVideoStreamingCapability *testVideoStreamingCapability = nil;
 
         beforeEach(^{
             testVideoStreamingCapability = nil;
         });
 
-        context(@"setting the bitrate", ^{
-            describe(@"the VideoStreamingCapability returns a maxBitrate", ^{
+        describe(@"setting the bitrate", ^{
+            context(@"the VideoStreamingCapability returns a maxBitrate", ^{
                 it(@"should use the custom averageBitRate set by the developer when it is less than the VideoStreamingCapability's maxBitrate", ^{
                     int testVideoStreamingCapabilityMaxBitrate = 99999;
                     float testCustomBitRate = 88;
@@ -1290,7 +1290,7 @@ describe(@"runtime tests", ^{
                 });
             });
 
-            describe(@"The VideoStreamingCapability returns a nil maxBitrate", ^{
+            context(@"the VideoStreamingCapability returns a nil maxBitrate", ^{
                 it(@"should use the custom averageBitRate set by the developer even if it is larger than the default averageBitRate", ^{
                     int testCustomBitRate = 9900000; // larger than the default of @600000
 
@@ -1330,8 +1330,8 @@ describe(@"runtime tests", ^{
             });
         });
 
-        context(@"setting the framerate", ^{
-            describe(@"the VideoStreamingCapability returns a preferredFPS", ^{
+        describe(@"setting the framerate", ^{
+            context(@"the VideoStreamingCapability returns a preferredFPS", ^{
                 it(@"should use the custom expectedFrameRate set by the developer when it is less than the VideoStreamingCapability's preferredFPS", ^{
                     int testVideoStreamingCapabilityPreferredFPS = 1001;
                     float testCustomExpectedFrameRate = 66;
@@ -1374,7 +1374,7 @@ describe(@"runtime tests", ^{
                 });
             });
 
-            describe(@"The VideoStreamingCapability returns a nil preferredFPS", ^{
+            context(@"the VideoStreamingCapability returns a nil preferredFPS", ^{
                 it(@"should use the custom expectedFrameRate set by the developer even if it is larger than the default expectedFrameRate", ^{
                     int testCustomExpectedFrameRate = 990; // larger than the default of @15
 


### PR DESCRIPTION
Fixes #1950

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Unit tests were added to the _SDLStreamingVideoLifecycleManagerSpec_ to test overriding the custom video encoder settings.

#### Core Tests
##### Frames Per Second
- [x] Tested returning a `preferredFPS` in the `VideoStreamingCapability` larger than the value set by the `ExpectedFrameRate` set by the developer. The `ExpectedFrameRate` should be used by the video encoder.
- [x] Tested returning a `preferredFPS` in the `VideoStreamingCapability` smaller than the value set by the `ExpectedFrameRate` set by the developer. The `preferredFPS` should be used by the video encoder.
- [x] Tested returning a `nil` `preferredFPS` in the `VideoStreamingCapability`. The `ExpectedFrameRate` should be used by the video encoder.
- [x] Tested returning a `nil` `preferredFPS` in the `VideoStreamingCapability` and not setting an `ExpectedFrameRate`. The video encoder should use the default value.
##### Bitrate
- [x] Tested returning a `maxBitrate` in the `VideoStreamingCapability` larger than the value set by the `AverageBitRate` set by the developer. The `AverageBitRate` should be used by the video encoder.
- [x] Tested returning a `maxBitrate` in the `VideoStreamingCapability` smaller than the value set by the `AverageBitRate` set by the developer. The `maxBitrate` should be used by the video encoder.
- [x] Tested returning a `nil` `maxBitrate ` in the `VideoStreamingCapability`. The `AverageBitRate ` should be used by the video encoder.
- [x] Tested returning a `nil` `maxBitrate ` in the `VideoStreamingCapability` and not setting an `AverageBitRate `. The video encoder should use the default value.
##### Updating the `VideoStreamingCapability` midstream
- [x] Tested updating the `VideoStreamingCapability` mid-stream and made sure the video encoder used the `preferredFPS` and `maxBitrate` in the `VideoStreamingCapability` if the parent `VideoStreamingCapability` contains the values but not the `VideoStreamingCapability.additionalVideoStreamingCapabilities`.

Core version / branch / commit hash / module tested against: 
* commit 40cf3dc7afdab7384c7a0f43336c7a88665db240 (HEAD -> release/7.1.0-RC1, origin/release/7.1.0-RC1)

HMI name / version / branch / commit hash / module tested against: 
* commit c04f179ca7bd51296ebd35a0b24ff3644c442826 (HEAD -> release/5.5.0, origin/release/5.5.0)

### Summary
Fixed a bug where the developer was not able to set their own custom video encoder settings if the `VideoStreamingCapability` returns a `nil` value for the respective setting.

### Changelog
##### Bug Fixes
* Fixed the developer not being able to set their own custom video encoder settings for `ExpectedFrameRate` or `AverageBitRate` if the `VideoStreamingCapability` returned by the module has a `nil` value for `preferredFPS` or `maxBitrate`. 
* Fixed the `SDLStreamingVideoLifecycleManager` not using the `VideoStreamingCapability`'s `preferredFPS` or `maxBitrate` if the root `VideoStreamingCapability` contained the `preferredFPS` or `maxBitrate` properties but not the `VideoStreamingCapability.additionalVideoStreamingCapabilities` (i.e. the child now inherit's the parent's `preferredFPS` and/or `maxBitrate` properties)

### Tasks Remaining:
- [x] Test with sdl_core

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
