### PR TITLE
Fixed queued menu updates failing

### DIFF
--- a/SmartDeviceLink/private/SDLMenuManager.m
+++ b/SmartDeviceLink/private/SDLMenuManager.m
@@ -407,6 +407,7 @@ UInt32 const MenuCellIdMin = 1;
         self.queuedDeleteMenuCells = deleteCells;
         return;
     }
+
     __weak typeof(self) weakself = self;
     [self sdl_sendDeleteCurrentMenu:deleteCells withCompletionHandler:^(NSError * _Nullable error) {
         [weakself sdl_sendUpdatedMenu:addCells usingMenu:weakself.menuCells withCompletionHandler:^(NSError * _Nullable error) {

--- a/SmartDeviceLink/private/SDLMenuManager.m
+++ b/SmartDeviceLink/private/SDLMenuManager.m
@@ -123,6 +123,8 @@ UInt32 const MenuCellIdMin = 1;
     _hasQueuedUpdate = NO;
     _waitingOnHMIUpdate = NO;
     _waitingUpdateMenuCells = @[];
+    _queuedAddMenuCells = @[];
+    _queuedDeleteMenuCells = @[];
 }
 
 #pragma mark - Setters

--- a/SmartDeviceLink/private/SDLMenuManager.m
+++ b/SmartDeviceLink/private/SDLMenuManager.m
@@ -71,6 +71,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic) UInt32 lastMenuId;
 @property (copy, nonatomic) NSArray<SDLMenuCell *> *oldMenuCells;
 
+@property (copy, nonatomic) NSArray<SDLMenuCell *> *queuedDeleteMenuCells;
+@property (copy, nonatomic) NSArray<SDLMenuCell *> *queuedAddMenuCells;
+
 @end
 
 UInt32 const ParentIdNotFound = UINT32_MAX;
@@ -400,6 +403,8 @@ UInt32 const MenuCellIdMin = 1;
     if (self.inProgressUpdate != nil) {
         // There's an in progress update, we need to put this on hold
         self.hasQueuedUpdate = YES;
+        self.queuedAddMenuCells = addCells;
+        self.queuedDeleteMenuCells = deleteCells;
         return;
     }
     __weak typeof(self) weakself = self;
@@ -412,7 +417,10 @@ UInt32 const MenuCellIdMin = 1;
             }
 
             if (weakself.hasQueuedUpdate) {
-                [weakself sdl_updateMenuWithCellsToDelete:deleteCells cellsToAdd:addCells completionHandler:nil];
+                SDLLogD(@"Sending queued menu updates");
+                [weakself sdl_updateMenuWithCellsToDelete:self.queuedDeleteMenuCells cellsToAdd:self.queuedAddMenuCells completionHandler:nil];
+                weakself.queuedDeleteMenuCells = @[];
+                weakself.queuedAddMenuCells = @[];
                 weakself.hasQueuedUpdate = NO;
             }
         }];

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLMenuManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLMenuManagerSpec.m
@@ -115,6 +115,8 @@ describe(@"menu manager", ^{
         expect(testManager.oldMenuCells).to(beEmpty());
         expect(testManager.waitingUpdateMenuCells).to(beNil());
         expect(testManager.menuConfiguration).toNot(beNil());
+        expect(testManager.queuedAddMenuCells).to(beNil());
+        expect(testManager.queuedDeleteMenuCells).to(beNil());
     });
 
     describe(@"updating menu cells before HMI is ready", ^{
@@ -855,6 +857,8 @@ describe(@"menu manager", ^{
             expect(testManager.oldMenuCells).to(beEmpty());
             expect(testManager.waitingUpdateMenuCells).to(beEmpty());
             expect(testManager.menuConfiguration).toNot(beNil());
+            expect(testManager.queuedAddMenuCells).to(beEmpty());
+            expect(testManager.queuedDeleteMenuCells).to(beEmpty());
         });
     });
 


### PR DESCRIPTION
Fixes #1957

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Test cases added to the _SDLMenuManagerSpec_ to test sending the queued menu with dynamic updates turned on as well as off. 

#### Core Tests
Updated the menu with new menu cells while the current menu is still uploading. 

Core version / branch / commit hash / module tested against: 
* Manticore: SDL Core v7.0.0
* SYNC 3.0: Build 17276_DEVTEST

HMI name / version / branch / commit hash / module tested against: 
* Manticore: Generic HMI v0.9.0
* SYNC 3.0: Build 17276_DEVTEST

### Summary
Fixed menu updates failing if a new menu is sent while the current menu is still being uploaded. The new menu updates would be queued but when the current menu finished uploading, the current menu would be sent again instead of the queued menu. 

### Changelog
##### Bug Fixes
* Fixed a new menu update failing if the current menu is still being updated.

### Tasks Remaining:
- [x] Perform smoke tests with sdl_core (dynamic updates on)
- [x] Perform smoke tests with SYNC 3.0 (dynamic updates off)

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
