### PR TITLE
Fix for example app menu not displayed correctly after app exit

### DIFF
--- a/Example Apps/Example ObjC/ProxyManager.m
+++ b/Example Apps/Example ObjC/ProxyManager.m
@@ -261,7 +261,8 @@ NS_ASSUME_NONNULL_BEGIN
     } else if ([newLevel isEqualToEnum:SDLHMILevelBackground]) {
         // The SDL app is not in the foreground
     } else if ([newLevel isEqualToEnum:SDLHMILevelNone]) {
-        // The SDL app is not yet running
+        // The SDL app is not yet running or is terminated
+        self.firstHMILevel = SDLHMILevelNone;
     }
 }
 

--- a/Example Apps/Example Swift/ProxyManager.swift
+++ b/Example Apps/Example Swift/ProxyManager.swift
@@ -178,7 +178,10 @@ extension ProxyManager: SDLManagerDelegate {
             subscribeButtonManager.subscribeToPresetButtons()
         case .limited: break // An active NAV or MEDIA SDL app is in the background
         case .background: break // The SDL app is not in the foreground
-        case .none: break // The SDL app is not yet running
+        case .none:
+            // The SDL app is not yet running or is terminated
+            firstHMILevelState = .none
+            break
         default: break
         }
     }


### PR DESCRIPTION
Fixes #1967 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [ ] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
N/A

#### Core Tests
Exited app through Menu on SYNC 3 then relaunched the app to check if the menu is displayed correctly

Core version / branch / commit hash / module tested against: N/A
HMI name / version / branch / commit hash / module tested against: SYNC3

### Summary
Update example apps HMI level state

### Changelog
##### Breaking Changes
* N/A

##### Enhancements
* N/A

##### Bug Fixes
* Update example apps HMI level state

### Tasks Remaining:
N/A

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
