### PR TITLE
Fixed the file manager erroring if the ListFiles RPC must be encrypted

### DIFF
--- a/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
+++ b/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
@@ -1645,6 +1645,7 @@
 		88D2AAE41F682BB20078D5B2 /* SDLLogConstantsSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 88D2AAE31F682BB20078D5B2 /* SDLLogConstantsSpec.m */; };
 		88D79EED255D8D5B005FACB1 /* SDLPresentAlertOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 88D79EEB255D8D5B005FACB1 /* SDLPresentAlertOperation.h */; };
 		88D79EEE255D8D5B005FACB1 /* SDLPresentAlertOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 88D79EEC255D8D5B005FACB1 /* SDLPresentAlertOperation.m */; };
+		88D930262630686100DA9E44 /* SDLFileManagerSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D9F50821BEA5C6100FEF399 /* SDLFileManagerSpec.m */; };
 		88DDD0F9229ECA57002F9623 /* SDLIAPConstantsSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 88DDD0F8229ECA57002F9623 /* SDLIAPConstantsSpec.m */; };
 		88DF998D22035CC600477AC1 /* EAAccessory+OCMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 88DF998C22035CC600477AC1 /* EAAccessory+OCMock.m */; };
 		88DF998F22035D1700477AC1 /* SDLIAPSessionSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 88DF998E22035D1700477AC1 /* SDLIAPSessionSpec.m */; };
@@ -8995,6 +8996,7 @@
 				162E83791A9BDE8B00906325 /* SDLDeviceStatusSpec.m in Sources */,
 				162E83821A9BDE8B00906325 /* SDLImageSpec.m in Sources */,
 				162E834A1A9BDE8B00906325 /* SDLAddSubMenuResponseSpec.m in Sources */,
+				88D930262630686100DA9E44 /* SDLFileManagerSpec.m in Sources */,
 				162E830C1A9BDE8B00906325 /* SDLWarningLightStatusSpec.m in Sources */,
 				881BBF5B255ADB8300761B7E /* SDLAlertViewSpec.m in Sources */,
 				1EE8C45F1F3884FF00FDC2CF /* SDLSetInteriorVehicleDataSpec.m in Sources */,

--- a/SmartDeviceLink/public/SDLFileManager.m
+++ b/SmartDeviceLink/public/SDLFileManager.m
@@ -184,7 +184,7 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
                 [weakSelf.stateMachine transitionToState:SDLFileManagerStateReady];
                 BLOCK_RETURN;
             } else if ([error.userInfo[@"resultCode"] isEqualToEnum:SDLResultEncryptionNeeded]) {
-                // HAX: If the module rejects the ListFiles request because it requires the request be encrypted, we still want to transition to a ready state. Unfortunately, since we do not know what files are on the module already, we may end up doing unnecessary duplicate file uploads.
+                // HAX: If the module rejects the ListFiles request because it requires that the request be encrypted, we still want to transition to a ready state. Unfortunately, since we do not know what files are on the module already, we may end up doing unnecessary duplicate file uploads.
                 SDLLogW(@"ListFiles must be encrypted. We do not know which files have already been uploaded to the module. Certain file manager APIs may not work properly.");
                 [weakSelf.stateMachine transitionToState:SDLFileManagerStateReady];
                 BLOCK_RETURN;

--- a/SmartDeviceLink/public/SDLFileManager.m
+++ b/SmartDeviceLink/public/SDLFileManager.m
@@ -178,9 +178,14 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
 
         // If there was an error, we'll pass the error to the startup handler and cancel out
         if (error != nil) {
-            // HAX: In the case we are DISALLOWED we still want to transition to a ready state. Some head units return DISALLOWED for this RPC but otherwise work.
-            if([error.userInfo[@"resultCode"] isEqualToEnum:SDLResultDisallowed]) {
+            if ([error.userInfo[@"resultCode"] isEqualToEnum:SDLResultDisallowed]) {
+                // HAX: In the case we are DISALLOWED we still want to transition to a ready state. Some head units return DISALLOWED for this RPC but otherwise work.
                 SDLLogW(@"ListFiles is disallowed. Certain file manager APIs may not work properly.");
+                [weakSelf.stateMachine transitionToState:SDLFileManagerStateReady];
+                BLOCK_RETURN;
+            } else if ([error.userInfo[@"resultCode"] isEqualToEnum:SDLResultEncryptionNeeded]) {
+                // HAX: If the module rejects the ListFiles request because it requires the request be encrypted, we still want to transition to a ready state. Unfortunately, since we do not know what files are on the module already, we may end up doing unnecessary duplicate file uploads.
+                SDLLogW(@"ListFiles must be encrypted. We do not know which files have already been uploaded to the module. Certain file manager APIs may not work properly.");
                 [weakSelf.stateMachine transitionToState:SDLFileManagerStateReady];
                 BLOCK_RETURN;
             }

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLFileManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLFileManagerSpec.m
@@ -172,6 +172,22 @@ describe(@"uploading / deleting single files with the file manager", ^{
             });
         });
 
+        describe(@"after receiving a ListFiles error with a resultCode ENCRYPTION_NEEDED", ^{
+            beforeEach(^{
+                SDLListFilesOperation *operation = testFileManager.pendingTransactions.firstObject;
+                NSMutableDictionary *userInfo = [[NSError sdl_fileManager_unableToStartError].userInfo mutableCopy];
+                userInfo[@"resultCode"] = SDLResultEncryptionNeeded;
+                NSError *errorWithResultCode = [NSError errorWithDomain:[NSError sdl_fileManager_unableToStartError].domain code:[NSError sdl_fileManager_unableToStartError].code userInfo:userInfo];
+                operation.completionHandler(NO, initialSpaceAvailable, testInitialFileNames, errorWithResultCode);
+            });
+
+            it(@"should handle the error properly", ^{
+                expect(testFileManager.currentState).to(match(SDLFileManagerStateReady));
+                expect(testFileManager.remoteFileNames).to(beEmpty());
+                expect(@(testFileManager.bytesAvailable)).to(equal(initialSpaceAvailable));
+            });
+        });
+
         describe(@"after receiving a ListFiles response", ^{
             beforeEach(^{
                 SDLListFilesOperation *operation = testFileManager.pendingTransactions.firstObject;

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLFileManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLFileManagerSpec.m
@@ -143,7 +143,7 @@ describe(@"uploading / deleting single files with the file manager", ^{
             });
         });
 
-        describe(@"after receiving a ListFiles error", ^{
+        describe(@"after receiving a ListFiles error due to the file manager not being able to start", ^{
             beforeEach(^{
                 SDLListFilesOperation *operation = testFileManager.pendingTransactions.firstObject;
                 operation.completionHandler(NO, initialSpaceAvailable, testInitialFileNames, [NSError sdl_fileManager_unableToStartError]);
@@ -156,33 +156,33 @@ describe(@"uploading / deleting single files with the file manager", ^{
             });
         });
 
-        describe(@"after receiving a ListFiles error with a resultCode DISALLOWED", ^{
+        describe(@"getting an error from the module to a ListFiles request", ^{
+            __block SDLListFilesOperation *operation = nil;
+
             beforeEach(^{
-                SDLListFilesOperation *operation = testFileManager.pendingTransactions.firstObject;
-                NSMutableDictionary *userInfo = [[NSError sdl_fileManager_unableToStartError].userInfo mutableCopy];
-                userInfo[@"resultCode"] = SDLResultDisallowed;
-                NSError *errorWithResultCode = [NSError errorWithDomain:[NSError sdl_fileManager_unableToStartError].domain code:[NSError sdl_fileManager_unableToStartError].code userInfo:userInfo];
-                operation.completionHandler(NO, initialSpaceAvailable, testInitialFileNames, errorWithResultCode);
+                operation = testFileManager.pendingTransactions.firstObject;
             });
 
-            it(@"should handle the error properly", ^{
+            it(@"should handle a ListFiles error with a resultCode of DISALLOWED and transition to the ready state", ^{
+                operation.completionHandler(NO, initialSpaceAvailable, testInitialFileNames, [NSError errorWithDomain:[NSError sdl_fileManager_unableToStartError].domain code:[NSError sdl_fileManager_unableToStartError].code userInfo:@{@"resultCode" : SDLResultDisallowed}]);
+
                 expect(testFileManager.currentState).to(match(SDLFileManagerStateReady));
                 expect(testFileManager.remoteFileNames).to(beEmpty());
                 expect(@(testFileManager.bytesAvailable)).to(equal(initialSpaceAvailable));
             });
-        });
 
-        describe(@"after receiving a ListFiles error with a resultCode ENCRYPTION_NEEDED", ^{
-            beforeEach(^{
-                SDLListFilesOperation *operation = testFileManager.pendingTransactions.firstObject;
-                NSMutableDictionary *userInfo = [[NSError sdl_fileManager_unableToStartError].userInfo mutableCopy];
-                userInfo[@"resultCode"] = SDLResultEncryptionNeeded;
-                NSError *errorWithResultCode = [NSError errorWithDomain:[NSError sdl_fileManager_unableToStartError].domain code:[NSError sdl_fileManager_unableToStartError].code userInfo:userInfo];
-                operation.completionHandler(NO, initialSpaceAvailable, testInitialFileNames, errorWithResultCode);
+            it(@"should handle a ListFiles error with a resultCode ENCRYPTION_NEEDED and transition to the ready state", ^{
+                operation.completionHandler(NO, initialSpaceAvailable, testInitialFileNames, [NSError errorWithDomain:[NSError sdl_fileManager_unableToStartError].domain code:[NSError sdl_fileManager_unableToStartError].code userInfo:@{@"resultCode" : SDLResultEncryptionNeeded}]);
+
+                expect(testFileManager.currentState).to(match(SDLFileManagerStateReady));
+                expect(testFileManager.remoteFileNames).to(beEmpty());
+                expect(@(testFileManager.bytesAvailable)).to(equal(initialSpaceAvailable));
             });
 
-            it(@"should handle the error properly", ^{
-                expect(testFileManager.currentState).to(match(SDLFileManagerStateReady));
+            it(@"should transition to the error state if it gets a ListFiles error with a resultCode that is not handled by the library", ^{
+                operation.completionHandler(NO, initialSpaceAvailable, testInitialFileNames, [NSError errorWithDomain:[NSError sdl_fileManager_unableToStartError].domain code:[NSError sdl_fileManager_unableToStartError].code userInfo:@{@"resultCode" : SDLResultUnsupportedRequest}]);
+
+                expect(testFileManager.currentState).to(match(SDLFileManagerStateStartupError));
                 expect(testFileManager.remoteFileNames).to(beEmpty());
                 expect(@(testFileManager.bytesAvailable)).to(equal(initialSpaceAvailable));
             });

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLFileManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLFileManagerSpec.m
@@ -143,20 +143,7 @@ describe(@"uploading / deleting single files with the file manager", ^{
             });
         });
 
-        describe(@"after receiving a ListFiles error due to the file manager not being able to start", ^{
-            beforeEach(^{
-                SDLListFilesOperation *operation = testFileManager.pendingTransactions.firstObject;
-                operation.completionHandler(NO, initialSpaceAvailable, testInitialFileNames, [NSError sdl_fileManager_unableToStartError]);
-            });
-
-            it(@"should handle the error properly", ^{
-                expect(testFileManager.currentState).to(match(SDLFileManagerStateStartupError));
-                expect(testFileManager.remoteFileNames).to(beEmpty());
-                expect(@(testFileManager.bytesAvailable)).to(equal(initialSpaceAvailable));
-            });
-        });
-
-        describe(@"getting an error from the module to a ListFiles request", ^{
+        describe(@"getting an error for a ListFiles request", ^{
             __block SDLListFilesOperation *operation = nil;
 
             beforeEach(^{
@@ -181,6 +168,14 @@ describe(@"uploading / deleting single files with the file manager", ^{
 
             it(@"should transition to the error state if it gets a ListFiles error with a resultCode that is not handled by the library", ^{
                 operation.completionHandler(NO, initialSpaceAvailable, testInitialFileNames, [NSError errorWithDomain:[NSError sdl_fileManager_unableToStartError].domain code:[NSError sdl_fileManager_unableToStartError].code userInfo:@{@"resultCode" : SDLResultUnsupportedRequest}]);
+
+                expect(testFileManager.currentState).to(match(SDLFileManagerStateStartupError));
+                expect(testFileManager.remoteFileNames).to(beEmpty());
+                expect(@(testFileManager.bytesAvailable)).to(equal(initialSpaceAvailable));
+            });
+
+            it(@"should transition to the error state if it gets a ListFiles error without a resultCode", ^{
+                operation.completionHandler(NO, initialSpaceAvailable, testInitialFileNames, [NSError sdl_fileManager_unableToStartError]);
 
                 expect(testFileManager.currentState).to(match(SDLFileManagerStateStartupError));
                 expect(testFileManager.remoteFileNames).to(beEmpty());


### PR DESCRIPTION
Fixes #1975

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
* Unit tests added to _SDLFileManagerSpec_ to test new state transition. 

#### Core Tests
* Configure the module to require encryption for the `ListFiles` RPC. Then, connect the SDL app to the module and launch the SDL app. The `SDLFileManager` should be able to send artworks even if the module rejects the `ListFiles` request due to `ENCRYPTION_NEEDED`.

##### Core version / branch / commit hash / module tested against: 
* sdl_core: commit d7c804de1e5bc90f9359ea21b9d9c54de70bb947 (HEAD -> develop, origin/develop)

##### HMI name / version / branch / commit hash / module tested against: 
* sdl_hmi: commit 71cbfe9a094a860df42577adb0f7579b18fc44c7 (HEAD -> develop, tag: 5.5.0, origin/master, origin/develop, origin/HEAD)

### Summary
If the module requires that `ListFiles` RPC be encrypted, the `SDLFileManager` is now still able to send artworks/files. 

### Changelog
##### Bug Fixes
* Fixed the `SDLFileManager` transitioning to the error sate if the module rejects the `ListFiles` RPC because it must be encrypted. 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
