### PR TITLE
Fixed File Manager not returning that files are uploaded when they are

### DIFF
--- a/Example Apps/Example ObjC/ProxyManager.m
+++ b/Example Apps/Example ObjC/ProxyManager.m
@@ -209,6 +209,12 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     [screenManager endUpdatesWithCompletionHandler:^(NSError * _Nullable error) {
+        if (error && screenManager.primaryGraphic == nil && [self sdlex_imageFieldSupported:SDLImageFieldNameGraphic]) {
+            screenManager.primaryGraphic = areImagesVisible ? [SDLArtwork persistentArtworkWithImage:[[UIImage imageNamed:ExampleAppLogoName] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal] asImageFormat:SDLArtworkImageFormatPNG] : nil;
+        } else if (error && screenManager.primaryGraphic == nil && [self sdlex_imageFieldSupported:SDLImageFieldNameSecondaryGraphic]) {
+            screenManager.secondaryGraphic = areImagesVisible ? [SDLArtwork persistentArtworkWithImage:[UIImage imageNamed:CarBWIconImageName] asImageFormat:SDLArtworkImageFormatPNG] : nil;
+        }
+
         SDLLogD(@"Updated text and graphics, error? %@", error);
     }];
 }

--- a/Example Apps/Example ObjC/ProxyManager.m
+++ b/Example Apps/Example ObjC/ProxyManager.m
@@ -209,12 +209,6 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     [screenManager endUpdatesWithCompletionHandler:^(NSError * _Nullable error) {
-        if (error && screenManager.primaryGraphic == nil && [self sdlex_imageFieldSupported:SDLImageFieldNameGraphic]) {
-            screenManager.primaryGraphic = areImagesVisible ? [SDLArtwork persistentArtworkWithImage:[[UIImage imageNamed:ExampleAppLogoName] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal] asImageFormat:SDLArtworkImageFormatPNG] : nil;
-        } else if (error && screenManager.primaryGraphic == nil && [self sdlex_imageFieldSupported:SDLImageFieldNameSecondaryGraphic]) {
-            screenManager.secondaryGraphic = areImagesVisible ? [SDLArtwork persistentArtworkWithImage:[UIImage imageNamed:CarBWIconImageName] asImageFormat:SDLArtworkImageFormatPNG] : nil;
-        }
-
         SDLLogD(@"Updated text and graphics, error? %@", error);
     }];
 }

--- a/Example Apps/Example Swift/ProxyManager.swift
+++ b/Example Apps/Example Swift/ProxyManager.swift
@@ -287,12 +287,12 @@ private extension ProxyManager {
 
         // Primary graphic
         if imageFieldSupported(imageFieldName: .graphic) {
-            screenManager.primaryGraphic = areImagesVisible ? SDLArtwork(image: UIImage(named: ExampleAppLogoName)!.withRenderingMode(.alwaysOriginal), persistent: false, as: .PNG) : nil
+            screenManager.primaryGraphic = areImagesVisible ? SDLArtwork(image: UIImage(named: ExampleAppLogoName)!.withRenderingMode(.alwaysOriginal), persistent: true, as: .PNG) : nil
         }
         
         // Secondary graphic
         if imageFieldSupported(imageFieldName: .secondaryGraphic) {
-            screenManager.secondaryGraphic = areImagesVisible ? SDLArtwork(image: UIImage(named: CarBWIconImageName)!, persistent: false, as: .PNG) : nil
+            screenManager.secondaryGraphic = areImagesVisible ? SDLArtwork(image: UIImage(named: CarBWIconImageName)!, persistent: true, as: .PNG) : nil
         }
         
         screenManager.endUpdates(completionHandler: { (error) in

--- a/Example Apps/Example Swift/ProxyManager.swift
+++ b/Example Apps/Example Swift/ProxyManager.swift
@@ -297,12 +297,6 @@ private extension ProxyManager {
         
         screenManager.endUpdates(completionHandler: { (error) in
             guard error != nil else { return }
-            if screenManager.primaryGraphic == nil && self.imageFieldSupported(imageFieldName: SDLImageFieldName.graphic) {
-                screenManager.primaryGraphic = areImagesVisible ? SDLArtwork(image: UIImage(named: ExampleAppLogoName)!.withRenderingMode(.alwaysOriginal), persistent: false, as: .PNG) : nil
-            } else if screenManager.primaryGraphic == nil && self.imageFieldSupported(imageFieldName:SDLImageFieldName.secondaryGraphic) {
-                screenManager.secondaryGraphic = areImagesVisible ? SDLArtwork(image: UIImage(named: CarBWIconImageName)!, persistent: false, as: .PNG) : nil
-            }
-
             SDLLog.e("Textfields, graphics and soft buttons failed to update: \(error!.localizedDescription)")
         })
     }

--- a/Example Apps/Example Swift/ProxyManager.swift
+++ b/Example Apps/Example Swift/ProxyManager.swift
@@ -297,6 +297,12 @@ private extension ProxyManager {
         
         screenManager.endUpdates(completionHandler: { (error) in
             guard error != nil else { return }
+            if screenManager.primaryGraphic == nil && self.imageFieldSupported(imageFieldName: SDLImageFieldName.graphic) {
+                screenManager.primaryGraphic = areImagesVisible ? SDLArtwork(image: UIImage(named: ExampleAppLogoName)!.withRenderingMode(.alwaysOriginal), persistent: false, as: .PNG) : nil
+            } else if screenManager.primaryGraphic == nil && self.imageFieldSupported(imageFieldName:SDLImageFieldName.secondaryGraphic) {
+                screenManager.secondaryGraphic = areImagesVisible ? SDLArtwork(image: UIImage(named: CarBWIconImageName)!, persistent: false, as: .PNG) : nil
+            }
+
             SDLLog.e("Textfields, graphics and soft buttons failed to update: \(error!.localizedDescription)")
         })
     }

--- a/SmartDeviceLink/public/SDLFileManager.m
+++ b/SmartDeviceLink/public/SDLFileManager.m
@@ -290,13 +290,14 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
     // HAX: [#827](https://github.com/smartdevicelink/sdl_ios/issues/827) Older versions of Core had a bug where list files would cache incorrectly.
     if ([[SDLGlobals sharedGlobals].rpcVersion isLessThanVersion:[SDLVersion versionWithMajor:4 minor:4 patch:0]]) {
         if (file.persistent && [self.remoteFileNames containsObject:file.name]) {
-            // If it's a persistent file, the bug won't present itself; just check if it's on the remote system
+            // HAX: If it's a persistent file, the bug won't present itself; just check if it's on the remote system
             return YES;
         } else if (!file.persistent && [self.remoteFileNames containsObject:file.name] && [self.uploadedEphemeralFileNames containsObject:file.name]) {
-            // If it's an ephemeral file, the bug will present itself; check that it's a remote file AND that we've uploaded it this session
+            // HAX: If it's an ephemeral file, the bug will present itself; check that it's a remote file AND that we've uploaded it this session
             return YES;
         }
     } else if ([self.remoteFileNames containsObject:file.name]) {
+        // If not connected to a system where the bug presents itself, we can trust the `remoteFileNames`
         return YES;
     }
 

--- a/SmartDeviceLink/public/SDLFileManager.m
+++ b/SmartDeviceLink/public/SDLFileManager.m
@@ -288,11 +288,15 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
 
 - (BOOL)hasUploadedFile:(SDLFile *)file {
     // HAX: [#827](https://github.com/smartdevicelink/sdl_ios/issues/827) Older versions of Core had a bug where list files would cache incorrectly.
-    if (file.persistent && [self.remoteFileNames containsObject:file.name]) {
-        // If it's a persistant file, the bug won't present itself; just check if it's on the remote system
-        return YES;
-    } else if (!file.persistent && [self.remoteFileNames containsObject:file.name] && [self.uploadedEphemeralFileNames containsObject:file.name]) {
-        // If it's an ephemeral file, the bug will present itself; check that it's a remote file AND that we've uploaded it this session
+    if ([[SDLGlobals sharedGlobals].rpcVersion isLessThanVersion:[SDLVersion versionWithMajor:4 minor:4 patch:0]]) {
+        if (file.persistent && [self.remoteFileNames containsObject:file.name]) {
+            // If it's a persistent file, the bug won't present itself; just check if it's on the remote system
+            return YES;
+        } else if (!file.persistent && [self.remoteFileNames containsObject:file.name] && [self.uploadedEphemeralFileNames containsObject:file.name]) {
+            // If it's an ephemeral file, the bug will present itself; check that it's a remote file AND that we've uploaded it this session
+            return YES;
+        }
+    } else if ([self.remoteFileNames containsObject:file.name]) {
         return YES;
     }
 

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLFileManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLFileManagerSpec.m
@@ -265,100 +265,28 @@ describe(@"uploading / deleting single files with the file manager", ^{
             beforeEach(^{
                 [SDLGlobals sharedGlobals].rpcVersion = [SDLVersion versionWithMajor:7 minor:1 patch:0];
                 [testFileManager.stateMachine setToState:SDLFileManagerStateReady fromOldState:SDLFileManagerStateShutdown callEnterTransition:NO];
+
+                NSData *testFileData = [@"someData" dataUsingEncoding:NSUTF8StringEncoding];
+                testFile = [SDLFile persistentFileWithData:testFileData name:@"testFile4" fileExtension:@"png"];
             });
 
-            context(@"when the file is persistent", ^{
+            context(@"when the file is in remoteFileNames", ^{
                 beforeEach(^{
-                    NSData *testFileData = [@"someData" dataUsingEncoding:NSUTF8StringEncoding];
-                    testFile = [SDLFile persistentFileWithData:testFileData name:@"testFile4" fileExtension:@"png"];
+                    testFileManager.mutableRemoteFileNames = [NSMutableSet setWithArray:testInitialFileNames2];
+                });
+
+                it(@"should return NO", ^{
+                    expect([testFileManager hasUploadedFile:testFile]).to(equal(YES));
+                });
+            });
+
+            context(@"when the file is not in remoteFileNames", ^{
+                beforeEach(^{
+                    testFileManager.mutableRemoteFileNames = [NSMutableSet setWithArray:testInitialFileNames];
                 });
 
                 it(@"should return NO", ^{
                     expect([testFileManager hasUploadedFile:testFile]).to(equal(NO));
-                });
-
-                context(@"when the file is in remoteFileNames", ^{
-                    beforeEach(^{
-                        testFileManager.mutableRemoteFileNames = [NSMutableSet setWithArray:testInitialFileNames2];
-                    });
-
-                    it(@"should return YES", ^{
-                        expect([testFileManager hasUploadedFile:testFile]).to(equal(YES));
-                    });
-
-                    context(@"when the file is in uploadedEphemeralFiles", ^{
-                        beforeEach(^{
-                            testFileManager.uploadedEphemeralFileNames = [NSMutableSet setWithArray:testInitialFileNames];
-
-                        });
-
-                        it(@"should return YES", ^{
-                            expect([testFileManager hasUploadedFile:testFile]).to(equal(YES));
-                        });
-                    });
-                });
-
-                context(@"when the file is not in remoteFileNames", ^{
-                    beforeEach(^{
-                        testFileManager.mutableRemoteFileNames = [NSMutableSet setWithArray:testInitialFileNames];
-                    });
-
-                    it(@"should return NO", ^{
-                        expect([testFileManager hasUploadedFile:testFile]).to(equal(NO));
-                    });
-                });
-            });
-
-            context(@"when the file is not persistent", ^{
-                beforeEach(^{
-                    NSData *testFileData = [@"someData" dataUsingEncoding:NSUTF8StringEncoding];
-                    testFile = [SDLFile fileWithData:testFileData name:@"testFile4" fileExtension:@"png"];
-                });
-
-                it(@"should return NO", ^{
-                    expect([testFileManager hasUploadedFile:testFile]).to(equal(NO));
-                });
-
-                context(@"when the file is in remoteFileNames", ^{
-                    beforeEach(^{
-                        testFileManager.mutableRemoteFileNames = [NSMutableSet setWithArray:testInitialFileNames2];
-                    });
-
-                    it(@"should return YES", ^{
-                        expect([testFileManager hasUploadedFile:testFile]).to(equal(YES));
-                    });
-
-                    context(@"when the file is in uploadedEphemeralFiles", ^{
-                        beforeEach(^{
-                            testFileManager.uploadedEphemeralFileNames = [NSMutableSet setWithArray:testInitialFileNames2];
-
-                        });
-
-                        it(@"should return YES", ^{
-                            expect([testFileManager hasUploadedFile:testFile]).to(equal(YES));
-                        });
-                    });
-
-                    context(@"when the file is not in uploadedEphemeralFiles", ^{
-                        beforeEach(^{
-                            testFileManager.uploadedEphemeralFileNames = [NSMutableSet setWithArray:testInitialFileNames];
-
-                        });
-
-                        it(@"should return YES", ^{
-                            expect([testFileManager hasUploadedFile:testFile]).to(equal(YES));
-                        });
-                    });
-                });
-
-                context(@"when the file is not in remoteFileNames", ^{
-                    beforeEach(^{
-                        testFileManager.mutableRemoteFileNames = [NSMutableSet setWithArray:testInitialFileNames];
-                    });
-
-                    it(@"should return NO", ^{
-                        expect([testFileManager hasUploadedFile:testFile]).to(equal(NO));
-                    });
                 });
             });
         });

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLFileManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLFileManagerSpec.m
@@ -87,6 +87,7 @@ describe(@"uploading / deleting single files with the file manager", ^{
     NSUInteger failureSpaceAvailabe = 2000000000;
     NSUInteger newBytesAvailable = 750;
     NSArray<NSString *> *testInitialFileNames = @[@"testFile1", @"testFile2", @"testFile3"];
+    NSArray<NSString *> *testInitialFileNames2 = @[@"testFile1", @"testFile2", @"testFile3", @"testFile4"];
 
     beforeEach(^{
         testConnectionManager = [[TestConnectionManager alloc] init];
@@ -260,44 +261,207 @@ describe(@"uploading / deleting single files with the file manager", ^{
     describe(@"check hasUploadedFile response", ^{
         __block SDLFile *testFile = nil;
 
-        beforeEach(^{
-            NSData *testFileData = [@"someData" dataUsingEncoding:NSUTF8StringEncoding];
-            testFile = [SDLFile fileWithData:testFileData name:@"testFile1" fileExtension:@"png"];
-
-            testFileManager.mutableRemoteFileNames = [NSMutableSet setWithArray:testInitialFileNames];
-            testFileManager.uploadedEphemeralFileNames = [[NSMutableSet alloc] init];
-            [testFileManager.stateMachine setToState:SDLFileManagerStateReady fromOldState:SDLFileManagerStateShutdown callEnterTransition:NO];
-        });
-
-        context(@"when the file is already uploaded and the RPC version is >= 4.4.0", ^{
+        context(@"on RPC version >= 4.4.0", ^{
             beforeEach(^{
                 [SDLGlobals sharedGlobals].rpcVersion = [SDLVersion versionWithMajor:7 minor:1 patch:0];
+                [testFileManager.stateMachine setToState:SDLFileManagerStateReady fromOldState:SDLFileManagerStateShutdown callEnterTransition:NO];
             });
 
-            it(@"should return yes even if uploadedEphemeralFileNames is empty", ^{
-                expect([testFileManager hasUploadedFile:testFile]).to(equal(YES));
+            context(@"when the file is persistent", ^{
+                beforeEach(^{
+                    NSData *testFileData = [@"someData" dataUsingEncoding:NSUTF8StringEncoding];
+                    testFile = [SDLFile persistentFileWithData:testFileData name:@"testFile4" fileExtension:@"png"];
+                });
+
+                it(@"should return NO", ^{
+                    expect([testFileManager hasUploadedFile:testFile]).to(equal(NO));
+                });
+
+                context(@"when the file is in remoteFileNames", ^{
+                    beforeEach(^{
+                        testFileManager.mutableRemoteFileNames = [NSMutableSet setWithArray:testInitialFileNames2];
+                    });
+
+                    it(@"should return YES", ^{
+                        expect([testFileManager hasUploadedFile:testFile]).to(equal(YES));
+                    });
+
+                    context(@"when the file is in uploadedEphemeralFiles", ^{
+                        beforeEach(^{
+                            testFileManager.uploadedEphemeralFileNames = [NSMutableSet setWithArray:testInitialFileNames];
+
+                        });
+
+                        it(@"should return YES", ^{
+                            expect([testFileManager hasUploadedFile:testFile]).to(equal(YES));
+                        });
+                    });
+                });
+
+                context(@"when the file is not in remoteFileNames", ^{
+                    beforeEach(^{
+                        testFileManager.mutableRemoteFileNames = [NSMutableSet setWithArray:testInitialFileNames];
+                    });
+
+                    it(@"should return NO", ^{
+                        expect([testFileManager hasUploadedFile:testFile]).to(equal(NO));
+                    });
+                });
             });
 
-            it(@"should return yes", ^{
-                [testFileManager.uploadedEphemeralFileNames addObject:@"testFile1"];
+            context(@"when the file is not persistent", ^{
+                beforeEach(^{
+                    NSData *testFileData = [@"someData" dataUsingEncoding:NSUTF8StringEncoding];
+                    testFile = [SDLFile fileWithData:testFileData name:@"testFile4" fileExtension:@"png"];
+                });
 
-                expect([testFileManager hasUploadedFile:testFile]).to(equal(YES));
+                it(@"should return NO", ^{
+                    expect([testFileManager hasUploadedFile:testFile]).to(equal(NO));
+                });
+
+                context(@"when the file is in remoteFileNames", ^{
+                    beforeEach(^{
+                        testFileManager.mutableRemoteFileNames = [NSMutableSet setWithArray:testInitialFileNames2];
+                    });
+
+                    it(@"should return YES", ^{
+                        expect([testFileManager hasUploadedFile:testFile]).to(equal(YES));
+                    });
+
+                    context(@"when the file is in uploadedEphemeralFiles", ^{
+                        beforeEach(^{
+                            testFileManager.uploadedEphemeralFileNames = [NSMutableSet setWithArray:testInitialFileNames2];
+
+                        });
+
+                        it(@"should return YES", ^{
+                            expect([testFileManager hasUploadedFile:testFile]).to(equal(YES));
+                        });
+                    });
+
+                    context(@"when the file is not in uploadedEphemeralFiles", ^{
+                        beforeEach(^{
+                            testFileManager.uploadedEphemeralFileNames = [NSMutableSet setWithArray:testInitialFileNames];
+
+                        });
+
+                        it(@"should return YES", ^{
+                            expect([testFileManager hasUploadedFile:testFile]).to(equal(YES));
+                        });
+                    });
+                });
+
+                context(@"when the file is not in remoteFileNames", ^{
+                    beforeEach(^{
+                        testFileManager.mutableRemoteFileNames = [NSMutableSet setWithArray:testInitialFileNames];
+                    });
+
+                    it(@"should return NO", ^{
+                        expect([testFileManager hasUploadedFile:testFile]).to(equal(NO));
+                    });
+                });
             });
         });
 
-        context(@"when the file is already uploaded and the RPC version is < 4.4.0", ^{
+        context(@"on RPC version < 4.4.0", ^{
             beforeEach(^{
                 [SDLGlobals sharedGlobals].rpcVersion = [SDLVersion versionWithMajor:4 minor:3 patch:0];
+                [testFileManager.stateMachine setToState:SDLFileManagerStateReady fromOldState:SDLFileManagerStateShutdown callEnterTransition:NO];
             });
 
-            it(@"should return no if uploadedEphemeralFileNames is empty", ^{
-                expect([testFileManager hasUploadedFile:testFile]).to(equal(NO));
+            context(@"when the file is persistent", ^{
+                beforeEach(^{
+                    NSData *testFileData = [@"someData" dataUsingEncoding:NSUTF8StringEncoding];
+                    testFile = [SDLFile persistentFileWithData:testFileData name:@"testFile4" fileExtension:@"png"];
+                });
+
+                it(@"should return NO", ^{
+                    expect([testFileManager hasUploadedFile:testFile]).to(equal(NO));
+                });
+
+                context(@"when the file is in remoteFileNames", ^{
+                    beforeEach(^{
+                        testFileManager.mutableRemoteFileNames = [NSMutableSet setWithArray:testInitialFileNames2];
+                    });
+
+                    it(@"should return YES", ^{
+                        expect([testFileManager hasUploadedFile:testFile]).to(equal(YES));
+                    });
+
+                    context(@"when the file is in uploadedEphemeralFiles", ^{
+                        beforeEach(^{
+                            testFileManager.uploadedEphemeralFileNames = [NSMutableSet setWithArray:testInitialFileNames];
+
+                        });
+
+                        it(@"should return YES", ^{
+                            expect([testFileManager hasUploadedFile:testFile]).to(equal(YES));
+                        });
+                    });
+                });
+
+                context(@"when the file is not in remoteFileNames", ^{
+                    beforeEach(^{
+                        testFileManager.mutableRemoteFileNames = [NSMutableSet setWithArray:testInitialFileNames];
+                    });
+
+                    it(@"should return NO", ^{
+                        expect([testFileManager hasUploadedFile:testFile]).to(equal(NO));
+                    });
+                });
             });
 
-            it(@"should return no if uploadedEphemeralFileNames contains fileName", ^{
-                [testFileManager.uploadedEphemeralFileNames addObject:@"testFile1"];
+            context(@"when the file is not persistent", ^{
+                beforeEach(^{
+                    NSData *testFileData = [@"someData" dataUsingEncoding:NSUTF8StringEncoding];
+                    testFile = [SDLFile fileWithData:testFileData name:@"testFile4" fileExtension:@"png"];
+                });
 
-                expect([testFileManager hasUploadedFile:testFile]).to(equal(YES));
+                it(@"should return NO", ^{
+                    expect([testFileManager hasUploadedFile:testFile]).to(equal(NO));
+                });
+
+                context(@"when the file is in remoteFileNames", ^{
+                    beforeEach(^{
+                        testFileManager.mutableRemoteFileNames = [NSMutableSet setWithArray:testInitialFileNames2];
+                    });
+
+                    it(@"should return NO", ^{
+                        expect([testFileManager hasUploadedFile:testFile]).to(equal(NO));
+                    });
+
+                    context(@"when the file is in uploadedEphemeralFiles", ^{
+                        beforeEach(^{
+                            testFileManager.uploadedEphemeralFileNames = [NSMutableSet setWithArray:testInitialFileNames2];
+
+                        });
+
+                        it(@"should return YES", ^{
+                            expect([testFileManager hasUploadedFile:testFile]).to(equal(YES));
+                        });
+                    });
+
+                    context(@"when the file is not in uploadedEphemeralFiles", ^{
+                        beforeEach(^{
+                            testFileManager.uploadedEphemeralFileNames = [NSMutableSet setWithArray:testInitialFileNames];
+
+                        });
+
+                        it(@"should return NO", ^{
+                            expect([testFileManager hasUploadedFile:testFile]).to(equal(NO));
+                        });
+                    });
+                });
+
+                context(@"when the file is not in remoteFileNames", ^{
+                    beforeEach(^{
+                        testFileManager.mutableRemoteFileNames = [NSMutableSet setWithArray:testInitialFileNames];
+                    });
+
+                    it(@"should return NO", ^{
+                        expect([testFileManager hasUploadedFile:testFile]).to(equal(NO));
+                    });
+                });
             });
         });
     });


### PR DESCRIPTION
Fixes #1978 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
N/A

#### Core Tests
1. Register and launch app on hmi
2. Check if the screenManager's `primaryGraphic` is presented.

7.1 Test plan: Screen Manager - Text & Graphic

Core version / branch / commit hash / module tested against: N/A
HMI name / version / branch / commit hash / module tested against: Manticore

### Summary
`hasUploadedFile` func of SDLFIleManager returns `NO` sometimes when it should be returning `YES` which caused the primaryGraphic not being displayed. This bug could be seen usually on second app launch.

### Changelog
##### Breaking Changes
* N/A

##### Enhancements
* N/A

##### Bug Fixes
* Updates in `hasUploadedFile` func of SDLFIleManager.

### Tasks Remaining:
N/A

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
