### PR TITLE
Update SCM to workaround Sync 3 bug with media capabilities

### DIFF
--- a/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
+++ b/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
@@ -7902,7 +7902,7 @@
 			attributes = {
 				CLASSPREFIX = SDL;
 				LastSwiftUpdateCheck = 0710;
-				LastUpgradeCheck = 1240;
+				LastUpgradeCheck = 1250;
 				ORGANIZATIONNAME = smartdevicelink;
 				TargetAttributes = {
 					5D4019AE1A76EC350006B0C2 = {
@@ -9433,7 +9433,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_ATOMIC_PROPERTIES = YES;
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = YES;
-				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
@@ -9489,7 +9489,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_ATOMIC_PROPERTIES = YES;
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = YES;
-				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;

--- a/SmartDeviceLink-iOS.xcodeproj/xcshareddata/xcschemes/SmartDeviceLink-Example-ObjC.xcscheme
+++ b/SmartDeviceLink-iOS.xcodeproj/xcshareddata/xcschemes/SmartDeviceLink-Example-ObjC.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SmartDeviceLink-iOS.xcodeproj/xcshareddata/xcschemes/SmartDeviceLink.xcscheme
+++ b/SmartDeviceLink-iOS.xcodeproj/xcshareddata/xcschemes/SmartDeviceLink.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SmartDeviceLink-iOS.xcodeproj/xcshareddata/xcschemes/SmartDeviceLinkSwift.xcscheme
+++ b/SmartDeviceLink-iOS.xcodeproj/xcshareddata/xcschemes/SmartDeviceLinkSwift.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SmartDeviceLink/private/SDLConnectionManagerType.h
+++ b/SmartDeviceLink/private/SDLConnectionManagerType.h
@@ -9,6 +9,7 @@
 #import "SDLNotificationConstants.h"
 #import <Foundation/Foundation.h>
 
+@class SDLConfiguration;
 @class SDLRPCRequest;
 @class SDLRPCMessage;
 @class SDLRegisterAppInterfaceResponse;
@@ -18,8 +19,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol SDLConnectionManagerType <NSObject>
 
+/// The configuration properties provided by the app to the SDL manager
+@property (copy, nonatomic, readonly) SDLConfiguration *configuration;
+
 /// An object describing the properties of the connected module
-@property (strong, nonatomic, nullable) SDLSystemInfo *systemInfo;
+@property (strong, nonatomic, readonly, nullable) SDLSystemInfo *systemInfo;
 
 /**
  *  A special method on the connection manager which is used by managers that must bypass the default block on RPC sends before managers complete setup.

--- a/SmartDeviceLink/private/SDLLifecycleManager.h
+++ b/SmartDeviceLink/private/SDLLifecycleManager.h
@@ -79,12 +79,12 @@ typedef void (^SDLManagerReadyBlock)(BOOL success, NSError *_Nullable error);
 @property (strong, nonatomic, readonly) SDLStateMachine *lifecycleStateMachine;
 
 @property (copy, nonatomic, readonly) SDLLifecycleState *lifecycleState;
-@property (copy, nonatomic, nullable) SDLHMILevel hmiLevel;
-@property (copy, nonatomic, nullable) SDLAudioStreamingState audioStreamingState;
-@property (copy, nonatomic, nullable) SDLVideoStreamingState videoStreamingState;
-@property (copy, nonatomic, nullable) SDLSystemContext systemContext;
-@property (strong, nonatomic, nullable) SDLRegisterAppInterfaceResponse *registerResponse;
-@property (strong, nonatomic, nullable) SDLSystemInfo *systemInfo;
+@property (copy, nonatomic, readonly, nullable) SDLHMILevel hmiLevel;
+@property (copy, nonatomic, readonly, nullable) SDLAudioStreamingState audioStreamingState;
+@property (copy, nonatomic, readonly, nullable) SDLVideoStreamingState videoStreamingState;
+@property (copy, nonatomic, readonly, nullable) SDLSystemContext systemContext;
+@property (strong, nonatomic, readonly, nullable) SDLRegisterAppInterfaceResponse *registerResponse;
+@property (strong, nonatomic, readonly, nullable) SDLSystemInfo *systemInfo;
 
 @property (strong, nonatomic) NSOperationQueue *rpcOperationQueue;
 

--- a/SmartDeviceLink/public/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/public/SDLSystemCapabilityManager.m
@@ -169,32 +169,19 @@ typedef NSString * SDLServiceID;
 
 #pragma mark Convert Deprecated to New
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated"
-/// Convert the capabilities from a `RegisterAppInterfaceResponse` into a new-style `DisplayCapability` for the main display.
-/// @param rpc The `RegisterAppInterfaceResponse` RPC
-- (NSArray<SDLDisplayCapability *> *)sdl_createDisplayCapabilityListFromRegisterResponse:(SDLRegisterAppInterfaceResponse *)rpc {
-    return [self sdl_createDisplayCapabilityListFromDeprecatedDisplayCapabilities:rpc.displayCapabilities buttons:rpc.buttonCapabilities softButtons:rpc.softButtonCapabilities];
-}
-
-- (NSArray<SDLDisplayCapability *> *)sdl_createDisplayCapabilityListFromSetDisplayLayoutResponse:(SDLSetDisplayLayoutResponse *)rpc {
-    return [self sdl_createDisplayCapabilityListFromDeprecatedDisplayCapabilities:rpc.displayCapabilities buttons:rpc.buttonCapabilities softButtons:rpc.softButtonCapabilities];
-}
-#pragma clang diagnostic pop
-
 /// Creates a "new-style" display capability from the "old-style" `SDLDisplayCapabilities` object and other "old-style" objects that were returned in `RegisterAppInterfaceResponse` and `SetDisplayLayoutResponse`
 /// @param display The old-style `SDLDisplayCapabilities` object to convert
 /// @param buttons The old-style `SDLButtonCapabilities` object to convert
 /// @param softButtons The old-style `SDLSoftButtonCapabilities` to convert
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-- (NSArray<SDLDisplayCapability *> *)sdl_createDisplayCapabilityListFromDeprecatedDisplayCapabilities:(SDLDisplayCapabilities *)display buttons:(NSArray<SDLButtonCapabilities *> *)buttons softButtons:(NSArray<SDLSoftButtonCapabilities *> *)softButtons {
+- (NSArray<SDLDisplayCapability *> *)sdl_createDisplayCapabilityListFromDeprecatedDisplayCapabilities {
     SDLLogV(@"Creating display capability from deprecated display capabilities");
     // Based on deprecated Display capabilities we don't know if widgets are supported. The default MAIN window is the only window we know is supported, so it's the only one we will expose.
     SDLWindowTypeCapabilities *windowTypeCapabilities = [[SDLWindowTypeCapabilities alloc] initWithType:SDLWindowTypeMain maximumNumberOfWindows:1];
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
-    NSString *displayName = display.displayName ?: display.displayType;
+    NSString *displayName = self.displayCapabilities.displayName ?: self.displayCapabilities.displayType;
 #pragma clang diagnostic pop
     SDLDisplayCapability *displayCapability = [[SDLDisplayCapability alloc] initWithDisplayName:displayName];
     displayCapability.windowTypeSupported = @[windowTypeCapabilities];
@@ -202,11 +189,11 @@ typedef NSString * SDLServiceID;
     // Create a window capability object for the default MAIN window
     SDLWindowCapability *defaultWindowCapability = [[SDLWindowCapability alloc] init];
     defaultWindowCapability.windowID = @(SDLPredefinedWindowsDefaultWindow);
-    defaultWindowCapability.buttonCapabilities = [buttons copy];
-    defaultWindowCapability.softButtonCapabilities = [softButtons copy];
+    defaultWindowCapability.buttonCapabilities = [self.buttonCapabilities copy];
+    defaultWindowCapability.softButtonCapabilities = [self.softButtonCapabilities copy];
 
     // return if display capabilities don't exist.
-    if (display == nil) {
+    if (self.displayCapabilities == nil) {
         defaultWindowCapability.textFields = [SDLTextField allTextFields];
         defaultWindowCapability.imageFields = [SDLImageField allImageFields];
         displayCapability.windowCapabilities = @[defaultWindowCapability];
@@ -214,17 +201,17 @@ typedef NSString * SDLServiceID;
     }
 
     // Copy all available display capability properties
-    defaultWindowCapability.templatesAvailable = [display.templatesAvailable copy];
-    defaultWindowCapability.numCustomPresetsAvailable = [display.numCustomPresetsAvailable copy];
-    defaultWindowCapability.textFields = [display.textFields copy];
-    defaultWindowCapability.imageFields = [display.imageFields copy];
+    defaultWindowCapability.templatesAvailable = [self.displayCapabilities.templatesAvailable copy];
+    defaultWindowCapability.numCustomPresetsAvailable = [self.displayCapabilities.numCustomPresetsAvailable copy];
+    defaultWindowCapability.textFields = [self.displayCapabilities.textFields copy];
+    defaultWindowCapability.imageFields = [self.displayCapabilities.imageFields copy];
 
     /*
      The description from the mobile API to "graphicSupported:
      > The display's persistent screen supports referencing a static or dynamic image.
      For backward compatibility (AppLink 2.0) static image type is always presented
      */
-    if (display.graphicSupported.boolValue) {
+    if (self.displayCapabilities.graphicSupported.boolValue) {
         defaultWindowCapability.imageTypeSupported = @[SDLImageTypeStatic, SDLImageTypeDynamic];
     } else {
         defaultWindowCapability.imageTypeSupported = @[SDLImageTypeStatic];
@@ -730,7 +717,7 @@ typedef NSString * SDLServiceID;
     self.pcmStreamCapability = response.pcmStreamCapabilities;
 
     self.shouldConvertDeprecatedDisplayCapabilities = YES;
-    self.displays = [self sdl_createDisplayCapabilityListFromRegisterResponse:response];
+    self.displays = [self sdl_createDisplayCapabilityListFromDeprecatedDisplayCapabilities];
 
     SDLLogV(@"Received RegisterAppInterface response, filled out display and other capabilities");
 
@@ -764,7 +751,7 @@ typedef NSString * SDLServiceID;
     self.softButtonCapabilities = response.softButtonCapabilities;
     self.presetBankCapabilities = response.presetBankCapabilities;
 
-    self.displays = [self sdl_createDisplayCapabilityListFromSetDisplayLayoutResponse:response];
+    self.displays = [self sdl_createDisplayCapabilityListFromDeprecatedDisplayCapabilities];
 
     SDLLogV(@"Received SetDisplayLayout response, filled out display and other capabilities");
 

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLLifecycleManagerSpec.m
@@ -4,48 +4,19 @@
 
 #import "SDLLifecycleManager.h"
 
-#import "SDLAppServiceData.h"
-#import "SDLChangeRegistration.h"
-#import "SDLConfiguration.h"
+#import <SmartDeviceLink/SmartDeviceLink.h>
+
 #import "SDLConnectionManagerType.h"
-#import "SDLEncryptionConfiguration.h"
 #import "SDLEncryptionLifecycleManager.h"
 #import "SDLError.h"
-#import "SDLFileManagerConfiguration.h"
-#import "SDLFileManager.h"
 #import "SDLGlobals.h"
-#import "SDLHMILevel.h"
-#import "SDLLifecycleConfiguration.h"
 #import "SDLLifecycleProtocolHandler.h"
-#import "SDLLockScreenConfiguration.h"
 #import "SDLLockScreenManager.h"
-#import "SDLLogConfiguration.h"
-#import "SDLManagerDelegate.h"
 #import "SDLNotificationDispatcher.h"
-#import "SDLOnAppInterfaceUnregistered.h"
-#import "SDLOnAppServiceData.h"
-#import "SDLOnHashChange.h"
-#import "SDLOnHMIStatus.h"
-#import "SDLPerformAppServiceInteractionResponse.h"
-#import "SDLPermissionManager.h"
 #import "SDLProtocol.h"
-#import "SDLRegisterAppInterface.h"
-#import "SDLRegisterAppInterfaceResponse.h"
-#import "SDLResult.h"
 #import "SDLRPCNotificationNotification.h"
 #import "SDLSecondaryTransportManager.h"
-#import "SDLShow.h"
 #import "SDLStateMachine.h"
-#import "SDLStreamingMediaConfiguration.h"
-#import "SDLStreamingMediaManager.h"
-#import "SDLSystemCapabilityManager.h"
-#import "SDLTextAlignment.h"
-#import "SDLTTSChunk.h"
-#import "SDLUnregisterAppInterface.h"
-#import "SDLUnregisterAppInterfaceResponse.h"
-#import "SDLVehicleType.h"
-#import "SDLVersion.h"
-#import "SDLVideoStreamingState.h"
 
 @interface SDLStreamingMediaManager ()
 
@@ -62,6 +33,13 @@
 @property (strong, nonatomic, nullable) SDLSecondaryTransportManager *secondaryTransportManager;
 @property (strong, nonatomic) SDLEncryptionLifecycleManager *encryptionLifecycleManager;
 @property (strong, nonatomic, nullable) SDLLifecycleProtocolHandler *protocolHandler;
+@property (copy, nonatomic, readwrite, nullable) SDLHMILevel hmiLevel;
+@property (copy, nonatomic, readwrite, nullable) SDLAudioStreamingState audioStreamingState;
+@property (copy, nonatomic, readwrite, nullable) SDLVideoStreamingState videoStreamingState;
+@property (copy, nonatomic, readwrite, nullable) SDLSystemContext systemContext;
+@property (strong, nonatomic, readwrite, nullable) SDLRegisterAppInterfaceResponse *registerResponse;
+@property (strong, nonatomic, readwrite, nullable) SDLSystemInfo *systemInfo;
+
 - (void)didEnterStateConnected;
 @end
 

--- a/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
+++ b/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
@@ -1,43 +1,12 @@
 #import <Quick/Quick.h>
 #import <Nimble/Nimble.h>
 
-#import "SDLAppServiceCapability.h"
-#import "SDLAppServiceManifest.h"
-#import "SDLAppServiceRecord.h"
-#import "SDLAppServicesCapabilities.h"
-#import "SDLAudioPassThruCapabilities.h"
-#import "SDLButtonCapabilities.h"
-#import "SDLDisplayCapabilities.h"
-#import "SDLDisplayCapability.h"
-#import "SDLGetSystemCapability.h"
-#import "SDLGetSystemCapabilityResponse.h"
+#import <SmartDeviceLink/SmartDeviceLink.h>
+
 #import "SDLGlobals.h"
-#import "SDLHMICapabilities.h"
-#import "SDLImageField.h"
-#import "SDLImageResolution.h"
-#import "SDLMediaServiceManifest.h"
-#import "SDLNavigationCapability.h"
 #import "SDLNotificationConstants.h"
-#import "SDLOnHMIStatus.h"
-#import "SDLOnSystemCapabilityUpdated.h"
-#import "SDLPhoneCapability.h"
-#import "SDLPredefinedWindows.h"
-#import "SDLPresetBankCapabilities.h"
-#import "SDLRegisterAppInterfaceResponse.h"
-#import "SDLRemoteControlCapabilities.h"
 #import "SDLRPCNotificationNotification.h"
-#import "SDLRPCResponseNotification.h"
-#import "SDLScreenParams.h"
-#import "SDLSetDisplayLayoutResponse.h"
-#import "SDLSoftButtonCapabilities.h"
-#import "SDLSystemCapability.h"
 #import "SDLSystemCapabilityObserver.h"
-#import "SDLSystemCapabilityManager.h"
-#import "SDLTextField.h"
-#import "SDLVersion.h"
-#import "SDLVideoStreamingCapability.h"
-#import "SDLWindowCapability.h"
-#import "SDLWindowTypeCapabilities.h"
 #import "TestConnectionManager.h"
 #import "TestSystemCapabilityObserver.h"
 
@@ -51,6 +20,9 @@ typedef NSString * SDLServiceID;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 @property (nullable, strong, nonatomic, readwrite) SDLDisplayCapabilities *displayCapabilities;
+
+@property (nullable, strong, nonatomic) SDLDisplayCapabilities *initialMediaCapabilities;
+@property (nullable, strong, nonatomic) NSString *lastDisplayLayoutRequestTemplate;
 #pragma clang diagnostic pop
 @property (nullable, strong, nonatomic, readwrite) SDLHMICapabilities *hmiCapabilities;
 @property (nullable, copy, nonatomic, readwrite) NSArray<SDLSoftButtonCapabilities *> *softButtonCapabilities;
@@ -85,7 +57,7 @@ typedef NSString * SDLServiceID;
 
 QuickSpecBegin(SDLSystemCapabilityManagerSpec)
 
-describe(@"System capability manager", ^{
+describe(@"a system capability manager", ^{
     __block SDLSystemCapabilityManager *testSystemCapabilityManager = nil;
     __block TestConnectionManager *testConnectionManager = nil;
 
@@ -93,6 +65,7 @@ describe(@"System capability manager", ^{
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     __block SDLDisplayCapabilities *testDisplayCapabilities = nil;
+    __block SDLDisplayCapabilities *testDisplayCapabilities2 = nil;
 #pragma clang diagnostic pop
     __block NSArray<SDLSoftButtonCapabilities *> *testSoftButtonCapabilities = nil;
     __block NSArray<SDLButtonCapabilities *> *testButtonCapabilities = nil;
@@ -125,6 +98,11 @@ describe(@"System capability manager", ^{
         testDisplayCapabilities.mediaClockFormats = @[];
         testDisplayCapabilities.templatesAvailable = @[@"DEFAULT", @"MEDIA"];
         testDisplayCapabilities.numCustomPresetsAvailable = @(8);
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        testDisplayCapabilities2 = [[SDLDisplayCapabilities alloc] init];
+#pragma clang diagnostic pop
 
         SDLSoftButtonCapabilities *softButtonCapability = [[SDLSoftButtonCapabilities alloc] init];
         softButtonCapability.shortPressAvailable = @YES;
@@ -167,6 +145,7 @@ describe(@"System capability manager", ^{
         }
     });
 
+    // should initialize the system capability manager properties correctly
     it(@"should initialize the system capability manager properties correctly", ^{
         expect(testSystemCapabilityManager.displays).to(beNil());
         expect(testSystemCapabilityManager.hmiCapabilities).to(beNil());
@@ -191,8 +170,11 @@ describe(@"System capability manager", ^{
         expect(testSystemCapabilityManager.seatLocationCapability).to(beNil());
         expect(testSystemCapabilityManager.driverDistractionCapability).to(beNil());
         expect(testSystemCapabilityManager.currentHMILevel).to(equal(SDLHMILevelNone));
+        expect(testSystemCapabilityManager.initialMediaCapabilities).to(beNil());
+        expect(testSystemCapabilityManager.lastDisplayLayoutRequestTemplate).to(beNil());
     });
 
+    // isCapabilitySupported method should work correctly
     describe(@"isCapabilitySupported method should work correctly", ^{
         __block SDLHMICapabilities *hmiCapabilities = nil;
 
@@ -200,6 +182,7 @@ describe(@"System capability manager", ^{
             hmiCapabilities = [[SDLHMICapabilities alloc] init];
         });
 
+        // when there's a cached phone capability and hmiCapabilities is nil
         context(@"when there's a cached phone capability and hmiCapabilities is nil", ^{
             beforeEach(^{
                 testSystemCapabilityManager.phoneCapability = [[SDLPhoneCapability alloc] initWithDialNumber:YES];
@@ -210,7 +193,9 @@ describe(@"System capability manager", ^{
             });
         });
 
+        // when there's no cached capability
         context(@"when there's no cached capability", ^{
+            // pulling a phone capability when HMICapabilites.phoneCapability is false
             describe(@"pulling a phone capability when HMICapabilites.phoneCapability is false", ^{
                 beforeEach(^{
                     hmiCapabilities.phoneCall = @NO;
@@ -222,24 +207,28 @@ describe(@"System capability manager", ^{
                 });
             });
 
+            // pulling a phone capability when HMICapabilites.phoneCapability is true
             describe(@"pulling a phone capability when HMICapabilites.phoneCapability is true", ^{
                 beforeEach(^{
                     hmiCapabilities.phoneCall = @YES;
                     testSystemCapabilityManager.hmiCapabilities = hmiCapabilities;
                 });
 
-                it(@"should return NO", ^{
+                it(@"should return YES", ^{
                     expect([testSystemCapabilityManager isCapabilitySupported:SDLSystemCapabilityTypePhoneCall]).to(beTrue());
                 });
             });
 
+            // pulling a phone capability when HMICapabilites.phoneCapability is nil
             describe(@"pulling a phone capability when HMICapabilites.phoneCapability is nil", ^{
                 it(@"should return NO", ^{
                     expect([testSystemCapabilityManager isCapabilitySupported:SDLSystemCapabilityTypePhoneCall]).to(beFalse());
                 });
             });
 
+            // pulling an app services capability
             describe(@"pulling an app services capability", ^{
+                // on RPC connection version 5.1.0 and HMICapabilities.appServices is false
                 context(@"on RPC connection version 5.1.0 and HMICapabilities.appServices is false", ^{
                     beforeEach(^{
                         [SDLGlobals sharedGlobals].rpcVersion = [SDLVersion versionWithString:@"5.1.0"];
@@ -252,6 +241,7 @@ describe(@"System capability manager", ^{
                     });
                 });
 
+                // on RPC connection version 5.2.0 and HMICapabilities.appServices is false
                 context(@"on RPC connection version 5.2.0 and HMICapabilities.appServices is false", ^{
                     beforeEach(^{
                         [SDLGlobals sharedGlobals].rpcVersion = [SDLVersion versionWithString:@"5.2.0"];
@@ -265,7 +255,9 @@ describe(@"System capability manager", ^{
                 });
             });
 
+            // pulling a video streaming capability
             describe(@"pulling a video streaming capability", ^{
+                // on RPC connection version 2.0.0 and HMICapabilities is nil
                 context(@"on RPC connection version 2.0.0 and HMICapabilities is nil", ^{
                     beforeEach(^{
                         [SDLGlobals sharedGlobals].rpcVersion = [SDLVersion versionWithString:@"2.0.0"];
@@ -276,11 +268,13 @@ describe(@"System capability manager", ^{
                     });
                 });
 
+                // on RPC connection version 3.0.0 and HMICapabilities is nil
                 context(@"on RPC connection version 3.0.0 and HMICapabilities is nil", ^{
                     beforeEach(^{
                         [SDLGlobals sharedGlobals].rpcVersion = [SDLVersion versionWithString:@"3.0.0"];
                     });
 
+                    // when displayCapabilities.graphicSupported is true
                     context(@"when displayCapabilities.graphicSupported is true", ^{
                         beforeEach(^{
 #pragma clang diagnostic push
@@ -295,6 +289,7 @@ describe(@"System capability manager", ^{
                         });
                     });
 
+                    // when displayCapabilities.graphicSupported is false
                     context(@"when displayCapabilities.graphicSupported is false", ^{
                         beforeEach(^{
                             testSystemCapabilityManager.displayCapabilities.graphicSupported = @NO;
@@ -306,11 +301,13 @@ describe(@"System capability manager", ^{
                     });
                 });
 
+                // on RPC connection version 5.1.0
                 context(@"on RPC connection version 5.1.0", ^{
                     beforeEach(^{
                         [SDLGlobals sharedGlobals].rpcVersion = [SDLVersion versionWithString:@"5.1.0"];
                     });
 
+                    // when HMICapabilites.videoStreaming is false
                     context(@"when HMICapabilites.videoStreaming is false", ^{
                         beforeEach(^{
                             hmiCapabilities.videoStreaming = @NO;
@@ -322,6 +319,7 @@ describe(@"System capability manager", ^{
                         });
                     });
 
+                    // when HMICapabilites.videoStreaming is true
                     context(@"when HMICapabilites.videoStreaming is true", ^{
                         beforeEach(^{
                             hmiCapabilities.videoStreaming = @YES;
@@ -333,6 +331,7 @@ describe(@"System capability manager", ^{
                         });
                     });
 
+                    // when HMICapabilites.videoStreaming is nil
                     context(@"when HMICapabilites.videoStreaming is nil", ^{
                         it(@"should return false", ^{
                             expect([testSystemCapabilityManager isCapabilitySupported:SDLSystemCapabilityTypeVideoStreaming]).to(beFalse());
@@ -343,7 +342,8 @@ describe(@"System capability manager", ^{
         });
     });
 
-    context(@"When notified of a register app interface response", ^{
+    // When notified of a register app interface response
+    describe(@"when notified of a register app interface response", ^{
         __block SDLRegisterAppInterfaceResponse *testRegisterAppInterfaceResponse = nil;
         __block SDLHMICapabilities *testHMICapabilities = nil;
         __block NSArray<SDLHMIZoneCapabilities> *testHMIZoneCapabilities = nil;
@@ -388,72 +388,122 @@ describe(@"System capability manager", ^{
             testRegisterAppInterfaceResponse.pcmStreamCapabilities = testPCMStreamCapability;
         });
 
-        describe(@"If the Register App Interface request fails", ^{
-            beforeEach(^{
-                testRegisterAppInterfaceResponse.success = @NO;
-                SDLRPCResponseNotification *notification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveRegisterAppInterfaceResponse object:self rpcResponse:testRegisterAppInterfaceResponse];
-                [[NSNotificationCenter defaultCenter] postNotification:notification];
+        context(@"if the appType = DEFAULT", ^{
+            // if the Register App Interface request fails
+            context(@"if the Register App Interface request fails", ^{
+                beforeEach(^{
+                    testRegisterAppInterfaceResponse.success = @NO;
+                    SDLRPCResponseNotification *notification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveRegisterAppInterfaceResponse object:self rpcResponse:testRegisterAppInterfaceResponse];
+                    [[NSNotificationCenter defaultCenter] postNotification:notification];
+                });
+
+                // should not save any of the RAIR capabilities
+                it(@"should not save any of the RAIR capabilities", ^{
+                    expect(testSystemCapabilityManager.displays).to(beNil());
+                    expect(testSystemCapabilityManager.hmiCapabilities).to(beNil());
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated"
+                    expect(testSystemCapabilityManager.displayCapabilities).to(beNil());
+                    expect(testSystemCapabilityManager.softButtonCapabilities).to(beNil());
+                    expect(testSystemCapabilityManager.buttonCapabilities).to(beNil());
+                    expect(testSystemCapabilityManager.presetBankCapabilities).to(beNil());
+    #pragma clang diagnostic pop
+                    expect(testSystemCapabilityManager.hmiZoneCapabilities).to(beNil());
+                    expect(testSystemCapabilityManager.speechCapabilities).to(beNil());
+                    expect(testSystemCapabilityManager.prerecordedSpeechCapabilities).to(beNil());
+                    expect(testSystemCapabilityManager.vrCapability).to(beFalse());
+                    expect(testSystemCapabilityManager.audioPassThruCapabilities).to(beNil());
+                    expect(testSystemCapabilityManager.pcmStreamCapability).to(beNil());
+
+                    expect(testSystemCapabilityManager.phoneCapability).to(beNil());
+                    expect(testSystemCapabilityManager.navigationCapability).to(beNil());
+                    expect(testSystemCapabilityManager.videoStreamingCapability).to(beNil());
+                    expect(testSystemCapabilityManager.remoteControlCapability).to(beNil());
+                    expect(testSystemCapabilityManager.appServicesCapabilities).to(beNil());
+                    expect(testSystemCapabilityManager.initialMediaCapabilities).to(beNil());
+                });
             });
 
-            it(@"should not save any of the RAIR capabilities", ^{
-                expect(testSystemCapabilityManager.displays).to(beNil());
-                expect(testSystemCapabilityManager.hmiCapabilities).to(beNil());
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated"
-                expect(testSystemCapabilityManager.displayCapabilities).to(beNil());
-                expect(testSystemCapabilityManager.softButtonCapabilities).to(beNil());
-                expect(testSystemCapabilityManager.buttonCapabilities).to(beNil());
-                expect(testSystemCapabilityManager.presetBankCapabilities).to(beNil());
-#pragma clang diagnostic pop
-                expect(testSystemCapabilityManager.hmiZoneCapabilities).to(beNil());
-                expect(testSystemCapabilityManager.speechCapabilities).to(beNil());
-                expect(testSystemCapabilityManager.prerecordedSpeechCapabilities).to(beNil());
-                expect(testSystemCapabilityManager.vrCapability).to(beFalse());
-                expect(testSystemCapabilityManager.audioPassThruCapabilities).to(beNil());
-                expect(testSystemCapabilityManager.pcmStreamCapability).to(beNil());
+            // if the Register App Interface request succeeds
+            context(@"if the Register App Interface request succeeds", ^{
+                beforeEach(^{
+                    testRegisterAppInterfaceResponse.success = @YES;
+                    SDLRPCResponseNotification *notification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveRegisterAppInterfaceResponse object:self rpcResponse:testRegisterAppInterfaceResponse];
+                    [[NSNotificationCenter defaultCenter] postNotification:notification];
+                });
 
-                expect(testSystemCapabilityManager.phoneCapability).to(beNil());
-                expect(testSystemCapabilityManager.navigationCapability).to(beNil());
-                expect(testSystemCapabilityManager.videoStreamingCapability).to(beNil());
-                expect(testSystemCapabilityManager.remoteControlCapability).to(beNil());
-                expect(testSystemCapabilityManager.appServicesCapabilities).to(beNil());
+                it(@"should should save the RAIR capabilities", ^{
+                    expect(testSystemCapabilityManager.displays).to(equal(testDisplayCapabilityList));
+                    expect(testSystemCapabilityManager.hmiCapabilities).to(equal(testHMICapabilities));
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated"
+                    expect(testSystemCapabilityManager.displayCapabilities).to(equal(testDisplayCapabilities));
+                    expect(testSystemCapabilityManager.initialMediaCapabilities).to(beNil());
+                    expect(testSystemCapabilityManager.softButtonCapabilities).to(equal(testSoftButtonCapabilities));
+                    expect(testSystemCapabilityManager.buttonCapabilities).to(equal(testButtonCapabilities));
+                    expect(testSystemCapabilityManager.presetBankCapabilities).to(equal(testPresetBankCapabilities));
+    #pragma clang diagnostic pop
+                    expect(testSystemCapabilityManager.hmiZoneCapabilities).to(equal(testHMIZoneCapabilities));
+                    expect(testSystemCapabilityManager.speechCapabilities).to(equal(testSpeechCapabilities));
+                    expect(testSystemCapabilityManager.prerecordedSpeechCapabilities).to(equal(testPrerecordedSpeechCapabilities));
+                    expect(testSystemCapabilityManager.vrCapability).to(beTrue());
+                    expect(testSystemCapabilityManager.audioPassThruCapabilities).to(equal(testAudioPassThruCapabilities));
+                    expect(testSystemCapabilityManager.pcmStreamCapability).to(equal(testPCMStreamCapability));
+
+                    expect(testSystemCapabilityManager.phoneCapability).to(beNil());
+                    expect(testSystemCapabilityManager.navigationCapability).to(beNil());
+                    expect(testSystemCapabilityManager.videoStreamingCapability).to(beNil());
+                    expect(testSystemCapabilityManager.remoteControlCapability).to(beNil());
+                    expect(testSystemCapabilityManager.appServicesCapabilities).to(beNil());
+                });
             });
         });
 
-        describe(@"If the Register App Interface request succeeds", ^{
+        // if the app has apptype = MEDIA and the RAIR succeeds
+        context(@"if the app has apptype = MEDIA", ^{
             beforeEach(^{
-                testRegisterAppInterfaceResponse.success = @YES;
-                SDLRPCResponseNotification *notification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveRegisterAppInterfaceResponse object:self rpcResponse:testRegisterAppInterfaceResponse];
-                [[NSNotificationCenter defaultCenter] postNotification:notification];
+                SDLLifecycleConfiguration *lifecycleConfig = [SDLLifecycleConfiguration defaultConfigurationWithAppName:@"TestApp" fullAppId:@"12345"];
+                lifecycleConfig.appType = SDLAppHMITypeMedia;
+                testConnectionManager.configuration = [[SDLConfiguration alloc] initWithLifecycle:lifecycleConfig lockScreen:nil logging:nil fileManager:nil encryption:nil];
             });
 
-            it(@"should should save the RAIR capabilities", ^{
-                expect(testSystemCapabilityManager.displays).to(equal(testDisplayCapabilityList));
-                expect(testSystemCapabilityManager.hmiCapabilities).to(equal(testHMICapabilities));
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated"
-                expect(testSystemCapabilityManager.displayCapabilities).to(equal(testDisplayCapabilities));
-                expect(testSystemCapabilityManager.softButtonCapabilities).to(equal(testSoftButtonCapabilities));
-                expect(testSystemCapabilityManager.buttonCapabilities).to(equal(testButtonCapabilities));
-                expect(testSystemCapabilityManager.presetBankCapabilities).to(equal(testPresetBankCapabilities));
-#pragma clang diagnostic pop
-                expect(testSystemCapabilityManager.hmiZoneCapabilities).to(equal(testHMIZoneCapabilities));
-                expect(testSystemCapabilityManager.speechCapabilities).to(equal(testSpeechCapabilities));
-                expect(testSystemCapabilityManager.prerecordedSpeechCapabilities).to(equal(testPrerecordedSpeechCapabilities));
-                expect(testSystemCapabilityManager.vrCapability).to(beTrue());
-                expect(testSystemCapabilityManager.audioPassThruCapabilities).to(equal(testAudioPassThruCapabilities));
-                expect(testSystemCapabilityManager.pcmStreamCapability).to(equal(testPCMStreamCapability));
+            describe(@"when the RAIR succeeds", ^{
+                beforeEach(^{
+                    testRegisterAppInterfaceResponse.success = @YES;
+                    SDLRPCResponseNotification *notification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveRegisterAppInterfaceResponse object:self rpcResponse:testRegisterAppInterfaceResponse];
+                    [[NSNotificationCenter defaultCenter] postNotification:notification];
+                });
 
-                expect(testSystemCapabilityManager.phoneCapability).to(beNil());
-                expect(testSystemCapabilityManager.navigationCapability).to(beNil());
-                expect(testSystemCapabilityManager.videoStreamingCapability).to(beNil());
-                expect(testSystemCapabilityManager.remoteControlCapability).to(beNil());
-                expect(testSystemCapabilityManager.appServicesCapabilities).to(beNil());
+                it(@"should store the display capabilities into the initialMediaCapabilities", ^{
+                    expect(testSystemCapabilityManager.initialMediaCapabilities).toNot(beNil());
+                });
+            });
+        });
+
+        // if the app has additionalAppTypes include MEDIA and the RAIR succeeds
+        context(@"if the app has additionalAppTypes include MEDIA", ^{
+            beforeEach(^{
+                SDLLifecycleConfiguration *lifecycleConfig = [SDLLifecycleConfiguration defaultConfigurationWithAppName:@"TestApp" fullAppId:@"12345"];
+                lifecycleConfig.additionalAppTypes = @[SDLAppHMITypeMedia];
+                testConnectionManager.configuration = [[SDLConfiguration alloc] initWithLifecycle:lifecycleConfig lockScreen:nil logging:nil fileManager:nil encryption:nil];
+            });
+
+            describe(@"when the RAIR succeeds", ^{
+                beforeEach(^{
+                    testRegisterAppInterfaceResponse.success = @YES;
+                    SDLRPCResponseNotification *notification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveRegisterAppInterfaceResponse object:self rpcResponse:testRegisterAppInterfaceResponse];
+                    [[NSNotificationCenter defaultCenter] postNotification:notification];
+                });
+
+                it(@"should store the display capabilities into the initialMediaCapabilities", ^{
+                    expect(testSystemCapabilityManager.initialMediaCapabilities).toNot(beNil());
+                });
             });
         });
     });
 
-    context(@"When notified of a SetDisplayLayout Response", ^ {
+    // when notified of a SetDisplayLayout Response
+    context(@"when notified of a SetDisplayLayout Response", ^ {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
         __block SDLSetDisplayLayoutResponse *testSetDisplayLayoutResponse = nil;
@@ -470,71 +520,117 @@ describe(@"System capability manager", ^{
             testSetDisplayLayoutResponse.presetBankCapabilities = testPresetBankCapabilities;
         });
 
-        describe(@"If the SetDisplayLayout request fails", ^{
+        context(@"if there are initialMediaCapabilities", ^{
             beforeEach(^{
-                testSetDisplayLayoutResponse.success = @NO;
-                SDLRPCResponseNotification *notification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveSetDisplayLayoutResponse object:self rpcResponse:testSetDisplayLayoutResponse];
-                [[NSNotificationCenter defaultCenter] postNotification:notification];
+                testSystemCapabilityManager.initialMediaCapabilities = testDisplayCapabilities2;
             });
 
-            it(@"should not save any capabilities", ^{
-                expect(testSystemCapabilityManager.displays).to(beNil());
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated"
-                expect(testSystemCapabilityManager.displayCapabilities).to(beNil());
-                expect(testSystemCapabilityManager.softButtonCapabilities).to(beNil());
-                expect(testSystemCapabilityManager.buttonCapabilities).to(beNil());
-                expect(testSystemCapabilityManager.presetBankCapabilities).to(beNil());
-#pragma clang diagnostic pop
+            context(@"if switching to a MEDIA template", ^{
+                beforeEach(^{
+                    testSystemCapabilityManager.lastDisplayLayoutRequestTemplate = SDLPredefinedLayoutMedia;
 
-                expect(testSystemCapabilityManager.hmiCapabilities).to(beNil());
-                expect(testSystemCapabilityManager.hmiZoneCapabilities).to(beNil());
-                expect(testSystemCapabilityManager.speechCapabilities).to(beNil());
-                expect(testSystemCapabilityManager.prerecordedSpeechCapabilities).to(beNil());
-                expect(testSystemCapabilityManager.vrCapability).to(beFalse());
-                expect(testSystemCapabilityManager.audioPassThruCapabilities).to(beNil());
-                expect(testSystemCapabilityManager.pcmStreamCapability).to(beNil());
-                expect(testSystemCapabilityManager.phoneCapability).to(beNil());
-                expect(testSystemCapabilityManager.navigationCapability).to(beNil());
-                expect(testSystemCapabilityManager.videoStreamingCapability).to(beNil());
-                expect(testSystemCapabilityManager.remoteControlCapability).to(beNil());
-                expect(testSystemCapabilityManager.appServicesCapabilities).to(beNil());
+                    testSetDisplayLayoutResponse.success = @YES;
+                    SDLRPCResponseNotification *notification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveSetDisplayLayoutResponse object:self rpcResponse:testSetDisplayLayoutResponse];
+                    [[NSNotificationCenter defaultCenter] postNotification:notification];
+                });
+
+                it(@"should use the initialMediaCapabilities, not the SetDisplayLayoutResponse displayCapabilities", ^{
+                    expect(testSystemCapabilityManager.displayCapabilities).toNot(equal(testSetDisplayLayoutResponse.displayCapabilities));
+                    expect(testSystemCapabilityManager.displayCapabilities).to(equal(testSystemCapabilityManager.initialMediaCapabilities));
+                });
+            });
+
+            context(@"if switching to a NON-MEDIA template", ^{
+                beforeEach(^{
+                    testSystemCapabilityManager.lastDisplayLayoutRequestTemplate = SDLPredefinedLayoutNonMedia;
+
+                    testSetDisplayLayoutResponse.success = @YES;
+                    SDLRPCResponseNotification *notification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveSetDisplayLayoutResponse object:self rpcResponse:testSetDisplayLayoutResponse];
+                    [[NSNotificationCenter defaultCenter] postNotification:notification];
+                });
+
+                it(@"should use the SetDisplayLayoutResponse displayCapabilities, not the initialMediaCapabilities", ^{
+                    expect(testSystemCapabilityManager.displayCapabilities).to(equal(testSetDisplayLayoutResponse.displayCapabilities));
+                    expect(testSystemCapabilityManager.displayCapabilities).toNot(equal(testSystemCapabilityManager.initialMediaCapabilities));
+                });
             });
         });
 
-        describe(@"If the SetDisplayLayout request succeeds", ^{
+        context(@"if there are no initialMediaCapabilities", ^{
             beforeEach(^{
-                testSetDisplayLayoutResponse.success = @YES;
-                SDLRPCResponseNotification *notification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveSetDisplayLayoutResponse object:self rpcResponse:testSetDisplayLayoutResponse];
-                [[NSNotificationCenter defaultCenter] postNotification:notification];
+                testSystemCapabilityManager.initialMediaCapabilities = nil;
             });
 
-            it(@"should should save the capabilities", ^{
-                expect(testSystemCapabilityManager.displays).to(equal(testDisplayCapabilityList));
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated"
-                expect(testSystemCapabilityManager.displayCapabilities).to(equal(testDisplayCapabilities));
-                expect(testSystemCapabilityManager.softButtonCapabilities).to(equal(testSoftButtonCapabilities));
-                expect(testSystemCapabilityManager.buttonCapabilities).to(equal(testButtonCapabilities));
-                expect(testSystemCapabilityManager.presetBankCapabilities).to(equal(testPresetBankCapabilities));
-#pragma clang diagnostic pop
+            // if the SetDisplayLayout request fails
+            context(@"if the SetDisplayLayout request fails", ^{
+                beforeEach(^{
+                    testSetDisplayLayoutResponse.success = @NO;
+                    SDLRPCResponseNotification *notification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveSetDisplayLayoutResponse object:self rpcResponse:testSetDisplayLayoutResponse];
+                    [[NSNotificationCenter defaultCenter] postNotification:notification];
+                });
 
-                expect(testSystemCapabilityManager.hmiCapabilities).to(beNil());
-                expect(testSystemCapabilityManager.hmiZoneCapabilities).to(beNil());
-                expect(testSystemCapabilityManager.speechCapabilities).to(beNil());
-                expect(testSystemCapabilityManager.prerecordedSpeechCapabilities).to(beNil());
-                expect(testSystemCapabilityManager.vrCapability).to(beFalse());
-                expect(testSystemCapabilityManager.audioPassThruCapabilities).to(beNil());
-                expect(testSystemCapabilityManager.pcmStreamCapability).to(beNil());
-                expect(testSystemCapabilityManager.phoneCapability).to(beNil());
-                expect(testSystemCapabilityManager.navigationCapability).to(beNil());
-                expect(testSystemCapabilityManager.videoStreamingCapability).to(beNil());
-                expect(testSystemCapabilityManager.remoteControlCapability).to(beNil());
-                expect(testSystemCapabilityManager.appServicesCapabilities).to(beNil());
+                it(@"should not save any capabilities", ^{
+                    expect(testSystemCapabilityManager.displays).to(beNil());
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated"
+                    expect(testSystemCapabilityManager.displayCapabilities).to(beNil());
+                    expect(testSystemCapabilityManager.initialMediaCapabilities).to(beNil());
+                    expect(testSystemCapabilityManager.softButtonCapabilities).to(beNil());
+                    expect(testSystemCapabilityManager.buttonCapabilities).to(beNil());
+                    expect(testSystemCapabilityManager.presetBankCapabilities).to(beNil());
+    #pragma clang diagnostic pop
+
+                    expect(testSystemCapabilityManager.hmiCapabilities).to(beNil());
+                    expect(testSystemCapabilityManager.hmiZoneCapabilities).to(beNil());
+                    expect(testSystemCapabilityManager.speechCapabilities).to(beNil());
+                    expect(testSystemCapabilityManager.prerecordedSpeechCapabilities).to(beNil());
+                    expect(testSystemCapabilityManager.vrCapability).to(beFalse());
+                    expect(testSystemCapabilityManager.audioPassThruCapabilities).to(beNil());
+                    expect(testSystemCapabilityManager.pcmStreamCapability).to(beNil());
+                    expect(testSystemCapabilityManager.phoneCapability).to(beNil());
+                    expect(testSystemCapabilityManager.navigationCapability).to(beNil());
+                    expect(testSystemCapabilityManager.videoStreamingCapability).to(beNil());
+                    expect(testSystemCapabilityManager.remoteControlCapability).to(beNil());
+                    expect(testSystemCapabilityManager.appServicesCapabilities).to(beNil());
+                });
+            });
+
+            // if the SetDisplayLayout request succeeds
+            context(@"if the SetDisplayLayout request succeeds", ^{
+                beforeEach(^{
+                    testSetDisplayLayoutResponse.success = @YES;
+                    SDLRPCResponseNotification *notification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveSetDisplayLayoutResponse object:self rpcResponse:testSetDisplayLayoutResponse];
+                    [[NSNotificationCenter defaultCenter] postNotification:notification];
+                });
+
+                it(@"should should save the capabilities", ^{
+                    expect(testSystemCapabilityManager.displays).to(equal(testDisplayCapabilityList));
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated"
+                    expect(testSystemCapabilityManager.displayCapabilities).to(equal(testDisplayCapabilities));
+                    expect(testSystemCapabilityManager.softButtonCapabilities).to(equal(testSoftButtonCapabilities));
+                    expect(testSystemCapabilityManager.buttonCapabilities).to(equal(testButtonCapabilities));
+                    expect(testSystemCapabilityManager.presetBankCapabilities).to(equal(testPresetBankCapabilities));
+    #pragma clang diagnostic pop
+
+                    expect(testSystemCapabilityManager.hmiCapabilities).to(beNil());
+                    expect(testSystemCapabilityManager.hmiZoneCapabilities).to(beNil());
+                    expect(testSystemCapabilityManager.speechCapabilities).to(beNil());
+                    expect(testSystemCapabilityManager.prerecordedSpeechCapabilities).to(beNil());
+                    expect(testSystemCapabilityManager.vrCapability).to(beFalse());
+                    expect(testSystemCapabilityManager.audioPassThruCapabilities).to(beNil());
+                    expect(testSystemCapabilityManager.pcmStreamCapability).to(beNil());
+                    expect(testSystemCapabilityManager.phoneCapability).to(beNil());
+                    expect(testSystemCapabilityManager.navigationCapability).to(beNil());
+                    expect(testSystemCapabilityManager.videoStreamingCapability).to(beNil());
+                    expect(testSystemCapabilityManager.remoteControlCapability).to(beNil());
+                    expect(testSystemCapabilityManager.appServicesCapabilities).to(beNil());
+                });
             });
         });
 
-        describe(@"if the setdisplaylayout has nil displaycapabilities", ^{
+        // if the SetDisplayLayout has nil DisplayCapabilities
+        context(@"if the SetDisplayLayout has nil DisplayCapabilities", ^{
             beforeEach(^{
                 testSetDisplayLayoutResponse.success = @YES;
                 testSetDisplayLayoutResponse.displayCapabilities = nil;
@@ -549,8 +645,9 @@ describe(@"System capability manager", ^{
             });
         });
     });
-    
-    context(@"when updating display capabilities with OnSystemCapabilityUpdated", ^{
+
+    // when updating display capabilities with OnSystemCapabilityUpdated
+    describe(@"when updating display capabilities with OnSystemCapabilityUpdated", ^{
         it(@"should properly update display capability including conversion two times", ^{
             // two times because capabilities are just saved in first run but merged/updated in subsequent runs
             for (int i = 0; i < 2; i++) {
@@ -590,7 +687,8 @@ describe(@"System capability manager", ^{
         });
     });
 
-    context(@"When sending a updateCapabilityType request in HMI FULL", ^{
+    // when sending a updateCapabilityType request in HMI FULL
+    context(@"when sending a updateCapabilityType request in HMI FULL", ^{
         __block SDLGetSystemCapabilityResponse *testGetSystemCapabilityResponse = nil;
         __block SDLPhoneCapability *testPhoneCapability = nil;
 
@@ -664,6 +762,7 @@ describe(@"System capability manager", ^{
         });
     });
 
+    // updating the SCM through OnSystemCapability in HMI Full
     describe(@"updating the SCM through OnSystemCapability in HMI Full", ^{
         __block SDLPhoneCapability *phoneCapability = nil;
 
@@ -683,6 +782,7 @@ describe(@"System capability manager", ^{
         });
     });
 
+    // subscribing to capability types when HMI is full
     describe(@"subscribing to capability types when HMI is full", ^{
         __block TestSystemCapabilityObserver *phoneObserver = nil;
         __block TestSystemCapabilityObserver *navigationObserver = nil;
@@ -824,6 +924,7 @@ describe(@"System capability manager", ^{
         });
     });
 
+    // merging app services capability changes
     describe(@"merging app services capability changes", ^{
         __block SDLAppServicesCapabilities *baseAppServices = nil;
         __block SDLAppServiceCapability *deleteCapability = nil;
@@ -885,6 +986,7 @@ describe(@"System capability manager", ^{
         });
     });
 
+    // when the system capability manager is stopped after being started
     describe(@"when the system capability manager is stopped after being started", ^{
         beforeEach(^{
             [testSystemCapabilityManager stop];

--- a/SmartDeviceLinkTests/TestUtilities/TestConnectionManager.h
+++ b/SmartDeviceLinkTests/TestUtilities/TestConnectionManager.h
@@ -16,6 +16,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface TestConnectionManager : NSObject <SDLConnectionManagerType>
 
+@property (copy, nonatomic) SDLConfiguration *configuration;
+
 @property (strong, nonatomic, nullable) SDLSystemInfo *systemInfo;
 
 @property (copy, nonatomic, readonly) NSError *defaultError;


### PR DESCRIPTION
Fixes #1152 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Unit tests were updated for all affected classes

#### Core Tests
Regression testing was performed to ensure that the graphic showed up in the relevant scenario. An affected Sync 3.0 head unit was not available to test the fix.

Core version / branch / commit hash / module tested against:
* v7.0 (Manticore)
* Sync v3.4

HMI name / version / branch / commit hash / module tested against:
* Generic HMI v0.9.0 (Manticore)
* Sync 3.4

### Summary
* SCM now has a public property set from the lifecycle manager to know what the next SetDisplayLayout template name will be
* ConnectionManagerType now has a configuration property used by the SCM to know the app types of the app
* SCM now stores the RAIR display capability if the app has app type MEDIA
* SCM now replaces the SetDisplayLayout response displayCapabilities with the RAIR displayCapabilities if the target of the SetDisplayLayout is the MEDIA template
* Changed some LifecycleManager public properties (the class is private) to be readonly to prevent outside classes from accidentally messing with them.

### Changelog
##### Bug Fixes
* Workaround for a Ford Sync 3 bug where doing `SetDisplayLayout` to the `MEDIA` template would result in incorrect display capabilities being returned that claim the `primaryGraphic` is not supported.

### Tasks Remaining:
- [x] Unit test updates
- [x] Smoke test updates

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
