### PR TITLE
Refactor Obj-C example app connection process to mirror Swift app

### DIFF
--- a/Example Apps/Example ObjC/ConnectionTCPTableViewController.m
+++ b/Example Apps/Example ObjC/ConnectionTCPTableViewController.m
@@ -72,9 +72,7 @@
 #pragma mark - Table view delegate
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
-    if (indexPath.section != 0) {
-        return;
-    }
+    if (indexPath.section != 0) { return; }
     
     switch (indexPath.row) {
         case 0: {

--- a/Example Apps/Example ObjC/ProxyManager.m
+++ b/Example Apps/Example ObjC/ProxyManager.m
@@ -99,29 +99,27 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)startWithProxyTransportType:(ProxyTransportType)proxyTransportType {
     [self sdlex_updateProxyState:ProxyStateSearchingForConnection];
 
-    SDLLifecycleConfiguration *lifecycleConfig = proxyTransportType == ProxyTransportTypeIAP ? [self.class sdlex_iapLifecycleConfiguration] : [self.class sdlex_tcpLifecycleConfiguration];
-    [self sdlex_setupConfigurationWithLifecycleConfiguration:lifecycleConfig];
-}
-
-+ (SDLLifecycleConfiguration *)sdlex_iapLifecycleConfiguration {
-    return [self.class sdlex_setLifecycleConfigurationPropertiesOnConfiguration:[SDLLifecycleConfiguration defaultConfigurationWithAppName:ExampleAppName fullAppId:ExampleFullAppId]];
-}
-
-+ (SDLLifecycleConfiguration *)sdlex_tcpLifecycleConfiguration {
-    return [self.class sdlex_setLifecycleConfigurationPropertiesOnConfiguration:[SDLLifecycleConfiguration debugConfigurationWithAppName:ExampleAppName fullAppId:ExampleFullAppId ipAddress:[Preferences sharedPreferences].ipAddress port:[Preferences sharedPreferences].port]];
-}
-
-- (void)sdlex_setupConfigurationWithLifecycleConfiguration:(SDLLifecycleConfiguration *)lifecycleConfiguration {
-    if (self.sdlManager != nil) {
-        // Manager already created, just start it again.
-        [self sdlex_startManager];
-        return;
-    }
-
-    SDLLockScreenConfiguration *lockScreenConfiguration = [SDLLockScreenConfiguration enabledConfigurationWithAppIcon:[UIImage imageNamed:ExampleAppLogoName] backgroundColor:nil];
-    SDLConfiguration *config = [[SDLConfiguration alloc] initWithLifecycle:lifecycleConfiguration lockScreen:lockScreenConfiguration logging:[self.class sdlex_logConfiguration] fileManager:[SDLFileManagerConfiguration defaultConfiguration] encryption:[SDLEncryptionConfiguration defaultConfiguration]];
+    SDLConfiguration *config = (proxyTransportType == ProxyTransportTypeIAP) ? [self.class sdlex_iapConfiguration] : [self.class sdlex_tcpConfiguration];
     self.sdlManager = [[SDLManager alloc] initWithConfiguration:config delegate:self];
     [self sdlex_startManager];
+}
+
++ (SDLConfiguration *)sdlex_iapConfiguration {
+    SDLLifecycleConfiguration *lifecycleConfig = [self.class sdlex_setLifecycleConfigurationPropertiesOnConfiguration:[SDLLifecycleConfiguration defaultConfigurationWithAppName:ExampleAppName fullAppId:ExampleFullAppId]];
+
+    return [self sdlex_setupManagerConfigurationWithLifecycleConfiguration:lifecycleConfig];
+}
+
++ (SDLConfiguration *)sdlex_tcpConfiguration {
+    SDLLifecycleConfiguration *lifecycleConfig = [self.class sdlex_setLifecycleConfigurationPropertiesOnConfiguration:[SDLLifecycleConfiguration debugConfigurationWithAppName:ExampleAppName fullAppId:ExampleFullAppId ipAddress:[Preferences sharedPreferences].ipAddress port:[Preferences sharedPreferences].port]];
+
+    return [self sdlex_setupManagerConfigurationWithLifecycleConfiguration:lifecycleConfig];
+}
+
++ (SDLConfiguration *)sdlex_setupManagerConfigurationWithLifecycleConfiguration:(SDLLifecycleConfiguration *)lifecycleConfiguration {
+    SDLLockScreenConfiguration *lockScreenConfiguration = [SDLLockScreenConfiguration enabledConfigurationWithAppIcon:[UIImage imageNamed:ExampleAppLogoName] backgroundColor:nil];
+
+    return [[SDLConfiguration alloc] initWithLifecycle:lifecycleConfiguration lockScreen:lockScreenConfiguration logging:[self.class sdlex_logConfiguration] fileManager:[SDLFileManagerConfiguration defaultConfiguration] encryption:[SDLEncryptionConfiguration defaultConfiguration]];
 }
 
 + (SDLLifecycleConfiguration *)sdlex_setLifecycleConfigurationPropertiesOnConfiguration:(SDLLifecycleConfiguration *)config {

--- a/Example Apps/Example Swift/ProxyManager.swift
+++ b/Example Apps/Example Swift/ProxyManager.swift
@@ -46,7 +46,8 @@ extension ProxyManager {
     /// - Parameter connectionType: The type of transport layer to use.
     func start(with proxyTransportType: ProxyTransportType) {
         delegate?.didChangeProxyState(ProxyState.searching)
-        sdlManager = SDLManager(configuration: proxyTransportType == .iap ? ProxyManager.connectIAP() : ProxyManager.connectTCP(), delegate: self)
+
+        sdlManager = SDLManager(configuration: (proxyTransportType == .iap) ? ProxyManager.iapConfiguration : ProxyManager.tcpConfiguration, delegate: self)
         startManager()
     }
 
@@ -71,7 +72,7 @@ private extension ProxyManager {
     /// Configures an iAP transport layer.
     ///
     /// - Returns: A SDLConfiguration object
-    class func connectIAP() -> SDLConfiguration {
+    class var iapConfiguration: SDLConfiguration {
         let lifecycleConfiguration = SDLLifecycleConfiguration(appName: ExampleAppName, fullAppId: ExampleFullAppId)
         return setupManagerConfiguration(with: lifecycleConfiguration)
     }
@@ -79,7 +80,7 @@ private extension ProxyManager {
     /// Configures a TCP transport layer with the IP address and port of the remote SDL Core instance.
     ///
     /// - Returns: A SDLConfiguration object
-    class func connectTCP() -> SDLConfiguration {
+    class var tcpConfiguration: SDLConfiguration {
         let lifecycleConfiguration = SDLLifecycleConfiguration(appName: ExampleAppName, fullAppId: ExampleFullAppId, ipAddress: AppUserDefaults.shared.ipAddress!, port: UInt16(AppUserDefaults.shared.port!)!)
         return setupManagerConfiguration(with: lifecycleConfiguration)
     }

--- a/Example Apps/Example Swift/ProxyManagerDelegate.swift
+++ b/Example Apps/Example Swift/ProxyManagerDelegate.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-protocol ProxyManagerDelegate: class {
+protocol ProxyManagerDelegate: AnyObject {
     var proxyState: ProxyState { get }
 
     func didChangeProxyState(_ newState: ProxyState)


### PR DESCRIPTION
Fixes #1984

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [ ] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
n/a - Example app changes only

#### Core Tests
1. Connect to manticore with Obj-C app
2. Kill manticore (top right button)
3. Click the disconnect button on Obj-C example app
4. Start manticore again
5. Type in new port to app
6. Connect to Manticore again

Core version / branch / commit hash / module tested against: v7.0 (Manticore)
HMI name / version / branch / commit hash / module tested against: Generic HMI v0.9.0 (Manticore)

### Summary
Update the Obj-C example app startup sequence to mirror the Swift example app, which does not have this issue.

### Changelog
##### Bug Fixes
* Obj-C Example App: Fixed connecting to another TCP connection after connecting a first time always fails.

### Tasks Remaining:
n/a

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
