### PR TITLE
Fixed Example apps button state does not match the image/text state if the app is reopened after exiting

### DIFF
--- a/Example Apps/Example ObjC/ButtonManager.m
+++ b/Example Apps/Example ObjC/ButtonManager.m
@@ -77,7 +77,8 @@ NS_ASSUME_NONNULL_BEGIN
     SDLSoftButtonState *textState = [[SDLSoftButtonState alloc] initWithStateName:AlertSoftButtonTextState text:AlertSoftButtonText image:nil];
 
     __weak typeof(self) weakself = self;
-    SDLSoftButtonObject *alertSoftButton = [[SDLSoftButtonObject alloc] initWithName:AlertSoftButton states:@[imageAndTextState, textState] initialStateName:imageAndTextState.name handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {
+    NSString *initialButtonStateName = self.imagesEnabled ? imageAndTextState.name : textState.name;
+    SDLSoftButtonObject *alertSoftButton = [[SDLSoftButtonObject alloc] initWithName:AlertSoftButton states:@[imageAndTextState, textState] initialStateName:initialButtonStateName handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {
         if (buttonPress == nil) { return; }
 
         if (self.sdlex_isAlertAllowed) {
@@ -99,7 +100,8 @@ NS_ASSUME_NONNULL_BEGIN
     SDLSoftButtonState *textState = [[SDLSoftButtonState alloc] initWithStateName:SubtleAlertSoftButtonTextState text:SubtleAlertSoftButtonText image:nil];
 
     __weak typeof(self) weakself = self;
-    SDLSoftButtonObject *subtleAlertSoftButton = [[SDLSoftButtonObject alloc] initWithName:SubtleAlertSoftButton states:@[imageAndTextState, textState] initialStateName:imageAndTextState.name handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {
+    NSString *initialButtonStateName = self.imagesEnabled ? imageAndTextState.name : textState.name;
+    SDLSoftButtonObject *subtleAlertSoftButton = [[SDLSoftButtonObject alloc] initWithName:SubtleAlertSoftButton states:@[imageAndTextState, textState] initialStateName:initialButtonStateName handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {
         if (buttonPress == nil) { return; }
 
         if (self.sdlex_isSubtleAlertAllowed) {
@@ -121,7 +123,8 @@ NS_ASSUME_NONNULL_BEGIN
     SDLSoftButtonState *textOffState = [[SDLSoftButtonState alloc] initWithStateName:TextVisibleSoftButtonTextOffState text:TextVisibleSoftButtonTextOffText image:nil];
 
     __weak typeof(self) weakself = self;
-    SDLSoftButtonObject *textButton = [[SDLSoftButtonObject alloc] initWithName:TextVisibleSoftButton states:@[textOnState, textOffState] initialStateName:textOnState.name handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {
+    NSString *initialButtonStateName = self.textEnabled ? textOnState.name : textOffState.name;
+    SDLSoftButtonObject *textButton = [[SDLSoftButtonObject alloc] initWithName:TextVisibleSoftButton states:@[textOnState, textOffState] initialStateName:initialButtonStateName handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {
         if (buttonPress == nil) { return; }
 
         weakself.textEnabled = !weakself.textEnabled;
@@ -140,7 +143,8 @@ NS_ASSUME_NONNULL_BEGIN
     SDLSoftButtonState *imagesOffState = [[SDLSoftButtonState alloc] initWithStateName:ImagesVisibleSoftButtonImageOffState text:ImagesVisibleSoftButtonImageOffText image:nil];
 
     __weak typeof(self) weakself = self;
-    SDLSoftButtonObject *imagesButton = [[SDLSoftButtonObject alloc] initWithName:ImagesVisibleSoftButton states:@[imagesOnState, imagesOffState] initialStateName:imagesOnState.name handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {
+    NSString *initialButtonStateName = self.imagesEnabled ? imagesOnState.name : imagesOffState.name;
+    SDLSoftButtonObject *imagesButton = [[SDLSoftButtonObject alloc] initWithName:ImagesVisibleSoftButton states:@[imagesOnState, imagesOffState] initialStateName:initialButtonStateName handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {
         if (buttonPress == nil) { return; }
 
         weakself.imagesEnabled = !weakself.imagesEnabled;

--- a/Example Apps/Example Swift/ButtonManager.swift
+++ b/Example Apps/Example Swift/ButtonManager.swift
@@ -97,7 +97,8 @@ extension ButtonManager {
     private var softButtonTextVisible: SDLSoftButtonObject {
         let textVisibleState = SDLSoftButtonState(stateName: TextVisibleSoftButtonTextOnState, text: TextVisibleSoftButtonTextOnText, artwork: nil)
         let textNotVisibleState = SDLSoftButtonState(stateName: TextVisibleSoftButtonTextOffState, text: TextVisibleSoftButtonTextOffText, image: nil)
-        return SDLSoftButtonObject(name: TextVisibleSoftButton, states: [textVisibleState, textNotVisibleState], initialStateName: textVisibleState.name) { [unowned self] (buttonPress, buttonEvent) in
+        let initialButtonStateName = self.textEnabled ? textVisibleState.name : textNotVisibleState.name
+        return SDLSoftButtonObject(name: TextVisibleSoftButton, states: [textVisibleState, textNotVisibleState], initialStateName: initialButtonStateName) { [unowned self] (buttonPress, buttonEvent) in
             guard buttonPress != nil else { return }
             self.textEnabled = !self.textEnabled
 
@@ -111,7 +112,8 @@ extension ButtonManager {
     private var softButtonImagesVisible: SDLSoftButtonObject {
         let imagesVisibleState = SDLSoftButtonState(stateName: ImagesVisibleSoftButtonImageOnState, text: ImagesVisibleSoftButtonImageOnText, image: nil)
         let imagesNotVisibleState = SDLSoftButtonState(stateName: ImagesVisibleSoftButtonImageOffState, text: ImagesVisibleSoftButtonImageOffText, image: nil)
-        return SDLSoftButtonObject(name: ImagesVisibleSoftButton, states: [imagesVisibleState, imagesNotVisibleState], initialStateName: imagesVisibleState.name) { [weak self] (buttonPress, buttonEvent) in
+        let initialButtonStateName = self.imagesEnabled ? imagesVisibleState.name : imagesNotVisibleState.name
+        return SDLSoftButtonObject(name: ImagesVisibleSoftButton, states: [imagesVisibleState, imagesNotVisibleState], initialStateName: initialButtonStateName) { [weak self] (buttonPress, buttonEvent) in
             guard let self = self, let sdlManager = self.sdlManager, buttonPress != nil else { return }
             
             self.imagesEnabled = !self.imagesEnabled

--- a/Example Apps/Example Swift/ButtonManager.swift
+++ b/Example Apps/Example Swift/ButtonManager.swift
@@ -63,7 +63,8 @@ extension ButtonManager {
     private var softButtonAlert: SDLSoftButtonObject {
         let imageAndTextState = SDLSoftButtonState(stateName: AlertSoftButtonImageAndTextState, text: AlertSoftButtonText, image: UIImage(named: AlertBWIconName)?.withRenderingMode(.alwaysTemplate))
         let textState = SDLSoftButtonState(stateName: AlertSoftButtonTextState, text: AlertSoftButtonText, image: nil)
-        return SDLSoftButtonObject(name: AlertSoftButton, states: [imageAndTextState, textState], initialStateName: imageAndTextState.name) { [weak self] (buttonPress, buttonEvent) in
+        let initialButtonStateName = self.imagesEnabled ? imageAndTextState.name : textState.name
+        return SDLSoftButtonObject(name: AlertSoftButton, states: [imageAndTextState, textState], initialStateName: initialButtonStateName) { [weak self] (buttonPress, buttonEvent) in
             guard let self = self, buttonPress != nil else { return }
 
             if (self.isAlertAllowed) {
@@ -80,7 +81,8 @@ extension ButtonManager {
     private var softButtonSubtleAlert: SDLSoftButtonObject {
         let imageAndTextState = SDLSoftButtonState(stateName: SubtleAlertSoftButtonImageAndTextState, text: SubtleAlertSoftButtonText, image: UIImage(named: BatteryFullBWIconName)?.withRenderingMode(.alwaysTemplate))
         let textState = SDLSoftButtonState(stateName: SubtleAlertSoftButtonTextState, text: SubtleAlertSoftButtonText, image: nil)
-        return SDLSoftButtonObject(name: SubtleAlertSoftButton, states: [imageAndTextState, textState], initialStateName: imageAndTextState.name) { [weak self] (buttonPress, buttonEvent) in
+        let initialButtonStateName = self.imagesEnabled ? imageAndTextState.name : textState.name
+        return SDLSoftButtonObject(name: SubtleAlertSoftButton, states: [imageAndTextState, textState], initialStateName: initialButtonStateName) { [weak self] (buttonPress, buttonEvent) in
             guard let self = self, buttonPress != nil else { return }
 
             if (self.isSubtleAlertAllowed) {


### PR DESCRIPTION
Fixes #1991 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [ ] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
N/A

#### Core Tests
Tested the reproduction steps mentioned in issue

Core version / branch / commit hash / module tested against: Branch develop
HMI name / version / branch / commit hash / module tested against: SYNC 3.0

### Summary
Maintained button state after user has reopened the app after exiting from menu

### Changelog
##### Breaking Changes
* N/A

##### Enhancements
* N/A

##### Bug Fixes
* Maintained button state after user has reopened the app after exiting from menu

### Tasks Remaining:
N/A

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
