### PR TITLE
Fix for race condition occur in NSMutableDictionary

### DIFF
--- a/SmartDeviceLink/private/SDLTCPTransport.m
+++ b/SmartDeviceLink/private/SDLTCPTransport.m
@@ -271,7 +271,9 @@ NSTimeInterval ConnectionTimeoutSecs = 30.0;
     }
 
     NSData *data = [NSData dataWithBytesNoCopy:buffer length:(NSUInteger)readBytes freeWhenDone:YES];
-    [self.delegate onDataReceived:data];
+    dispatch_after(DISPATCH_TIME_NOW, SDLGlobals.sharedGlobals.sdlProcessingQueue, ^{
+        [self.delegate onDataReceived:data];
+    });
 }
 
 - (void)sdl_writeToStream {

--- a/SmartDeviceLink/private/SDLTCPTransport.m
+++ b/SmartDeviceLink/private/SDLTCPTransport.m
@@ -271,7 +271,8 @@ NSTimeInterval ConnectionTimeoutSecs = 30.0;
     }
 
     NSData *data = [NSData dataWithBytesNoCopy:buffer length:(NSUInteger)readBytes freeWhenDone:YES];
-    dispatch_after(DISPATCH_TIME_NOW, SDLGlobals.sharedGlobals.sdlProcessingQueue, ^{
+    // Handle a race condition thats caused by the TCP readFromStream thread and a read-only thread when app is in didEnterStateConnected state of the lifeCycleManager
+    dispatch_sync(SDLGlobals.sharedGlobals.sdlProcessingQueue, ^{
         [self.delegate onDataReceived:data];
     });
 }


### PR DESCRIPTION
Fixes #1996 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
N/A

#### Core Tests
Applied the reproduction steps mentioned in issue

Core version / branch / commit hash / module tested against: 7.1.0
HMI name / version / branch / commit hash / module tested against: Manticore

### Summary
Enqueue a block after one thread has finished executing

### Changelog
##### Breaking Changes
* N/A

##### Enhancements
* N/A

##### Bug Fixes
* Enqueue a block after one thread has finished executing

### Tasks Remaining:
N/A

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)