### PR TITLE
Fix SDLPredefinedLayoutNonMedia not found in templatesAvailable

### DIFF
--- a/SmartDeviceLink/public/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/public/SDLSystemCapabilityManager.m
@@ -233,10 +233,10 @@ typedef NSString * SDLServiceID;
 
     // Copy all available display capability properties
     NSArray *templatesArray = display.templatesAvailable;
-    if ([display.templatesAvailable containsObject:@"NON_MEDIA"]) {
-        NSMutableArray *array = [display.templatesAvailable mutableCopy];
-        [array addObject:@"NON-MEDIA"];
-        templatesArray = [NSArray arrayWithArray:array];
+    if ([templatesArray containsObject:@"NON_MEDIA"]) {
+        NSMutableArray *templatesMutableArray = [templatesArray mutableCopy];
+        [templatesMutableArray addObject:@"NON-MEDIA"];
+        templatesArray = [NSArray arrayWithArray:templatesMutableArray];
     }
     defaultWindowCapability.templatesAvailable = templatesArray;
     defaultWindowCapability.numCustomPresetsAvailable = [display.numCustomPresetsAvailable copy];

--- a/SmartDeviceLink/public/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/public/SDLSystemCapabilityManager.m
@@ -201,16 +201,15 @@ typedef NSString * SDLServiceID;
     }
 
     // HAX: Issue #1999, Ford Sync bug returning incorrect template name for "NON-MEDIA" (https://github.com/smartdevicelink/sdl_ios/issues/1999).
-    NSArray<NSString *> *templatesArray = [self.displayCapabilities.templatesAvailable copy];
-    for (NSUInteger i = 0; i < templatesArray.count; i++) {
-        if ([templatesArray[i] isEqual:@"NON_MEDIA"]) {
-            NSMutableArray<NSString *> *templatesMutableArray = [templatesArray mutableCopy];
-            templatesMutableArray[i] = @"NON-MEDIA";
-            templatesArray = [NSArray arrayWithArray:templatesMutableArray];
+    NSMutableArray<NSString *> *mutableTemplatesAvailable = [self.displayCapabilities.templatesAvailable mutableCopy];
+    for (NSUInteger i = 0; i < mutableTemplatesAvailable.count; i++) {
+        if ([mutableTemplatesAvailable[i] isEqualToString:@"NON_MEDIA"]) {
+            mutableTemplatesAvailable[i] = @"NON-MEDIA";
+            break;
         }
     }
     // Copy all available display capability properties
-    defaultWindowCapability.templatesAvailable = templatesArray;
+    defaultWindowCapability.templatesAvailable = [mutableTemplatesAvailable copy];
     defaultWindowCapability.numCustomPresetsAvailable = [self.displayCapabilities.numCustomPresetsAvailable copy];
     defaultWindowCapability.textFields = [self.displayCapabilities.textFields copy];
     defaultWindowCapability.imageFields = [self.displayCapabilities.imageFields copy];

--- a/SmartDeviceLink/public/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/public/SDLSystemCapabilityManager.m
@@ -200,7 +200,7 @@ typedef NSString * SDLServiceID;
         return @[displayCapability];
     }
 
-    // Copy all available display capability properties
+    // HAX: Issue #1999, Ford Sync bug returning incorrect template name for "NON-MEDIA" (https://github.com/smartdevicelink/sdl_ios/issues/1999).
     NSArray<NSString *> *templatesArray = [self.displayCapabilities.templatesAvailable copy];
     for (NSUInteger i = 0; i < templatesArray.count; i++) {
         if ([templatesArray[i] isEqual:@"NON_MEDIA"]) {
@@ -209,6 +209,7 @@ typedef NSString * SDLServiceID;
             templatesArray = [NSArray arrayWithArray:templatesMutableArray];
         }
     }
+    // Copy all available display capability properties
     defaultWindowCapability.templatesAvailable = templatesArray;
     defaultWindowCapability.numCustomPresetsAvailable = [self.displayCapabilities.numCustomPresetsAvailable copy];
     defaultWindowCapability.textFields = [self.displayCapabilities.textFields copy];

--- a/SmartDeviceLink/public/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/public/SDLSystemCapabilityManager.m
@@ -201,11 +201,13 @@ typedef NSString * SDLServiceID;
     }
 
     // Copy all available display capability properties
-    NSArray *templatesArray = [self.displayCapabilities.templatesAvailable copy];
-    if ([templatesArray containsObject:@"NON_MEDIA"]) {
-        NSMutableArray *templatesMutableArray = [templatesArray mutableCopy];
-        [templatesMutableArray addObject:@"NON-MEDIA"];
-        templatesArray = [NSArray arrayWithArray:templatesMutableArray];
+    NSArray<NSString *> *templatesArray = [self.displayCapabilities.templatesAvailable copy];
+    for (NSUInteger i = 0; i < templatesArray.count; i++) {
+        if ([templatesArray[i] isEqual:@"NON_MEDIA"]) {
+            NSMutableArray<NSString *> *templatesMutableArray = [templatesArray mutableCopy];
+            templatesMutableArray[i] = @"NON-MEDIA";
+            templatesArray = [NSArray arrayWithArray:templatesMutableArray];
+        }
     }
     defaultWindowCapability.templatesAvailable = templatesArray;
     defaultWindowCapability.numCustomPresetsAvailable = [self.displayCapabilities.numCustomPresetsAvailable copy];

--- a/SmartDeviceLink/public/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/public/SDLSystemCapabilityManager.m
@@ -232,7 +232,13 @@ typedef NSString * SDLServiceID;
     }
 
     // Copy all available display capability properties
-    defaultWindowCapability.templatesAvailable = [display.templatesAvailable copy];
+    NSArray *templatesArray = display.templatesAvailable;
+    if ([display.templatesAvailable containsObject:@"NON_MEDIA"]) {
+        NSMutableArray *array = [display.templatesAvailable mutableCopy];
+        [array addObject:@"NON-MEDIA"];
+        templatesArray = [NSArray arrayWithArray:array];
+    }
+    defaultWindowCapability.templatesAvailable = templatesArray;
     defaultWindowCapability.numCustomPresetsAvailable = [display.numCustomPresetsAvailable copy];
     defaultWindowCapability.textFields = [display.textFields copy];
     defaultWindowCapability.imageFields = [display.imageFields copy];

--- a/SmartDeviceLink/public/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/public/SDLSystemCapabilityManager.m
@@ -208,6 +208,7 @@ typedef NSString * SDLServiceID;
             break;
         }
     }
+    
     // Copy all available display capability properties
     defaultWindowCapability.templatesAvailable = [mutableTemplatesAvailable copy];
     defaultWindowCapability.numCustomPresetsAvailable = [self.displayCapabilities.numCustomPresetsAvailable copy];

--- a/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
+++ b/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
@@ -93,6 +93,7 @@ describe(@"System capability manager", ^{
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     __block SDLDisplayCapabilities *testDisplayCapabilities = nil;
+    __block SDLDisplayCapabilities *testDisplayCapabilities2 = nil;
 #pragma clang diagnostic pop
     __block NSArray<SDLSoftButtonCapabilities *> *testSoftButtonCapabilities = nil;
     __block NSArray<SDLButtonCapabilities *> *testButtonCapabilities = nil;
@@ -157,6 +158,9 @@ describe(@"System capability manager", ^{
         defaultWindowCapability.imageTypeSupported = @[SDLImageTypeStatic];
         displayCapability.windowCapabilities = @[defaultWindowCapability];
         testDisplayCapabilityList = @[displayCapability];
+
+        testDisplayCapabilities2 = [testDisplayCapabilities copy];
+        testDisplayCapabilities2.templatesAvailable = @[@"DEFAULT", @"MEDIA", @"NON_MEDIA"];
     });
 
     afterEach(^{
@@ -449,6 +453,61 @@ describe(@"System capability manager", ^{
                 expect(testSystemCapabilityManager.videoStreamingCapability).to(beNil());
                 expect(testSystemCapabilityManager.remoteControlCapability).to(beNil());
                 expect(testSystemCapabilityManager.appServicesCapabilities).to(beNil());
+            });
+        });
+    });
+
+    context(@"When notified of a SetDisplayLayout Response with NON_MEDIA in templates", ^ {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        __block SDLSetDisplayLayoutResponse *testSetDisplayLayoutResponse = nil;
+#pragma clang diagnostic pop
+
+        beforeEach(^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+            testSetDisplayLayoutResponse = [[SDLSetDisplayLayoutResponse alloc] init];
+#pragma clang diagnostic pop
+            testSetDisplayLayoutResponse.displayCapabilities = testDisplayCapabilities2;
+            testSetDisplayLayoutResponse.buttonCapabilities = testButtonCapabilities;
+            testSetDisplayLayoutResponse.softButtonCapabilities = testSoftButtonCapabilities;
+            testSetDisplayLayoutResponse.presetBankCapabilities = testPresetBankCapabilities;
+        });
+
+        describe(@"If the SetDisplayLayout request succeeds", ^{
+            beforeEach(^{
+                testSetDisplayLayoutResponse.success = @YES;
+                SDLRPCResponseNotification *notification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveSetDisplayLayoutResponse object:self rpcResponse:testSetDisplayLayoutResponse];
+                [[NSNotificationCenter defaultCenter] postNotification:notification];
+            });
+
+            it(@"should should save the capabilities", ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+                expect(testSystemCapabilityManager.displayCapabilities).to(equal(testDisplayCapabilities2));
+                expect(testSystemCapabilityManager.softButtonCapabilities).to(equal(testSoftButtonCapabilities));
+                expect(testSystemCapabilityManager.buttonCapabilities).to(equal(testButtonCapabilities));
+                expect(testSystemCapabilityManager.presetBankCapabilities).to(equal(testPresetBankCapabilities));
+#pragma clang diagnostic pop
+
+                expect(testSystemCapabilityManager.hmiCapabilities).to(beNil());
+                expect(testSystemCapabilityManager.hmiZoneCapabilities).to(beNil());
+                expect(testSystemCapabilityManager.speechCapabilities).to(beNil());
+                expect(testSystemCapabilityManager.prerecordedSpeechCapabilities).to(beNil());
+                expect(testSystemCapabilityManager.vrCapability).to(beFalse());
+                expect(testSystemCapabilityManager.audioPassThruCapabilities).to(beNil());
+                expect(testSystemCapabilityManager.pcmStreamCapability).to(beNil());
+                expect(testSystemCapabilityManager.phoneCapability).to(beNil());
+                expect(testSystemCapabilityManager.navigationCapability).to(beNil());
+                expect(testSystemCapabilityManager.videoStreamingCapability).to(beNil());
+                expect(testSystemCapabilityManager.remoteControlCapability).to(beNil());
+                expect(testSystemCapabilityManager.appServicesCapabilities).to(beNil());
+            });
+
+            describe(@"If templatesAvailable has NON_MEDIA", ^{
+                it(@"should also include NON-MEDIA", ^{
+                    expect(testSystemCapabilityManager.defaultMainWindowCapability.templatesAvailable).to(equal(@[@"DEFAULT", @"MEDIA", @"NON_MEDIA", @"NON-MEDIA"]));
+                });
             });
         });
     });

--- a/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
+++ b/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
@@ -554,7 +554,7 @@ describe(@"a system capability manager", ^{
 
             describe(@"If templatesAvailable has NON_MEDIA", ^{
                 it(@"should also include NON-MEDIA", ^{
-                    expect(testSystemCapabilityManager.defaultMainWindowCapability.templatesAvailable).to(equal(@[@"DEFAULT", @"MEDIA", @"NON_MEDIA", @"NON-MEDIA"]));
+                    expect(testSystemCapabilityManager.defaultMainWindowCapability.templatesAvailable).to(equal(@[@"DEFAULT", @"MEDIA", @"NON-MEDIA"]));
                 });
             });
         });

--- a/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
+++ b/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
@@ -505,7 +505,7 @@ describe(@"a system capability manager", ^{
         });
     });
 
-    context(@"When notified of a SetDisplayLayout Response with NON_MEDIA in templates", ^ {
+    describe(@"when notified of a SetDisplayLayout Response with NON_MEDIA in templates", ^ {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
         __block SDLSetDisplayLayoutResponse *testSetDisplayLayoutResponse = nil;
@@ -522,7 +522,7 @@ describe(@"a system capability manager", ^{
             testSetDisplayLayoutResponse.presetBankCapabilities = testPresetBankCapabilities;
         });
 
-        describe(@"If the SetDisplayLayout request succeeds", ^{
+        describe(@"if the SetDisplayLayout request succeeds", ^{
             beforeEach(^{
                 testSetDisplayLayoutResponse.success = @YES;
                 SDLRPCResponseNotification *notification = [[SDLRPCResponseNotification alloc] initWithName:SDLDidReceiveSetDisplayLayoutResponse object:self rpcResponse:testSetDisplayLayoutResponse];
@@ -552,9 +552,10 @@ describe(@"a system capability manager", ^{
                 expect(testSystemCapabilityManager.appServicesCapabilities).to(beNil());
             });
 
-            describe(@"If templatesAvailable has NON_MEDIA", ^{
-                it(@"should also include NON-MEDIA", ^{
+            describe(@"if templatesAvailable has NON_MEDIA", ^{
+                it(@"should be changed to include NON-MEDIA and not NON_MEDIA", ^{
                     expect(testSystemCapabilityManager.defaultMainWindowCapability.templatesAvailable).to(equal(@[@"DEFAULT", @"MEDIA", @"NON-MEDIA"]));
+                    expect(testSystemCapabilityManager.defaultMainWindowCapability.templatesAvailable).notTo(contain(@"NON_MEDIA"));
                 });
             });
         });


### PR DESCRIPTION
Fixes #1999

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Unit test added in SDLSystemCapabilityManagerSpec to check if "NON-MEDIA" is added

#### Core Tests
On Manticore the returned templatesAvailable includes "NON-MEDIA" which does not present the bug

Core version / branch / commit hash / module tested against: 7.1.1 develop
HMI name / version / branch / commit hash / module tested against: N/A

### Summary
Added "NON-MEDIA" to `templatesAvailable` In a case where sync's response for templatesAvailable had "NON_MEDIA" instead

### Changelog
##### Breaking Changes
* N/A

##### Enhancements
* N/A

##### Bug Fixes
* Added "NON-MEDIA" to `templatesAvailable` In a case where sync's response for templatesAvailable had "NON_MEDIA" instead

### Tasks Remaining:
N/A

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
