### PR TITLE
If raw data fails to encrypt, don't send the protocol message

### DIFF
--- a/SmartDeviceLink/private/SDLProtocol.m
+++ b/SmartDeviceLink/private/SDLProtocol.m
@@ -470,13 +470,14 @@ NS_ASSUME_NONNULL_BEGIN
         NSError *encryptError = nil;
         data = [self.securityManager encryptData:data withError:&encryptError];
 
-        if (encryptError) {
+        // If the data fails to encrypt, fail out of sending this chunk of data.
+        if ((data.length == 0) || (encryptError != nil)) {
             SDLLogE(@"Error attempting to encrypt raw data for service: %@, error: %@", @(service), encryptError);
+            return;
         }
     }
 
     SDLProtocolMessage *message = [SDLProtocolMessage messageWithHeader:header andPayload:data];
-
     if (message.size < [[SDLGlobals sharedGlobals] mtuSizeForServiceType:service]) {
         SDLLogV(@"Sending protocol message: %@", message);
         [self sdl_sendDataToTransport:message.data onService:header.serviceType];
@@ -531,7 +532,7 @@ NS_ASSUME_NONNULL_BEGIN
             NSError *decryptError = nil;
             payload = [self.securityManager decryptData:payload withError:&decryptError];
 
-            if (decryptError) {
+            if (decryptError != nil) {
                 SDLLogE(@"Error attempting to decrypt a payload with error: %@", decryptError);
                 return;
             }

--- a/SmartDeviceLink/private/SDLProtocol.m
+++ b/SmartDeviceLink/private/SDLProtocol.m
@@ -178,14 +178,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)startSecureServiceWithType:(SDLServiceType)serviceType payload:(nullable NSData *)payload tlsInitializationHandler:(void (^)(BOOL success, NSError *error))tlsInitializationHandler {
     SDLLogD(@"Attempting to start TLS for service type: %hhu", serviceType);
     [self sdl_initializeTLSEncryptionWithCompletionHandler:^(BOOL success, NSError *error) {
+        tlsInitializationHandler(success, error);
         if (!success) {
             // We can't start the service because we don't have encryption, return the error
-            tlsInitializationHandler(success, error);
             BLOCK_RETURN;
         }
 
         // TLS initialization succeeded. Build and send the message.
-        SDLProtocolMessage *message = [self sdl_createStartServiceMessageWithType:serviceType encrypted:YES payload:nil];
+        SDLProtocolMessage *message = [self sdl_createStartServiceMessageWithType:serviceType encrypted:YES payload:payload];
         SDLLogD(@"TLS initialized, sending start service with encryption for message: %@", message);
         [self sdl_sendDataToTransport:message.data onService:serviceType];
     }];

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLMenuCellSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLMenuCellSpec.m
@@ -125,7 +125,7 @@ describe(@"a menu cell", ^{
             testCell2 = [[SDLMenuCell alloc] initWithTitle:@"False" icon:nil submenuLayout:testLayout subCells:@[]];
 #pragma clang diagnostic pop
 
-            expect([testCell isEqual:testCell2]).to(beFalse()));
+            expect([testCell isEqual:testCell2]).to(beFalse());
         });
     });
 });

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLMenuCellSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLMenuCellSpec.m
@@ -93,19 +93,19 @@ describe(@"a menu cell", ^{
         });
     });
 
-    describe(@"check cell eqality", ^{
+    describe(@"check cell equality", ^{
         it(@"should compare cells and return true if cells equal", ^{
             testCell = [[SDLMenuCell alloc] initWithTitle:someTitle secondaryText:someSecondaryTitle tertiaryText:someTertiaryTitle icon:nil secondaryArtwork:someSecondaryArtwork submenuLayout:testLayout subCells:@[]];
             testCell2 = [[SDLMenuCell alloc] initWithTitle:someTitle secondaryText:someSecondaryTitle tertiaryText:someTertiaryTitle icon:nil secondaryArtwork:someSecondaryArtwork submenuLayout:testLayout subCells:@[]];
 
-            expect([testCell isEqual:testCell2]).to(equal(true));
+            expect([testCell isEqual:testCell2]).to(beTrue());
         });
 
         it(@"should compare cells and return false if not equal ", ^{
             testCell = [[SDLMenuCell alloc] initWithTitle:@"True" secondaryText:someSecondaryTitle tertiaryText:someTertiaryTitle icon:nil secondaryArtwork:someSecondaryArtwork submenuLayout:testLayout subCells:@[]];
             testCell2 = [[SDLMenuCell alloc] initWithTitle:@"False" secondaryText:nil tertiaryText:nil icon:nil secondaryArtwork:nil submenuLayout:testLayout subCells:@[]];
 
-            expect([testCell isEqual:testCell2]).to(equal(false));
+            expect([testCell isEqual:testCell2]).to(beFalse());
         });
 
         it(@"should compare cells and return true if cells equal", ^{
@@ -115,7 +115,7 @@ describe(@"a menu cell", ^{
             testCell2 = [[SDLMenuCell alloc] initWithTitle:someTitle icon:nil submenuLayout:testLayout subCells:@[]];
 #pragma clang diagnostic pop
 
-            expect([testCell isEqual:testCell2]).to(equal(true));
+            expect([testCell isEqual:testCell2]).to(beTrue());
         });
 
         it(@"should compare cells and return false if not equal ", ^{
@@ -125,7 +125,7 @@ describe(@"a menu cell", ^{
             testCell2 = [[SDLMenuCell alloc] initWithTitle:@"False" icon:nil submenuLayout:testLayout subCells:@[]];
 #pragma clang diagnostic pop
 
-            expect([testCell isEqual:testCell2]).to(equal(false));
+            expect([testCell isEqual:testCell2]).to(beFalse()));
         });
     });
 });


### PR DESCRIPTION
Fixes #1830 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
No unit test updates needed

#### Core Tests
- [x] Start up an encrypted video stream

Core version / branch / commit hash / module tested against: v7.1.1
HMI name / version / branch / commit hash / module tested against: generic_hmi v0.10.0

### Summary
1. If a packet of video data fails to encrypt, the protocol message wrapper will not be sent.
2. If a `StartService` is encrypted, it's payload should be sent.

### Changelog
##### Bug Fixes
* If a packet of video data fails to encrypt, the protocol message wrapper will not be sent. This should prevent Core from receiving malformed video data.
* If an encrypted `StartService` is sent, the payload should be included. This should prevent Core from rejecting video `StartService` above a certain RPC version level.

### Tasks Remaining:
- [x] Smoke Tests

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
