### PR TITLE
Numerous fixes to SDLVideoStreamingRange

### DIFF
--- a/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
+++ b/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
@@ -300,6 +300,7 @@
 		4A457DD524A3C16E00386CBA /* SDLLifecycleMobileHMIStateHandlerSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A457DD424A3C16E00386CBA /* SDLLifecycleMobileHMIStateHandlerSpec.m */; };
 		4A457DD724A3CCED00386CBA /* SDLLifecycleSystemRequestHandlerSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A457DD624A3CCED00386CBA /* SDLLifecycleSystemRequestHandlerSpec.m */; };
 		4A457DD924A5137100386CBA /* SDLLifecycleProtocolHandlerSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A457DD824A5137100386CBA /* SDLLifecycleProtocolHandlerSpec.m */; };
+		4A55BBB5268119C200BAEBEA /* SDLVideoStreamingRangeSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A55BBB4268119C200BAEBEA /* SDLVideoStreamingRangeSpec.m */; };
 		4A5822C225E40BB5002822F1 /* NSArray+ExtensionsSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A5822C125E40BB5002822F1 /* NSArray+ExtensionsSpec.m */; };
 		4A8BD23B24F93135000945E3 /* SDLMassageCushionFirmness.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A8BD22324F93131000945E3 /* SDLMassageCushionFirmness.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4A8BD23C24F93135000945E3 /* SDLMediaServiceData.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A8BD22424F93131000945E3 /* SDLMediaServiceData.m */; };
@@ -1623,7 +1624,6 @@
 		88A4A0FA22242AB400C6F01D /* SDLNavigationServiceDataSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 88A4A0F922242AB400C6F01D /* SDLNavigationServiceDataSpec.m */; };
 		88A5E7F4220B57F900495E8A /* SDLOnSystemCapabilityUpdatedSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 88A5E7F3220B57F900495E8A /* SDLOnSystemCapabilityUpdatedSpec.m */; };
 		88A5E7FA220B60EC00495E8A /* SDLGetAppServiceDataSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 88A5E7F9220B60EC00495E8A /* SDLGetAppServiceDataSpec.m */; };
-		88A670DF266136EE002541F0 /* SDLVoiceCommandManagerSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DF40B27208FDA9700DD6FDA /* SDLVoiceCommandManagerSpec.m */; };
 		88A795D5210678E000056542 /* SDLStaticIconNameSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 88A795D4210678E000056542 /* SDLStaticIconNameSpec.m */; };
 		88A81F6C2200FD4A00A691A9 /* SDLAppServiceRecordSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 88A81F6B2200FD4A00A691A9 /* SDLAppServiceRecordSpec.m */; };
 		88AAD4C02211B7E200F1E6D7 /* SDLMediaServiceManifestSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 88AAD4BF2211B7E200F1E6D7 /* SDLMediaServiceManifestSpec.m */; };
@@ -2160,6 +2160,7 @@
 		4A457DD424A3C16E00386CBA /* SDLLifecycleMobileHMIStateHandlerSpec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SDLLifecycleMobileHMIStateHandlerSpec.m; path = DevAPISpecs/SDLLifecycleMobileHMIStateHandlerSpec.m; sourceTree = "<group>"; };
 		4A457DD624A3CCED00386CBA /* SDLLifecycleSystemRequestHandlerSpec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SDLLifecycleSystemRequestHandlerSpec.m; path = DevAPISpecs/SDLLifecycleSystemRequestHandlerSpec.m; sourceTree = "<group>"; };
 		4A457DD824A5137100386CBA /* SDLLifecycleProtocolHandlerSpec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SDLLifecycleProtocolHandlerSpec.m; path = DevAPISpecs/SDLLifecycleProtocolHandlerSpec.m; sourceTree = "<group>"; };
+		4A55BBB4268119C200BAEBEA /* SDLVideoStreamingRangeSpec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SDLVideoStreamingRangeSpec.m; path = DevAPISpecs/SDLVideoStreamingRangeSpec.m; sourceTree = "<group>"; };
 		4A5822C125E40BB5002822F1 /* NSArray+ExtensionsSpec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = "NSArray+ExtensionsSpec.m"; path = "DevAPISpecs/NSArray+ExtensionsSpec.m"; sourceTree = "<group>"; };
 		4A680F192513E1F4004A2C31 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = SOURCE_ROOT; };
 		4A8BD22324F93131000945E3 /* SDLMassageCushionFirmness.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SDLMassageCushionFirmness.h; path = public/SDLMassageCushionFirmness.h; sourceTree = "<group>"; };
@@ -7105,6 +7106,7 @@
 				5DEF69621FD6FEB6004B8C2F /* Video */,
 				EEB2537D2067D3E80069584E /* SDLSecondaryTransportManagerSpec.m */,
 				DA661E2B1E553E7E001C1345 /* SDLStreamingMediaManagerSpec.m */,
+				4A55BBB4268119C200BAEBEA /* SDLVideoStreamingRangeSpec.m */,
 			);
 			name = Streaming;
 			sourceTree = "<group>";
@@ -8912,7 +8914,6 @@
 				B38D8E7E24A118BD00B977D0 /* SDLGearStatusSpec.m in Sources */,
 				5D60DF26202B7A97001EDA01 /* SDLSequentialRPCRequestOperationSpec.m in Sources */,
 				162E832C1A9BDE8B00906325 /* SDLDiagnosticMessageSpec.m in Sources */,
-				88A670DF266136EE002541F0 /* SDLVoiceCommandManagerSpec.m in Sources */,
 				162E83381A9BDE8B00906325 /* SDLScrollableMessageSpec.m in Sources */,
 				889D0B9624D065EE008AD494 /* SDLSubtleAlertResponseSpec.m in Sources */,
 				162E82E81A9BDE8B00906325 /* SDLKeyboardLayoutSpec.m in Sources */,
@@ -9112,6 +9113,7 @@
 				B3838A01257C47FD00420C11 /* SDLDoorStatusTypeSpec.m in Sources */,
 				88A5E7F4220B57F900495E8A /* SDLOnSystemCapabilityUpdatedSpec.m in Sources */,
 				5DCF76FC1ACDDB4200BB647B /* SDLSendLocationSpec.m in Sources */,
+				4A55BBB5268119C200BAEBEA /* SDLVideoStreamingRangeSpec.m in Sources */,
 				5DB1BCD81D243AA6002FFC37 /* SDLPermissionFilterSpec.m in Sources */,
 				88EEC5B8220A2144005AA2F9 /* SDLPublishAppServiceSpec.m in Sources */,
 				162E83561A9BDE8B00906325 /* SDLGenericResponseSpec.m in Sources */,

--- a/SmartDeviceLink/private/SDLError.h
+++ b/SmartDeviceLink/private/SDLError.h
@@ -112,6 +112,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSException *)sdl_invalidLockscreenSetupException;
 + (NSException *)sdl_invalidSystemCapabilitySelectorExceptionWithSelector:(SEL)selector;
 + (NSException *)sdl_invalidSubscribeButtonSelectorExceptionWithSelector:(SEL)selector;
++ (NSException *)sdl_invalidVideoStreamingRange;
 
 @end
 

--- a/SmartDeviceLink/private/SDLError.m
+++ b/SmartDeviceLink/private/SDLError.m
@@ -511,6 +511,12 @@ NS_ASSUME_NONNULL_BEGIN
                                  userInfo:nil];
 }
 
++ (NSException *)sdl_invalidVideoStreamingRange {
+    return [NSException exceptionWithName:@"com.sdl.videostreamingrange.rangeException"
+                                   reason:[NSString stringWithFormat:@"A video streaming resolution range was created with an invalid range. The minimum was probably greater than the maximum."]
+                                 userInfo:nil];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartDeviceLink/private/SDLLogFileModuleMap.m
+++ b/SmartDeviceLink/private/SDLLogFileModuleMap.m
@@ -99,7 +99,7 @@
 }
 
 + (SDLLogFileModule *)sdl_videoStreamingMediaManagerModule {
-    return [SDLLogFileModule moduleWithName:@"Video Streaming" files:[NSSet setWithArray:@[@"SDLStreamingVideoLifecycleManager", @"SDLTouchManager", @"SDLCarWindow", @"SDLFocusableItemLocator"]]];
+    return [SDLLogFileModule moduleWithName:@"Video Streaming" files:[NSSet setWithArray:@[@"SDLStreamingVideoLifecycleManager", @"SDLTouchManager", @"SDLCarWindow", @"SDLFocusableItemLocator", @"SDLVideoStreamingRange"]]];
 }
 
 + (SDLLogFileModule *)sdl_videoStreamingMediaTranscoderModule {

--- a/SmartDeviceLink/public/SDLVideoStreamingRange.h
+++ b/SmartDeviceLink/public/SDLVideoStreamingRange.h
@@ -13,31 +13,42 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SDLVideoStreamingRange : NSObject <NSCopying>
 
-// The minimum supported normalized aspect ratio, Min value is 1
+/// The minimum supported normalized aspect ratio, min value is 1.0, defaults to 1.0
 @property (nonatomic, assign) float minimumAspectRatio;
 
-// The maximum supported normalized aspect ratio, Min value is 1
+/// The maximum supported normalized aspect ratio, min value is 1.0, defaults to 9999.0
 @property (nonatomic, assign) float maximumAspectRatio;
 
-// The minimum supported diagonal screen size in inches, defaults to 0 (0 matches any size)
+/// The minimum supported diagonal screen size in inches, defaults to 0.0 (matches any size)
 @property (nonatomic, assign) float minimumDiagonal;
 
-// The minimum resolution to support, it overrides .minimumAspectRatio
+/// The minimum resolution to support, it overrides .minimumAspectRatio
 @property (nonatomic, strong, nullable) SDLImageResolution *minimumResolution;
 
-// The maximum resolution to support, it overrides .maximumAspectRatio
+/// The maximum resolution to support, it overrides .maximumAspectRatio
 @property (nonatomic, strong, nullable) SDLImageResolution *maximumResolution;
 
-// Check if the argument is within the [.minimumResolution, .maximumResolution] range
+/// Create a video streaming range based on a minimum and maximum resolution
+/// @param minResolution The minimum supported height / width resolution
+/// @param maxResolution The maximum supported height / width resolution
+- (instancetype)initWithMinimumResolution:(nullable SDLImageResolution *)minResolution maximumResolution:(nullable SDLImageResolution *)maxResolution;
+
+/// Create a video streaming range with all supported options
+/// @param minResolution The minimum supported height / width resolution
+/// @param maxResolution The maximum supported height / width resolution
+/// @param minimumAspectRatio The minimum supported normalized aspect ratio, min value is 1.0, defaults to 1.0
+/// @param maximumAspectRatio The maximum supported normalized aspect ratio, min value is 1.0, defaults to 9999.0
+/// @param minimumDiagonal The minimum supported diagonal screen size in inches, defaults to 0 (0 matches any size)
+- (instancetype)initWithMinimumResolution:(nullable SDLImageResolution *)minResolution maximumResolution:(nullable SDLImageResolution *)maxResolution minimumAspectRatio:(float)minimumAspectRatio maximumAspectRatio:(float)maximumAspectRatio minimumDiagonal:(float)minimumDiagonal;
+
+/// A convenience method to create a disabled range with the min and max resolutions equal to zero
++ (instancetype)disabled;
+
+/// Check if the argument is within the [.minimumResolution, .maximumResolution] range
 - (BOOL)isImageResolutionInRange:(SDLImageResolution *)imageResolution;
 
-// Check if the argument is within the [.minimumAspectRatio, .maximumAspectRatio] range
+/// Check if the argument is within the [.minimumAspectRatio, .maximumAspectRatio] range
 - (BOOL)isAspectRatioInRange:(float)aspectRatio;
-
-- (instancetype)initWithMinimumResolution:(SDLImageResolution *)minResolution maximumResolution:(SDLImageResolution *)maxResolution;
-
-// A convenience method to create a disabled range with the min and max resolutions equal to zero
-+ (instancetype)disabled;
 
 @end
 

--- a/SmartDeviceLink/public/SDLVideoStreamingRange.m
+++ b/SmartDeviceLink/public/SDLVideoStreamingRange.m
@@ -6,12 +6,18 @@
 //
 
 #import "SDLVideoStreamingRange.h"
+
+#import "SDLError.h"
 #import "SDLImageResolution+StreamingVideoExtensions.h"
 #import "SDLLogMacros.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLVideoStreamingRange
+
+- (instancetype)init {
+    return [self initWithMinimumResolution:[[SDLImageResolution alloc] initWithWidth:0.0 height:0.0] maximumResolution:[[SDLImageResolution alloc] initWithWidth:0.0 height:0.0]];
+}
 
 - (instancetype)initWithMinimumResolution:(nullable SDLImageResolution *)minResolution maximumResolution:(nullable SDLImageResolution *)maxResolution {
     return [self initWithMinimumResolution:minResolution maximumResolution:maxResolution minimumAspectRatio:1.0 maximumAspectRatio:9999.0 minimumDiagonal:0.0];
@@ -21,12 +27,12 @@ NS_ASSUME_NONNULL_BEGIN
     self = [super init];
     if (!self) { return nil; }
 
-    // Min must be below max
+    // Min must be below max, if this `if` passes, this is an invalid check, throw an exception.
     if ((minResolution != nil && maxResolution != nil) &&
         ((minResolution.resolutionWidth.floatValue > maxResolution.resolutionWidth.floatValue) ||
         (minResolution.resolutionHeight.floatValue > maxResolution.resolutionHeight.floatValue))) {
         SDLLogE(@"VideoStreamingRange minResolution is bigger than maxResolution (%@ <> %@)", minResolution, maxResolution);
-        return nil;
+        @throw [NSException sdl_invalidVideoStreamingRange];
     }
 
     _minimumResolution = minResolution;
@@ -39,8 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 + (instancetype)disabled {
-    SDLImageResolution *disabledResolution = [[SDLImageResolution alloc] initWithWidth:0.0 height:0.0];
-    return [[self alloc] initWithMinimumResolution:disabledResolution maximumResolution:disabledResolution];
+    return [[self alloc] init];
 }
 
 #pragma mark - Setters

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingVideoLifecycleManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLStreamingVideoLifecycleManagerSpec.m
@@ -1529,24 +1529,16 @@ describe(@"supported video capabilities and formats", ^{
     });
          
     context(@"portrait restricted and wrong landscape", ^{
-        SDLImageResolution *resMinP = [[SDLImageResolution alloc] initWithWidth:200 height:320];
-        SDLImageResolution *resMaxP = [[SDLImageResolution alloc] initWithWidth:300 height:420];
-        SDLVideoStreamingRange *portRange = [[SDLVideoStreamingRange alloc] initWithMinimumResolution:resMinP maximumResolution:resMaxP];
-
-        // wrong range: max < min, nothing will pass in landscape
-        SDLImageResolution *resMaxL = [[SDLImageResolution alloc] initWithWidth:320 height:200];
-        SDLImageResolution *resMinL = [[SDLImageResolution alloc] initWithWidth:350 height:220];
-        SDLVideoStreamingRange *landRange = [[SDLVideoStreamingRange alloc] initWithMinimumResolution:resMinL maximumResolution:resMaxL];
-
         it(@"should filter portrait small", ^{
-            streamingLifecycleManager.supportedLandscapeStreamingRange = landRange;
-            streamingLifecycleManager.supportedPortraitStreamingRange = portRange;
+            // wrong range: max < min, will throw an exception
+            SDLImageResolution *resMaxL = [[SDLImageResolution alloc] initWithWidth:320 height:200];
+            SDLImageResolution *resMinL = [[SDLImageResolution alloc] initWithWidth:350 height:220];
 
-            expect(streamingLifecycleManager.supportedLandscapeStreamingRange).to(equal(landRange));
-            expect(streamingLifecycleManager.supportedPortraitStreamingRange).to(equal(portRange));
-            NSArray *expectedArray = @[capability8];
-            NSArray *matchArray = [streamingLifecycleManager matchVideoCapability:capability0];
-            expect(matchArray).to(equal(expectedArray));
+            expectAction(^{
+                SDLVideoStreamingRange *landRange = [[SDLVideoStreamingRange alloc] initWithMinimumResolution:resMinL maximumResolution:resMaxL];
+                expect(landRange).to(beNil());
+            }).to(raiseException());
+
         });
     });
 

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLVideoStreamingRangeSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLVideoStreamingRangeSpec.m
@@ -1,0 +1,221 @@
+//
+//  SDLVideoStreamingRangeSpec.m
+//  SmartDeviceLinkTests
+//
+//  Created by Joel Fischer on 6/21/21.
+//  Copyright © 2021 smartdevicelink. All rights reserved.
+//
+
+#import <Quick/Quick.h>
+#import <Nimble/Nimble.h>
+
+#import <SmartDeviceLink/SmartDeviceLink.h>
+
+QuickSpecBegin(SDLVideoStreamingRangeSpec)
+
+describe(@"video streaming range", ^{
+    __block SDLVideoStreamingRange *testRange = nil;
+    SDLImageResolution *disabledResolution = [[SDLImageResolution alloc] initWithWidth:0 height:0];
+    SDLImageResolution *lowResolution = [[SDLImageResolution alloc] initWithWidth:1 height:1];
+    SDLImageResolution *highResolution = [[SDLImageResolution alloc] initWithWidth:999 height:999];
+
+    float defaultMinimumAspectRatio = 1.0;
+    float defaultMaximumAspectRatio = 9999.0;
+    float defaultMinimumDiagonal = 0.0;
+
+    float testMinimumAspectRatio = 4.0;
+    float testMaximumAspectRatio = 12.0;
+    float testMinimumDiagonal = 6.0;
+
+    beforeEach(^{
+        testRange = [[SDLVideoStreamingRange alloc] initWithMinimumResolution:lowResolution maximumResolution:highResolution];;
+    });
+
+    context(@"initialized with initWithMinimumResolution:maximumResolution", ^{
+        it(@"should set all parameters correctly", ^{
+            expect(testRange.minimumResolution).to(equal(lowResolution));
+            expect(testRange.maximumResolution).to(equal(highResolution));
+            expect(testRange.minimumAspectRatio).to(equal(1.0));
+            expect(testRange.maximumAspectRatio).to(equal(9999.0));
+            expect(testRange.minimumDiagonal).to(equal(0.0));
+        });
+    });
+
+    context(@"initialized with initWithMinimumResolution:maximumResolution:minimumAspectRatio:maximumAspectRatio:minimumDiagonal:", ^{
+        beforeEach(^{
+            testRange = [[SDLVideoStreamingRange alloc] initWithMinimumResolution:lowResolution maximumResolution:highResolution minimumAspectRatio:testMinimumAspectRatio maximumAspectRatio:testMaximumAspectRatio minimumDiagonal:testMinimumDiagonal];
+        });
+
+        it(@"should set all parameters correctly", ^{
+            expect(testRange.minimumResolution).to(equal(lowResolution));
+            expect(testRange.maximumResolution).to(equal(highResolution));
+            expect(testRange.minimumAspectRatio).to(equal(testMinimumAspectRatio));
+            expect(testRange.maximumAspectRatio).to(equal(testMaximumAspectRatio));
+            expect(testRange.minimumDiagonal).to(equal(testMinimumDiagonal));
+        });
+    });
+
+    context(@"initialized with disabled", ^{
+        beforeEach(^{
+            testRange = [SDLVideoStreamingRange disabled];
+        });
+
+        it(@"should set all parameters correctly", ^{
+            expect(testRange.minimumResolution).to(equal(disabledResolution));
+            expect(testRange.maximumResolution).to(equal(disabledResolution));
+            expect(testRange.minimumAspectRatio).to(equal(defaultMinimumAspectRatio));
+            expect(testRange.maximumAspectRatio).to(equal(defaultMaximumAspectRatio));
+            expect(testRange.minimumDiagonal).to(equal(defaultMinimumDiagonal));
+        });
+    });
+
+    describe(@"setting float parameters", ^{
+        describe(@"minimum aspect ratio", ^{
+            context(@"below the minimum", ^{
+                it(@"should be set to the minimum", ^{
+                    testRange.minimumAspectRatio = -2.0;
+                    expect(testRange.minimumAspectRatio).to(equal(defaultMinimumAspectRatio));
+                });
+            });
+
+            context(@"above the minimum", ^{
+                it(@"should set the value", ^{
+                    testRange.minimumAspectRatio = testMinimumAspectRatio;
+                    expect(testRange.minimumAspectRatio).to(equal(testMinimumAspectRatio));
+                });
+            });
+        });
+
+        describe(@"maximum aspect ratio", ^{
+            context(@"below the minimum", ^{
+                it(@"should be set to the minimum", ^{
+                    testRange.maximumAspectRatio = -2.0;
+                    expect(testRange.maximumAspectRatio).to(equal(defaultMinimumAspectRatio));
+                });
+            });
+
+            context(@"above the minimum", ^{
+                it(@"should set the value", ^{
+                    testRange.maximumAspectRatio = testMaximumAspectRatio;
+                    expect(testRange.maximumAspectRatio).to(equal(testMaximumAspectRatio));
+                });
+            });
+        });
+
+        describe(@"minimum diagonal", ^{
+            context(@"below the minimum", ^{
+                it(@"should be set to the minimum", ^{
+                    testRange.minimumDiagonal = -2.0;
+                    expect(testRange.minimumDiagonal).to(equal(defaultMinimumDiagonal));
+                });
+            });
+
+            context(@"above the minimum", ^{
+                it(@"should set the value", ^{
+                    testRange.minimumDiagonal = testMinimumDiagonal;
+                    expect(testRange.minimumDiagonal).to(equal(testMinimumDiagonal));
+                });
+            });
+        });
+    });
+
+    describe(@"checking if the resolution is in a given range", ^{
+        beforeEach(^{
+            testRange = [[SDLVideoStreamingRange alloc] initWithMinimumResolution:lowResolution maximumResolution:highResolution];
+        });
+
+        context(@"when there is no minimum or maximum resolution", ^{
+            beforeEach(^{
+                testRange = [[SDLVideoStreamingRange alloc] initWithMinimumResolution:nil maximumResolution:nil];
+            });
+
+            it(@"should return NO", ^{
+                expect([testRange isImageResolutionInRange:[[SDLImageResolution alloc] initWithWidth:2 height:2]]).to(beFalse());
+            });
+        });
+
+        context(@"when there is no maximum resolution", ^{
+            beforeEach(^{
+                testRange = [[SDLVideoStreamingRange alloc] initWithMinimumResolution:lowResolution maximumResolution:nil];
+            });
+
+            it(@"should return YES", ^{
+                expect([testRange isImageResolutionInRange:[[SDLImageResolution alloc] initWithWidth:2 height:2]]).to(beTrue());
+            });
+        });
+
+        context(@"when there is no minimum resolution", ^{
+            beforeEach(^{
+                testRange = [[SDLVideoStreamingRange alloc] initWithMinimumResolution:nil maximumResolution:highResolution];
+            });
+
+            it(@"should return YES", ^{
+                expect([testRange isImageResolutionInRange:[[SDLImageResolution alloc] initWithWidth:2 height:2]]).to(beTrue());
+            });
+        });
+
+        context(@"when the resolution is below the range", ^{
+            it(@"should return NO", ^{
+                expect([testRange isImageResolutionInRange:[[SDLImageResolution alloc] initWithWidth:0 height:0]]).to(beFalse());
+            });
+        });
+
+        context(@"when the resolution is above the range", ^{
+            it(@"should return NO", ^{
+                expect([testRange isImageResolutionInRange:[[SDLImageResolution alloc] initWithWidth:34463 height:34463]]).to(beFalse());
+            });
+        });
+
+        context(@"when the resolution is in the range", ^{
+            it(@"should return YES", ^{
+                expect([testRange isImageResolutionInRange:[[SDLImageResolution alloc] initWithWidth:2 height:2]]).to(beTrue());
+            });
+        });
+    });
+
+    describe(@"checking if the aspect ratio is in a given range", ^{
+        beforeEach(^{
+            testRange = [[SDLVideoStreamingRange alloc] initWithMinimumResolution:nil maximumResolution:nil minimumAspectRatio:testMinimumAspectRatio maximumAspectRatio:testMaximumAspectRatio minimumDiagonal:1.0];
+        });
+
+        context(@"when there is no maximum aspect ratio", ^{
+            beforeEach(^{
+                testRange = [[SDLVideoStreamingRange alloc] initWithMinimumResolution:nil maximumResolution:nil minimumAspectRatio:testMinimumAspectRatio maximumAspectRatio:0.0 minimumDiagonal:1.0];
+            });
+
+            it(@"should return NO", ^{
+                expect([testRange isAspectRatioInRange:10.0]);
+            });
+        });
+
+        context(@"when there is no minimum aspect ratio", ^{
+            beforeEach(^{
+                testRange = [[SDLVideoStreamingRange alloc] initWithMinimumResolution:nil maximumResolution:nil minimumAspectRatio:0.0 maximumAspectRatio:testMaximumAspectRatio minimumDiagonal:1.0];
+            });
+
+            it(@"should return NO", ^{
+                expect([testRange isAspectRatioInRange:10.0]);
+            });
+        });
+
+        context(@"when the aspect ratio is below the range", ^{
+            it(@"should return NO", ^{
+                expect([testRange isAspectRatioInRange:2.0]);
+            });
+        });
+
+        context(@"when the aspect ratio is above the range", ^{
+            it(@"should return NO", ^{
+                expect([testRange isAspectRatioInRange:99.0]);
+            });
+        });
+
+        context(@"when the aspect ratio is in the range", ^{
+            it(@"should return NO", ^{
+                expect([testRange isAspectRatioInRange:10.0]);
+            });
+        });
+    });
+});
+
+QuickSpecEnd

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLVideoStreamingRangeSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLVideoStreamingRangeSpec.m
@@ -184,7 +184,7 @@ describe(@"video streaming range", ^{
             });
 
             it(@"should return NO", ^{
-                expect([testRange isAspectRatioInRange:10.0]);
+                expect([testRange isAspectRatioInRange:10.0]).to(beTrue());
             });
         });
 
@@ -194,25 +194,25 @@ describe(@"video streaming range", ^{
             });
 
             it(@"should return NO", ^{
-                expect([testRange isAspectRatioInRange:10.0]);
+                expect([testRange isAspectRatioInRange:10.0]).to(beTrue());
             });
         });
 
         context(@"when the aspect ratio is below the range", ^{
             it(@"should return NO", ^{
-                expect([testRange isAspectRatioInRange:2.0]);
+                expect([testRange isAspectRatioInRange:2.0]).to(beFalse());
             });
         });
 
         context(@"when the aspect ratio is above the range", ^{
             it(@"should return NO", ^{
-                expect([testRange isAspectRatioInRange:99.0]);
+                expect([testRange isAspectRatioInRange:99.0]).to(beFalse());
             });
         });
 
         context(@"when the aspect ratio is in the range", ^{
             it(@"should return NO", ^{
-                expect([testRange isAspectRatioInRange:10.0]);
+                expect([testRange isAspectRatioInRange:10.0]).to(beTrue());
             });
         });
     });

--- a/SmartDeviceLinkTests/SDLSupportedStreamingRangeSpec.m
+++ b/SmartDeviceLinkTests/SDLSupportedStreamingRangeSpec.m
@@ -13,6 +13,7 @@
 
 QuickSpecBegin(SDLSupportedStreamingRangeSpec)
 
+SDLImageResolution *disabledResolution = [[SDLImageResolution alloc] initWithWidth:0 height:0];
 SDLImageResolution *minResolution = [[SDLImageResolution alloc] initWithWidth:10 height:50];
 SDLImageResolution *maxResolution = [[SDLImageResolution alloc] initWithWidth:100 height:500];
 const float minimumAspectRatio = 2.5;
@@ -25,10 +26,10 @@ describe(@"initialization", ^{
 
         it(@"expect object to be created with empty fields", ^{
             expect(streamingRange).toNot(beNil());
-            expect(streamingRange.minimumResolution).to(beNil());
-            expect(streamingRange.maximumResolution).to(beNil());
-            expect(streamingRange.minimumAspectRatio).to(equal(0));
-            expect(streamingRange.maximumAspectRatio).to(equal(0));
+            expect(streamingRange.minimumResolution).to(equal(disabledResolution));
+            expect(streamingRange.maximumResolution).to(equal(disabledResolution));
+            expect(streamingRange.minimumAspectRatio).to(equal(1));
+            expect(streamingRange.maximumAspectRatio).to(equal(9999));
             expect(streamingRange.minimumDiagonal).to(equal(0));
         });
     });
@@ -53,13 +54,25 @@ describe(@"initialization", ^{
 
     context(@"initWithMinimumResolution:maximumResolution:", ^{
         SDLVideoStreamingRange *streamingRange = [[SDLVideoStreamingRange alloc] initWithMinimumResolution:minResolution maximumResolution:maxResolution];
-        it(@"expect min and max resolution to be set and others are not", ^{
+        it(@"expect min and max resolution to be set and others are defaults", ^{
             expect(streamingRange).toNot(beNil());
             expect(streamingRange.minimumResolution).to(equal(minResolution));
             expect(streamingRange.maximumResolution).to(equal(maxResolution));
-            expect(streamingRange.minimumAspectRatio).to(equal(0));
-            expect(streamingRange.maximumAspectRatio).to(equal(0));
+            expect(streamingRange.minimumAspectRatio).to(equal(1));
+            expect(streamingRange.maximumAspectRatio).to(equal(9999));
             expect(streamingRange.minimumDiagonal).to(equal(0));
+        });
+    });
+
+    context(@"initWithMinimumResolution:maximumResolution:minimumAspectRatio:maximumAspectRatio:minimumDiagonal:", ^{
+        SDLVideoStreamingRange *streamingRange = [[SDLVideoStreamingRange alloc] initWithMinimumResolution:minResolution maximumResolution:maxResolution minimumAspectRatio:minimumAspectRatio maximumAspectRatio:maximumAspectRatio minimumDiagonal:minimumDiagonal];
+        it(@"expect min and max resolution to be set and others are defaults", ^{
+            expect(streamingRange).toNot(beNil());
+            expect(streamingRange.minimumResolution).to(equal(minResolution));
+            expect(streamingRange.maximumResolution).to(equal(maxResolution));
+            expect(streamingRange.minimumAspectRatio).to(equal(minimumAspectRatio));
+            expect(streamingRange.maximumAspectRatio).to(equal(maximumAspectRatio));
+            expect(streamingRange.minimumDiagonal).to(equal(minimumDiagonal));
         });
     });
 });


### PR DESCRIPTION
Fixes #2011 

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Added unit tests for SDLVideoStreamingRange

#### Core Tests
Ran on Sync 3 TDK with ranges, ran on Core 7.1.1 with ranges that disabled some support.

Core version / branch / commit hash / module tested against: Sync 3.4 | Core v7.1.1
HMI name / version / branch / commit hash / module tested against: Sync 3.4 | Generic HMI v0.10.0

### Summary
* Add tests
* Fix comments not being documentation comments
* Add a full initializer
* Fix nullability
* Add to module map
* Add setters to enforce minimums

### Changelog
##### Bug Fixes
* Fixed missing documentation and initializers in `SDLVideoStreamingRange`.

### Tasks Remaining:
- [x] Run Smoke Tests on Core

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
