### PR TITLE
Fixed menu manager sending secondary image with menuCells when menuCommandSecondaryImage is not supported

### DIFF
--- a/SmartDeviceLink/private/SDLMenuManager.m
+++ b/SmartDeviceLink/private/SDLMenuManager.m
@@ -837,7 +837,7 @@ UInt32 const MenuCellIdMin = 1;
     command.vrCommands = (cell.voiceCommands.count == 0) ? nil : cell.voiceCommands;
     command.cmdIcon = (cell.icon && shouldHaveArtwork) ? cell.icon.imageRPC : nil;
     command.cmdID = @(cell.cellId);
-    command.secondaryImage = (cell.secondaryArtwork && shouldHaveArtwork && ![self.fileManager fileNeedsUpload:cell.secondaryArtwork]) ? cell.secondaryArtwork.imageRPC : nil;
+    command.secondaryImage = (cell.secondaryArtwork && shouldHaveArtwork && ![self.fileManager fileNeedsUpload:cell.secondaryArtwork] && [self.windowCapability hasImageFieldOfName:SDLImageFieldNameMenuCommandSecondaryImage]) ? cell.secondaryArtwork.imageRPC : nil;
 
     return command;
 }
@@ -849,7 +849,7 @@ UInt32 const MenuCellIdMin = 1;
 /// @returns The SDLAddSubMenu RPC
 - (SDLAddSubMenu *)sdl_subMenuCommandForMenuCell:(SDLMenuCell *)cell withArtwork:(BOOL)shouldHaveArtwork position:(UInt16)position {
     SDLImage *icon = (shouldHaveArtwork && (cell.icon.name != nil)) ? cell.icon.imageRPC : nil;
-    SDLImage *secondaryImage = (shouldHaveArtwork && ![self.fileManager fileNeedsUpload:cell.secondaryArtwork] && (cell.secondaryArtwork.name != nil)) ? cell.secondaryArtwork.imageRPC : nil;
+    SDLImage *secondaryImage = (shouldHaveArtwork && ![self.fileManager fileNeedsUpload:cell.secondaryArtwork] && (cell.secondaryArtwork.name != nil)  && [self.windowCapability hasImageFieldOfName:SDLImageFieldNameMenuSubMenuSecondaryImage]) ? cell.secondaryArtwork.imageRPC : nil;
 
     SDLMenuLayout submenuLayout = nil;
     if (cell.submenuLayout && [self.systemCapabilityManager.defaultMainWindowCapability.menuLayoutsAvailable containsObject:cell.submenuLayout]) {

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLMenuManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLMenuManagerSpec.m
@@ -209,8 +209,8 @@ describe(@"menu manager", ^{
             testManager.currentSystemContext = SDLSystemContextMain;
         });
 
-        // hmi does not support menuCommandSecondaryImage
-        context(@"hmi does not support menuCommandSecondaryImage", ^{
+        // HMI does not support a command secondary image
+        context(@"HMI does not support a command secondary image", ^{
             SDLArtwork *staticArtwork = [[SDLArtwork alloc] initWithStaticIcon:SDLStaticIconNameKey];
 
             beforeEach(^{
@@ -229,8 +229,8 @@ describe(@"menu manager", ^{
             });
         });
 
-        // hmi does not support menuSubMenuSecondaryImage
-        context(@"hmi does not support menuSubMenuSecondaryImage", ^{
+        // HMI does not support a submenu secondary image
+        context(@"HMI does not support a submenu secondary image", ^{
             SDLArtwork *staticArtwork = [[SDLArtwork alloc] initWithStaticIcon:SDLStaticIconNameKey];
 
             beforeEach(^{


### PR DESCRIPTION
Fixes #2006 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
N/A

#### Core Tests
Tested if the secondaryImage is still being sent in a menu command or a menu submenu cell after the `menuCommandSecondaryImage` and `menuSubMenuSecondaryImage` are removed from displayCapabilities in generic hmi.

Core version / branch / commit hash / module tested against: 7.1.0
HMI name / version / branch / commit hash / module tested against: Generic / 0.10.0

### Summary
Check if the if the image is supported in our windowCapability before sending the Command/SubMenu cell

### Changelog
##### Breaking Changes
* N/A

##### Enhancements
* N/A

##### Bug Fixes
* Check if the if the image is supported in our windowCapability before sending the Command/SubMenu cell

### Tasks Remaining:
N/A

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
