### PR TITLE
Add Ability to Run CI Manually

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on: [push, pull_request, workflow_dispatch]
 
 env:
     PROJECT: 'SmartDeviceLink-iOS.xcodeproj'
-    DESTINATION: 'platform=iOS Simulator,name=iPhone 12,OS=14.6'
+    DESTINATION: 'platform=iOS Simulator,name=iPhone 12,OS=14.4'
 
 jobs:
     build:
@@ -27,7 +27,7 @@ jobs:
 
             # Select the Xcode version (the platform/simulator/OS available for testing depend on the Xcode version)
             - name: Select Xcode version
-              run: sudo xcode-select -switch /Applications/Xcode_12.5.app
+              run: sudo xcode-select -switch /Applications/Xcode_12.4.app
 
             - name: Build
               run: set -o pipefail && xcodebuild -scheme "${{ matrix.scheme }}" -destination "$DESTINATION" build | xcpretty --color --simple
@@ -46,7 +46,7 @@ jobs:
 
             # Select the Xcode version (the platform/simulator/OS available for testing depend on the Xcode version)
             - name: Select Xcode version
-              run: sudo xcode-select -switch /Applications/Xcode_12.5.app
+              run: sudo xcode-select -switch /Applications/Xcode_12.4.app
 
             - name: Checkout repository
               uses: actions/checkout@v2.3.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,11 @@
 name: SmartDeviceLink Tests
 
 # This workflow is triggered on a push or pull request.
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 env:
     PROJECT: 'SmartDeviceLink-iOS.xcodeproj'
-    DESTINATION: 'platform=iOS Simulator,name=iPhone 12,OS=14.4'
+    DESTINATION: 'platform=iOS Simulator,name=iPhone 12,OS=14.6'
 
 jobs:
     build:
@@ -27,7 +27,7 @@ jobs:
 
             # Select the Xcode version (the platform/simulator/OS available for testing depend on the Xcode version)
             - name: Select Xcode version
-              run: sudo xcode-select -switch /Applications/Xcode_12.4.app
+              run: sudo xcode-select -switch /Applications/Xcode_12.5.app
 
             - name: Build
               run: set -o pipefail && xcodebuild -scheme "${{ matrix.scheme }}" -destination "$DESTINATION" build | xcpretty --color --simple
@@ -46,7 +46,7 @@ jobs:
 
             # Select the Xcode version (the platform/simulator/OS available for testing depend on the Xcode version)
             - name: Select Xcode version
-              run: sudo xcode-select -switch /Applications/Xcode_12.4.app
+              run: sudo xcode-select -switch /Applications/Xcode_12.5.app
 
             - name: Checkout repository
               uses: actions/checkout@v2.3.1


### PR DESCRIPTION
Fixes #2016 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [ ] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [ ] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Github CI YAML-only changes

#### Core Tests
Github CI YAML-only changes

Core version / branch / commit hash / module tested against: n/a
HMI name / version / branch / commit hash / module tested against: n/a

### Summary
This PR update the CI test instructions to allow manually re-running tests.

### Changelog
##### Bug Fixes
* Add the ability to re-run CI tests manually.

### Tasks Remaining:
n/a

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
