### PR TITLE
Fix modifying and looping dictionaries without sync

### DIFF
--- a/SmartDeviceLink-iOS.xcodeproj/xcshareddata/xcschemes/SmartDeviceLink-Example-Swift.xcscheme
+++ b/SmartDeviceLink-iOS.xcodeproj/xcshareddata/xcschemes/SmartDeviceLink-Example-Swift.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8829567D207CF68800EF056C"
+               BuildableName = "SDL Example Swift.app"
+               BlueprintName = "SmartDeviceLink-Example-Swift"
+               ReferencedContainer = "container:SmartDeviceLink-iOS.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8829567D207CF68800EF056C"
+            BuildableName = "SDL Example Swift.app"
+            BlueprintName = "SmartDeviceLink-Example-Swift"
+            ReferencedContainer = "container:SmartDeviceLink-iOS.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8829567D207CF68800EF056C"
+            BuildableName = "SDL Example Swift.app"
+            BlueprintName = "SmartDeviceLink-Example-Swift"
+            ReferencedContainer = "container:SmartDeviceLink-iOS.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SmartDeviceLink/public/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/public/SDLSystemCapabilityManager.m
@@ -606,17 +606,15 @@ typedef NSString * SDLServiceID;
     [SDLGlobals runSyncOnSerialSubQueue:self.readWriteQueue block:^{
         for (SDLSystemCapabilityType key in self.capabilityObservers.allKeys) {
             for (SDLSystemCapabilityObserver *observer in self.capabilityObservers[key]) {
-                [SDLGlobals runSyncOnSerialSubQueue:self.readWriteQueue block:^{
-                    // If an observer object is nil, remove it
-                    if (observer.observer == nil) {
-                        [self.capabilityObservers[key] removeObject:observer];
-                    }
+                // If an observer object is nil, remove it
+                if (observer.observer == nil) {
+                    [self.capabilityObservers[key] removeObject:observer];
+                }
 
-                    // If we no longer have any observers for that type, remove the array
-                    if (self.capabilityObservers[key].count == 0) {
-                        [self.capabilityObservers removeObjectForKey:key];
-                    }
-                }];
+                // If we no longer have any observers for that type, remove the array
+                if (self.capabilityObservers[key].count == 0) {
+                    [self.capabilityObservers removeObjectForKey:key];
+                }
             }
         }
 

--- a/SmartDeviceLink/public/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/public/SDLSystemCapabilityManager.m
@@ -123,7 +123,7 @@ typedef NSString * SDLServiceID;
 
         self.supportsSubscriptions = NO;
 
-        self.appServicesCapabilitiesDictionary = [NSMutableDictionary dictionary];
+        [self.appServicesCapabilitiesDictionary removeAllObjects];
         [self.capabilityObservers removeAllObjects];
         [self.subscriptionStatus removeAllObjects];
 
@@ -386,7 +386,8 @@ typedef NSString * SDLServiceID;
 }
 
 - (void)sdl_notifyObserversOfCapabilityType:(SDLSystemCapabilityType)type capability:(nullable SDLSystemCapability *)capability error:(nullable NSError *)error {
-    for (SDLSystemCapabilityObserver *observer in self.capabilityObservers[type]) {
+    NSDictionary<SDLSystemCapabilityType, NSMutableArray<SDLSystemCapabilityObserver *> *> *capabilityObservers = [self.capabilityObservers copy];
+    for (SDLSystemCapabilityObserver *observer in capabilityObservers[type]) {
         [self sdl_invokeObserver:observer withCapabilityType:type capability:capability error:error];
     }
 }
@@ -584,55 +585,56 @@ typedef NSString * SDLServiceID;
     return observerObject.observer;
 }
 
-#pragma mark Unubscribing
+#pragma mark Unsubscribing
 
 - (void)unsubscribeFromCapabilityType:(SDLSystemCapabilityType)type withObserver:(id)observer {
     SDLLogD(@"Unsubscribing from capability type: %@", type);
-    for (SDLSystemCapabilityObserver *capabilityObserver in self.capabilityObservers[type]) {
-        if ([observer isEqual:capabilityObserver.observer] && self.capabilityObservers[type] != nil) {
-            [SDLGlobals runSyncOnSerialSubQueue:self.readWriteQueue block:^{
+    [SDLGlobals runSyncOnSerialSubQueue:self.readWriteQueue block:^{
+        for (SDLSystemCapabilityObserver *capabilityObserver in self.capabilityObservers[type]) {
+            if ([observer isEqual:capabilityObserver.observer] && self.capabilityObservers[type] != nil) {
                 [self.capabilityObservers[type] removeObject:capabilityObserver];
-            }];
-
-            [self sdl_removeNilObserversAndUnsubscribeIfNecessary];
-            break;
+                [self sdl_removeNilObserversAndUnsubscribeIfNecessary];
+                break;
+            }
         }
-    }
+    }];
 }
 
 - (void)sdl_removeNilObserversAndUnsubscribeIfNecessary {
     SDLLogV(@"Checking for nil observers and removing them, then checking for subscriptions we don't need and unsubscribing.");
-    // Loop through our observers
-    for (SDLSystemCapabilityType key in self.capabilityObservers.allKeys) {
-        for (SDLSystemCapabilityObserver *observer in self.capabilityObservers[key]) {
-            [SDLGlobals runSyncOnSerialSubQueue:self.readWriteQueue block:^{
-                // If an observer object is nil, remove it
-                if (observer.observer == nil) {
-                    [self.capabilityObservers[key] removeObject:observer];
-                }
 
-                // If we no longer have any observers for that type, remove the array
-                if (self.capabilityObservers[key].count == 0) {
-                    [self.capabilityObservers removeObjectForKey:key];
-                }
-            }];
+    [SDLGlobals runSyncOnSerialSubQueue:self.readWriteQueue block:^{
+        for (SDLSystemCapabilityType key in self.capabilityObservers.allKeys) {
+            for (SDLSystemCapabilityObserver *observer in self.capabilityObservers[key]) {
+                [SDLGlobals runSyncOnSerialSubQueue:self.readWriteQueue block:^{
+                    // If an observer object is nil, remove it
+                    if (observer.observer == nil) {
+                        [self.capabilityObservers[key] removeObject:observer];
+                    }
+
+                    // If we no longer have any observers for that type, remove the array
+                    if (self.capabilityObservers[key].count == 0) {
+                        [self.capabilityObservers removeObjectForKey:key];
+                    }
+                }];
+            }
         }
-    }
 
-    // If we don't support subscriptions, we don't want to unsubscribe by sending an RPC below
-    if (!self.supportsSubscriptions) {
-        return;
-    }
-
-    // Loop through our subscription statuses, check if we're subscribed. If we are, and we do not have observers for that type, and that type is not DISPLAYS, then unsubscribe.
-    for (SDLSystemCapabilityType type in self.subscriptionStatus.allKeys) {
-        if ([self.subscriptionStatus[type] isEqualToNumber:@YES]
-            && self.capabilityObservers[type] == nil
-            && ![type isEqualToEnum:SDLSystemCapabilityTypeDisplays]) {
-            SDLLogD(@"Removing the last subscription to type %@, sending a GetSystemCapability with subscribe false (will unsubscribe)", type);
-            [self sdl_sendGetSystemCapabilityWithType:type subscribe:@NO completionHandler:nil];
+        // If we don't support subscriptions, we don't want to unsubscribe by sending an RPC below
+        if (!self.supportsSubscriptions) {
+            return;
         }
-    }
+
+        // Loop through our subscription statuses, check if we're subscribed. If we are, and we do not have observers for that type, and that type is not DISPLAYS, then unsubscribe.
+        for (SDLSystemCapabilityType type in self.subscriptionStatus.allKeys) {
+            if ([self.subscriptionStatus[type] isEqualToNumber:@YES]
+                && self.capabilityObservers[type] == nil
+                && ![type isEqualToEnum:SDLSystemCapabilityTypeDisplays]) {
+                SDLLogD(@"Removing the last subscription to type %@, sending a GetSystemCapability with subscribe false (will unsubscribe)", type);
+                [self sdl_sendGetSystemCapabilityWithType:type subscribe:@NO completionHandler:nil];
+            }
+        }
+    }];
 }
 
 #pragma mark Notifying Subscribers
@@ -736,9 +738,9 @@ typedef NSString * SDLServiceID;
 }
 
 /**
- *  Called when a `SetDisplayLayoutResponse` response is received from Core. If the template was set successfully, the the new capabilities for the template are saved.
+ * Called when a `SetDisplayLayoutResponse` response is received from Core. If the template was set successfully, the the new capabilities for the template are saved.
  *
- *  @param notification The `SetDisplayLayoutResponse` response received from Core
+ * @param notification The `SetDisplayLayoutResponse` response received from Core
  */
 - (void)sdl_displayLayoutResponse:(SDLRPCResponseNotification *)notification {
 #pragma clang diagnostic push
@@ -784,36 +786,6 @@ typedef NSString * SDLServiceID;
 - (void)sdl_hmiStatusNotification:(SDLRPCNotificationNotification *)notification {
     SDLOnHMIStatus *onHMIStatus = (SDLOnHMIStatus *)notification.notification;
     self.currentHMILevel = onHMIStatus.hmiLevel;
-}
-
-
-#pragma mark Getters
-
-- (NSMutableDictionary<SDLSystemCapabilityType, NSMutableArray<SDLSystemCapabilityObserver *> *> *)capabilityObservers {
-    __block NSMutableDictionary<SDLSystemCapabilityType, NSMutableArray<SDLSystemCapabilityObserver *> *> *dict = nil;
-    [SDLGlobals runSyncOnSerialSubQueue:self.readWriteQueue block:^{
-        dict = self->_capabilityObservers;
-    }];
-
-    return dict;
-}
-
-- (NSMutableDictionary<SDLSystemCapabilityType, NSNumber<SDLBool> *> *)subscriptionStatus {
-    __block NSMutableDictionary<SDLSystemCapabilityType, NSNumber<SDLBool> *> *dict = nil;
-    [SDLGlobals runSyncOnSerialSubQueue:self.readWriteQueue block:^{
-        dict = self->_subscriptionStatus;
-    }];
-
-    return dict;
-}
-
-- (nullable NSMutableDictionary<SDLServiceID, SDLAppServiceCapability *> *)appServicesCapabilitiesDictionary {
-    __block NSMutableDictionary<SDLServiceID, SDLAppServiceCapability *> *dict = nil;
-    [SDLGlobals runSyncOnSerialSubQueue:self.readWriteQueue block:^{
-        dict = self->_appServicesCapabilitiesDictionary;
-    }];
-
-    return dict;
 }
 
 @end


### PR DESCRIPTION
Fixes #2033, #2036

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Ran unit tests to ensure they continue to pass

#### Core Tests
Repeatedly connect and disconnect device.

Core version / branch / commit hash / module tested against: Sync Gen 3.4
HMI name / version / branch / commit hash / module tested against: Sync Gen 3.4

### Summary
Fixed looping and setting system capability dictionaries without forcing sync on a serial queue.

### Changelog
##### Bug Fixes
* Fixed possible crashes when mutating system capabilities on two different threads (such as occasionally on disconnection)

### Tasks Remaining:
- [x] Core tests

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
