### PR TITLE
Fix completion handlers not being called

### DIFF
--- a/SmartDeviceLink/private/SDLCheckChoiceVROptionalOperation.m
+++ b/SmartDeviceLink/private/SDLCheckChoiceVROptionalOperation.m
@@ -12,6 +12,7 @@
 #import "SDLCreateInteractionChoiceSet.h"
 #import "SDLConnectionManagerType.h"
 #import "SDLDeleteInteractionChoiceSet.h"
+#import "SDLError.h"
 #import "SDLLogMacros.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -28,9 +29,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLCheckChoiceVROptionalOperation
 
-- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager completionHandler:(nonnull SDLCheckChoiceVROptionalCompletionHandler)completionHandler {
+- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager completionHandler:(SDLCheckChoiceVROptionalCompletionHandler)completionHandler {
     self = [super init];
-    if (!self) { return nil; }
+    if (!self) {
+        completionHandler(NO, [NSError sdl_failedToCreateObjectOfClass:[SDLCheckChoiceVROptionalOperation class]]);
+        return nil;
+    }
 
     _connectionManager = connectionManager;
     _operationId = [NSUUID UUID];

--- a/SmartDeviceLink/private/SDLChoiceSetManager.m
+++ b/SmartDeviceLink/private/SDLChoiceSetManager.m
@@ -222,7 +222,16 @@ UInt16 const ChoiceCellCancelIdMax = 200;
 
 - (void)preloadChoices:(NSArray<SDLChoiceCell *> *)choices withCompletionHandler:(nullable SDLPreloadChoiceCompletionHandler)handler {
     SDLLogV(@"Request to preload choices: %@", choices);
-    if (choices.count == 0) { return; }
+    if (choices.count == 0) {
+        if (handler != nil) {
+            handler([NSError sdl_choiceSetManager_choiceUploadFailed:@{
+                NSLocalizedDescriptionKey: @"Choice upload failed",
+                NSLocalizedFailureReasonErrorKey: @"No choices were provided for upload",
+                NSLocalizedRecoverySuggestionErrorKey: @"Provide some choice cells to upload instead of an empty list"
+            }]);
+        }
+        return;
+    }
     if (![self.currentState isEqualToString:SDLChoiceManagerStateReady]) {
         NSError *error = [NSError sdl_choiceSetManager_incorrectState:self.currentState];
         SDLLogE(@"Cannot preload choices when the manager isn't in the ready state: %@", error);

--- a/SmartDeviceLink/private/SDLDeleteChoicesOperation.m
+++ b/SmartDeviceLink/private/SDLDeleteChoicesOperation.m
@@ -37,7 +37,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager cellsToDelete:(NSSet<SDLChoiceCell *> *)cellsToDelete loadedCells:(NSSet<SDLChoiceCell *> *)loadedCells completionHandler:(SDLDeleteChoicesCompletionHandler)completionHandler {
     self = [super init];
-    if (!self) { return nil; }
+    if (!self) {
+        completionHandler(loadedCells, [NSError sdl_failedToCreateObjectOfClass:[SDLDeleteChoicesOperation class]]);
+        return nil;
+    }
 
     _connectionManager = connectionManager;
     _cellsToDelete = cellsToDelete;

--- a/SmartDeviceLink/private/SDLDeleteFileOperation.m
+++ b/SmartDeviceLink/private/SDLDeleteFileOperation.m
@@ -11,6 +11,7 @@
 #import "SDLConnectionManagerType.h"
 #import "SDLDeleteFile.h"
 #import "SDLDeleteFileResponse.h"
+#import "SDLError.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -28,6 +29,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithFileName:(NSString *)fileName connectionManager:(id<SDLConnectionManagerType>)connectionManager completionHandler:(nullable SDLFileManagerDeleteCompletionHandler)completionHandler {
     self = [super init];
     if (!self) {
+        if (completionHandler != nil) {
+            completionHandler(NO, NSNotFound, [NSError sdl_failedToCreateObjectOfClass:[SDLDeleteFileOperation class]]);
+        }
         return nil;
     }
 

--- a/SmartDeviceLink/private/SDLError.h
+++ b/SmartDeviceLink/private/SDLError.h
@@ -20,6 +20,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface NSError (SDLErrors)
 
++ (NSError *)sdl_failedToCreateObjectOfClass:(Class)objectClass;
+
 #pragma mark SDLEncryptionLifecycleManager
 + (NSError *)sdl_encryption_lifecycle_notReadyError;
 + (NSError *)sdl_encryption_lifecycle_encryption_off;

--- a/SmartDeviceLink/private/SDLError.h
+++ b/SmartDeviceLink/private/SDLError.h
@@ -58,6 +58,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSError *)sdl_softButtonManager_pendingUpdateSuperseded;
 + (NSError *)sdl_subscribeButtonManager_notSubscribed;
 + (NSError *)sdl_textAndGraphicManager_pendingUpdateSuperseded;
++ (NSError *)sdl_textAndGraphicManager_batchingUpdate;
++ (NSError *)sdl_textAndGraphicManager_nothingToUpdate;
 
 #pragma mark Menu Manager
 
@@ -91,6 +93,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSError *)sdl_systemCapabilityManager_moduleDoesNotSupportSystemCapabilities;
 + (NSError *)sdl_systemCapabilityManager_cannotUpdateInHMINONE;
 + (NSError *)sdl_systemCapabilityManager_cannotUpdateTypeDISPLAYS;
++ (NSError *)sdl_systemCapabilityManager_unknownSystemCapabilityType;
 
 #pragma mark Transport
 

--- a/SmartDeviceLink/private/SDLError.m
+++ b/SmartDeviceLink/private/SDLError.m
@@ -277,6 +277,22 @@ NS_ASSUME_NONNULL_BEGIN
     return [NSError errorWithDomain:SDLErrorDomainSubscribeButtonManager code:SDLSubscribeButtonManagerErrorNotSubscribed userInfo:userInfo];
 }
 
++ (NSError *)sdl_textAndGraphicManager_batchingUpdate {
+    return [NSError errorWithDomain:SDLErrorDomainTextAndGraphicManager code:SDLTextAndGraphicManagerErrorCurrentlyBatching userInfo:@{
+        NSLocalizedDescriptionKey: @"Update will not run because batching is enabled",
+        NSLocalizedFailureReasonErrorKey: @"Text and Graphic manager will not run this update and call this handler because its currently batching updates. The update will occur when batching ends.",
+        NSLocalizedRecoverySuggestionErrorKey: @"This callback shouldn't occur. Please open an issue on https://www.github.com/smartdevicelink/sdl_ios/ if it does"
+    }];
+}
+
++ (NSError *)sdl_textAndGraphicManager_nothingToUpdate {
+    return [NSError errorWithDomain:SDLErrorDomainTextAndGraphicManager code:SDLTextAndGraphicManagerErrorNothingToUpdate userInfo:@{
+        NSLocalizedDescriptionKey: @"Update will not run because there's nothing to update",
+        NSLocalizedFailureReasonErrorKey: @"This callback shouldn't occur, so there's no known reason for this failure.",
+        NSLocalizedRecoverySuggestionErrorKey: @"This callback shouldn't occur. Please open an issue on https://www.github.com/smartdevicelink/sdl_ios/ if it does"
+    }];
+}
+
 #pragma mark Menu Manager
 
 + (NSError *)sdl_menuManager_configurationOperationLayoutsNotSupported {
@@ -452,6 +468,14 @@ NS_ASSUME_NONNULL_BEGIN
                                                        NSLocalizedRecoverySuggestionErrorKey: @"Subscribe to DISPLAYS to automatically receive updates or retrieve a cached display capability value directly from the SystemCapabilityManager."
                                                        };
     return [NSError errorWithDomain:SDLErrorDomainSystemCapabilityManager code:SDLSystemCapabilityManagerErrorCannotUpdateTypeDisplays userInfo:userInfo];
+}
+
++ (NSError *)sdl_systemCapabilityManager_unknownSystemCapabilityType {
+    return [NSError errorWithDomain:SDLErrorDomainSystemCapabilityManager code:SDLSystemCapabilityManagerErrorUnknownType userInfo:@{
+        NSLocalizedDescriptionKey: @"An unknown system capability type was received.",
+        NSLocalizedFailureReasonErrorKey: @"Failure reason unknown. If you see this, please open an issue on https://www.github.com/smartdevicelink/sdl_ios/",
+        NSLocalizedRecoverySuggestionErrorKey: @"Ensure you are only attempting to manually subscribe to known system capability types for the version of this library. You may also want to update this library to its latest version."
+    }];
 }
 
 #pragma mark Transport

--- a/SmartDeviceLink/private/SDLError.m
+++ b/SmartDeviceLink/private/SDLError.m
@@ -15,6 +15,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation NSError (SDLErrors)
 
++ (NSError *)sdl_failedToCreateObjectOfClass:(Class)objectClass {
+    return [NSError errorWithDomain:SDLErrorDomainSystem code:SDLSystemErrorFailedToCreateObject userInfo:@{
+        NSLocalizedDescriptionKey: [NSString stringWithFormat: @"iOS system failed to create a new object of class: %@", objectClass],
+        NSLocalizedFailureReasonErrorKey: @"An unknown error caused iOS to fail to create an object",
+        NSLocalizedRecoverySuggestionErrorKey: @"There is no known way to fix this error"
+    }];
+}
+
 #pragma mark - SDLEncryptionLifecycleManager
 + (NSError *)sdl_encryption_lifecycle_notReadyError {
     NSDictionary<NSString *, NSString *> *userInfo = @{

--- a/SmartDeviceLink/private/SDLFileWrapper.m
+++ b/SmartDeviceLink/private/SDLFileWrapper.m
@@ -8,6 +8,7 @@
 
 #import "SDLFileWrapper.h"
 
+#import "SDLError.h"
 #import "SDLFile.h"
 
 
@@ -18,6 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithFile:(SDLFile *)file completionHandler:(SDLFileManagerUploadCompletionHandler)completionHandler {
     self = [super init];
     if (!self) {
+        completionHandler(NO, NSNotFound, [NSError sdl_failedToCreateObjectOfClass:[SDLFileWrapper class]]);
         return nil;
     }
 

--- a/SmartDeviceLink/private/SDLListFilesOperation.m
+++ b/SmartDeviceLink/private/SDLListFilesOperation.m
@@ -9,6 +9,7 @@
 #import "SDLListFilesOperation.h"
 
 #import "SDLConnectionManagerType.h"
+#import "SDLError.h"
 #import "SDLListFiles.h"
 #import "SDLListFilesResponse.h"
 
@@ -29,6 +30,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager completionHandler:(nullable SDLFileManagerListFilesCompletionHandler)completionHandler {
     self = [super init];
     if (!self) {
+        if (completionHandler != nil) {
+            completionHandler(NO, NSNotFound, @[], [NSError sdl_failedToCreateObjectOfClass:[SDLListFilesOperation class]]);
+        }
         return nil;
     }
 

--- a/SmartDeviceLink/private/SDLMenuShowOperation.m
+++ b/SmartDeviceLink/private/SDLMenuShowOperation.m
@@ -38,9 +38,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLMenuShowOperation
 
-- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager toMenuCell:(nullable SDLMenuCell *)menuCell completionHandler:(nonnull SDLMenuShowCompletionBlock)completionHandler {
+- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager toMenuCell:(nullable SDLMenuCell *)menuCell completionHandler:(SDLMenuShowCompletionBlock)completionHandler {
     self = [super init];
-    if (!self) { return nil; }
+    if (!self) {
+        completionHandler([NSError sdl_failedToCreateObjectOfClass:[SDLMenuShowOperation class]]);
+        return nil;
+    }
 
     _connectionManager = connectionManager;
     _submenuCell = menuCell;

--- a/SmartDeviceLink/private/SDLProtocolMessageAssembler.m
+++ b/SmartDeviceLink/private/SDLProtocolMessageAssembler.m
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
     // Validate input
     if (message.header.sessionID != self.sessionID) {
         SDLLogE(@"Message part sent to the wrong assembler. This session id: %d, message session id: %d", self.sessionID, message.header.sessionID);
-        return;
+        return completionHandler(NO, nil);
     }
 
     if (self.parts == nil) {

--- a/SmartDeviceLink/private/SDLSequentialRPCRequestOperation.m
+++ b/SmartDeviceLink/private/SDLSequentialRPCRequestOperation.m
@@ -34,7 +34,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager requests:(NSArray<SDLRPCRequest *> *)requests progressHandler:(nullable SDLMultipleSequentialRequestProgressHandler)progressHandler completionHandler:(nullable SDLMultipleRequestCompletionHandler)completionHandler {
     self = [super init];
-    if (!self) { return nil; }
+    if (!self) {
+        if (completionHandler != nil) {
+            completionHandler(NO);
+        }
+        return nil;
+    }
 
     executing = NO;
     finished = NO;

--- a/SmartDeviceLink/private/SDLTextAndGraphicManager.m
+++ b/SmartDeviceLink/private/SDLTextAndGraphicManager.m
@@ -150,11 +150,18 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Upload / Send
 
 - (void)updateWithCompletionHandler:(nullable SDLTextAndGraphicUpdateCompletionHandler)handler {
-    if (self.isBatchingUpdates) { return; }
-
-    if (self.isDirty) {
+    if (self.isBatchingUpdates) {
+        if (handler != nil) {
+            // This shouldn't be possible, but just in case
+            handler([NSError sdl_textAndGraphicManager_batchingUpdate]);
+        }
+    } else if (self.isDirty) {
         self.isDirty = NO;
         [self sdl_updateAndCancelPreviousOperations:YES completionHandler:handler];
+    } else {
+        if (handler != nil) {
+            handler([NSError sdl_textAndGraphicManager_nothingToUpdate]);
+        }
     }
 }
 

--- a/SmartDeviceLink/private/SDLVoiceCommandUpdateOperation.m
+++ b/SmartDeviceLink/private/SDLVoiceCommandUpdateOperation.m
@@ -39,7 +39,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager pendingVoiceCommands:(NSArray<SDLVoiceCommand *> *)pendingVoiceCommands oldVoiceCommands:(NSArray<SDLVoiceCommand *> *)oldVoiceCommands updateCompletionHandler:(SDLVoiceCommandUpdateCompletionHandler)completionHandler {
     self = [self init];
-    if (!self) { return nil; }
+    if (!self) {
+        completionHandler(@[], [NSError sdl_failedToCreateObjectOfClass:[SDLVoiceCommandUpdateOperation class]]);
+        return nil;
+    }
 
     _connectionManager = connectionManager;
     _pendingVoiceCommands = pendingVoiceCommands;

--- a/SmartDeviceLink/public/SDLErrorConstants.h
+++ b/SmartDeviceLink/public/SDLErrorConstants.h
@@ -177,7 +177,13 @@ typedef NS_ENUM(NSInteger, SDLFileManagerError) {
  */
 typedef NS_ENUM(NSInteger, SDLTextAndGraphicManagerError) {
     /// A pending update was superseded by a newer requested update. The old update will not be sent
-    SDLTextAndGraphicManagerErrorPendingUpdateSuperseded = -1
+    SDLTextAndGraphicManagerErrorPendingUpdateSuperseded = -1,
+
+    /// The manager is currently batching updates so the update will not yet be sent and the handler will not be called
+    SDLTextAndGraphicManagerErrorCurrentlyBatching = -2,
+
+    /// The manager could find nothing to update
+    SDLTextAndGraphicManagerErrorNothingToUpdate = -3,
 };
 
 /**
@@ -251,7 +257,10 @@ typedef NS_ENUM(NSInteger, SDLSystemCapabilityManagerError) {
     SDLSystemCapabilityManagerErrorHMINone = -2,
 
     /// You may not update the system capability type DISPLAYS because it is always subscribed
-    SDLSystemCapabilityManagerErrorCannotUpdateTypeDisplays = -3
+    SDLSystemCapabilityManagerErrorCannotUpdateTypeDisplays = -3,
+
+    /// The module sent an unknown system capability type
+    SDLSystemCapabilityManagerErrorUnknownType = -4,
 };
 
 /**

--- a/SmartDeviceLink/public/SDLErrorConstants.h
+++ b/SmartDeviceLink/public/SDLErrorConstants.h
@@ -13,6 +13,9 @@
 /// A typedef declaration of the SDL error domain
 typedef NSString SDLErrorDomain;
 
+/// An error with the iOS system
+extern SDLErrorDomain *const SDLErrorDomainSystem;
+
 /// An error in the SDLAudioStreamManager
 extern SDLErrorDomain *const SDLErrorDomainAudioStreamManager;
 
@@ -57,6 +60,12 @@ extern SDLErrorDomain *const SDLErrorDomainTransport;
 
 
 #pragma mark Error Codes
+
+/// Error associated with the underlying operating system
+typedef NS_ENUM(NSInteger, SDLSystemError) {
+    /// iOS failed to create an object
+    SDLSystemErrorFailedToCreateObject = -1
+};
 
 /**
  *  Errors associated with the SDLManager class.

--- a/SmartDeviceLink/public/SDLErrorConstants.m
+++ b/SmartDeviceLink/public/SDLErrorConstants.m
@@ -10,6 +10,7 @@
 
 #pragma mark Error Domains
 
+SDLErrorDomain *const SDLErrorDomainSystem = @"com.sdl.system.error";
 SDLErrorDomain *const SDLErrorDomainAudioStreamManager = @"com.sdl.extension.pcmAudioStreamManager";
 SDLErrorDomain *const SDLErrorDomainCacheFileManager = @"com.sdl.cachefilemanager.error";
 SDLErrorDomain *const SDLErrorDomainChoiceSetManager = @"com.sdl.choicesetmanager.error";

--- a/SmartDeviceLink/public/SDLFileManager.m
+++ b/SmartDeviceLink/public/SDLFileManager.m
@@ -407,7 +407,6 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
 
 - (void)sdl_uploadFile:(SDLFile *)file completionHandler:(nullable SDLFileManagerUploadCompletionHandler)handler {
     __block NSString *fileName = file.name;
-    __block SDLFileManagerUploadCompletionHandler uploadCompletion = [handler copy];
 
     __weak typeof(self) weakSelf = self;
     SDLFileWrapper *fileWrapper = [SDLFileWrapper wrapperWithFile:file completionHandler:^(BOOL success, NSUInteger bytesAvailable, NSError *_Nullable error) {
@@ -425,8 +424,8 @@ SDLFileManagerState *const SDLFileManagerStateStartupError = @"StartupError";
             }
         }
 
-        if (uploadCompletion != nil) {
-            uploadCompletion(success, bytesAvailable, error);
+        if (handler != nil) {
+            handler(success, bytesAvailable, error);
         }
     }];
 

--- a/SmartDeviceLink/public/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/public/SDLSystemCapabilityManager.m
@@ -450,11 +450,13 @@ typedef NSString * SDLServiceID;
         [self sdl_saveDisplayCapabilityListUpdate:systemCapability.displayCapabilities];
     } else {
         SDLLogW(@"Received response for unknown System Capability Type: %@", systemCapabilityType);
+        if (handler != nil) {
+            handler(systemCapability, NO, [NSError sdl_systemCapabilityManager_unknownSystemCapabilityType]);
+        }
         return NO;
     }
 
     SDLLogD(@"Updated system capability manager with new data: %@", systemCapability);
-
     [self sdl_callObserversForUpdate:systemCapability error:error handler:handler];
     return YES;
 }

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLPreloadPresentChoicesOperationSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLPreloadPresentChoicesOperationSpec.m
@@ -293,7 +293,7 @@ describe(@"a preload choices operation", ^{
                     });
                 });
 
-                fcontext(@"when artworks are not already on the system", ^{
+                context(@"when artworks are not already on the system", ^{
                     beforeEach(^{
                         OCMStub([testFileManager hasUploadedFile:[OCMArg isNotNil]]).andReturn(NO);
                     });


### PR DESCRIPTION
Fixes #2044 

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
None

#### Core Tests
Basic connection test with Manticore

Core version / branch / commit hash / module tested against: Manticore (Core v7.1.0)
HMI name / version / branch / commit hash / module tested against: Manticore (Generic HMI v0.10.0)

### Summary
This PR fixes warnings from Xcode 13 about code paths that don't result in the completion handler being called

### Changelog
##### Bug Fixes
* Fixed code paths that resulted in a completion handler never being called

### Tasks Remaining:
None

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
