### PR TITLE
Fix menu configuration update crash

### DIFF
--- a/SmartDeviceLink/private/SDLMenuConfigurationUpdateOperation.m
+++ b/SmartDeviceLink/private/SDLMenuConfigurationUpdateOperation.m
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (weak, nonatomic) id<SDLConnectionManagerType> connectionManager;
 @property (strong, nonatomic) NSArray<SDLMenuLayout> *availableMenuLayouts;
 @property (strong, nonatomic) SDLMenuConfiguration *updatedMenuConfiguration;
-@property (assign, nonatomic) SDLMenuConfigurationUpdatedBlock menuConfigurationUpdatedBlock;
+@property (copy, nonatomic) SDLMenuConfigurationUpdatedBlock menuConfigurationUpdatedBlock;
 
 @property (copy, nonatomic, nullable) NSError *internalError;
 


### PR DESCRIPTION
Fixes #2051 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
n/a

#### Core Tests
Tested changing the menu configuration

Core version / branch / commit hash / module tested against: v7.1.1
HMI name / version / branch / commit hash / module tested against: v0.10.0

### Summary
This PR fixes a crashing bug when changing the menu configuration. This was introduced in v7.3.0-rc.1

### Changelog
##### Bug Fixes
* n/a internal to this release

### Tasks Remaining:
n/a

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
