### PR TITLE
Fix submenu layout is not copied on menu cells

### DIFF
--- a/SmartDeviceLink/public/SDLMenuCell.m
+++ b/SmartDeviceLink/public/SDLMenuCell.m
@@ -134,6 +134,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     if (_subCells.count > 0) {
         newCell.subCells = [[NSArray alloc] initWithArray:_subCells copyItems:YES];
+        newCell->_submenuLayout = _submenuLayout;
     }
 
     return newCell;

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLMenuCellSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLMenuCellSpec.m
@@ -15,6 +15,8 @@ describe(@"a menu cell", ^{
     __block NSString *someTertiaryTitle = nil;
     __block SDLArtwork *someArtwork = nil;
     __block SDLArtwork *someSecondaryArtwork = nil;
+    __block NSArray<NSString *> *someVoiceCommands = nil;
+    __block NSArray<SDLMenuCell *> *someSubcells = nil;
 
     beforeEach(^{
         someTitle = @"Some Title";
@@ -22,19 +24,11 @@ describe(@"a menu cell", ^{
         someTertiaryTitle = @"Some Title 3";
         someArtwork = [[SDLArtwork alloc] initWithData:[[NSData alloc] initWithBase64EncodedString:@"data" options:kNilOptions] name:@"Some artwork" fileExtension:@"png" persistent:NO];
         someSecondaryArtwork = [[SDLArtwork alloc] initWithData:[[NSData alloc] initWithBase64EncodedString:@"data" options:kNilOptions] name:@"Some artwork 2" fileExtension:@"png" persistent:NO];
+        someVoiceCommands = @[@"some command"];
+        someSubcells = @[[[SDLMenuCell alloc] initWithTitle:@"Test Subcell" secondaryText:nil tertiaryText:nil icon:nil secondaryArtwork:nil voiceCommands:nil handler:^(SDLTriggerSource  _Nonnull triggerSource) {}], [[SDLMenuCell alloc] initWithTitle:@"Test Subcell2" secondaryText:nil tertiaryText:nil icon:nil secondaryArtwork:nil voiceCommands:nil handler:^(SDLTriggerSource  _Nonnull triggerSource) {}]];
     });
 
     describe(@"initializing", ^{
-        __block NSArray<NSString *> *someVoiceCommands = nil;
-        __block NSArray<SDLMenuCell *> *someSubcells = nil;
-
-        beforeEach(^{
-            someVoiceCommands = @[@"some command"];
-
-            SDLMenuCell *subcell = [[SDLMenuCell alloc] initWithTitle:@"Hello" secondaryText:nil tertiaryText:nil icon:nil secondaryArtwork:nil voiceCommands:nil handler:^(SDLTriggerSource  _Nonnull triggerSource) {}];
-            someSubcells = @[subcell];
-        });
-
         it(@"should set initWithTitle:icon:submenuLayout:subCells: propertly", ^{
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -133,6 +127,24 @@ describe(@"a menu cell", ^{
 #pragma clang diagnostic pop
 
             expect([testCell isEqual:testCell2]).to(beFalse());
+        });
+    });
+
+    describe(@"copying a cell", ^{
+        context(@"a submenu cell", ^{
+            it(@"should copy correctly", ^{
+                testCell = [[SDLMenuCell alloc] initWithTitle:someTitle secondaryText:someSecondaryTitle tertiaryText:someTertiaryTitle icon:someArtwork secondaryArtwork:someSecondaryArtwork submenuLayout:testLayout subCells:someSubcells];
+                testCell2 = [testCell copy];
+
+                expect(testCell2).to(equal(testCell));
+            });
+        });
+
+        context(@"a normal cell", ^{
+            testCell = [[SDLMenuCell alloc] initWithTitle:someTitle secondaryText:someSecondaryTitle tertiaryText:someTertiaryTitle icon:someArtwork secondaryArtwork:someSecondaryArtwork voiceCommands:someVoiceCommands handler:^(SDLTriggerSource  _Nonnull triggerSource) {}];
+            testCell2 = [testCell copy];
+
+            expect(testCell2).to(equal(testCell));
         });
     });
 });


### PR DESCRIPTION
Fixes #2048 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Unit tests for copying SDLMenuCell are added

#### Core Tests
Created a cell with a submenu with the submenu layout as TILES

Core version / branch / commit hash / module tested against: Manticore (Core v7.1.1)
HMI name / version / branch / commit hash / module tested against: Manticore (Generic HMI 

### Summary
This PR fixes copying a menu cell does not copy the submenu layout

### Changelog
##### Bug Fixes
* Fixed submenu cells not using the submenu layout

### Tasks Remaining:
n/a

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
