### PR TITLE
Fixed missing error description/code in security notifications

### DIFF
--- a/SmartDeviceLink/private/SDLProtocol.m
+++ b/SmartDeviceLink/private/SDLProtocol.m
@@ -869,8 +869,8 @@ NS_ASSUME_NONNULL_BEGIN
 
     // For a control service packet, we need a binary header with a function ID corresponding to what type of packet we're sending.
     UInt8 errorCode = 0xFF;
-    NSDictionary *jsonDictionary = @{@"id" : @0xFF, @"text" : [SDLSecurityQueryError convertErrorIdToStringEnum:@(errorCode)]};
-    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:jsonDictionary options:NSJSONWritingPrettyPrinted error:nil];
+    NSDictionary *jsonDictionary = @{@"id" : @(errorCode), @"text" : [SDLSecurityQueryError convertErrorIdToStringEnum:@(errorCode)]};
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:jsonDictionary options:kNilOptions error:nil];
 
     NSData *binaryDataPayload = [NSData dataWithBytes:&errorCode length:sizeof(errorCode)];
     SDLSecurityQueryPayload *serverTLSPayload = [[SDLSecurityQueryPayload alloc] initWithQueryType:SDLSecurityQueryTypeNotification queryID:SDLSecurityQueryIdSendInternalError sequenceNumber:0x00 jsonData:jsonData binaryData:binaryDataPayload];

--- a/SmartDeviceLink/private/SDLProtocol.m
+++ b/SmartDeviceLink/private/SDLProtocol.m
@@ -828,7 +828,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (serverHandshakeData == nil) {
         SDLLogE(@"Error running TLS handshake procedure. Sending error to module. Error: %@", handshakeError);
 
-        serverSecurityMessage = [self.class sdl_serverSecurityFailedMessageWithClientMessageHeader:clientHandshakeMessage.header messageId:++_messageID handshakeError:handshakeError];
+        serverSecurityMessage = [self.class sdl_serverSecurityFailedMessageWithClientMessageHeader:clientHandshakeMessage.header messageId:++_messageID];
     } else {
         // The handshake went fine, send the module the remaining handshake data
         serverSecurityMessage = [self.class sdl_serverSecurityHandshakeMessageWithData:serverHandshakeData clientMessageHeader:clientHandshakeMessage.header messageId:++_messageID];
@@ -857,7 +857,7 @@ NS_ASSUME_NONNULL_BEGIN
     return [SDLProtocolMessage messageWithHeader:serverMessageHeader andPayload:binaryData];
 }
 
-+ (SDLProtocolMessage *)sdl_serverSecurityFailedMessageWithClientMessageHeader:(SDLProtocolHeader *)clientHeader messageId:(UInt32)messageId handshakeError:(NSError *)handshakeError {
++ (SDLProtocolMessage *)sdl_serverSecurityFailedMessageWithClientMessageHeader:(SDLProtocolHeader *)clientHeader messageId:(UInt32)messageId {
     // This can't possibly be a v1 header because v1 does not have control protocol messages
     SDLV2ProtocolHeader *serverMessageHeader = [SDLProtocolHeader headerForVersion:clientHeader.version];
     serverMessageHeader.encrypted = NO;
@@ -868,12 +868,11 @@ NS_ASSUME_NONNULL_BEGIN
     serverMessageHeader.messageID = messageId;
 
     // For a control service packet, we need a binary header with a function ID corresponding to what type of packet we're sending.
-    UInt8 codeError = (UInt8)handshakeError.code;
-
-    NSDictionary *jsonDictionary = @{@"id" : @(codeError), @"text" : [SDLSecurityQueryError convertErrorIdToStringEnum:@(codeError)]};
+    UInt8 errorCode = 0xFF;
+    NSDictionary *jsonDictionary = @{@"id" : @0xFF, @"text" : [SDLSecurityQueryError convertErrorIdToStringEnum:@(errorCode)]};
     NSData *jsonData = [NSJSONSerialization dataWithJSONObject:jsonDictionary options:NSJSONWritingPrettyPrinted error:nil];
 
-    NSData *binaryDataPayload = [NSData dataWithBytes:&index length:sizeof(codeError)];
+    NSData *binaryDataPayload = [NSData dataWithBytes:&errorCode length:sizeof(errorCode)];
     SDLSecurityQueryPayload *serverTLSPayload = [[SDLSecurityQueryPayload alloc] initWithQueryType:SDLSecurityQueryTypeNotification queryID:SDLSecurityQueryIdSendInternalError sequenceNumber:0x00 jsonData:jsonData binaryData:binaryDataPayload];
 
     NSData *binaryData = [serverTLSPayload convertToData];


### PR DESCRIPTION
Fixes #2049 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
N/A

#### Core Tests
Tested setting a serverHandshakeData on runtime to force a run of `sdl_serverSecurityFailedMessageWithClientMessageHeader` in order to check if the control message created by the app is formed correctly as instructed in the proposal

Core version / branch / commit hash / module tested against: 8.0.0
HMI name / version / branch / commit hash / module tested against: generic_hmi v0.11.0

### Summary
Added a jsonData and binaryData based on the proposal to our SDLSecurity in case our serverHandshakeData has failed

### Changelog
##### Breaking Changes
* Added a jsonData and binaryData based on the proposal to our SDLSecurity in case our serverHandshakeData has failed

##### Enhancements
* N/A

##### Bug Fixes
* N/A

### Tasks Remaining:
N/A

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
