### PR TITLE
Fixed lockScreen not presenting after user dismissal

### DIFF
--- a/SmartDeviceLink/private/SDLLockScreenManager.m
+++ b/SmartDeviceLink/private/SDLLockScreenManager.m
@@ -224,7 +224,7 @@ NS_ASSUME_NONNULL_BEGIN
         self.lockScreenDismissedByUser = NO;
     }
 
-    if (!self.lockScreenDismissedByUser) {
+    if (!self.lockScreenDismissedByUser || !self.lockScreenDismissable) {
         [self sdl_updateLockscreenViewControllerWithDismissableState:self.lockScreenDismissable];
     }
 }


### PR DESCRIPTION
Fixes #2061 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
N/A

#### Core Tests
Ran the failing test mentioned in issue. #886

Core version / branch / commit hash / module tested against: N/A
HMI name / version / branch / commit hash / module tested against: Manticore

### Summary
Enable the lockScreen to be presented even after user dismissal, if the enableLockScreenDismissal value received from module is `false` when the displayMode is .always

### Changelog
##### Breaking Changes
* N/A

##### Enhancements
* N/A

##### Bug Fixes
* Enable the lockScreen to be presented even after user dismissal, if the enableLockScreenDismissal value received from module is `false` when the displayMode is .always

### Tasks Remaining:
N/A

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
