### PR TITLE
Fix searchable choice set callbacks are incorrect

### DIFF
--- a/SmartDeviceLink/private/SDLPreloadPresentChoicesOperation.m
+++ b/SmartDeviceLink/private/SDLPreloadPresentChoicesOperation.m
@@ -366,8 +366,10 @@ typedef NS_ENUM(NSUInteger, SDLPreloadPresentChoicesOperationState) {
         }
 
         SDLPerformInteractionResponse *performResponse = response;
-        [weakself sdl_setSelectedCellWithId:performResponse.choiceID];
-        weakself.selectedTriggerSource = performResponse.triggerSource;
+        if (![performResponse.triggerSource isEqualToEnum:SDLTriggerSourceKeyboard]) {
+            [weakself sdl_setSelectedCellWithId:performResponse.choiceID];
+            weakself.selectedTriggerSource = performResponse.triggerSource;
+        }
 
         return completionHandler(error);
     }];

--- a/SmartDeviceLink/private/SDLPreloadPresentChoicesOperation.m
+++ b/SmartDeviceLink/private/SDLPreloadPresentChoicesOperation.m
@@ -162,6 +162,8 @@ typedef NS_ENUM(NSUInteger, SDLPreloadPresentChoicesOperationState) {
     [super start];
     if (self.isCancelled) { return; }
 
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_keyboardInputNotification:) name:SDLDidReceiveKeyboardInputNotification object:nil];
+
     // If we have no loaded cells, reset choice ids to ensure reconnections restart numbering
     if (self.loadedCells.count == 0) {
         SDLPreloadPresentChoicesOperationUtilities.choiceId = 0;
@@ -310,8 +312,6 @@ typedef NS_ENUM(NSUInteger, SDLPreloadPresentChoicesOperationState) {
 - (void)sdl_updateKeyboardPropertiesWithCompletionHandler:(void(^)(NSError *_Nullable))completionHandler {
     self.currentState = SDLPreloadPresentChoicesOperationStateUpdatingKeyboardProperties;
     if (self.keyboardDelegate == nil) { return completionHandler(nil); }
-
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_keyboardInputNotification:) name:SDLDidReceiveKeyboardInputNotification object:nil];
 
     // Check if we're using a keyboard (searchable) choice set and setup keyboard properties if we need to
     if (self.keyboardDelegate != nil && [self.keyboardDelegate respondsToSelector:@selector(customKeyboardConfiguration)]) {


### PR DESCRIPTION
Fixes #2064

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
None changed

#### Core Tests
1. Present a searchable choice set
2. Submit a keyboard search
3. Multiple keyboard callbacks occur, but only one per keypress should be
3. No choice cell should be selected, but one is

Core version / branch / commit hash / module tested against: Sync 3.4
HMI name / version / branch / commit hash / module tested against: Sync 3.4

### Summary
This PR ensures that a cell is not selected if the input from the perform interaction is a keyboard input.

### Changelog
##### Bug Fixes
* Fixes choice cell callbacks when keyboard input is submitted
* Fixes multiple keyboard input callbacks for each keypress

### Tasks Remaining:
n/a

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
