### PR TITLE
Fix potential lock screen race condition

### DIFF
--- a/SmartDeviceLink/private/SDLLockScreenManager.m
+++ b/SmartDeviceLink/private/SDLLockScreenManager.m
@@ -17,6 +17,7 @@
 #import "SDLNotificationDispatcher.h"
 #import "SDLLockScreenStatusInfo.h"
 #import "SDLOnDriverDistraction.h"
+#import "SDLOnHMIStatus.h"
 #import "SDLRPCNotificationNotification.h"
 #import "SDLViewControllerPresentable.h"
 
@@ -52,7 +53,8 @@ NS_ASSUME_NONNULL_BEGIN
     _presenter = presenter;
     _lockScreenDismissedByUser = NO;
     _statusManager = [[SDLLockScreenStatusManager alloc] initWithNotificationDispatcher:dispatcher];
-    
+
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_hmiStatusDidChange:) name:SDLDidChangeHMIStatusNotification object:dispatcher];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_lockScreenStatusDidChange:) name:SDLDidChangeLockScreenStatusNotification object:dispatcher];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_lockScreenIconReceived:) name:SDLDidReceiveLockScreenIcon object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_appDidBecomeActive:) name:UIApplicationDidBecomeActiveNotification object:nil];
@@ -131,7 +133,6 @@ NS_ASSUME_NONNULL_BEGIN
     if (lockScreenStatus == nil) { return; }
 
     self.lastLockNotification = lockScreenStatus;
-
     [self sdl_checkLockScreen];
 }
 
@@ -161,18 +162,26 @@ NS_ASSUME_NONNULL_BEGIN
     });
 }
 
+- (void)sdl_hmiStatusDidChange:(SDLRPCNotificationNotification *)notification {
+    if (![notification isNotificationMemberOfClass:[SDLOnHMIStatus class]]) { return; }
+
+    [self.statusManager updateHMIStatus:notification.notification];
+}
+
 - (void)sdl_driverDistractionStateDidChange:(SDLRPCNotificationNotification *)notification {
-    if (![notification isNotificationMemberOfClass:[SDLOnDriverDistraction class]]) {
-        return;
-    }
+    if (![notification isNotificationMemberOfClass:[SDLOnDriverDistraction class]]) { return; }
+
     // When an `OnDriverDistraction` notification is sent with a `lockScreenDismissalEnabled` value, keep track of said value if subsequent `OnDriverDistraction`s are missing the `lockScreenDismissalEnabled` value. This is done because the `lockScreenDismissalEnabled` state is assumed to be the same value until a new `lockScreenDismissalEnabled` value is received.
     SDLOnDriverDistraction *currentDriverDistraction = notification.notification;
     if (currentDriverDistraction.lockScreenDismissalEnabled == nil && self.lastDriverDistractionNotification.lockScreenDismissalEnabled != nil){
         currentDriverDistraction.lockScreenDismissalEnabled = self.lastDriverDistractionNotification.lockScreenDismissalEnabled;
         currentDriverDistraction.lockScreenDismissalWarning = self.lastDriverDistractionNotification.lockScreenDismissalWarning;
     }
+
+    // Update dismissible state, then update the lock screen status itself
     self.lastDriverDistractionNotification = currentDriverDistraction;
     [self sdl_updateLockScreenDismissable];
+    [self.statusManager updateDriverDistractionState:currentDriverDistraction];
 }
 
 #pragma mark - Private Helpers

--- a/SmartDeviceLink/private/SDLLockScreenManager.m
+++ b/SmartDeviceLink/private/SDLLockScreenManager.m
@@ -177,9 +177,9 @@ NS_ASSUME_NONNULL_BEGIN
         currentDriverDistraction.lockScreenDismissalEnabled = self.lastDriverDistractionNotification.lockScreenDismissalEnabled;
         currentDriverDistraction.lockScreenDismissalWarning = self.lastDriverDistractionNotification.lockScreenDismissalWarning;
     }
+    self.lastDriverDistractionNotification = currentDriverDistraction;
 
     // Update dismissible state, then update the lock screen status itself
-    self.lastDriverDistractionNotification = currentDriverDistraction;
     [self sdl_updateLockScreenDismissable];
     [self.statusManager updateDriverDistractionState:currentDriverDistraction];
 }

--- a/SmartDeviceLink/private/SDLLockScreenStatusInfo.m
+++ b/SmartDeviceLink/private/SDLLockScreenStatusInfo.m
@@ -37,7 +37,15 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"driverDistractionStatus: %@, userSelected: %@, lockScreenStatus: %lu, hmiLevel: %@", self.driverDistractionStatus, self.userSelected, (unsigned long)self.lockScreenStatus, self.hmiLevel];
+    return [NSString stringWithFormat:@"driverDistractionStatus: %@, userSelected: %@, lockScreenStatus: %@, hmiLevel: %@", (self.driverDistractionStatus ? @"ON" : @"OFF"), (self.userSelected ? @"YES" : @"NO"), [self descriptionForStatus:self.lockScreenStatus], self.hmiLevel];
+}
+
+- (NSString *)descriptionForStatus:(SDLLockScreenStatus)status {
+    switch (status) {
+        case SDLLockScreenStatusOff: return @"Off";
+        case SDLLockScreenStatusOptional: return @"Optional";
+        case SDLLockScreenStatusRequired: return @"Required";
+    }
 }
 
 @end

--- a/SmartDeviceLink/private/SDLLockScreenStatusManager.h
+++ b/SmartDeviceLink/private/SDLLockScreenStatusManager.h
@@ -8,8 +8,10 @@
 #import "SDLHMILevel.h"
 #import "SDLLockScreenConstants.h"
 
-@class SDLNotificationDispatcher;
 @class SDLLockScreenStatusInfo;
+@class SDLNotificationDispatcher;
+@class SDLOnDriverDistraction;
+@class SDLOnHMIStatus;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -26,6 +28,9 @@ static NSString *const SDLDidChangeLockScreenStatusNotification = @"com.sdl.noti
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithNotificationDispatcher:(SDLNotificationDispatcher *)dispatcher;
+
+- (void)updateHMIStatus:(SDLOnHMIStatus *)hmiStatus;
+- (void)updateDriverDistractionState:(SDLOnDriverDistraction *)driverDistraction;
 
 @end
 

--- a/SmartDeviceLink/private/SDLLockScreenStatusManager.m
+++ b/SmartDeviceLink/private/SDLLockScreenStatusManager.m
@@ -31,6 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
     self = [super init];
     if (!self) { return nil; }
 
+    _notificationDispatcher = dispatcher;
     _userSelected = NO;
     _driverDistracted = NO;
     _haveDriverDistractionStatus = NO;

--- a/SmartDeviceLink/private/SDLLockScreenStatusManager.m
+++ b/SmartDeviceLink/private/SDLLockScreenStatusManager.m
@@ -34,14 +34,21 @@ NS_ASSUME_NONNULL_BEGIN
     _userSelected = NO;
     _driverDistracted = NO;
     _haveDriverDistractionStatus = NO;
-    _notificationDispatcher = dispatcher;
-
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_hmiStatusDidUpdate:) name:SDLDidChangeHMIStatusNotification object:dispatcher];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sdl_driverDistractionDidUpdate:) name:SDLDidChangeDriverDistractionStateNotification object:dispatcher];
 
     return self;
 }
 
+#pragma mark - Component Updates
+
+- (void)updateHMIStatus:(SDLOnHMIStatus *)hmiStatus {
+    self.hmiLevel = hmiStatus.hmiLevel;
+    [self sdl_postLockScreenStatus:self.lockScreenStatusNotification];
+}
+
+- (void)updateDriverDistractionState:(SDLOnDriverDistraction *)driverDistraction {
+    self.driverDistracted = [driverDistraction.state isEqualToEnum:SDLDriverDistractionStateOn];
+    [self sdl_postLockScreenStatus:self.lockScreenStatusNotification];
+}
 
 #pragma mark - Getters / Setters
 #pragma mark Custom setters
@@ -110,22 +117,6 @@ NS_ASSUME_NONNULL_BEGIN
     SDLLogD(@"Lock screen status changed: %@", statusNotification);
 
     [self.notificationDispatcher postNotificationName:SDLDidChangeLockScreenStatusNotification infoObject:statusNotification];
-}
-
-#pragma mark - Observers
-
-- (void)sdl_hmiStatusDidUpdate:(SDLRPCNotificationNotification *)notification {
-    SDLOnHMIStatus *hmiStatus = notification.notification;
-
-    self.hmiLevel = hmiStatus.hmiLevel;
-    [self sdl_postLockScreenStatus:self.lockScreenStatusNotification];
-}
-
-- (void)sdl_driverDistractionDidUpdate:(SDLRPCNotificationNotification *)notification {
-    SDLOnDriverDistraction *driverDistraction = notification.notification;
-
-    self.driverDistracted = [driverDistraction.state isEqualToEnum:SDLDriverDistractionStateOn];
-    [self sdl_postLockScreenStatus:self.lockScreenStatusNotification];
 }
 
 @end

--- a/SmartDeviceLinkTests/ProxySpecs/SDLLockScreenStatusManagerSpec.m
+++ b/SmartDeviceLinkTests/ProxySpecs/SDLLockScreenStatusManagerSpec.m
@@ -270,8 +270,7 @@ describe(@"the lockscreen status manager", ^{
             }]]);
 
             SDLOnHMIStatus *hmiStatus = [[SDLOnHMIStatus alloc] initWithHMILevel:SDLHMILevelFull systemContext:SDLSystemContextMain audioStreamingState:SDLAudioStreamingStateAudible videoStreamingState:nil windowID:nil];
-            SDLRPCNotificationNotification *hmiStatusNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidChangeHMIStatusNotification object:mockDispatcher rpcNotification:hmiStatus];
-            [[NSNotificationCenter defaultCenter] postNotification:hmiStatusNotification];
+            [testManager updateHMIStatus:hmiStatus];
         });
 
         it(@"should update the driver distraction status and send a notification", ^{
@@ -290,8 +289,7 @@ describe(@"the lockscreen status manager", ^{
 
             SDLOnDriverDistraction *driverDistraction = [[SDLOnDriverDistraction alloc] init];
             driverDistraction.state = SDLDriverDistractionStateOn;
-            SDLRPCNotificationNotification *driverDistractionStateNotification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidChangeDriverDistractionStateNotification object:mockDispatcher rpcNotification:driverDistraction];
-            [[NSNotificationCenter defaultCenter] postNotification:driverDistractionStateNotification];
+            [testManager updateDriverDistractionState:driverDistraction];
         });
 
         it(@"should update the driver distraction status and send a notification", ^{


### PR DESCRIPTION
Fixes #2063 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Fixed broken unit tests to expect messages, not notifications

#### Core Tests
* Connect, then enable and disable driver distraction

Core version / branch / commit hash / module tested against: Sync 3.4
HMI name / version / branch / commit hash / module tested against: Sync 3.4

### Summary
This PR updates the lock screen manager and lock screen status manager to fix a potential race condition. The LSM owns the LSSM, so instead of observing the same notifications, we have the LSM message the LSSM when the HMI status or driver distraction notifications change.

### Changelog
##### Bug Fixes
* Fixed a potential race condition between the lock screen manager and lock screen status manager. This could result in undefined lock screen behavior.

### Tasks Remaining:
n/a

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
