### PR TITLE
Fix initializing soft button object error states

### DIFF
--- a/SmartDeviceLink/public/SDLSoftButtonObject.m
+++ b/SmartDeviceLink/public/SDLSoftButtonObject.m
@@ -42,10 +42,16 @@ NS_ASSUME_NONNULL_BEGIN
             hasStateWithInitialName = YES;
         }
     }
-    NSAssert(![self sdl_hasTwoStatesOfSameName:states], @"A SoftButtonObject must have states with different names.");
+    NSAssert(![SDLSoftButtonObject sdl_hasTwoStatesOfSameName:states], @"A SoftButtonObject must have states with different names.");
     NSAssert(hasStateWithInitialName, @"A SoftButtonObject must have a state with initialStateName.");
-    if ([self sdl_hasTwoStatesOfSameName:states]) { return nil; }
-    if (!hasStateWithInitialName) { return nil; }
+    if ([SDLSoftButtonObject sdl_hasTwoStatesOfSameName:states]) {
+        SDLLogE(@"Error creating soft button object: the soft button object was created with two states of the same name. Soft button object name: %@, states: %@, initialStateName: %@", name, states, initialStateName);
+        return nil;
+    }
+    if (!hasStateWithInitialName) {
+        SDLLogE(@"Error creating soft button object: the soft button object does not have a state with the specified initial state name. Soft button object name: %@, states: %@, initialStateName: %@", name, states, initialStateName);
+        return nil;
+    }
 
     _name = name;
     _states = states;
@@ -127,7 +133,7 @@ NS_ASSUME_NONNULL_BEGIN
     return nil;
 }
 
-- (BOOL)sdl_hasTwoStatesOfSameName:(NSArray<SDLSoftButtonState *> *)states {
++ (BOOL)sdl_hasTwoStatesOfSameName:(NSArray<SDLSoftButtonState *> *)states {
     for (NSUInteger i = 0; i < states.count; i++) {
         NSString *stateName = states[i].name;
         for (NSUInteger j = (i + 1); j < states.count; j++) {

--- a/SmartDeviceLink/public/SDLSoftButtonObject.m
+++ b/SmartDeviceLink/public/SDLSoftButtonObject.m
@@ -36,10 +36,18 @@ NS_ASSUME_NONNULL_BEGIN
     self = [super init];
     if (!self) { return nil; }
 
-    // Make sure there aren't two states with the same name
-    if ([self sdl_hasTwoStatesOfSameName:states]) {
-        return nil;
+    BOOL hasStateWithInitialName = NO;
+    for (SDLSoftButtonState *state in states) {
+        if ([state.name isEqualToString:initialStateName]) {
+            hasStateWithInitialName = YES;
+        }
     }
+
+    // Make sure there aren't two states with the same name
+    NSAssert(![self sdl_hasTwoStatesOfSameName:states], @"A SoftButtonObject must have states with different names.");
+    NSAssert(hasStateWithInitialName, @"A SoftButtonObject must have a state with initialStateName.");
+    if ([self sdl_hasTwoStatesOfSameName:states]) { return nil; }
+    if (!hasStateWithInitialName) { return nil; }
 
     _name = name;
     _states = states;

--- a/SmartDeviceLink/public/SDLSoftButtonObject.m
+++ b/SmartDeviceLink/public/SDLSoftButtonObject.m
@@ -42,8 +42,6 @@ NS_ASSUME_NONNULL_BEGIN
             hasStateWithInitialName = YES;
         }
     }
-
-    // Make sure there aren't two states with the same name
     NSAssert(![self sdl_hasTwoStatesOfSameName:states], @"A SoftButtonObject must have states with different names.");
     NSAssert(hasStateWithInitialName, @"A SoftButtonObject must have a state with initialStateName.");
     if ([self sdl_hasTwoStatesOfSameName:states]) { return nil; }

--- a/SmartDeviceLink/public/SDLSoftButtonObject.m
+++ b/SmartDeviceLink/public/SDLSoftButtonObject.m
@@ -40,6 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
     for (SDLSoftButtonState *state in states) {
         if ([state.name isEqualToString:initialStateName]) {
             hasStateWithInitialName = YES;
+            break;
         }
     }
     NSAssert(![SDLSoftButtonObject sdl_hasTwoStatesOfSameName:states], @"A SoftButtonObject must have states with different names.");

--- a/SmartDeviceLink/public/SDLSoftButtonState.m
+++ b/SmartDeviceLink/public/SDLSoftButtonState.m
@@ -33,6 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithStateName:(NSString *)stateName text:(nullable NSString *)text image:(nullable UIImage *)image {
     NSParameterAssert((text != nil) || (image != nil));
+    if ((text == nil) && (image == nil)) { return nil; }
 
     SDLArtwork *artwork = [[SDLArtwork alloc] initWithImage:image persistent:YES asImageFormat:SDLArtworkImageFormatPNG];
     return [self initWithStateName:stateName text:text artwork:artwork];
@@ -43,6 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (!self) { return nil; }
 
     NSParameterAssert((text != nil) || (artwork != nil));
+    if ((text == nil) && (artwork == nil)) { return nil; }
 
     _name = stateName;
     _text = text;

--- a/SmartDeviceLink/public/SDLSoftButtonState.m
+++ b/SmartDeviceLink/public/SDLSoftButtonState.m
@@ -47,7 +47,10 @@ NS_ASSUME_NONNULL_BEGIN
     if (!self) { return nil; }
 
     NSParameterAssert((text != nil) || (artwork != nil));
-    if ((text == nil) && (artwork == nil)) { return nil; }
+    if ((text == nil) && (artwork == nil)) {
+        SDLLogE(@"Error creating soft button state: the state requires either text or an image, or both. StateName: %@", stateName);
+        return nil;
+    }
 
     _name = stateName;
     _text = text;

--- a/SmartDeviceLink/public/SDLSoftButtonState.m
+++ b/SmartDeviceLink/public/SDLSoftButtonState.m
@@ -33,7 +33,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithStateName:(NSString *)stateName text:(nullable NSString *)text image:(nullable UIImage *)image {
     NSParameterAssert((text != nil) || (image != nil));
-    if ((text == nil) && (image == nil)) { return nil; }
+    if ((text == nil) && (image == nil)) {
+        SDLLogE(@"Error creating soft button state: the state requires either text or an image, or both. StateName: %@", stateName);
+        return nil;
+    }
 
     SDLArtwork *artwork = [[SDLArtwork alloc] initWithImage:image persistent:YES asImageFormat:SDLArtworkImageFormatPNG];
     return [self initWithStateName:stateName text:text artwork:artwork];

--- a/SmartDeviceLinkTests/SDLSoftButtonObjectSpec.m
+++ b/SmartDeviceLinkTests/SDLSoftButtonObjectSpec.m
@@ -14,14 +14,11 @@ describe(@"a soft button object", ^{
     __block NSString *testObjectName = @"Test Object Name";
 
     context(@"with a single state", ^{
-        __block SDLSoftButtonState *testSingleState = OCMClassMock([SDLSoftButtonState class]);
         __block NSString *testSingleStateName = @"Test state name";
+        __block SDLSoftButtonState *testSingleState = [[SDLSoftButtonState alloc] initWithStateName:testSingleStateName text:@"Some Text" image:nil];
         __block SDLSoftButton *testSingleStateSoftButton = [[SDLSoftButton alloc] initWithType:SDLSoftButtonTypeText text:@"Some Text" image:nil highlighted:NO buttonId:0 systemAction:SDLSystemActionDefaultAction handler:nil];
 
         beforeEach(^{
-            OCMStub(testSingleState.name).andReturn(testSingleStateName);
-            OCMStub(testSingleState.softButton).andReturn(testSingleStateSoftButton);
-
             testObject = [[SDLSoftButtonObject alloc] initWithName:testObjectName state:testSingleState handler:nil];
         });
 
@@ -77,19 +74,14 @@ describe(@"a soft button object", ^{
     });
 
     context(@"with multiple states", ^{
-        __block SDLSoftButtonState *testFirstState = OCMClassMock([SDLSoftButtonState class]);
         __block NSString *testFirstStateName = @"Test First Name";
+        __block SDLSoftButtonState *testFirstState = [[SDLSoftButtonState alloc] initWithStateName:testFirstStateName text:@"Some Text" image:nil];
         __block SDLSoftButton *testFirstStateSoftButton = [[SDLSoftButton alloc] initWithType:SDLSoftButtonTypeText text:@"Some Text" image:nil highlighted:NO buttonId:0 systemAction:SDLSystemActionDefaultAction handler:nil];
 
-        __block SDLSoftButtonState *testSecondState = OCMClassMock([SDLSoftButtonState class]);
         __block NSString *testSecondStateName = @"Test Second Name";
+        __block SDLSoftButtonState *testSecondState = [[SDLSoftButtonState alloc] initWithStateName:testSecondStateName text:@"Some Second Text" image:nil];
 
         beforeEach(^{
-            OCMStub(testFirstState.name).andReturn(testFirstStateName);
-            OCMStub(testFirstState.softButton).andReturn(testFirstStateSoftButton);
-
-            OCMStub(testSecondState.name).andReturn(testSecondStateName);
-
             testObject = [[SDLSoftButtonObject alloc] initWithName:testObjectName states:@[testFirstState, testSecondState] initialStateName:testFirstStateName handler:nil];
         });
 


### PR DESCRIPTION
Fixes #2067 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
* Removed unnecessary stubs from soft button object tests

#### Core Tests
* Tested setting multiple soft buttons, some with one state and some with multiple states

Core version / branch / commit hash / module tested against: Manticore (Core v8.0.0)
HMI name / version / branch / commit hash / module tested against: Manticore (Generic_HMI v0.11.0)

### Summary
This PR updates creating `SoftButtonObject`s to properly crash in DEBUG when states are invalid and return `nil` in RELEASE.

### Changelog
##### Bug Fixes
* Creating `SoftButtonObject`s properly crash in DEBUG when states are invalid and return `nil` in RELEASE.

### Tasks Remaining:
n/a

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
