### PR TITLE
Update alert operation soft button image to display if no soft button capability is present

### DIFF
--- a/SmartDeviceLink/private/SDLPresentAlertOperation.m
+++ b/SmartDeviceLink/private/SDLPresentAlertOperation.m
@@ -335,9 +335,13 @@ static const int SDLAlertSoftButtonCount = 4;
 }
 
 /// Checks if the connected module or current template supports soft button images.
-/// @return True if soft button images are currently supported; false if not.
+/// @return True if soft button images are currently supported or unknown; false if not.
 - (BOOL)sdl_supportsSoftButtonImages {
-    return self.currentWindowCapability.softButtonCapabilities.firstObject.imageSupported.boolValue;
+    if (self.currentWindowCapability.softButtonCapabilities.count > 0) {
+        return self.currentWindowCapability.softButtonCapabilities.firstObject.imageSupported.boolValue;
+    } else {
+        return YES;
+    }
 }
 
 /// Checks if the connected module supports audio files. Using an audio file in an alert will only work if connected to modules supporting RPC spec versions 5.0+. If the module does not return a speechCapabilities, assume that the module supports playing an audio file.

--- a/SmartDeviceLinkTests/SDLPresentAlertOperationSpec.m
+++ b/SmartDeviceLinkTests/SDLPresentAlertOperationSpec.m
@@ -553,6 +553,25 @@ describe(@"SDLPresentAlertOperation", ^{
                 OCMVerifyAll(strictMockCurrentWindowCapability);
             });
 
+            it(@"should upload the soft button images if soft button image support is unknown", ^{
+                testPresentAlertOperation = [[SDLPresentAlertOperation alloc] initWithConnectionManager:mockConnectionManager fileManager:strictMockFileManager systemCapabilityManager:strictMockSystemCapabilityManager currentWindowCapability:nil alertView:testAlertView cancelID:testCancelID];
+
+                OCMStub([strictMockFileManager fileNeedsUpload:[OCMArg any]]).andReturn(YES);
+
+                OCMExpect([strictMockFileManager uploadArtworks:[OCMArg checkWithBlock:^BOOL(id value) {
+                    NSArray<SDLArtwork *> *files = (NSArray<SDLArtwork *> *)value;
+                    expect(files.count).to(equal(1));
+                    expect(files[0].name).to(equal(testAlertView.icon.name));
+                    return [value isKindOfClass:[NSArray class]];
+                }] progressHandler:[OCMArg invokeBlock] completionHandler:[OCMArg invokeBlock]]);
+
+                [testPresentAlertOperation start];
+
+                OCMVerifyAll(strictMockFileManager);
+                OCMVerifyAll(strictMockSystemCapabilityManager);
+                OCMVerifyAll(strictMockCurrentWindowCapability);
+            });
+
             it(@"should not upload the soft button images if soft button images are not supported on the module", ^{
                 testPresentAlertOperation = [[SDLPresentAlertOperation alloc] initWithConnectionManager:mockConnectionManager fileManager:strictMockFileManager systemCapabilityManager:strictMockSystemCapabilityManager currentWindowCapability:strictMockCurrentWindowCapability alertView:testAlertView cancelID:testCancelID];
 


### PR DESCRIPTION
Fixes #2079 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Added a unit test for when there's no soft button capability

#### Core Tests
- Alerts with soft button images presented (manticore / Sync).
- Removed soft button capability then presented an alert with a softbutton with an image. Image was presented properly.

Core version / branch / commit hash / module tested against: Manticore (Core 7.1.1), Sync 3.4, Core 8.1.0-develop
HMI name / version / branch / commit hash / module tested against: Manticore (Generic HMI 0.11.0), Sync 3.4, Generic_HMI 0.12.0-develop

### Summary
Updated the PresentAlertOperation to send soft button images when the alert soft button image capability is unknown.

### Changelog
##### Bug Fixes
* Alert operation soft button images are now on by default if there's no capability

### Tasks Remaining:
- [x] Test against Core with the soft button image capability removed

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
