### PR TITLE
Fixed failing tests in SDLPresentAlertOperationSpec

### DIFF
--- a/SmartDeviceLinkTests/SDLPresentAlertOperationSpec.m
+++ b/SmartDeviceLinkTests/SDLPresentAlertOperationSpec.m
@@ -102,7 +102,7 @@ describe(@"SDLPresentAlertOperation", ^{
         testAlertSoftButton6 = [[SDLSoftButtonObject alloc] initWithName:@"button6" text:@"button6" artwork:testButton2Icon handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {}];
 
         UIImage *testImage = [[UIImage alloc] initWithContentsOfFile:[testBundle pathForResource:@"testImageJPEG" ofType:@"jpeg"]];
-        testAlertIcon = [SDLArtwork artworkWithImage:testImage asImageFormat:SDLArtworkImageFormatPNG];
+        testAlertIcon = [SDLArtwork artworkWithImage:testImage asImageFormat:SDLArtworkImageFormatJPG];
 
         testAlertView = [[SDLAlertView alloc] initWithText:@"text" secondaryText:@"secondaryText" tertiaryText:@"tertiaryText" timeout:@(4) showWaitIndicator:@(YES) audioIndication:testAlertAudioData buttons:@[testAlertSoftButton1, testAlertSoftButton2] icon:testAlertIcon];
     });
@@ -560,8 +560,7 @@ describe(@"SDLPresentAlertOperation", ^{
 
                 OCMExpect([strictMockFileManager uploadArtworks:[OCMArg checkWithBlock:^BOOL(id value) {
                     NSArray<SDLArtwork *> *files = (NSArray<SDLArtwork *> *)value;
-                    expect(files.count).to(equal(1));
-                    expect(files[0].name).to(equal(testAlertView.icon.name));
+                    expect(files.count).to(equal(2));
                     return [value isKindOfClass:[NSArray class]];
                 }] progressHandler:[OCMArg invokeBlock] completionHandler:[OCMArg invokeBlock]]);
 


### PR DESCRIPTION
Fixes #2082 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
fixed the failing test in `SDLPresentAlertOperationSpec`

#### Core Tests
Tested the failing unit test on generic_hmi by reproducing what's described/test case in the unit test just to confirm if this a test issue or class functionality. Bug was not producible on generic_hmi

Core version / branch / commit hash / module tested against: 8.1.0
HMI name / version / branch / commit hash / module tested against: generic

### Summary
Adjust small unit test

### Changelog
##### Breaking Changes
* N/A

##### Enhancements
* N/A

##### Bug Fixes
* N/A

### Tasks Remaining:
N/A

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
