### PR TITLE
2093 - Soft button manager image upload fix

### DIFF
--- a/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
+++ b/SmartDeviceLink-iOS.xcodeproj/project.pbxproj
@@ -7967,7 +7967,7 @@
 			attributes = {
 				CLASSPREFIX = SDL;
 				LastSwiftUpdateCheck = 0710;
-				LastUpgradeCheck = 1330;
+				LastUpgradeCheck = 1340;
 				ORGANIZATIONNAME = smartdevicelink;
 				TargetAttributes = {
 					5D4019AE1A76EC350006B0C2 = {

--- a/SmartDeviceLink-iOS.xcodeproj/xcshareddata/xcschemes/SmartDeviceLink-Example-ObjC.xcscheme
+++ b/SmartDeviceLink-iOS.xcodeproj/xcshareddata/xcschemes/SmartDeviceLink-Example-ObjC.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1330"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SmartDeviceLink-iOS.xcodeproj/xcshareddata/xcschemes/SmartDeviceLink-Example-Swift.xcscheme
+++ b/SmartDeviceLink-iOS.xcodeproj/xcshareddata/xcschemes/SmartDeviceLink-Example-Swift.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1330"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SmartDeviceLink-iOS.xcodeproj/xcshareddata/xcschemes/SmartDeviceLink.xcscheme
+++ b/SmartDeviceLink-iOS.xcodeproj/xcshareddata/xcschemes/SmartDeviceLink.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1330"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SmartDeviceLink-iOS.xcodeproj/xcshareddata/xcschemes/SmartDeviceLinkSwift.xcscheme
+++ b/SmartDeviceLink-iOS.xcodeproj/xcshareddata/xcschemes/SmartDeviceLinkSwift.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1330"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SmartDeviceLink/private/SDLSoftButtonManager.m
+++ b/SmartDeviceLink/private/SDLSoftButtonManager.m
@@ -9,6 +9,7 @@
 #import "SDLSoftButtonManager.h"
 
 #import "SDLConnectionManagerType.h"
+#import "SDLDisplayCapabilities.h"
 #import "SDLError.h"
 #import "SDLFileManager.h"
 #import "SDLGlobals.h"
@@ -48,6 +49,7 @@ static const int SDLShowSoftButtonIDCount = 8;
 @property (weak, nonatomic) id<SDLConnectionManagerType> connectionManager;
 @property (weak, nonatomic) SDLFileManager *fileManager;
 @property (weak, nonatomic) SDLSystemCapabilityManager *systemCapabilityManager;
+@property (assign, nonatomic) BOOL graphicsSupported;
 
 @property (strong, nonatomic) NSOperationQueue *transactionQueue;
 
@@ -60,13 +62,17 @@ static const int SDLShowSoftButtonIDCount = 8;
 
 @implementation SDLSoftButtonManager
 
-- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager fileManager:(SDLFileManager *)fileManager systemCapabilityManager:(SDLSystemCapabilityManager *)systemCapabilityManager{
+- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager fileManager:(SDLFileManager *)fileManager systemCapabilityManager:(SDLSystemCapabilityManager *)systemCapabilityManager {
     self = [super init];
     if (!self) { return nil; }
 
     _connectionManager = connectionManager;
     _fileManager = fileManager;
     _systemCapabilityManager = systemCapabilityManager;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    _graphicsSupported = systemCapabilityManager.displayCapabilities.graphicSupported.boolValue;
+#pragma clang diagnostic pop
     _softButtonObjects = @[];
 
     _currentLevel = nil;
@@ -151,7 +157,7 @@ static const int SDLShowSoftButtonIDCount = 8;
     _softButtonObjects = softButtonObjects;
 
     // We only need to pass the first `softButtonCapabilities` in the array due to the fact that all soft button capabilities are the same (i.e. there is no way to assign a `softButtonCapabilities` to a specific soft button).
-    SDLSoftButtonReplaceOperation *op = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:self.connectionManager fileManager:self.fileManager capabilities:self.softButtonCapabilities softButtonObjects:_softButtonObjects mainField1:self.currentMainField1];
+    SDLSoftButtonReplaceOperation *op = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:self.connectionManager fileManager:self.fileManager capabilities:self.softButtonCapabilities graphicsEnabled:self.graphicsSupported softButtonObjects:_softButtonObjects mainField1:self.currentMainField1];
 
     if (self.isBatchingUpdates) {
         [self.batchQueue removeAllObjects];
@@ -233,7 +239,7 @@ static const int SDLShowSoftButtonIDCount = 8;
     if (self.softButtonObjects.count > 0
         && self.softButtonCapabilities != nil
         && ![self.softButtonCapabilities isEqual:oldCapabilities]) {
-        SDLSoftButtonReplaceOperation *op = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:self.connectionManager fileManager:self.fileManager capabilities:self.softButtonCapabilities softButtonObjects:self.softButtonObjects mainField1:self.currentMainField1];
+        SDLSoftButtonReplaceOperation *op = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:self.connectionManager fileManager:self.fileManager capabilities:self.softButtonCapabilities graphicsEnabled:self.graphicsSupported softButtonObjects:self.softButtonObjects mainField1:self.currentMainField1];
         [self.transactionQueue addOperation:op];
     }
 }

--- a/SmartDeviceLink/private/SDLSoftButtonManager.m
+++ b/SmartDeviceLink/private/SDLSoftButtonManager.m
@@ -71,7 +71,7 @@ static const int SDLShowSoftButtonIDCount = 8;
     _systemCapabilityManager = systemCapabilityManager;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    _graphicsSupported = systemCapabilityManager.displayCapabilities.graphicSupported.boolValue;
+    _graphicsSupported = systemCapabilityManager.displayCapabilities.graphicSupported ? systemCapabilityManager.displayCapabilities.graphicSupported.boolValue : YES;
 #pragma clang diagnostic pop
     _softButtonObjects = @[];
 

--- a/SmartDeviceLink/private/SDLSoftButtonManager.m
+++ b/SmartDeviceLink/private/SDLSoftButtonManager.m
@@ -49,7 +49,7 @@ static const int SDLShowSoftButtonIDCount = 8;
 @property (weak, nonatomic) id<SDLConnectionManagerType> connectionManager;
 @property (weak, nonatomic) SDLFileManager *fileManager;
 @property (weak, nonatomic) SDLSystemCapabilityManager *systemCapabilityManager;
-@property (assign, nonatomic) BOOL graphicsSupported;
+@property (assign, nonatomic, getter=isDynamicGraphicSupported) BOOL dynamicGraphicSupported;
 
 @property (strong, nonatomic) NSOperationQueue *transactionQueue;
 
@@ -71,7 +71,7 @@ static const int SDLShowSoftButtonIDCount = 8;
     _systemCapabilityManager = systemCapabilityManager;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    _graphicsSupported = systemCapabilityManager.displayCapabilities.graphicSupported ? systemCapabilityManager.displayCapabilities.graphicSupported.boolValue : YES;
+    _dynamicGraphicSupported = systemCapabilityManager.displayCapabilities.graphicSupported ? systemCapabilityManager.displayCapabilities.graphicSupported.boolValue : YES;
 #pragma clang diagnostic pop
     _softButtonObjects = @[];
 
@@ -157,7 +157,7 @@ static const int SDLShowSoftButtonIDCount = 8;
     _softButtonObjects = softButtonObjects;
 
     // We only need to pass the first `softButtonCapabilities` in the array due to the fact that all soft button capabilities are the same (i.e. there is no way to assign a `softButtonCapabilities` to a specific soft button).
-    SDLSoftButtonReplaceOperation *op = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:self.connectionManager fileManager:self.fileManager capabilities:self.softButtonCapabilities graphicsEnabled:self.graphicsSupported softButtonObjects:_softButtonObjects mainField1:self.currentMainField1];
+    SDLSoftButtonReplaceOperation *op = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:self.connectionManager fileManager:self.fileManager capabilities:self.softButtonCapabilities dynamicGraphicSupported:self.isDynamicGraphicSupported softButtonObjects:_softButtonObjects mainField1:self.currentMainField1];
 
     if (self.isBatchingUpdates) {
         [self.batchQueue removeAllObjects];
@@ -239,7 +239,7 @@ static const int SDLShowSoftButtonIDCount = 8;
     if (self.softButtonObjects.count > 0
         && self.softButtonCapabilities != nil
         && ![self.softButtonCapabilities isEqual:oldCapabilities]) {
-        SDLSoftButtonReplaceOperation *op = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:self.connectionManager fileManager:self.fileManager capabilities:self.softButtonCapabilities graphicsEnabled:self.graphicsSupported softButtonObjects:self.softButtonObjects mainField1:self.currentMainField1];
+        SDLSoftButtonReplaceOperation *op = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:self.connectionManager fileManager:self.fileManager capabilities:self.softButtonCapabilities dynamicGraphicSupported:self.isDynamicGraphicSupported softButtonObjects:self.softButtonObjects mainField1:self.currentMainField1];
         [self.transactionQueue addOperation:op];
     }
 }

--- a/SmartDeviceLink/private/SDLSoftButtonReplaceOperation.h
+++ b/SmartDeviceLink/private/SDLSoftButtonReplaceOperation.h
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param mainField1 The primary text field of the system template
  @return The operation
  */
-- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager fileManager:(SDLFileManager *)fileManager capabilities:(nullable SDLSoftButtonCapabilities *)capabilities softButtonObjects:(NSArray<SDLSoftButtonObject *> *)softButtonObjects mainField1:(NSString *)mainField1;
+- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager fileManager:(SDLFileManager *)fileManager capabilities:(nullable SDLSoftButtonCapabilities *)capabilities graphicsEnabled:(BOOL)graphicsEnabled softButtonObjects:(NSArray<SDLSoftButtonObject *> *)softButtonObjects mainField1:(NSString *)mainField1;
 
 @end
 

--- a/SmartDeviceLink/private/SDLSoftButtonReplaceOperation.h
+++ b/SmartDeviceLink/private/SDLSoftButtonReplaceOperation.h
@@ -34,11 +34,12 @@ NS_ASSUME_NONNULL_BEGIN
  @param connectionManager The manager that will send the resultant RPCs
  @param fileManager The file manager that will handle uploading any images
  @param capabilities The capabilites of the soft buttons on the current template
+ @param dynamicGraphicSupported Whether or not the connected system supports dynamic graphics. This is needed because the soft button image supported capability tells us if any graphics are supported, including static ones.
  @param softButtonObjects The soft buttons that should be sent
  @param mainField1 The primary text field of the system template
  @return The operation
  */
-- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager fileManager:(SDLFileManager *)fileManager capabilities:(nullable SDLSoftButtonCapabilities *)capabilities graphicsEnabled:(BOOL)graphicsEnabled softButtonObjects:(NSArray<SDLSoftButtonObject *> *)softButtonObjects mainField1:(NSString *)mainField1;
+- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager fileManager:(SDLFileManager *)fileManager capabilities:(nullable SDLSoftButtonCapabilities *)capabilities dynamicGraphicSupported:(BOOL)dynamicGraphicSupported softButtonObjects:(NSArray<SDLSoftButtonObject *> *)softButtonObjects mainField1:(NSString *)mainField1;
 
 @end
 

--- a/SmartDeviceLink/private/SDLSoftButtonReplaceOperation.m
+++ b/SmartDeviceLink/private/SDLSoftButtonReplaceOperation.m
@@ -23,6 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SDLSoftButtonReplaceOperation ()
 
 @property (strong, nonatomic, nullable) SDLSoftButtonCapabilities *softButtonCapabilities;
+@property (assign, nonatomic) BOOL graphicsEnabled;
 @property (strong, nonatomic) NSArray<SDLSoftButtonObject *> *softButtonObjects;
 
 @property (weak, nonatomic) id<SDLConnectionManagerType> connectionManager;
@@ -33,13 +34,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLSoftButtonReplaceOperation
 
-- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager fileManager:(SDLFileManager *)fileManager capabilities:(nullable SDLSoftButtonCapabilities *)capabilities softButtonObjects:(NSArray<SDLSoftButtonObject *> *)softButtonObjects mainField1:(NSString *)mainField1 {
+- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager fileManager:(SDLFileManager *)fileManager capabilities:(nullable SDLSoftButtonCapabilities *)capabilities graphicsEnabled:(BOOL)graphicsEnabled softButtonObjects:(NSArray<SDLSoftButtonObject *> *)softButtonObjects mainField1:(NSString *)mainField1 {
     self = [super init];
     if (!self) { return nil; }
 
     _connectionManager = connectionManager;
     _fileManager = fileManager;
     _softButtonCapabilities = capabilities;
+    _graphicsEnabled = graphicsEnabled;
     _softButtonObjects = softButtonObjects;
     _mainField1 = mainField1;
 
@@ -243,7 +245,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (BOOL)sdl_supportsSoftButtonImages {
-    return self.softButtonCapabilities.imageSupported.boolValue;
+    return self.graphicsEnabled && self.softButtonCapabilities.imageSupported.boolValue;
 }
 
 #pragma mark - Property Overrides

--- a/SmartDeviceLink/private/SDLSoftButtonReplaceOperation.m
+++ b/SmartDeviceLink/private/SDLSoftButtonReplaceOperation.m
@@ -260,7 +260,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     SDLLogV(@"Preparing to send text and static image only soft buttons");
-    NSMutableArray<SDLSoftButton *> *textButtons = [NSMutableArray arrayWithCapacity:self.softButtonObjects.count];
+    NSMutableArray<SDLSoftButton *> *softButtons = [NSMutableArray arrayWithCapacity:self.softButtonObjects.count];
     for (SDLSoftButtonObject *buttonObject in self.softButtonObjects) {
         SDLSoftButton *button = buttonObject.currentStateSoftButton;
         if ((button.text == nil) && (button.image.imageType == SDLImageTypeDynamic)) {
@@ -270,14 +270,14 @@ NS_ASSUME_NONNULL_BEGIN
 
         if (button.image.imageType == SDLImageTypeDynamic) {
             button.image = nil;
+            button.type = SDLSoftButtonTypeText;
         }
-        button.type = SDLSoftButtonTypeText;
-        [textButtons addObject:button];
+        [softButtons addObject:button];
     }
 
     SDLShow *show = [[SDLShow alloc] init];
     show.mainField1 = self.mainField1;
-    show.softButtons = [textButtons copy];
+    show.softButtons = [softButtons copy];
 
     [self.connectionManager sendConnectionRequest:show withResponseHandler:^(__kindof SDLRPCRequest * _Nullable request, __kindof SDLRPCResponse * _Nullable response, NSError * _Nullable error) {
         if (error != nil) {

--- a/SmartDeviceLink/private/SDLSoftButtonReplaceOperation.m
+++ b/SmartDeviceLink/private/SDLSoftButtonReplaceOperation.m
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SDLSoftButtonReplaceOperation ()
 
 @property (strong, nonatomic, nullable) SDLSoftButtonCapabilities *softButtonCapabilities;
-@property (assign, nonatomic) BOOL graphicsEnabled;
+@property (assign, nonatomic, getter=isDynamicGraphicSupported) BOOL dynamicGraphicSupported;
 @property (strong, nonatomic) NSArray<SDLSoftButtonObject *> *softButtonObjects;
 
 @property (weak, nonatomic) id<SDLConnectionManagerType> connectionManager;
@@ -35,14 +35,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SDLSoftButtonReplaceOperation
 
-- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager fileManager:(SDLFileManager *)fileManager capabilities:(nullable SDLSoftButtonCapabilities *)capabilities graphicsEnabled:(BOOL)graphicsEnabled softButtonObjects:(NSArray<SDLSoftButtonObject *> *)softButtonObjects mainField1:(NSString *)mainField1 {
+- (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager fileManager:(SDLFileManager *)fileManager capabilities:(nullable SDLSoftButtonCapabilities *)capabilities dynamicGraphicSupported:(BOOL)dynamicGraphicSupported softButtonObjects:(NSArray<SDLSoftButtonObject *> *)softButtonObjects mainField1:(NSString *)mainField1 {
     self = [super init];
     if (!self) { return nil; }
 
     _connectionManager = connectionManager;
     _fileManager = fileManager;
     _softButtonCapabilities = capabilities;
-    _graphicsEnabled = graphicsEnabled;
+    _dynamicGraphicSupported = dynamicGraphicSupported;
     _softButtonObjects = softButtonObjects;
     _mainField1 = mainField1;
 
@@ -307,7 +307,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (BOOL)sdl_supportsDynamicSoftButtonImages {
-    return self.graphicsEnabled && self.softButtonCapabilities.imageSupported.boolValue;
+    return self.isDynamicGraphicSupported && self.softButtonCapabilities.imageSupported.boolValue;
 }
 
 - (BOOL)sdl_supportsSoftButtonImages {

--- a/SmartDeviceLinkTests/SDLSoftButtonReplaceOperationSpec.m
+++ b/SmartDeviceLinkTests/SDLSoftButtonReplaceOperationSpec.m
@@ -144,7 +144,7 @@ describe(@"a soft button replace operation", ^{
 
             beforeEach(^{
                 testSoftButtonObjects = @[buttonWithText];
-                testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities graphicsEnabled:dynamicGraphicsEnabled softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
+                testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities dynamicGraphicSupported:dynamicGraphicsEnabled softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
 
                 capabilities = [[SDLSoftButtonCapabilities alloc] init];
                 capabilities.imageSupported = @YES;
@@ -202,7 +202,7 @@ describe(@"a soft button replace operation", ^{
                     capabilities = [[SDLSoftButtonCapabilities alloc] init];
                     capabilities.imageSupported = @NO;
 
-                    testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities graphicsEnabled:dynamicGraphicsEnabled softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
+                    testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities dynamicGraphicSupported:dynamicGraphicsEnabled softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
                 });
 
                 it(@"should only send the button text", ^{
@@ -252,7 +252,7 @@ describe(@"a soft button replace operation", ^{
                     capabilities.imageSupported = @YES;
                     dynamicGraphicsEnabled = NO;
 
-                    testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities graphicsEnabled:dynamicGraphicsEnabled softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
+                    testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities dynamicGraphicSupported:dynamicGraphicsEnabled softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
                 });
 
                 it(@"should only send the button text", ^{
@@ -303,7 +303,7 @@ describe(@"a soft button replace operation", ^{
                     capabilities = [[SDLSoftButtonCapabilities alloc] init];
                     capabilities.imageSupported = @NO;
 
-                    testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities graphicsEnabled:dynamicGraphicsEnabled softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
+                    testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities dynamicGraphicSupported:dynamicGraphicsEnabled softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
                 });
 
                 it(@"should not send any buttons", ^{
@@ -332,7 +332,7 @@ describe(@"a soft button replace operation", ^{
                         OCMStub([testFileManager hasUploadedFile:[OCMArg isNotNil]]).andReturn(NO);
 
                         testSoftButtonObjects = @[buttonWithTextAndStaticImage];
-                        testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities graphicsEnabled:dynamicGraphicsEnabled softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
+                        testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities dynamicGraphicSupported:dynamicGraphicsEnabled softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
                     });
 
                     it(@"should send the soft button", ^{
@@ -362,7 +362,7 @@ describe(@"a soft button replace operation", ^{
                         OCMStub([testFileManager hasUploadedFile:[OCMArg isNotNil]]).andReturn(YES);
 
                         testSoftButtonObjects = @[buttonWithText, buttonWithTextAndImage];
-                        testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities  graphicsEnabled:dynamicGraphicsEnabled softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
+                        testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities  dynamicGraphicSupported:dynamicGraphicsEnabled softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
                     });
 
                     it(@"should not upload artworks", ^{
@@ -392,7 +392,7 @@ describe(@"a soft button replace operation", ^{
                         object2State1 = [[SDLSoftButtonState alloc] initWithStateName:object2State1Name text:object2State1Text artwork:object2State11Art];
                         buttonWithTextAndImage = [[SDLSoftButtonObject alloc] initWithName:object2Name states:@[object2State1, object2State2] initialStateName:object2State1.name handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {}];
                         testSoftButtonObjects = @[buttonWithText, buttonWithTextAndImage];
-                        testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities  graphicsEnabled:dynamicGraphicsEnabled softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
+                        testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities  dynamicGraphicSupported:dynamicGraphicsEnabled softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
                         OCMExpect([testFileManager fileNeedsUpload:[OCMArg any]]);
                         [testOp start];
                         OCMVerify([testFileManager uploadArtworks:[OCMArg any] progressHandler:[OCMArg any] completionHandler:[OCMArg any]]);
@@ -430,7 +430,7 @@ describe(@"a soft button replace operation", ^{
                             OCMStub([testFileManager fileNeedsUpload:[OCMArg isNotNil]]).andReturn(NO);
                             testSoftButtonObjects = @[buttonWithTextAndStaticImage];
 
-                            testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities graphicsEnabled:dynamicGraphicsEnabled softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
+                            testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities dynamicGraphicSupported:dynamicGraphicsEnabled softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
                         });
 
                         it(@"should skip uploading artwork", ^{
@@ -478,7 +478,7 @@ describe(@"a soft button replace operation", ^{
                             OCMExpect([testFileManager fileNeedsUpload:[OCMArg any]]);
                             OCMStub([testFileManager fileNeedsUpload:[OCMArg isNotNil]]).andReturn(YES);
                             testSoftButtonObjects = @[buttonWithText, buttonWithTextAndImage];
-                            testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities graphicsEnabled:dynamicGraphicsEnabled softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
+                            testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities dynamicGraphicSupported:dynamicGraphicsEnabled softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
                             OCMExpect([testFileManager fileNeedsUpload:[OCMArg any]]);
                             [testOp start];
                             OCMVerifyAllWithDelay(testFileManager, 0.5);
@@ -520,7 +520,7 @@ describe(@"a soft button replace operation", ^{
 
                             // buttonWithTextAndImage2 has text in the first state and an text and image in the second & third states
                             testSoftButtonObjects = @[buttonWithTextAndStaticImage, buttonWithTextAndImage2];
-                            testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities graphicsEnabled:dynamicGraphicsEnabled softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
+                            testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities dynamicGraphicSupported:dynamicGraphicsEnabled softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
 
                             [testOp start];
                             OCMVerifyAllWithDelay(testFileManager, 0.5);
@@ -561,7 +561,7 @@ describe(@"a soft button replace operation", ^{
                                 OCMExpect([testFileManager uploadArtworks:[OCMArg isNotNil] progressHandler:[OCMArg invokeBlock] completionHandler:[OCMArg invokeBlock]]);
 
                                 testSoftButtonObjects = @[buttonWithTextAndImage];
-                                testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities graphicsEnabled:dynamicGraphicsEnabled softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
+                                testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities dynamicGraphicSupported:dynamicGraphicsEnabled softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
                                 [testOp start];
 
                                 OCMVerifyAllWithDelay(testFileManager, 0.5);

--- a/SmartDeviceLinkTests/SDLSoftButtonReplaceOperationSpec.m
+++ b/SmartDeviceLinkTests/SDLSoftButtonReplaceOperationSpec.m
@@ -140,7 +140,7 @@ describe(@"a soft button replace operation", ^{
 
             beforeEach(^{
                 testSoftButtonObjects = @[buttonWithText];
-                testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
+                testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities graphicsEnabled:YES softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
 
                 capabilities = [[SDLSoftButtonCapabilities alloc] init];
                 capabilities.imageSupported = @YES;
@@ -193,15 +193,15 @@ describe(@"a soft button replace operation", ^{
                 testSoftButtonObjects = @[buttonWithText, buttonWithTextAndImage];
             });
 
-            context(@"but the HMI does not support artworks", ^{
+            context(@"but the HMI does not support artworks via soft button capabilities", ^{
                 beforeEach(^{
                     capabilities = [[SDLSoftButtonCapabilities alloc] init];
                     capabilities.imageSupported = @NO;
 
-                    testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
+                    testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities graphicsEnabled:YES softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
                 });
 
-                it(@"should send the button text", ^{
+                it(@"should only send the button text", ^{
                     OCMReject([testFileManager uploadArtworks:[OCMArg any] progressHandler:nil completionHandler:nil]);
 
                     [testOp start];
@@ -221,7 +221,56 @@ describe(@"a soft button replace operation", ^{
                     expect(sentRequests.firstObject.softButtons.lastObject.type).to(equal(SDLSoftButtonTypeText));
                 });
 
-                context(@"When a response is received to the upload", ^{
+                context(@"when a response is received to the upload", ^{
+                    beforeEach(^{
+                        [testOp start];
+                    });
+
+                    it(@"should finish the operation on a successful response", ^{
+                        [testConnectionManager respondToLastRequestWithResponse:successResponse];
+
+                        expect(testOp.isFinished).to(beTrue());
+                        expect(testOp.isExecuting).to(beFalse());
+                    });
+
+                    it(@"should finish the operation on a failed response", ^{
+                        [testConnectionManager respondToLastRequestWithResponse:failedResponse];
+
+                        expect(testOp.isFinished).to(beTrue());
+                        expect(testOp.isExecuting).to(beFalse());
+                    });
+                });
+            });
+
+            context(@"but the HMI does not support artworks via displayCapabilities", ^{
+                beforeEach(^{
+                    capabilities = [[SDLSoftButtonCapabilities alloc] init];
+                    capabilities.imageSupported = @YES;
+
+                    testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities graphicsEnabled:NO softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
+                });
+
+                it(@"should only send the button text", ^{
+                    OCMReject([testFileManager uploadArtworks:[OCMArg any] progressHandler:nil completionHandler:nil]);
+
+                    [testOp start];
+
+                    OCMVerifyAllWithDelay(testFileManager, 0.5);
+
+                    NSArray<SDLShow *> *sentRequests = testConnectionManager.receivedRequests;
+                    expect(sentRequests).to(haveCount(1));
+                    expect(sentRequests.firstObject.mainField1).to(equal(testMainField1));
+                    expect(sentRequests.firstObject.mainField2).to(beNil());
+                    expect(sentRequests.firstObject.softButtons).to(haveCount(2));
+                    expect(sentRequests.firstObject.softButtons.firstObject.text).to(equal(object1State1Text));
+                    expect(sentRequests.firstObject.softButtons.firstObject.image).to(beNil());
+                    expect(sentRequests.firstObject.softButtons.firstObject.type).to(equal(SDLSoftButtonTypeText));
+                    expect(sentRequests.firstObject.softButtons.lastObject.text).to(equal(object2State1Text));
+                    expect(sentRequests.firstObject.softButtons.lastObject.image).to(beNil());
+                    expect(sentRequests.firstObject.softButtons.lastObject.type).to(equal(SDLSoftButtonTypeText));
+                });
+
+                context(@"when a response is received to the upload", ^{
                     beforeEach(^{
                         [testOp start];
                     });
@@ -249,7 +298,7 @@ describe(@"a soft button replace operation", ^{
                     capabilities = [[SDLSoftButtonCapabilities alloc] init];
                     capabilities.imageSupported = @NO;
 
-                    testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
+                    testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities graphicsEnabled:YES softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
                 });
 
                 it(@"should not send any buttons", ^{
@@ -277,7 +326,7 @@ describe(@"a soft button replace operation", ^{
                         OCMStub([testFileManager hasUploadedFile:[OCMArg isNotNil]]).andReturn(YES);
 
                         testSoftButtonObjects = @[buttonWithText, buttonWithTextAndImage];
-                        testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
+                        testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities  graphicsEnabled:YES softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
                     });
 
                     it(@"should not upload artworks", ^{
@@ -307,7 +356,7 @@ describe(@"a soft button replace operation", ^{
                         object2State1 = [[SDLSoftButtonState alloc] initWithStateName:object2State1Name text:object2State1Text artwork:object2State11Art];
                         buttonWithTextAndImage = [[SDLSoftButtonObject alloc] initWithName:object2Name states:@[object2State1, object2State2] initialStateName:object2State1.name handler:^(SDLOnButtonPress * _Nullable buttonPress, SDLOnButtonEvent * _Nullable buttonEvent) {}];
                         testSoftButtonObjects = @[buttonWithText, buttonWithTextAndImage];
-                        testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
+                        testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities  graphicsEnabled:YES softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
                         OCMExpect([testFileManager fileNeedsUpload:[OCMArg any]]);
                         [testOp start];
                         OCMVerify([testFileManager uploadArtworks:[OCMArg any] progressHandler:[OCMArg any] completionHandler:[OCMArg any]]);
@@ -345,7 +394,7 @@ describe(@"a soft button replace operation", ^{
                             OCMStub([testFileManager fileNeedsUpload:[OCMArg isNotNil]]).andReturn(NO);
                             testSoftButtonObjects = @[buttonWithTextAndStaticImage];
 
-                            testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
+                            testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities graphicsEnabled:YES softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
                         });
 
                         it(@"should skip uploading artwork", ^{
@@ -393,7 +442,7 @@ describe(@"a soft button replace operation", ^{
                             OCMExpect([testFileManager fileNeedsUpload:[OCMArg any]]);
                             OCMStub([testFileManager fileNeedsUpload:[OCMArg isNotNil]]).andReturn(YES);
                             testSoftButtonObjects = @[buttonWithText, buttonWithTextAndImage];
-                            testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
+                            testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities graphicsEnabled:YES softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
                             OCMExpect([testFileManager fileNeedsUpload:[OCMArg any]]);
                             [testOp start];
                             OCMVerifyAllWithDelay(testFileManager, 0.5);
@@ -435,7 +484,7 @@ describe(@"a soft button replace operation", ^{
 
                             // buttonWithTextAndImage2 has text in the first state and an text and image in the second & third states
                             testSoftButtonObjects = @[buttonWithTextAndStaticImage, buttonWithTextAndImage2];
-                            testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
+                            testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities graphicsEnabled:YES softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
 
                             [testOp start];
                             OCMVerifyAllWithDelay(testFileManager, 0.5);
@@ -476,7 +525,7 @@ describe(@"a soft button replace operation", ^{
                                 OCMExpect([testFileManager uploadArtworks:[OCMArg isNotNil] progressHandler:[OCMArg invokeBlock] completionHandler:[OCMArg invokeBlock]]);
 
                                 testSoftButtonObjects = @[buttonWithTextAndImage];
-                                testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
+                                testOp = [[SDLSoftButtonReplaceOperation alloc] initWithConnectionManager:testConnectionManager fileManager:testFileManager capabilities:capabilities graphicsEnabled:YES softButtonObjects:testSoftButtonObjects mainField1:testMainField1];
                                 [testOp start];
 
                                 OCMVerifyAllWithDelay(testFileManager, 0.5);


### PR DESCRIPTION
Fixes #2093 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Unit test added for `softButtonCapabilities.imageSupported = YES` and `displayCapabilities.graphicEnabled = NO`, as well as visa-versa.

#### Core Tests
Tested that existing behavior continues to

Core version / branch / commit hash / module tested against: Sync 3.4 TDK (19353_DEVTEST)
HMI name / version / branch / commit hash / module tested against: Sync 3.4 TDK (19353_DEVTEST)

### Summary
This PR works around a bug when connecting to Sync 2.0 head units that causes the app to attempt to upload soft button images that will never work. This wastes bandwidth and time.

The issues happens because Sync 2.0 doesn't support `softButtonCapabilities`, so the library assumes all capabilities are available. However, Sync 2.0 does report that all graphics are unsupported in `RAIR.displayCapabilities.graphicSupported`.

### Changelog
##### Bug Fixes
* Fixes attempted uploads of image data on SDL 2.0

### Tasks Remaining:
n/a

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
