### PR TITLE
Bugfix/issue 1633 open sub menu

### DIFF
--- a/SmartDeviceLink/private/SDLMenuManager.m
+++ b/SmartDeviceLink/private/SDLMenuManager.m
@@ -227,6 +227,16 @@ NS_ASSUME_NONNULL_BEGIN
         return NO;
     }
 
+    // Check for cloned cell
+    if (cell != nil) {
+        for(id clonedCell in self.menuCells) {
+            if ([cell isEqual:clonedCell]) {
+                cell = clonedCell;
+                break;
+            }
+        }
+    }
+    
     // Create the operation
     SDLMenuShowOperation *showMenuOp = [[SDLMenuShowOperation alloc] initWithConnectionManager:self.connectionManager toMenuCell:cell completionHandler:^(NSError * _Nullable error) {
         if (error != nil) {

--- a/SmartDeviceLink/private/SDLMenuManager.m
+++ b/SmartDeviceLink/private/SDLMenuManager.m
@@ -228,7 +228,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     // Check if a passed cell is a "re-created" cell without a cellID. If it is, then try to find the equivalent cell and use it instead
-    if (cell != nil) {
+    if (cell != nil && cell.cellId == UINT32_MAX) {
         for(id clonedCell in self.menuCells) {
             if ([cell isEqual:clonedCell]) {
                 cell = clonedCell;

--- a/SmartDeviceLink/private/SDLMenuManager.m
+++ b/SmartDeviceLink/private/SDLMenuManager.m
@@ -229,7 +229,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     // Check if a passed cell is a "re-created" cell without a cellID. If it is, then try to find the equivalent cell and use it instead
     if (cell != nil && cell.cellId == UINT32_MAX) {
-        for(id clonedCell in self.menuCells) {
+        for (SDLMenuCell *headUnitCell in self.menuCells) {
             if ([cell isEqual:clonedCell]) {
                 cell = clonedCell;
                 break;

--- a/SmartDeviceLink/private/SDLMenuManager.m
+++ b/SmartDeviceLink/private/SDLMenuManager.m
@@ -230,8 +230,8 @@ NS_ASSUME_NONNULL_BEGIN
     // Check if a passed cell is a "re-created" cell without a cellID. If it is, then try to find the equivalent cell and use it instead
     if (cell != nil && cell.cellId == UINT32_MAX) {
         for (SDLMenuCell *headUnitCell in self.menuCells) {
-            if ([cell isEqual:clonedCell]) {
-                cell = clonedCell;
+            if ([cell isEqual:headUnitCell]) {
+                cell = headUnitCell;
                 break;
             }
         }

--- a/SmartDeviceLink/private/SDLMenuManager.m
+++ b/SmartDeviceLink/private/SDLMenuManager.m
@@ -227,7 +227,7 @@ NS_ASSUME_NONNULL_BEGIN
         return NO;
     }
 
-    // Check for cloned cell
+    // Check if a passed cell is a "re-created" cell without a cellID. If it is, then try to find the equivalent cell and use it instead
     if (cell != nil) {
         for(id clonedCell in self.menuCells) {
             if ([cell isEqual:clonedCell]) {

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLMenuManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLMenuManagerSpec.m
@@ -269,6 +269,17 @@ describe(@"menu manager", ^{
                     expect(canSendRPC).to(equal(YES));
                 });
 
+                // should queue an open menu operation for a copied submenu cell
+                it(@"should queue an open menu operation for a copied submenu cell", ^ {
+                    testManager.menuCells = @[submenuCell];
+                    SDLMenuCell *copiedCell = [[SDLMenuCell alloc] initWithTitle:@"Test 3" secondaryText:nil tertiaryText:nil icon:nil secondaryArtwork:nil submenuLayout:nil subCells:@[textOnlyCell]];
+                    
+                    BOOL canSendRPC = [testManager openMenu:copiedCell];
+                    
+                    expect(testManager.transactionQueue.operationCount).to(equal(2));
+                    expect(canSendRPC).to(equal(YES));
+                });
+
                 it(@"should cancel the first task if a second is queued", ^{
                     testManager.menuCells = @[submenuCell];
                     [testManager openMenu:nil];

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLMenuManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLMenuManagerSpec.m
@@ -6,6 +6,7 @@
 
 #import "SDLGlobals.h"
 #import "SDLMenuManager.h"
+#import "SDLMenuShowOperation.h"
 #import "SDLMenuReplaceOperation.h"
 #import "TestConnectionManager.h"
 
@@ -14,6 +15,12 @@
 
 @property (assign, nonatomic) UInt32 parentCellId;
 @property (assign, nonatomic) UInt32 cellId;
+
+@end
+
+@interface SDLMenuShowOperation()
+
+@property (strong, nonatomic, nullable) SDLMenuCell *submenuCell;
 
 @end
 
@@ -270,12 +277,17 @@ describe(@"menu manager", ^{
                 });
 
                 // should queue an open menu operation for a copied submenu cell
-                it(@"should queue an open menu operation for a copied submenu cell", ^ {
+                it(@"should queue an open menu operation for a copied submenu cell and match the original cell id", ^ {
+                    submenuCell.cellId = 1;
                     testManager.menuCells = @[submenuCell];
+
                     SDLMenuCell *copiedCell = [[SDLMenuCell alloc] initWithTitle:@"Test 3" secondaryText:nil tertiaryText:nil icon:nil secondaryArtwork:nil submenuLayout:nil subCells:@[textOnlyCell]];
                     
                     BOOL canSendRPC = [testManager openMenu:copiedCell];
-                    
+                    SDLMenuShowOperation *showOperation = (SDLMenuShowOperation *)testManager.transactionQueue.operations[1];
+
+                    expect(showOperation.submenuCell.cellId).to(equal(submenuCell.cellId));
+                    expect(showOperation.submenuCell.cellId).toNot(equal(copiedCell.cellId));
                     expect(testManager.transactionQueue.operationCount).to(equal(2));
                     expect(canSendRPC).to(equal(YES));
                 });


### PR DESCRIPTION
Fixes #1633 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Created a unit test to check when a submenu item is added to the menu and the same recreated cell is opened with openSubmenu it performs a successful transaction and is able to send an RPC.

#### Core Tests
In manticore I created a function that returns a menu with a submenu. I Added this menu into the screen managers menu property. I then called the function again to recreate the same menu cell inside a ```openSubMenu``` call. Before, it would fail with an error due to the default cell ID set to ```UINT32_MAX```, after changes it would successfully open the menu cell.

Core version / branch / commit hash / module tested against: sdl_core 8.1.0 (manticore)
HMI name / version / branch / commit hash / module tested against: generic_hmi 0.12.0 (manticore)

### Summary
- Added check for a clone cell in ```openMenu```
- Added additional unit test in ```SDLMenuManagerSpec.m```

### Changelog
##### Breaking Changes
* NA

##### Enhancements
* NA

##### Bug Fixes
* Fixes ```openMenu``` and ```openSubMenu``` calls when trying to open a copied cell

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
