### PR TITLE
Fix SystemCapabilityManager windowID, screenParams nil, and mediaClockFormats empty when updating DisplayCapability

### DIFF
--- a/SmartDeviceLink/public/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/public/SDLSystemCapabilityManager.m
@@ -255,8 +255,10 @@ typedef NSString * SDLServiceID;
     convertedCapabilities.imageFields = [defaultMainWindowCapabilities.imageFields copy];
     convertedCapabilities.templatesAvailable = [defaultMainWindowCapabilities.templatesAvailable copy];
     convertedCapabilities.numCustomPresetsAvailable = [defaultMainWindowCapabilities.numCustomPresetsAvailable copy];
-    convertedCapabilities.mediaClockFormats = @[]; // mandatory field but allows empty array
+    // Set to an empty list if no formats are available
+    convertedCapabilities.mediaClockFormats = self.displayCapabilities.mediaClockFormats ? self.displayCapabilities.mediaClockFormats : @[];
     convertedCapabilities.graphicSupported = @([defaultMainWindowCapabilities.imageTypeSupported containsObject:SDLImageTypeDynamic]);
+    convertedCapabilities.screenParams = self.displayCapabilities.screenParams;
 
     self.displayCapabilities = convertedCapabilities;
     self.buttonCapabilities = defaultMainWindowCapabilities.buttonCapabilities;

--- a/SmartDeviceLink/public/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/public/SDLSystemCapabilityManager.m
@@ -157,6 +157,7 @@ typedef NSString * SDLServiceID;
         NSUInteger currentWindowID = windowCapability.windowID != nil ? windowCapability.windowID.unsignedIntegerValue : SDLPredefinedWindowsDefaultWindow;
         if (currentWindowID != windowID) { continue; }
 
+        windowCapability.windowID = [NSNumber<SDLUInt> numberWithUnsignedLong:windowID];
         return windowCapability;
     }
 

--- a/SmartDeviceLink/public/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/public/SDLSystemCapabilityManager.m
@@ -158,7 +158,7 @@ typedef NSString * SDLServiceID;
         if (currentWindowID != windowID) { continue; }
 
         // A nil windowID is assumed to be the DefaultWindow according to the spec, but that can be hard for developers to check, so set it explicitly.
-        windowCapability.windowID = [NSNumber numberWithUnsignedLong:currentWindowID];
+        windowCapability.windowID = @(currentWindowID);
         return windowCapability;
     }
 
@@ -257,7 +257,6 @@ typedef NSString * SDLServiceID;
     convertedCapabilities.imageFields = [defaultMainWindowCapabilities.imageFields copy];
     convertedCapabilities.templatesAvailable = [defaultMainWindowCapabilities.templatesAvailable copy];
     convertedCapabilities.numCustomPresetsAvailable = [defaultMainWindowCapabilities.numCustomPresetsAvailable copy];
-    // Set to an empty list if no formats are available
     convertedCapabilities.mediaClockFormats = self.displayCapabilities.mediaClockFormats ?: @[];
     convertedCapabilities.graphicSupported = @([defaultMainWindowCapabilities.imageTypeSupported containsObject:SDLImageTypeDynamic]);
     convertedCapabilities.screenParams = self.displayCapabilities.screenParams;

--- a/SmartDeviceLink/public/SDLSystemCapabilityManager.m
+++ b/SmartDeviceLink/public/SDLSystemCapabilityManager.m
@@ -157,7 +157,8 @@ typedef NSString * SDLServiceID;
         NSUInteger currentWindowID = windowCapability.windowID != nil ? windowCapability.windowID.unsignedIntegerValue : SDLPredefinedWindowsDefaultWindow;
         if (currentWindowID != windowID) { continue; }
 
-        windowCapability.windowID = [NSNumber<SDLUInt> numberWithUnsignedLong:windowID];
+        // A nil windowID is assumed to be the DefaultWindow according to the spec, but that can be hard for developers to check, so set it explicitly.
+        windowCapability.windowID = [NSNumber numberWithUnsignedLong:currentWindowID];
         return windowCapability;
     }
 
@@ -257,7 +258,7 @@ typedef NSString * SDLServiceID;
     convertedCapabilities.templatesAvailable = [defaultMainWindowCapabilities.templatesAvailable copy];
     convertedCapabilities.numCustomPresetsAvailable = [defaultMainWindowCapabilities.numCustomPresetsAvailable copy];
     // Set to an empty list if no formats are available
-    convertedCapabilities.mediaClockFormats = self.displayCapabilities.mediaClockFormats ? self.displayCapabilities.mediaClockFormats : @[];
+    convertedCapabilities.mediaClockFormats = self.displayCapabilities.mediaClockFormats ?: @[];
     convertedCapabilities.graphicSupported = @([defaultMainWindowCapabilities.imageTypeSupported containsObject:SDLImageTypeDynamic]);
     convertedCapabilities.screenParams = self.displayCapabilities.screenParams;
 

--- a/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
+++ b/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
@@ -714,12 +714,12 @@ describe(@"a system capability manager", ^{
                 expect(testSystemCapabilityManager.defaultMainWindowCapability.imageFields).to(haveCount(18));
             });
 
-            it(@"should retrieve window id if window id is missing in window capabilities", ^{
-                // set window id to nil. windowID can be potentialy nil in real applications
+            it(@"should set the default window id if window id is missing", ^{
+                // Set window id to nil. windowID can be potentially nil in real applications
                 testSystemCapabilityManager.displays[0].windowCapabilities[0].windowID = nil;
 
-                expect(testSystemCapabilityManager.defaultMainWindowCapability.windowID).to(equal(0));
-                expect([testSystemCapabilityManager windowCapabilityWithWindowID:0].windowID).to(equal(0));
+                expect(testSystemCapabilityManager.defaultMainWindowCapability.windowID).to(equal(SDLPredefinedWindowsDefaultWindow));
+                expect([testSystemCapabilityManager windowCapabilityWithWindowID:0].windowID).to(equal(SDLPredefinedWindowsDefaultWindow));
             });
         });
     });

--- a/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
+++ b/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
@@ -713,6 +713,14 @@ describe(@"a system capability manager", ^{
                 expect(testSystemCapabilityManager.defaultMainWindowCapability.textFields).to(haveCount(38));
                 expect(testSystemCapabilityManager.defaultMainWindowCapability.imageFields).to(haveCount(18));
             });
+
+            it(@"should retrieve window id if window id is missing in window capabilities", ^{
+                // set window id to nil. windowID can be potentialy nil in real applications
+                testSystemCapabilityManager.displays[0].windowCapabilities[0].windowID = nil;
+
+                expect(testSystemCapabilityManager.defaultMainWindowCapability.windowID).to(equal(0));
+                expect([testSystemCapabilityManager windowCapabilityWithWindowID:0].windowID).to(equal(0));
+            });
         });
     });
 

--- a/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
+++ b/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
@@ -66,6 +66,7 @@ describe(@"a system capability manager", ^{
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     __block SDLDisplayCapabilities *testDisplayCapabilities = nil;
     __block SDLDisplayCapabilities *testDisplayCapabilities2 = nil;
+    __block SDLDisplayCapabilities *testDisplayCapabilities3 = nil;
 #pragma clang diagnostic pop
     __block NSArray<SDLSoftButtonCapabilities *> *testSoftButtonCapabilities = nil;
     __block NSArray<SDLButtonCapabilities *> *testButtonCapabilities = nil;
@@ -138,6 +139,16 @@ describe(@"a system capability manager", ^{
 
         testDisplayCapabilities2 = [testDisplayCapabilities copy];
         testDisplayCapabilities2.templatesAvailable = @[@"DEFAULT", @"MEDIA", @"NON_MEDIA"];
+
+        testDisplayCapabilities3 = [testDisplayCapabilities copy];
+        testDisplayCapabilities3.mediaClockFormats = @[SDLMediaClockFormatClock1, SDLMediaClockFormatClock2];
+        SDLScreenParams *screenParams = [[SDLScreenParams alloc] init];
+        [screenParams setResolution:[[SDLImageResolution alloc] initWithWidth:675 height:960]];
+        [screenParams setTouchEventAvailable:[[SDLTouchEventCapabilities alloc] init]];
+        [screenParams.touchEventAvailable setPressAvailable:@YES];
+        [screenParams.touchEventAvailable setMultiTouchAvailable:@YES];
+        [screenParams.touchEventAvailable setDoublePressAvailable:@YES];
+        testDisplayCapabilities3.screenParams = screenParams;
     });
 
     afterEach(^{
@@ -713,7 +724,7 @@ describe(@"a system capability manager", ^{
                 testDisplayCapabilities.displayName = [NSString stringWithFormat:@"Display %i", i];
                 testDisplayCapabilities.graphicSupported = i == 0 ? @(NO) : @(YES);
                 testDisplayCapabilities.templatesAvailable = @[[NSString stringWithFormat:@"Template %i", i]];
-                
+
                 SDLWindowTypeCapabilities *windowTypeCapabilities = [[SDLWindowTypeCapabilities alloc] initWithType:SDLWindowTypeMain maximumNumberOfWindows:1];
                 SDLDisplayCapability *displayCapability = [[SDLDisplayCapability alloc] initWithDisplayName:testDisplayCapabilities.displayName];
                 displayCapability.windowTypeSupported = @[windowTypeCapabilities];
@@ -728,12 +739,12 @@ describe(@"a system capability manager", ^{
                 defaultWindowCapability.imageTypeSupported = testDisplayCapabilities.graphicSupported.boolValue ? @[SDLImageTypeStatic, SDLImageTypeDynamic] : @[SDLImageTypeStatic];
                 displayCapability.windowCapabilities = @[defaultWindowCapability];
                 NSArray<SDLDisplayCapability *> *newDisplayCapabilityList = testDisplayCapabilityList = @[displayCapability];
-                
+
                 SDLSystemCapability *newCapability = [[SDLSystemCapability alloc] initWithDisplayCapabilities:newDisplayCapabilityList];
                 SDLOnSystemCapabilityUpdated *testUpdateNotification = [[SDLOnSystemCapabilityUpdated alloc] initWithSystemCapability:newCapability];
                 SDLRPCNotificationNotification *notification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidReceiveSystemCapabilityUpdatedNotification object:nil rpcNotification:testUpdateNotification];
                 [[NSNotificationCenter defaultCenter] postNotification:notification];
-                
+
                 expect(testSystemCapabilityManager.displays).to(equal(testDisplayCapabilityList));
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
@@ -743,6 +754,40 @@ describe(@"a system capability manager", ^{
                 expect(testSystemCapabilityManager.presetBankCapabilities).to(beNil());
 #pragma clang diagnostic pop
             }
+        });
+
+        it(@"it should keep maintain screenParams and mediaClockFormats values in display capabilities", ^{
+            // Set to display capabilities that have screenParams and mediaClockFormats set
+            testSystemCapabilityManager.displayCapabilities = testDisplayCapabilities3;
+
+            SDLWindowTypeCapabilities *windowTypeCapabilities = [[SDLWindowTypeCapabilities alloc] initWithType:SDLWindowTypeMain maximumNumberOfWindows:1];
+            SDLDisplayCapability *displayCapability = [[SDLDisplayCapability alloc] initWithDisplayName:testDisplayCapabilities.displayName];
+            displayCapability.windowTypeSupported = @[windowTypeCapabilities];
+            SDLWindowCapability *defaultWindowCapability = [[SDLWindowCapability alloc] init];
+            defaultWindowCapability.windowID = @(SDLPredefinedWindowsDefaultWindow);
+            defaultWindowCapability.buttonCapabilities = testButtonCapabilities.copy;
+            defaultWindowCapability.softButtonCapabilities = testSoftButtonCapabilities.copy;
+            defaultWindowCapability.templatesAvailable = testDisplayCapabilities.templatesAvailable.copy;
+            defaultWindowCapability.numCustomPresetsAvailable = testDisplayCapabilities.numCustomPresetsAvailable.copy;
+            defaultWindowCapability.textFields = testDisplayCapabilities.textFields.copy;
+            defaultWindowCapability.imageFields = testDisplayCapabilities.imageFields.copy;
+            defaultWindowCapability.imageTypeSupported = testDisplayCapabilities.graphicSupported.boolValue ? @[SDLImageTypeStatic, SDLImageTypeDynamic] : @[SDLImageTypeStatic];
+            displayCapability.windowCapabilities = @[defaultWindowCapability];
+            NSArray<SDLDisplayCapability *> *newDisplayCapabilityList = testDisplayCapabilityList = @[displayCapability];
+
+            SDLSystemCapability *newCapability = [[SDLSystemCapability alloc] initWithDisplayCapabilities:newDisplayCapabilityList];
+            SDLOnSystemCapabilityUpdated *testUpdateNotification = [[SDLOnSystemCapabilityUpdated alloc] initWithSystemCapability:newCapability];
+            SDLRPCNotificationNotification *notification = [[SDLRPCNotificationNotification alloc] initWithName:SDLDidReceiveSystemCapabilityUpdatedNotification object:nil rpcNotification:testUpdateNotification];
+            [[NSNotificationCenter defaultCenter] postNotification:notification];
+
+#pragma clang diagnostic push
+            expect(testSystemCapabilityManager.displays).to(equal(testDisplayCapabilityList));
+#pragma clang diagnostic ignored "-Wdeprecated"
+            expect(testSystemCapabilityManager.displayCapabilities).to(equal(testDisplayCapabilities3));
+            expect(testSystemCapabilityManager.buttonCapabilities).to(equal(testButtonCapabilities));
+            expect(testSystemCapabilityManager.softButtonCapabilities).to(equal(testSoftButtonCapabilities));
+            expect(testSystemCapabilityManager.presetBankCapabilities).to(beNil());
+#pragma clang diagnostic pop
         });
     });
 

--- a/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
+++ b/SmartDeviceLinkTests/SDLSystemCapabilityManagerSpec.m
@@ -66,7 +66,6 @@ describe(@"a system capability manager", ^{
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     __block SDLDisplayCapabilities *testDisplayCapabilities = nil;
     __block SDLDisplayCapabilities *testDisplayCapabilities2 = nil;
-    __block SDLDisplayCapabilities *testDisplayCapabilities3 = nil;
 #pragma clang diagnostic pop
     __block NSArray<SDLSoftButtonCapabilities *> *testSoftButtonCapabilities = nil;
     __block NSArray<SDLButtonCapabilities *> *testButtonCapabilities = nil;
@@ -756,6 +755,8 @@ describe(@"a system capability manager", ^{
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
                 expect(testSystemCapabilityManager.displayCapabilities).to(equal(testDisplayCapabilities));
+                expect(testSystemCapabilityManager.displayCapabilities.screenParams).to(equal(testDisplayCapabilities.screenParams));
+                expect(testSystemCapabilityManager.displayCapabilities.mediaClockFormats).to(equal(testDisplayCapabilities.mediaClockFormats));
                 expect(testSystemCapabilityManager.buttonCapabilities).to(equal(testButtonCapabilities));
                 expect(testSystemCapabilityManager.softButtonCapabilities).to(equal(testSoftButtonCapabilities));
                 expect(testSystemCapabilityManager.presetBankCapabilities).to(beNil());


### PR DESCRIPTION
Fixes #2105 

### Risk
This PR makes no API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
- Added unit test in `SDLSystemCapabilityManagerSpec` to verify when updated `displayCapabilities` properties `screenParams` and `mediaClockFormats` stays the same.
- Unit test for if `windowID` is nil in `windowCapabilities` returns the `windowID` in `defaultMainWindowCapability` and `windowCapabilityWithWindowID`

#### Core Tests
- Accessed `screenParams` and `mediaClockFormats` from `systemCapabilityManager`
- Accessed `windowID` from `defaultMainWindowCapabilty` and `windowCapabiltyWithWindowID`

Core version / branch / commit hash / module tested against: sdl_core 8.1.0 (manticore)
HMI name / version / branch / commit hash / module tested against: generic_hmi 0.12.0 (manticore)

### Summary
- `sdl_updateDeprecatedDisplayCapabilities` sets the mediaClockFormats and screenParams to the initialized values.
- `windowCapabiltyWithWindowID` sets the windowID property before returning the `windowCapabilty`
- Unit test added in `SDLSystemCapabilityManagerSpec` for verifying `displayCapabilities` after update.
- Unit test added in `SDLSystemCapabiltyManagerSpec` to verify `windowID` was returned if set to nil

### Changelog
##### Breaking Changes
* NA

##### Enhancements
* NA

##### Bug Fixes
* windowID, screenParams, and mediaClockFormats are not nil or empty

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
