### PR TITLE
Bugfix/issue 1781 good text failing

### DIFF
--- a/SmartDeviceLink/private/SDLTextAndGraphicManager.m
+++ b/SmartDeviceLink/private/SDLTextAndGraphicManager.m
@@ -178,7 +178,10 @@ NS_ASSUME_NONNULL_BEGIN
         } else if (error != nil) {
             // Invalidate data that's different from our current screen data if a Show or SetDisplayLayout fails. This will prevent subsequent `Show`s from failing if the request failed due to the developer setting invalid data or subsequent `SetDisplayLayout`s from failing if the template is not supported on the module. 
             [strongSelf sdl_resetFieldsToCurrentScreenData];
-            [strongSelf sdl_updatePendingOperationsWithFailedScreenState:error.userInfo[SDLTextAndGraphicFailedScreenStateErrorKey]];
+            SDLTextAndGraphicState *errorState = [error.userInfo objectForKey:SDLTextAndGraphicFailedScreenStateErrorKey];
+            if (errorState) {
+                [strongSelf sdl_updatePendingOperationsWithFailedScreenState:errorState];
+            }
         }
     } updateCompletionHandler:handler];
 

--- a/SmartDeviceLink/private/SDLTextAndGraphicManager.m
+++ b/SmartDeviceLink/private/SDLTextAndGraphicManager.m
@@ -197,7 +197,10 @@ NS_ASSUME_NONNULL_BEGIN
         SDLTextAndGraphicUpdateOperation *updateOp = (SDLTextAndGraphicUpdateOperation *)operation;
 
         updateOp.currentScreenData = newScreenData;
-        [updateOp updateStateDataWithErrorData:errorData];
+
+        if (errorData != nil) {
+            [updateOp updateStateDataWithErrorData:errorData];
+        }
     }
 }
 

--- a/SmartDeviceLink/private/SDLTextAndGraphicManager.m
+++ b/SmartDeviceLink/private/SDLTextAndGraphicManager.m
@@ -205,7 +205,7 @@ NS_ASSUME_NONNULL_BEGIN
         if (operation.isExecuting) { continue; }
         SDLTextAndGraphicUpdateOperation *updateOp = (SDLTextAndGraphicUpdateOperation *)operation;
 
-        [updateOp updateStateDataWithErrorData:errorState];
+        [updateOp updateTargetStateWithErrorState:errorState];
     }
 }
 

--- a/SmartDeviceLink/private/SDLTextAndGraphicManager.m
+++ b/SmartDeviceLink/private/SDLTextAndGraphicManager.m
@@ -178,7 +178,7 @@ NS_ASSUME_NONNULL_BEGIN
         } else if (error != nil) {
             // Invalidate data that's different from our current screen data if a Show or SetDisplayLayout fails. This will prevent subsequent `Show`s from failing if the request failed due to the developer setting invalid data or subsequent `SetDisplayLayout`s from failing if the template is not supported on the module. 
             [strongSelf sdl_resetFieldsToCurrentScreenData];
-            [strongSelf sdl_updatePendingOperationsWithFailedScreenState:error.userInfo[@"failedScreenState"]];
+            [strongSelf sdl_updatePendingOperationsWithFailedScreenState:error.userInfo[SDLTextAndGraphicFailedScreenStateErrorKey]];
         }
     } updateCompletionHandler:handler];
 

--- a/SmartDeviceLink/private/SDLTextAndGraphicManager.m
+++ b/SmartDeviceLink/private/SDLTextAndGraphicManager.m
@@ -179,7 +179,7 @@ NS_ASSUME_NONNULL_BEGIN
             // Invalidate data that's different from our current screen data if a Show or SetDisplayLayout fails. This will prevent subsequent `Show`s from failing if the request failed due to the developer setting invalid data or subsequent `SetDisplayLayout`s from failing if the template is not supported on the module. 
             [strongSelf sdl_resetFieldsToCurrentScreenData];
             SDLTextAndGraphicState *errorState = error.userInfo[SDLTextAndGraphicFailedScreenStateErrorKey];
-            if (errorState) {
+            if (errorState != nil) {
                 [strongSelf sdl_updatePendingOperationsWithFailedScreenState:errorState];
             }
         }

--- a/SmartDeviceLink/private/SDLTextAndGraphicManager.m
+++ b/SmartDeviceLink/private/SDLTextAndGraphicManager.m
@@ -167,10 +167,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)sdl_updateAndCancelPreviousOperations:(BOOL)supersedePreviousOperations completionHandler:(nullable SDLTextAndGraphicUpdateCompletionHandler)handler {
     SDLLogD(@"Updating text and graphics");
-    if (self.transactionQueue.operationCount > 0 && supersedePreviousOperations) {
-        SDLLogV(@"Transactions already exist, cancelling them");
-        [self.transactionQueue cancelAllOperations];
-    }
 
     __weak typeof(self) weakSelf = self;
     SDLTextAndGraphicUpdateOperation *updateOperation = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:self.connectionManager fileManager:self.fileManager currentCapabilities:self.windowCapability currentScreenData:self.currentScreenData newState:[self currentState] currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState *_Nullable newScreenData, NSError *_Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {

--- a/SmartDeviceLink/private/SDLTextAndGraphicManager.m
+++ b/SmartDeviceLink/private/SDLTextAndGraphicManager.m
@@ -178,7 +178,7 @@ NS_ASSUME_NONNULL_BEGIN
         } else if (error != nil) {
             // Invalidate data that's different from our current screen data if a Show or SetDisplayLayout fails. This will prevent subsequent `Show`s from failing if the request failed due to the developer setting invalid data or subsequent `SetDisplayLayout`s from failing if the template is not supported on the module. 
             [strongSelf sdl_resetFieldsToCurrentScreenData];
-            SDLTextAndGraphicState *errorState = [error.userInfo objectForKey:SDLTextAndGraphicFailedScreenStateErrorKey];
+            SDLTextAndGraphicState *errorState = error.userInfo[SDLTextAndGraphicFailedScreenStateErrorKey];
             if (errorState) {
                 [strongSelf sdl_updatePendingOperationsWithFailedScreenState:errorState];
             }

--- a/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.h
+++ b/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.h
@@ -38,9 +38,9 @@ typedef void(^CurrentDataUpdatedHandler)(SDLTextAndGraphicState *__nullable newS
 /// @param updateCompletionHandler The handler potentially passed by the developer to be called when the update finishes
 - (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager fileManager:(SDLFileManager *)fileManager currentCapabilities:(SDLWindowCapability *)currentCapabilities currentScreenData:(SDLTextAndGraphicState *)currentData newState:(SDLTextAndGraphicState *)newState currentScreenDataUpdatedHandler:(CurrentDataUpdatedHandler)currentDataUpdatedHandler updateCompletionHandler:(nullable SDLTextAndGraphicUpdateCompletionHandler)updateCompletionHandler;
 
-/// Changes updated state to remove potential errors from previous update operations
-/// @param errorData A updated state that failed in a previous operation that will be used to filter out erroneous data
-- (void)updateStateDataWithErrorData:(SDLTextAndGraphicState *)errorData;
+/// Changes updated state to remove failed updates from previous update operations. This will find and revert those failed updates back to current screen data so that we don't duplicate the failure.
+/// @param errorState A updated state that failed in a previous operation that will be used to filter out erroneous data
+- (void)updateTargetStateWithErrorState:(SDLTextAndGraphicState *)errorState;
 
 @end
 

--- a/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.h
+++ b/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.h
@@ -22,7 +22,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 typedef void(^SDLTextAndGraphicUpdateCompletionHandler)(NSError *__nullable error);
-typedef void(^CurrentDataUpdatedHandler)(SDLTextAndGraphicState *__nullable newScreenData, NSError *__nullable error, SDLTextAndGraphicState *__nullable errorScreenData);
+typedef void(^CurrentDataUpdatedHandler)(SDLTextAndGraphicState *__nullable newScreenData, NSError *__nullable error);
 
 @interface SDLTextAndGraphicUpdateOperation : SDLAsynchronousOperation
 

--- a/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.h
+++ b/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.h
@@ -22,7 +22,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 typedef void(^SDLTextAndGraphicUpdateCompletionHandler)(NSError *__nullable error);
-typedef void(^CurrentDataUpdatedHandler)(SDLTextAndGraphicState *__nullable newScreenData, NSError *__nullable error);
+typedef void(^CurrentDataUpdatedHandler)(SDLTextAndGraphicState *__nullable newScreenData, NSError *__nullable error, SDLTextAndGraphicState *__nullable errorScreenData);
 
 @interface SDLTextAndGraphicUpdateOperation : SDLAsynchronousOperation
 
@@ -37,6 +37,10 @@ typedef void(^CurrentDataUpdatedHandler)(SDLTextAndGraphicState *__nullable newS
 /// @param newState The new text and graphic manager state to be compared with currentData and sent in a Show update if needed.
 /// @param updateCompletionHandler The handler potentially passed by the developer to be called when the update finishes
 - (instancetype)initWithConnectionManager:(id<SDLConnectionManagerType>)connectionManager fileManager:(SDLFileManager *)fileManager currentCapabilities:(SDLWindowCapability *)currentCapabilities currentScreenData:(SDLTextAndGraphicState *)currentData newState:(SDLTextAndGraphicState *)newState currentScreenDataUpdatedHandler:(CurrentDataUpdatedHandler)currentDataUpdatedHandler updateCompletionHandler:(nullable SDLTextAndGraphicUpdateCompletionHandler)updateCompletionHandler;
+
+/// Changes updated state to remove potential errors from previous update operations
+/// @param errorData A updated state that failed in a previous operation that will be used to filter out erroneous data
+- (void)updateStateDataWithErrorData:(SDLTextAndGraphicState *)errorData;
 
 @end
 

--- a/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.h
+++ b/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.h
@@ -21,6 +21,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+extern NSString *const SDLTextAndGraphicFailedScreenStateErrorKey;
+
 typedef void(^SDLTextAndGraphicUpdateCompletionHandler)(NSError *__nullable error);
 typedef void(^CurrentDataUpdatedHandler)(SDLTextAndGraphicState *__nullable newScreenData, NSError *__nullable error);
 

--- a/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
+++ b/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
@@ -97,6 +97,23 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
+- (void)updateStateDataWithErrorData:(SDLTextAndGraphicState *)errorData {
+    self.updatedState.textField1 = errorData.textField1 == self.updatedState.textField1 ? self.currentScreenData.textField1 : self.updatedState.textField1;
+    self.updatedState.textField2 = errorData.textField2 == self.updatedState.textField2 ? self.currentScreenData.textField2 : self.updatedState.textField2;
+    self.updatedState.textField3 = errorData.textField3 == self.updatedState.textField3 ? self.currentScreenData.textField3 : self.updatedState.textField3;
+    self.updatedState.textField4 = errorData.textField4 == self.updatedState.textField4 ? self.currentScreenData.textField4 : self.updatedState.textField4;
+    self.updatedState.mediaTrackTextField = errorData.mediaTrackTextField == self.updatedState.mediaTrackTextField ? self.currentScreenData.mediaTrackTextField : self.updatedState.mediaTrackTextField;
+    self.updatedState.title = errorData.title == self.updatedState.title ? self.currentScreenData.title : self.updatedState.title;
+    self.updatedState.primaryGraphic = errorData.primaryGraphic == self.updatedState.primaryGraphic ? self.currentScreenData.primaryGraphic : self.updatedState.primaryGraphic;
+    self.updatedState.secondaryGraphic = errorData.secondaryGraphic == self.updatedState.secondaryGraphic ? self.currentScreenData.secondaryGraphic : self.updatedState.secondaryGraphic;
+    self.updatedState.alignment = errorData.alignment == self.updatedState.alignment ? self.currentScreenData.alignment : self.updatedState.alignment;
+    self.updatedState.textField1Type = errorData.textField1Type == self.updatedState.textField1Type ? self.currentScreenData.textField1Type : self.updatedState.textField1Type;
+    self.updatedState.textField2Type = errorData.textField2Type == self.updatedState.textField2Type ? self.currentScreenData.textField2Type : self.updatedState.textField2Type;
+    self.updatedState.textField3Type = errorData.textField3Type == self.updatedState.textField3Type ? self.currentScreenData.textField3Type : self.updatedState.textField3Type;
+    self.updatedState.textField4Type = errorData.textField4Type == self.updatedState.textField4Type ? self.currentScreenData.textField4Type : self.updatedState.textField4Type;
+    self.updatedState.templateConfig = errorData.templateConfig == self.updatedState.templateConfig ? self.currentScreenData.templateConfig : self.updatedState.templateConfig;
+}
+
 #pragma mark - Send Show / Set Display Layout
 
 - (void)sdl_updateGraphicsAndShow:(SDLShow *)show {
@@ -159,7 +176,7 @@ NS_ASSUME_NONNULL_BEGIN
             [strongSelf sdl_updateCurrentScreenDataFromShow:request];
         } else {
             SDLLogD(@"Text and Graphic Show failed");
-            self.currentDataUpdatedHandler(nil, error);
+            self.currentDataUpdatedHandler(nil, error, self.updatedState);
         }
 
         handler(error);
@@ -182,7 +199,7 @@ NS_ASSUME_NONNULL_BEGIN
             [strongSelf sdl_updateCurrentScreenDataFromSetDisplayLayout:request];
         } else {
             SDLLogD(@"Text and Graphic SetDisplayLayout failed to change to new layout: %@", setLayout.displayLayout);
-            self.currentDataUpdatedHandler(nil, error);
+            self.currentDataUpdatedHandler(nil, error, nil);
         }
 
         handler(error);
@@ -498,7 +515,7 @@ NS_ASSUME_NONNULL_BEGIN
     self.currentScreenData.templateConfig = show.templateConfiguration ? self.updatedState.templateConfig : self.currentScreenData.templateConfig;
 
     if (self.currentDataUpdatedHandler != nil) {
-        self.currentDataUpdatedHandler(self.currentScreenData, nil);
+        self.currentDataUpdatedHandler(self.currentScreenData, nil, nil);
     }
 }
 
@@ -509,7 +526,7 @@ NS_ASSUME_NONNULL_BEGIN
     self.currentScreenData.templateConfig = [[SDLTemplateConfiguration alloc] initWithTemplate:setDisplayLayout.displayLayout dayColorScheme:setDisplayLayout.dayColorScheme nightColorScheme:setDisplayLayout.nightColorScheme];
 
     if (self.currentDataUpdatedHandler != nil) {
-        self.currentDataUpdatedHandler(self.currentScreenData, nil);
+        self.currentDataUpdatedHandler(self.currentScreenData, nil, nil);
     }
 }
 

--- a/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
+++ b/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
@@ -176,11 +176,10 @@ NS_ASSUME_NONNULL_BEGIN
             [strongSelf sdl_updateCurrentScreenDataFromShow:request];
         } else {
             SDLLogD(@"Text and Graphic Show failed");
-            NSDictionary *newUserInfo = @{
-                @"NSUnderlyingErrorKey": error.userInfo,
+            NSError *updateError = [NSError errorWithDomain:error.domain code:error.code userInfo:@{
+                NSUnderlyingErrorKey: error.userInfo,
                 @"failedScreenState": self.updatedState
-            };
-            NSError *updateError = [NSError errorWithDomain:error.domain code:error.code userInfo:newUserInfo];
+            }];
             self.currentDataUpdatedHandler(nil, updateError);
         }
 

--- a/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
+++ b/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
@@ -97,21 +97,21 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
-- (void)updateStateDataWithErrorData:(SDLTextAndGraphicState *)errorData {
-    self.updatedState.textField1 = (errorData.textField1 == self.updatedState.textField1) ? self.currentScreenData.textField1 : self.updatedState.textField1;
-    self.updatedState.textField2 = errorData.textField2 == self.updatedState.textField2 ? self.currentScreenData.textField2 : self.updatedState.textField2;
-    self.updatedState.textField3 = errorData.textField3 == self.updatedState.textField3 ? self.currentScreenData.textField3 : self.updatedState.textField3;
-    self.updatedState.textField4 = errorData.textField4 == self.updatedState.textField4 ? self.currentScreenData.textField4 : self.updatedState.textField4;
-    self.updatedState.mediaTrackTextField = errorData.mediaTrackTextField == self.updatedState.mediaTrackTextField ? self.currentScreenData.mediaTrackTextField : self.updatedState.mediaTrackTextField;
-    self.updatedState.title = errorData.title == self.updatedState.title ? self.currentScreenData.title : self.updatedState.title;
-    self.updatedState.primaryGraphic = errorData.primaryGraphic == self.updatedState.primaryGraphic ? self.currentScreenData.primaryGraphic : self.updatedState.primaryGraphic;
-    self.updatedState.secondaryGraphic = errorData.secondaryGraphic == self.updatedState.secondaryGraphic ? self.currentScreenData.secondaryGraphic : self.updatedState.secondaryGraphic;
-    self.updatedState.alignment = errorData.alignment == self.updatedState.alignment ? self.currentScreenData.alignment : self.updatedState.alignment;
-    self.updatedState.textField1Type = errorData.textField1Type == self.updatedState.textField1Type ? self.currentScreenData.textField1Type : self.updatedState.textField1Type;
-    self.updatedState.textField2Type = errorData.textField2Type == self.updatedState.textField2Type ? self.currentScreenData.textField2Type : self.updatedState.textField2Type;
-    self.updatedState.textField3Type = errorData.textField3Type == self.updatedState.textField3Type ? self.currentScreenData.textField3Type : self.updatedState.textField3Type;
-    self.updatedState.textField4Type = errorData.textField4Type == self.updatedState.textField4Type ? self.currentScreenData.textField4Type : self.updatedState.textField4Type;
-    self.updatedState.templateConfig = errorData.templateConfig == self.updatedState.templateConfig ? self.currentScreenData.templateConfig : self.updatedState.templateConfig;
+- (void)updateTargetStateWithErrorState:(SDLTextAndGraphicState *)errorState {
+    self.updatedState.textField1 = (errorState.textField1 == self.updatedState.textField1) ? self.currentScreenData.textField1 : self.updatedState.textField1;
+    self.updatedState.textField2 = (errorState.textField2 == self.updatedState.textField2) ? self.currentScreenData.textField2 : self.updatedState.textField2;
+    self.updatedState.textField3 = (errorState.textField3 == self.updatedState.textField3) ? self.currentScreenData.textField3 : self.updatedState.textField3;
+    self.updatedState.textField4 = (errorState.textField4 == self.updatedState.textField4) ? self.currentScreenData.textField4 : self.updatedState.textField4;
+    self.updatedState.mediaTrackTextField = (errorState.mediaTrackTextField == self.updatedState.mediaTrackTextField) ? self.currentScreenData.mediaTrackTextField : self.updatedState.mediaTrackTextField;
+    self.updatedState.title = (errorState.title == self.updatedState.title) ? self.currentScreenData.title : self.updatedState.title;
+    self.updatedState.primaryGraphic = (errorState.primaryGraphic == self.updatedState.primaryGraphic) ? self.currentScreenData.primaryGraphic : self.updatedState.primaryGraphic;
+    self.updatedState.secondaryGraphic = (errorState.secondaryGraphic == self.updatedState.secondaryGraphic) ? self.currentScreenData.secondaryGraphic : self.updatedState.secondaryGraphic;
+    self.updatedState.alignment = (errorState.alignment == self.updatedState.alignment) ? self.currentScreenData.alignment : self.updatedState.alignment;
+    self.updatedState.textField1Type = (errorState.textField1Type == self.updatedState.textField1Type) ? self.currentScreenData.textField1Type : self.updatedState.textField1Type;
+    self.updatedState.textField2Type = (errorState.textField2Type == self.updatedState.textField2Type) ? self.currentScreenData.textField2Type : self.updatedState.textField2Type;
+    self.updatedState.textField3Type = (errorState.textField3Type == self.updatedState.textField3Type) ? self.currentScreenData.textField3Type : self.updatedState.textField3Type;
+    self.updatedState.textField4Type = (errorState.textField4Type == self.updatedState.textField4Type) ? self.currentScreenData.textField4Type : self.updatedState.textField4Type;
+    self.updatedState.templateConfig = (errorState.templateConfig == self.updatedState.templateConfig) ? self.currentScreenData.templateConfig : self.updatedState.templateConfig;
 }
 
 #pragma mark - Send Show / Set Display Layout

--- a/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
+++ b/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
@@ -175,7 +175,7 @@ NS_ASSUME_NONNULL_BEGIN
             SDLLogD(@"Text and Graphic Show completed successfully");
             [strongSelf sdl_updateCurrentScreenDataFromShow:request];
         } else {
-            SDLLogD(@"Text and Graphic Show failed");
+            SDLLogE(@"Text and Graphic Show failed: %@", error);
             NSError *updateError = [NSError errorWithDomain:error.domain code:error.code userInfo:@{
                 NSUnderlyingErrorKey: error.userInfo,
                 @"failedScreenState": self.updatedState

--- a/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
+++ b/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
@@ -100,20 +100,21 @@ NSString *const SDLTextAndGraphicFailedScreenStateErrorKey = @"failedScreenState
 }
 
 - (void)updateTargetStateWithErrorState:(SDLTextAndGraphicState *)errorState {
-    self.updatedState.textField1 = (errorState.textField1 == self.updatedState.textField1) ? self.currentScreenData.textField1 : self.updatedState.textField1;
-    self.updatedState.textField2 = (errorState.textField2 == self.updatedState.textField2) ? self.currentScreenData.textField2 : self.updatedState.textField2;
-    self.updatedState.textField3 = (errorState.textField3 == self.updatedState.textField3) ? self.currentScreenData.textField3 : self.updatedState.textField3;
-    self.updatedState.textField4 = (errorState.textField4 == self.updatedState.textField4) ? self.currentScreenData.textField4 : self.updatedState.textField4;
-    self.updatedState.mediaTrackTextField = (errorState.mediaTrackTextField == self.updatedState.mediaTrackTextField) ? self.currentScreenData.mediaTrackTextField : self.updatedState.mediaTrackTextField;
-    self.updatedState.title = (errorState.title == self.updatedState.title) ? self.currentScreenData.title : self.updatedState.title;
-    self.updatedState.primaryGraphic = (errorState.primaryGraphic == self.updatedState.primaryGraphic) ? self.currentScreenData.primaryGraphic : self.updatedState.primaryGraphic;
-    self.updatedState.secondaryGraphic = (errorState.secondaryGraphic == self.updatedState.secondaryGraphic) ? self.currentScreenData.secondaryGraphic : self.updatedState.secondaryGraphic;
-    self.updatedState.alignment = (errorState.alignment == self.updatedState.alignment) ? self.currentScreenData.alignment : self.updatedState.alignment;
-    self.updatedState.textField1Type = (errorState.textField1Type == self.updatedState.textField1Type) ? self.currentScreenData.textField1Type : self.updatedState.textField1Type;
-    self.updatedState.textField2Type = (errorState.textField2Type == self.updatedState.textField2Type) ? self.currentScreenData.textField2Type : self.updatedState.textField2Type;
-    self.updatedState.textField3Type = (errorState.textField3Type == self.updatedState.textField3Type) ? self.currentScreenData.textField3Type : self.updatedState.textField3Type;
-    self.updatedState.textField4Type = (errorState.textField4Type == self.updatedState.textField4Type) ? self.currentScreenData.textField4Type : self.updatedState.textField4Type;
-    self.updatedState.templateConfig = (errorState.templateConfig == self.updatedState.templateConfig) ? self.currentScreenData.templateConfig : self.updatedState.templateConfig;
+    self.updatedState.textField1 = [errorState.textField1 isEqualToString:self.updatedState.textField1] ? self.currentScreenData.textField1 : self.updatedState.textField1;
+    self.updatedState.textField2 = [errorState.textField2 isEqualToString:self.updatedState.textField2] ? self.currentScreenData.textField2 : self.updatedState.textField2;
+    self.updatedState.textField3 = [errorState.textField3 isEqualToString:self.updatedState.textField3] ? self.currentScreenData.textField3 : self.updatedState.textField3;
+    self.updatedState.textField4 = [errorState.textField4 isEqualToString:self.updatedState.textField4] ? self.currentScreenData.textField4 : self.updatedState.textField4;
+    self.updatedState.mediaTrackTextField = [errorState.mediaTrackTextField isEqualToString:self.updatedState.mediaTrackTextField] ? self.currentScreenData.mediaTrackTextField : self.updatedState.mediaTrackTextField;
+    self.updatedState.title = [errorState.title isEqualToString:self.updatedState.title] ? self.currentScreenData.title : self.updatedState.title;
+    self.updatedState.primaryGraphic = [errorState.primaryGraphic isEqual:self.updatedState.primaryGraphic] ? self.currentScreenData.primaryGraphic : self.updatedState.primaryGraphic;
+    [errorState.primaryGraphic isEqual:self.updatedState.primaryGraphic];
+    self.updatedState.secondaryGraphic = [errorState.secondaryGraphic isEqual:self.updatedState.secondaryGraphic] ? self.currentScreenData.secondaryGraphic : self.updatedState.secondaryGraphic;
+    self.updatedState.alignment = [errorState.alignment isEqualToEnum:self.updatedState.alignment] ? self.currentScreenData.alignment : self.updatedState.alignment;
+    self.updatedState.textField1Type = [errorState.textField1Type isEqualToEnum:self.updatedState.textField1Type] ? self.currentScreenData.textField1Type : self.updatedState.textField1Type;
+    self.updatedState.textField2Type = [errorState.textField2Type isEqualToEnum:self.updatedState.textField2Type] ? self.currentScreenData.textField2Type : self.updatedState.textField2Type;
+    self.updatedState.textField3Type = [errorState.textField3Type isEqualToEnum:self.updatedState.textField3Type] ? self.currentScreenData.textField3Type : self.updatedState.textField3Type;
+    self.updatedState.textField4Type = [errorState.textField4Type isEqualToEnum:self.updatedState.textField4Type] ? self.currentScreenData.textField4Type : self.updatedState.textField4Type;
+    self.updatedState.templateConfig = [errorState.templateConfig isEqual:self.updatedState.templateConfig] ? self.currentScreenData.templateConfig : self.updatedState.templateConfig;
 }
 
 #pragma mark - Send Show / Set Display Layout

--- a/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
+++ b/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
@@ -98,7 +98,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)updateStateDataWithErrorData:(SDLTextAndGraphicState *)errorData {
-    self.updatedState.textField1 = errorData.textField1 == self.updatedState.textField1 ? self.currentScreenData.textField1 : self.updatedState.textField1;
+    self.updatedState.textField1 = (errorData.textField1 == self.updatedState.textField1) ? self.currentScreenData.textField1 : self.updatedState.textField1;
     self.updatedState.textField2 = errorData.textField2 == self.updatedState.textField2 ? self.currentScreenData.textField2 : self.updatedState.textField2;
     self.updatedState.textField3 = errorData.textField3 == self.updatedState.textField3 ? self.currentScreenData.textField3 : self.updatedState.textField3;
     self.updatedState.textField4 = errorData.textField4 == self.updatedState.textField4 ? self.currentScreenData.textField4 : self.updatedState.textField4;

--- a/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
+++ b/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
@@ -176,7 +176,12 @@ NS_ASSUME_NONNULL_BEGIN
             [strongSelf sdl_updateCurrentScreenDataFromShow:request];
         } else {
             SDLLogD(@"Text and Graphic Show failed");
-            self.currentDataUpdatedHandler(nil, error, self.updatedState);
+            NSDictionary *newUserInfo = @{
+                @"NSUnderlyingErrorKey": error.userInfo,
+                @"failedScreenState": self.updatedState
+            };
+            NSError *updateError = [NSError errorWithDomain:error.domain code:error.code userInfo:newUserInfo];
+            self.currentDataUpdatedHandler(nil, updateError);
         }
 
         handler(error);
@@ -199,7 +204,7 @@ NS_ASSUME_NONNULL_BEGIN
             [strongSelf sdl_updateCurrentScreenDataFromSetDisplayLayout:request];
         } else {
             SDLLogD(@"Text and Graphic SetDisplayLayout failed to change to new layout: %@", setLayout.displayLayout);
-            self.currentDataUpdatedHandler(nil, error, nil);
+            self.currentDataUpdatedHandler(nil, error);
         }
 
         handler(error);
@@ -515,7 +520,7 @@ NS_ASSUME_NONNULL_BEGIN
     self.currentScreenData.templateConfig = show.templateConfiguration ? self.updatedState.templateConfig : self.currentScreenData.templateConfig;
 
     if (self.currentDataUpdatedHandler != nil) {
-        self.currentDataUpdatedHandler(self.currentScreenData, nil, nil);
+        self.currentDataUpdatedHandler(self.currentScreenData, nil);
     }
 }
 
@@ -526,7 +531,7 @@ NS_ASSUME_NONNULL_BEGIN
     self.currentScreenData.templateConfig = [[SDLTemplateConfiguration alloc] initWithTemplate:setDisplayLayout.displayLayout dayColorScheme:setDisplayLayout.dayColorScheme nightColorScheme:setDisplayLayout.nightColorScheme];
 
     if (self.currentDataUpdatedHandler != nil) {
-        self.currentDataUpdatedHandler(self.currentScreenData, nil, nil);
+        self.currentDataUpdatedHandler(self.currentScreenData, nil);
     }
 }
 

--- a/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
+++ b/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
@@ -26,6 +26,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+NSString *const SDLTextAndGraphicFailedScreenStateErrorKey = @"failedScreenState";
+
 @interface SDLTextAndGraphicUpdateOperation ()
 
 @property (weak, nonatomic) id<SDLConnectionManagerType> connectionManager;
@@ -178,7 +180,7 @@ NS_ASSUME_NONNULL_BEGIN
             SDLLogE(@"Text and Graphic Show failed: %@", error);
             NSError *updateError = [NSError errorWithDomain:error.domain code:error.code userInfo:@{
                 NSUnderlyingErrorKey: error.userInfo,
-                @"failedScreenState": self.updatedState
+                SDLTextAndGraphicFailedScreenStateErrorKey: self.updatedState
             }];
             self.currentDataUpdatedHandler(nil, updateError);
         }

--- a/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
+++ b/SmartDeviceLink/private/SDLTextAndGraphicUpdateOperation.m
@@ -107,7 +107,6 @@ NSString *const SDLTextAndGraphicFailedScreenStateErrorKey = @"failedScreenState
     self.updatedState.mediaTrackTextField = [errorState.mediaTrackTextField isEqualToString:self.updatedState.mediaTrackTextField] ? self.currentScreenData.mediaTrackTextField : self.updatedState.mediaTrackTextField;
     self.updatedState.title = [errorState.title isEqualToString:self.updatedState.title] ? self.currentScreenData.title : self.updatedState.title;
     self.updatedState.primaryGraphic = [errorState.primaryGraphic isEqual:self.updatedState.primaryGraphic] ? self.currentScreenData.primaryGraphic : self.updatedState.primaryGraphic;
-    [errorState.primaryGraphic isEqual:self.updatedState.primaryGraphic];
     self.updatedState.secondaryGraphic = [errorState.secondaryGraphic isEqual:self.updatedState.secondaryGraphic] ? self.currentScreenData.secondaryGraphic : self.updatedState.secondaryGraphic;
     self.updatedState.alignment = [errorState.alignment isEqualToEnum:self.updatedState.alignment] ? self.currentScreenData.alignment : self.updatedState.alignment;
     self.updatedState.textField1Type = [errorState.textField1Type isEqualToEnum:self.updatedState.textField1Type] ? self.currentScreenData.textField1Type : self.updatedState.textField1Type;

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicManagerSpec.m
@@ -492,7 +492,7 @@ describe(@"text and graphic manager", ^{
 
                 // Simulate a failure of the first operation
                 NSDictionary *userInfo = @{
-                    @"failedScreenState": errorState
+                    SDLTextAndGraphicFailedScreenStateErrorKey: errorState
                 };
                 testOperation.currentDataUpdatedHandler(nil, [NSError errorWithDomain:@"any" code:1 userInfo:userInfo]);
             });

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicManagerSpec.m
@@ -466,7 +466,7 @@ describe(@"text and graphic manager", ^{
         // with good data
         context(@"with good data", ^{
             beforeEach(^{
-                testOperation.currentDataUpdatedHandler(testOperation.updatedState, nil, nil);
+                testOperation.currentDataUpdatedHandler(testOperation.updatedState, nil);
             });
 
             it(@"should update the manager's and pending operations' current screen data", ^{
@@ -486,7 +486,11 @@ describe(@"text and graphic manager", ^{
                 testManager.textField1 = errorState.textField1;
                 testManager.textField4 = @"Good Data";
                 testOperation3 = testManager.transactionQueue.operations[3];
-                testOperation.currentDataUpdatedHandler(nil, [NSError errorWithDomain:@"any" code:1 userInfo:nil], errorState);
+
+                NSDictionary *userInfo = @{
+                    @"failedScreenState": errorState
+                };
+                testOperation.currentDataUpdatedHandler(nil, [NSError errorWithDomain:@"any" code:1 userInfo:userInfo]);
             });
 
             it(@"should reset the manager's data and update other operations updated state", ^{

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicManagerSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicManagerSpec.m
@@ -150,7 +150,7 @@ describe(@"text and graphic manager", ^{
                 testManager.textField4 = @"test4";
             });
 
-            it(@"should create indiviudal operations and not be cancelled", ^{
+            it(@"should create individual operations and not be cancelled", ^{
                 expect(testManager.transactionQueue.isSuspended).to(beTrue());
                 expect(testManager.transactionQueue.operationCount).to(equal(4));
                 expect(testManager.transactionQueue.operations[0].cancelled).to(beFalse());
@@ -481,12 +481,16 @@ describe(@"text and graphic manager", ^{
                 testManager.currentScreenData = [[SDLTextAndGraphicState alloc] init];
                 testManager.currentScreenData.textField1 = @"Test1";
 
+                // Create a "bad data" text field 1, then set it in the manager, which should create an operation (op 2)
                 SDLTextAndGraphicState *errorState = [[SDLTextAndGraphicState alloc] init];
                 errorState.textField1 = @"Bad Data";
                 testManager.textField1 = errorState.textField1;
+                
+                // Create a "good data text field 4, which should create a second operation (op 3)
                 testManager.textField4 = @"Good Data";
                 testOperation3 = testManager.transactionQueue.operations[3];
 
+                // Simulate a failure of the first operation
                 NSDictionary *userInfo = @{
                     @"failedScreenState": errorState
                 };
@@ -495,7 +499,7 @@ describe(@"text and graphic manager", ^{
 
             it(@"should reset the manager's data and update other operations updated state", ^{
                 expect(testManager.textField1).to(equal(testManager.currentScreenData.textField1));
-                expect(testOperation3.updatedState.textField1).to(equal(@"Test1"));
+                expect(testOperation3.updatedState.textField1).to(equal(testManager.currentScreenData.textField1));
             });
         });
     });

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicUpdateOperationSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicUpdateOperationSpec.m
@@ -120,7 +120,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState.textField3 = field3String;
                     updatedState.textField4 = field4String;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     [testConnectionManager respondToLastRequestWithResponse:successShowResponse];
@@ -163,7 +163,7 @@ describe(@"the text and graphic operation", ^{
                 });
 
                 it(@"should send the media track and title", ^{
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     SDLShow *sentShow = testConnectionManager.receivedRequests.firstObject;
@@ -179,7 +179,7 @@ describe(@"the text and graphic operation", ^{
                 });
 
                 it(@"should not send the media track and title", ^{
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     SDLShow *sentShow = testConnectionManager.receivedRequests.firstObject;
@@ -201,7 +201,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState = [[SDLTextAndGraphicState alloc] init];
                     updatedState.textField1 = field1String;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     [testConnectionManager respondToLastRequestWithResponse:successShowResponse];
@@ -233,7 +233,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState.textField1 = field1String;
                     updatedState.textField2 = field2String;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     [testConnectionManager respondToLastRequestWithResponse:successShowResponse];
@@ -266,7 +266,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState.textField2 = field2String;
                     updatedState.textField3 = field3String;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     [testConnectionManager respondToLastRequestWithResponse:successShowResponse];
@@ -300,7 +300,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState.textField3 = field3String;
                     updatedState.textField4 = field4String;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     [testConnectionManager respondToLastRequestWithResponse:successShowResponse];
@@ -339,7 +339,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState = [[SDLTextAndGraphicState alloc] init];
                     updatedState.textField1 = field1String;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     [testConnectionManager respondToLastRequestWithResponse:successShowResponse];
@@ -371,7 +371,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState.textField1 = field1String;
                     updatedState.textField2 = field2String;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     [testConnectionManager respondToLastRequestWithResponse:successShowResponse];
@@ -404,7 +404,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState.textField2 = field2String;
                     updatedState.textField3 = field3String;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     [testConnectionManager respondToLastRequestWithResponse:successShowResponse];
@@ -438,7 +438,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState.textField3 = field3String;
                     updatedState.textField4 = field4String;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     [testConnectionManager respondToLastRequestWithResponse:successShowResponse];
@@ -477,7 +477,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState = [[SDLTextAndGraphicState alloc] init];
                     updatedState.textField1 = field1String;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     [testConnectionManager respondToLastRequestWithResponse:successShowResponse];
@@ -509,7 +509,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState.textField1 = field1String;
                     updatedState.textField2 = field2String;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     [testConnectionManager respondToLastRequestWithResponse:successShowResponse];
@@ -542,7 +542,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState.textField2 = field2String;
                     updatedState.textField3 = field3String;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     [testConnectionManager respondToLastRequestWithResponse:successShowResponse];
@@ -576,7 +576,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState.textField3 = field3String;
                     updatedState.textField4 = field4String;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     [testConnectionManager respondToLastRequestWithResponse:successShowResponse];
@@ -615,7 +615,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState = [[SDLTextAndGraphicState alloc] init];
                     updatedState.textField1 = field1String;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     [testConnectionManager respondToLastRequestWithResponse:successShowResponse];
@@ -647,7 +647,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState.textField1 = field1String;
                     updatedState.textField2 = field2String;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     [testConnectionManager respondToLastRequestWithResponse:successShowResponse];
@@ -680,7 +680,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState.textField2 = field2String;
                     updatedState.textField3 = field3String;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     [testConnectionManager respondToLastRequestWithResponse:successShowResponse];
@@ -714,7 +714,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState.textField3 = field3String;
                     updatedState.textField4 = field4String;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     [testConnectionManager respondToLastRequestWithResponse:successShowResponse];
@@ -754,7 +754,7 @@ describe(@"the text and graphic operation", ^{
                 updatedState.textField3 = field3String;
                 updatedState.textField4 = field4String;
 
-                testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:^(NSError * _Nullable error) {
+                testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:^(NSError * _Nullable error) {
                     didCallHandler = YES;
                 }];
                 [testOp start];
@@ -780,7 +780,7 @@ describe(@"the text and graphic operation", ^{
                 updatedState.textField3 = field3String;
                 updatedState.textField4 = field4String;
 
-                testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {
+                testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {
                     updatedData = newScreenData;
                 } updateCompletionHandler:nil];
                 [testOp start];
@@ -823,7 +823,7 @@ describe(@"the text and graphic operation", ^{
                 });
 
                 it(@"should send a show and not upload any artworks", ^{
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     expect(testConnectionManager.receivedRequests).to(haveCount(1));
@@ -845,7 +845,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState2.primaryGraphic = testArtwork3;
                     updatedState2.secondaryGraphic = testArtwork2;
 
-                    SDLTextAndGraphicUpdateOperation *testOp2 = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:updatedState newState:updatedState2 currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
+                    SDLTextAndGraphicUpdateOperation *testOp2 = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:updatedState newState:updatedState2 currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
                     [testOp2 start];
 
                     [testConnectionManager respondToLastRequestWithResponse:successShowResponse];
@@ -862,7 +862,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState.primaryGraphic = testArtwork;
                     updatedState.secondaryGraphic = testArtwork2;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
                     [testOp start];
                 });
 
@@ -892,7 +892,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState.textField1 = field1String;
                     updatedState.primaryGraphic = testArtwork;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {
                         receivedState = newScreenData;
                         receivedError = error;
                     } updateCompletionHandler:^(NSError * _Nullable error) {
@@ -967,7 +967,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState = [[SDLTextAndGraphicState alloc] init];
                     updatedState.primaryGraphic = testArtwork;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
                     [testOp start];
                 });
 
@@ -997,7 +997,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState = [[SDLTextAndGraphicState alloc] init];
                     updatedState.primaryGraphic = testStaticIcon;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
                     [testOp start];
                 });
 
@@ -1032,7 +1032,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState.primaryGraphic = testArtwork;
                     updatedState.secondaryGraphic = testArtwork2;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
                     [testOp start];
                 });
 
@@ -1059,7 +1059,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState.primaryGraphic = testArtwork;
                     updatedState.secondaryGraphic = testArtwork2;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     expect(testConnectionManager.receivedRequests).to(haveCount(1));
@@ -1088,7 +1088,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState.primaryGraphic = testArtwork;
                     updatedState.secondaryGraphic = testArtwork2;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     expect(testConnectionManager.receivedRequests).to(haveCount(1));
@@ -1121,7 +1121,7 @@ describe(@"the text and graphic operation", ^{
                 beforeEach(^{
                     updatedState = [[SDLTextAndGraphicState alloc] init];
                     updatedState.templateConfig = newConfiguration;
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:allEnabledCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:allEnabledCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {
                         receivedState = newScreenData;
                         receivedError = error;
                     } updateCompletionHandler:nil];
@@ -1153,7 +1153,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState = [[SDLTextAndGraphicState alloc] init];
                     updatedState.templateConfig = newConfiguration;
                     updatedState.textField1 = field1String;
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:allEnabledCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:allEnabledCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {
                         receivedState = newScreenData;
                         receivedError = error;
                     } updateCompletionHandler:^(NSError * _Nullable error) {
@@ -1240,7 +1240,7 @@ describe(@"the text and graphic operation", ^{
                 beforeEach(^{
                     updatedState = [[SDLTextAndGraphicState alloc] init];
                     updatedState.templateConfig = newConfiguration;
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:allEnabledCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:allEnabledCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {
                         receivedState = newScreenData;
                         receivedError = error;
                     } updateCompletionHandler:nil];
@@ -1266,7 +1266,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState = [[SDLTextAndGraphicState alloc] init];
                     updatedState.templateConfig = newConfiguration;
                     updatedState.textField1 = field1String;
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:allEnabledCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:allEnabledCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {
                         receivedState = newScreenData;
                         receivedError = error;
                     } updateCompletionHandler:nil];

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicUpdateOperationSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicUpdateOperationSpec.m
@@ -120,7 +120,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState.textField3 = field3String;
                     updatedState.textField4 = field4String;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     [testConnectionManager respondToLastRequestWithResponse:successShowResponse];
@@ -163,7 +163,7 @@ describe(@"the text and graphic operation", ^{
                 });
 
                 it(@"should send the media track and title", ^{
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     SDLShow *sentShow = testConnectionManager.receivedRequests.firstObject;
@@ -179,7 +179,7 @@ describe(@"the text and graphic operation", ^{
                 });
 
                 it(@"should not send the media track and title", ^{
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     SDLShow *sentShow = testConnectionManager.receivedRequests.firstObject;
@@ -201,7 +201,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState = [[SDLTextAndGraphicState alloc] init];
                     updatedState.textField1 = field1String;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     [testConnectionManager respondToLastRequestWithResponse:successShowResponse];
@@ -233,7 +233,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState.textField1 = field1String;
                     updatedState.textField2 = field2String;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     [testConnectionManager respondToLastRequestWithResponse:successShowResponse];
@@ -266,7 +266,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState.textField2 = field2String;
                     updatedState.textField3 = field3String;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     [testConnectionManager respondToLastRequestWithResponse:successShowResponse];
@@ -300,7 +300,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState.textField3 = field3String;
                     updatedState.textField4 = field4String;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     [testConnectionManager respondToLastRequestWithResponse:successShowResponse];
@@ -339,7 +339,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState = [[SDLTextAndGraphicState alloc] init];
                     updatedState.textField1 = field1String;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     [testConnectionManager respondToLastRequestWithResponse:successShowResponse];
@@ -371,7 +371,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState.textField1 = field1String;
                     updatedState.textField2 = field2String;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     [testConnectionManager respondToLastRequestWithResponse:successShowResponse];
@@ -404,7 +404,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState.textField2 = field2String;
                     updatedState.textField3 = field3String;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     [testConnectionManager respondToLastRequestWithResponse:successShowResponse];
@@ -438,7 +438,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState.textField3 = field3String;
                     updatedState.textField4 = field4String;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     [testConnectionManager respondToLastRequestWithResponse:successShowResponse];
@@ -477,7 +477,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState = [[SDLTextAndGraphicState alloc] init];
                     updatedState.textField1 = field1String;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     [testConnectionManager respondToLastRequestWithResponse:successShowResponse];
@@ -509,7 +509,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState.textField1 = field1String;
                     updatedState.textField2 = field2String;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     [testConnectionManager respondToLastRequestWithResponse:successShowResponse];
@@ -542,7 +542,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState.textField2 = field2String;
                     updatedState.textField3 = field3String;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     [testConnectionManager respondToLastRequestWithResponse:successShowResponse];
@@ -576,7 +576,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState.textField3 = field3String;
                     updatedState.textField4 = field4String;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     [testConnectionManager respondToLastRequestWithResponse:successShowResponse];
@@ -615,7 +615,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState = [[SDLTextAndGraphicState alloc] init];
                     updatedState.textField1 = field1String;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     [testConnectionManager respondToLastRequestWithResponse:successShowResponse];
@@ -647,7 +647,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState.textField1 = field1String;
                     updatedState.textField2 = field2String;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     [testConnectionManager respondToLastRequestWithResponse:successShowResponse];
@@ -680,7 +680,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState.textField2 = field2String;
                     updatedState.textField3 = field3String;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     [testConnectionManager respondToLastRequestWithResponse:successShowResponse];
@@ -714,7 +714,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState.textField3 = field3String;
                     updatedState.textField4 = field4String;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     [testConnectionManager respondToLastRequestWithResponse:successShowResponse];
@@ -754,7 +754,7 @@ describe(@"the text and graphic operation", ^{
                 updatedState.textField3 = field3String;
                 updatedState.textField4 = field4String;
 
-                testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:^(NSError * _Nullable error) {
+                testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:^(NSError * _Nullable error) {
                     didCallHandler = YES;
                 }];
                 [testOp start];
@@ -780,7 +780,7 @@ describe(@"the text and graphic operation", ^{
                 updatedState.textField3 = field3String;
                 updatedState.textField4 = field4String;
 
-                testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState *_Nullable newScreenData, NSError *_Nullable error) {
+                testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {
                     updatedData = newScreenData;
                 } updateCompletionHandler:nil];
                 [testOp start];
@@ -823,7 +823,7 @@ describe(@"the text and graphic operation", ^{
                 });
 
                 it(@"should send a show and not upload any artworks", ^{
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     expect(testConnectionManager.receivedRequests).to(haveCount(1));
@@ -845,7 +845,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState2.primaryGraphic = testArtwork3;
                     updatedState2.secondaryGraphic = testArtwork2;
 
-                    SDLTextAndGraphicUpdateOperation *testOp2 = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:updatedState newState:updatedState2 currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
+                    SDLTextAndGraphicUpdateOperation *testOp2 = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:updatedState newState:updatedState2 currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
                     [testOp2 start];
 
                     [testConnectionManager respondToLastRequestWithResponse:successShowResponse];
@@ -862,7 +862,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState.primaryGraphic = testArtwork;
                     updatedState.secondaryGraphic = testArtwork2;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
                     [testOp start];
                 });
 
@@ -892,7 +892,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState.textField1 = field1String;
                     updatedState.primaryGraphic = testArtwork;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {
                         receivedState = newScreenData;
                         receivedError = error;
                     } updateCompletionHandler:^(NSError * _Nullable error) {
@@ -967,7 +967,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState = [[SDLTextAndGraphicState alloc] init];
                     updatedState.primaryGraphic = testArtwork;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
                     [testOp start];
                 });
 
@@ -997,7 +997,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState = [[SDLTextAndGraphicState alloc] init];
                     updatedState.primaryGraphic = testStaticIcon;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
                     [testOp start];
                 });
 
@@ -1032,7 +1032,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState.primaryGraphic = testArtwork;
                     updatedState.secondaryGraphic = testArtwork2;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
                     [testOp start];
                 });
 
@@ -1059,7 +1059,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState.primaryGraphic = testArtwork;
                     updatedState.secondaryGraphic = testArtwork2;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     expect(testConnectionManager.receivedRequests).to(haveCount(1));
@@ -1088,7 +1088,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState.primaryGraphic = testArtwork;
                     updatedState.secondaryGraphic = testArtwork2;
 
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {} updateCompletionHandler:nil];
                     [testOp start];
 
                     expect(testConnectionManager.receivedRequests).to(haveCount(1));
@@ -1121,7 +1121,7 @@ describe(@"the text and graphic operation", ^{
                 beforeEach(^{
                     updatedState = [[SDLTextAndGraphicState alloc] init];
                     updatedState.templateConfig = newConfiguration;
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:allEnabledCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:allEnabledCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {
                         receivedState = newScreenData;
                         receivedError = error;
                     } updateCompletionHandler:nil];
@@ -1153,7 +1153,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState = [[SDLTextAndGraphicState alloc] init];
                     updatedState.templateConfig = newConfiguration;
                     updatedState.textField1 = field1String;
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:allEnabledCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:allEnabledCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {
                         receivedState = newScreenData;
                         receivedError = error;
                     } updateCompletionHandler:^(NSError * _Nullable error) {
@@ -1240,7 +1240,7 @@ describe(@"the text and graphic operation", ^{
                 beforeEach(^{
                     updatedState = [[SDLTextAndGraphicState alloc] init];
                     updatedState.templateConfig = newConfiguration;
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:allEnabledCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:allEnabledCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {
                         receivedState = newScreenData;
                         receivedError = error;
                     } updateCompletionHandler:nil];
@@ -1266,7 +1266,7 @@ describe(@"the text and graphic operation", ^{
                     updatedState = [[SDLTextAndGraphicState alloc] init];
                     updatedState.templateConfig = newConfiguration;
                     updatedState.textField1 = field1String;
-                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:allEnabledCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {
+                    testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:allEnabledCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error, SDLTextAndGraphicState *_Nullable errorScreenData) {
                         receivedState = newScreenData;
                         receivedError = error;
                     } updateCompletionHandler:nil];

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicUpdateOperationSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicUpdateOperationSpec.m
@@ -802,8 +802,20 @@ describe(@"the text and graphic operation", ^{
         beforeEach(^{
             updatedState = [[SDLTextAndGraphicState alloc] init];
             updatedState.textField1 = field1String;
+            updatedState.textField2 = field2String;
+            updatedState.textField3 = field3String;
+            updatedState.textField4 = field4String;
+            updatedState.mediaTrackTextField = mediaTrackString;
+            updatedState.title = titleString;
             updatedState.primaryGraphic = testArtwork;
             updatedState.secondaryGraphic = testArtwork2;
+            updatedState.alignment = SDLTextAlignmentLeft;
+            updatedState.textField1Type = SDLMetadataTypeMediaTitle;
+            updatedState.textField2Type = SDLMetadataTypeMediaArtist;
+            updatedState.textField3Type = SDLMetadataTypeMediaAlbum;
+            updatedState.textField4Type = SDLMetadataTypeMediaYear;
+
+            emptyCurrentData = [[SDLTextAndGraphicState alloc] init];
 
             testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {} updateCompletionHandler:nil];
             [testOp start];
@@ -811,30 +823,87 @@ describe(@"the text and graphic operation", ^{
 
         it(@"should reset to current screen data for equivalent properties in updated state and error state", ^{
             // Create an error state that matches the updated state, which should reset the updated state
-            SDLTextAndGraphicState *errorState = [[SDLTextAndGraphicState alloc] init];
-            errorState.textField1 = updatedState.textField1;
-            errorState.primaryGraphic = updatedState.primaryGraphic;
-            errorState.secondaryGraphic = updatedState.secondaryGraphic;
+            SDLTextAndGraphicState *errorState = [updatedState copy];
+            errorState.primaryGraphic = testArtwork;
+            errorState.secondaryGraphic = testArtwork2;
 
             [testOp updateTargetStateWithErrorState:errorState];
 
             expect(updatedState.textField1).to(beNil());
+            expect(updatedState.textField2).to(beNil());
+            expect(updatedState.textField3).to(beNil());
+            expect(updatedState.textField4).to(beNil());
+            expect(updatedState.mediaTrackTextField).to(beNil());
+            expect(updatedState.title).to(beNil());
             expect(updatedState.primaryGraphic).to(beNil());
             expect(updatedState.secondaryGraphic).to(beNil());
+            expect(updatedState.textField1Type).to(beNil());
+            expect(updatedState.textField2Type).to(beNil());
+            expect(updatedState.textField3Type).to(beNil());
+            expect(updatedState.textField4Type).to(beNil());
         });
 
         it(@"should not reset to current screen data for non equivalent properties in updated state and error state", ^{
+            // Save an original of the updatedState for confirming no changes later
+            SDLTextAndGraphicState *originalState = [updatedState copy];
+            originalState.primaryGraphic = testArtwork;
+            originalState.secondaryGraphic = testArtwork2;
+
             // Create an error state that does not match the updated state, which should not reset the updated state
             SDLTextAndGraphicState *errorState = [[SDLTextAndGraphicState alloc] init];
-            errorState.textField1 = nil;
-            errorState.primaryGraphic = nil;
-            errorState.secondaryGraphic = nil;
+            errorState.textField1 = @"Error Text";
+            errorState.textField2 = @"Error Text";
+            errorState.textField3 = @"Error Text";
+            errorState.textField4 = @"Error Text";
+            errorState.mediaTrackTextField = @"Error Text";
+            errorState.title = @"Error Text";
+            errorState.primaryGraphic = testArtwork2;
+            errorState.secondaryGraphic = testArtwork;
+            errorState.alignment = SDLTextAlignmentRight;
+            errorState.textField1Type = SDLMetadataTypeMediaYear;
+            errorState.textField2Type = SDLMetadataTypeMediaAlbum;
+            errorState.textField3Type = SDLMetadataTypeMediaArtist;
+            errorState.textField4Type = SDLMetadataTypeMediaTitle;
 
             [testOp updateTargetStateWithErrorState:errorState];
 
-            expect(updatedState.textField1).toNot(beNil());
-            expect(updatedState.primaryGraphic).toNot(beNil());
-            expect(updatedState.secondaryGraphic).toNot(beNil());
+            expect(updatedState.textField1).to(equal(originalState.textField1));
+            expect(updatedState.textField2).to(equal(originalState.textField2));
+            expect(updatedState.textField3).to(equal(originalState.textField3));
+            expect(updatedState.textField4).to(equal(originalState.textField4));
+            expect(updatedState.mediaTrackTextField).to(equal(originalState.mediaTrackTextField));
+            expect(updatedState.title).to(equal(originalState.title));
+            expect(updatedState.primaryGraphic).to(equal(originalState.primaryGraphic));
+            expect(updatedState.secondaryGraphic).to(equal(originalState.secondaryGraphic));
+            expect(updatedState.textField1Type).to(equal(originalState.textField1Type));
+            expect(updatedState.textField2Type).to(equal(originalState.textField2Type));
+            expect(updatedState.textField3Type).to(equal(originalState.textField3Type));
+            expect(updatedState.textField4Type).to(equal(originalState.textField4Type));
+        });
+
+        it(@"should not reset to current screen data for nil error state", ^{
+            // Save an original of the updatedState for confirming no changes later
+            SDLTextAndGraphicState *originalState = [updatedState copy];
+            originalState.primaryGraphic = testArtwork;
+            originalState.secondaryGraphic = testArtwork2;
+
+            // Create an empty error state
+            SDLTextAndGraphicState *errorState = [[SDLTextAndGraphicState alloc] init];
+
+            [testOp updateTargetStateWithErrorState:errorState];
+
+            expect(updatedState.textField1).to(equal(originalState.textField1));
+            expect(updatedState.textField2).to(equal(originalState.textField2));
+            expect(updatedState.textField3).to(equal(originalState.textField3));
+            expect(updatedState.textField4).to(equal(originalState.textField4));
+            expect(updatedState.mediaTrackTextField).to(equal(originalState.mediaTrackTextField));
+            expect(updatedState.title).to(equal(originalState.title));
+            expect(updatedState.primaryGraphic).to(equal(originalState.primaryGraphic));
+            expect(updatedState.secondaryGraphic).to(equal(originalState.secondaryGraphic));
+            expect(updatedState.textField1Type).to(equal(originalState.textField1Type));
+            expect(updatedState.textField2Type).to(equal(originalState.textField2Type));
+            expect(updatedState.textField3Type).to(equal(originalState.textField3Type));
+            expect(updatedState.textField4Type).to(equal(originalState.textField4Type));
         });
     });
 

--- a/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicUpdateOperationSpec.m
+++ b/SmartDeviceLinkTests/DevAPISpecs/SDLTextAndGraphicUpdateOperationSpec.m
@@ -780,7 +780,7 @@ describe(@"the text and graphic operation", ^{
                 updatedState.textField3 = field3String;
                 updatedState.textField4 = field4String;
 
-                testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState * _Nullable newScreenData, NSError * _Nullable error) {
+                testOp = [[SDLTextAndGraphicUpdateOperation alloc] initWithConnectionManager:testConnectionManager fileManager:mockFileManager currentCapabilities:windowCapability currentScreenData:emptyCurrentData newState:updatedState currentScreenDataUpdatedHandler:^(SDLTextAndGraphicState *_Nullable newScreenData, NSError *_Nullable error) {
                     updatedData = newScreenData;
                 } updateCompletionHandler:nil];
                 [testOp start];


### PR DESCRIPTION
Fixes #1781 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Created two unit tests in `SDLTextAndGraphicManagerSpec`. One to test without batching if invidual operations are created and not cancelled. Another, to test the currentDataUpdatedHandler when given the error state.

#### Core Tests
In manticore verified that properties in screen manager when set would not fail when one attribute was given bad data.

Core version / branch / commit hash / module tested against: sdl_core 8.1.0 (manticore)
HMI name / version / branch / commit hash / module tested against: generic_hmi 0.12.0 (manticore)

### Summary
- Removed cancellation of mutliple `SDLTextAndGraphicUpdateOperation`.
- In `sdl_updatePendingOperationsWithNewScreenData` update pending operations updated state property based on previously failed updates.
- Add errorScreenData parameter to `currentScreenDataUpdatedHandler`.
- In `SDLTextAndGraphicUpdateOperation` add method to updated teh state with error data.
- Added additional unit test.

### Changelog

##### Enhancements
* Update screen data even if other screen properties were given bad data.

##### Bug Fixes
* Update screen data even if other screen properties were given bad data.

### Tasks Remaining:
- [x] [Create Fix]
- [x] [Add unit test
- [ ] [Code review]

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
