### PR TITLE
deprecate didReceivePinchInView function

### DIFF
--- a/SmartDeviceLink/public/SDLTouchManagerDelegate.h
+++ b/SmartDeviceLink/public/SDLTouchManagerDelegate.h
@@ -99,7 +99,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param point Center point of the pinch in the head unit's coordinate system
  @param scale Scale relative to the distance between touch points
  */
-- (void)touchManager:(SDLTouchManager *)manager didReceivePinchInView:(UIView *_Nullable)view atCenterPoint:(CGPoint)point withScale:(CGFloat)scale __deprecated_msg("Use didReceivePinchAtCenterPoint:withScale: instead");
+- (void)touchManager:(SDLTouchManager *)manager didReceivePinchInView:(UIView *_Nullable)view atCenterPoint:(CGPoint)point withScale:(CGFloat)scale __deprecated_msg("Use touchManager:didReceivePinchAtCenterPoint:withScale: instead");
 
 /**
  Pinch did end

--- a/SmartDeviceLink/public/SDLTouchManagerDelegate.h
+++ b/SmartDeviceLink/public/SDLTouchManagerDelegate.h
@@ -99,7 +99,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param point Center point of the pinch in the head unit's coordinate system
  @param scale Scale relative to the distance between touch points
  */
-- (void)touchManager:(SDLTouchManager *)manager didReceivePinchInView:(UIView *_Nullable)view atCenterPoint:(CGPoint)point withScale:(CGFloat)scale;
+- (void)touchManager:(SDLTouchManager *)manager didReceivePinchInView:(UIView *_Nullable)view atCenterPoint:(CGPoint)point withScale:(CGFloat)scale __deprecated_msg("Use didReceivePinchAtCenterPoint:withScale: instead");
 
 /**
  Pinch did end


### PR DESCRIPTION
Fixes #1637 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
No unit tests needed. Function was deprecated and never used in the code base.

#### Core Tests
No core tests needed. Function was deprecated and never used in the code base.

Core version / branch / commit hash / module tested against: sdl_core 8.1.0 (manticore)
HMI name / version / branch / commit hash / module tested against: generic_hmi 0.12.0 (manticore)

### Summary
Deprectated with a message `didReceivePinchInView` in `SDLTouchManagerDelegate`.

### Changelog
##### Breaking Changes
* NA

##### Enhancements
* [NA

##### Bug Fixes
* Add a deprecation warning to `didReceivePinchInView`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
