### PR TITLE
Fix overwriting alert view images not being shown

### DIFF
--- a/SmartDeviceLink/private/SDLPresentAlertOperation.m
+++ b/SmartDeviceLink/private/SDLPresentAlertOperation.m
@@ -213,7 +213,7 @@ static const int SDLAlertSoftButtonCount = 4;
             if ([self.fileManager fileNeedsUpload:object.currentState.artwork]) {
                 [artworksToBeUploaded addObject:object.currentState.artwork];
             } else if ([self.fileManager hasUploadedFile:object.currentState.artwork] || object.currentState.artwork.isStaticIcon) {
-                [self.uploadedImageNames addObject:self.alertView.icon.name];
+                [self.uploadedImageNames addObject:object.currentState.artwork.name];
             }
         }
     }

--- a/SmartDeviceLinkTests/SDLPresentAlertOperationSpec.m
+++ b/SmartDeviceLinkTests/SDLPresentAlertOperationSpec.m
@@ -636,6 +636,25 @@ describe(@"SDLPresentAlertOperation", ^{
                 OCMVerifyAll(strictMockSystemCapabilityManager);
                 OCMVerifyAll(strictMockCurrentWindowCapability);
             });
+
+            fit(@"should not upload the image if the alert icon is a static icon", ^{
+                SDLAlertView *alertView = [[SDLAlertView alloc] initWithText:@"Test" secondaryText:nil tertiaryText:nil timeout:nil showWaitIndicator:nil audioIndication:nil buttons:nil icon:[SDLArtwork artworkWithStaticIcon:SDLStaticIconNameKey]];
+                testPresentAlertOperation = [[SDLPresentAlertOperation alloc] initWithConnectionManager:mockConnectionManager fileManager:strictMockFileManager systemCapabilityManager:strictMockSystemCapabilityManager currentWindowCapability:strictMockCurrentWindowCapability alertView:alertView cancelID:testCancelID];
+
+                OCMStub([strictMockCurrentWindowCapability hasImageFieldOfName:SDLImageFieldNameAlertIcon]).andReturn(YES);
+                OCMStub([strictMockFileManager hasUploadedFile:[OCMArg any]]).andReturn(NO);
+                OCMStub([strictMockFileManager fileNeedsUpload:[OCMArg any]]).andReturn(NO);
+
+                OCMReject([strictMockFileManager uploadArtworks:[OCMArg any] progressHandler:[OCMArg any] completionHandler:[OCMArg any]]);
+
+                [testPresentAlertOperation start];
+
+                OCMVerifyAll(strictMockFileManager);
+                OCMVerifyAll(strictMockSystemCapabilityManager);
+                OCMVerifyAll(strictMockCurrentWindowCapability);
+                expect(testPresentAlertOperation.alertIconUploaded).to(beTrue());
+                expect(testPresentAlertOperation.alertRPC.alertIcon).toNot(beNil());
+            });
         });
     });
 

--- a/SmartDeviceLinkTests/SDLPresentAlertOperationSpec.m
+++ b/SmartDeviceLinkTests/SDLPresentAlertOperationSpec.m
@@ -42,6 +42,7 @@
 @property (strong, nonatomic, readwrite) SDLAlertView *alertView;
 @property (assign, nonatomic) UInt16 cancelId;
 @property (copy, nonatomic, nullable) NSError *internalError;
+@property (strong, nonatomic) NSSet<NSString *> *uploadedImageNames;
 
 - (nullable NSError *)sdl_isValidAlertViewData:(SDLAlertView *)alertView;
 - (SDLAlert *)alertRPC;
@@ -365,16 +366,16 @@ describe(@"SDLPresentAlertOperation", ^{
                 testPresentAlertOperation = [[SDLPresentAlertOperation alloc] initWithConnectionManager:mockConnectionManager fileManager:mockFileManager systemCapabilityManager:mockSystemCapabilityManager currentWindowCapability:mockCurrentWindowCapability alertView:testAlertView cancelID:testCancelID];
             });
 
-            it(@"should set the image if icons are supported on the module", ^{
-                OCMStub([mockCurrentWindowCapability hasImageFieldOfName:SDLImageFieldNameAlertIcon]).andReturn(YES);
+            it(@"should not set the image if it fails to upload to the module", ^{
                 SDLAlert *testAlert = testPresentAlertOperation.alertRPC;
-                expect(testAlert.alertIcon.value).to(equal(testAlertView.icon.name));
+                expect(testAlert.alertIcon.value).to(beNil());
             });
 
-            it(@"should not set the image if icons are not supported on the module", ^{
-                OCMStub([mockCurrentWindowCapability hasImageFieldOfName:SDLImageFieldNameAlertIcon]).andReturn(NO);
+            it(@"should set the image if it is uploaded to the module", ^{
+                testPresentAlertOperation.uploadedImageNames = [NSSet setWithObject:testAlertView.icon.name];
+
                 SDLAlert *testAlert = testPresentAlertOperation.alertRPC;
-                expect(testAlert.alertIcon).to(beNil());
+                expect(testAlert.alertIcon.value).to(equal(testAlertView.icon.name));
             });
         });
     });
@@ -781,6 +782,7 @@ describe(@"SDLPresentAlertOperation", ^{
 
                 testAlertViewWithExtraSoftButtons = [[SDLAlertView alloc] initWithText:@"text" secondaryText:@"secondaryText" tertiaryText:@"tertiaryText" timeout:@(4) showWaitIndicator:@(YES) audioIndication:testAlertAudioData buttons:@[testAlertSoftButton1, testAlertSoftButton2, testAlertSoftButton3, testAlertSoftButton4, testAlertSoftButton5, testAlertSoftButton6] icon:testAlertIcon];
                 testPresentAlertOperation = [[SDLPresentAlertOperation alloc] initWithConnectionManager:mockConnectionManager fileManager:mockFileManager systemCapabilityManager:mockSystemCapabilityManager currentWindowCapability:mockCurrentWindowCapability alertView:testAlertViewWithExtraSoftButtons cancelID:testCancelID];
+                testPresentAlertOperation.uploadedImageNames = [NSSet setWithObject:testAlertViewWithExtraSoftButtons.icon.name];
 
                 testPresentAlertOperation.completionBlock = ^{
                     hasCalledOperationCompletionHandler = YES;
@@ -829,7 +831,7 @@ describe(@"SDLPresentAlertOperation", ^{
                 testSoftButtonCapabilities.imageSupported = @YES;
                 OCMStub([mockCurrentWindowCapability softButtonCapabilities]).andReturn(@[testSoftButtonCapabilities]);
                 OCMStub([mockFileManager fileNeedsUpload:[OCMArg any]]).andReturn(YES);
-                OCMStub([mockFileManager uploadArtworks:[OCMArg any] progressHandler:[OCMArg invokeBlock] completionHandler:([OCMArg invokeBlockWithArgs: @[testAlertView.icon.name], [NSNull null], nil])]);
+                OCMStub([mockFileManager uploadArtworks:[OCMArg any] progressHandler:[OCMArg invokeBlock] completionHandler:([OCMArg invokeBlockWithArgs: @[], [NSNull null], nil])]);
                 OCMStub([mockFileManager uploadFiles:[OCMArg any] progressHandler:[OCMArg invokeBlock] completionHandler:[OCMArg invokeBlock]]);
 
                 SDLVersion *supportedVersion = [SDLVersion versionWithMajor:6 minor:3 patch:0];
@@ -883,8 +885,8 @@ describe(@"SDLPresentAlertOperation", ^{
                 SDLSoftButtonCapabilities *testSoftButtonCapabilities = [[SDLSoftButtonCapabilities alloc] init];
                 testSoftButtonCapabilities.imageSupported = @YES;
                 OCMStub([mockCurrentWindowCapability softButtonCapabilities]).andReturn(@[testSoftButtonCapabilities]);
-                OCMStub([mockFileManager fileNeedsUpload:[OCMArg any]]).andReturn(NO);
-                OCMStub([mockFileManager uploadArtworks:[OCMArg any] progressHandler:[OCMArg invokeBlock] completionHandler:[OCMArg invokeBlock]]);
+                OCMStub([mockFileManager fileNeedsUpload:[OCMArg any]]).andReturn(YES);
+                OCMStub([mockFileManager uploadArtworks:[OCMArg any] progressHandler:[OCMArg invokeBlock] completionHandler:([OCMArg invokeBlockWithArgs: @[testAlertView.icon.name], [NSNull null], nil])]);
                 OCMStub([mockFileManager uploadFiles:[OCMArg any] progressHandler:[OCMArg invokeBlock] completionHandler:[OCMArg invokeBlock]]);
 
                 SDLVersion *supportedVersion = [SDLVersion versionWithMajor:6 minor:3 patch:0];

--- a/SmartDeviceLinkTests/SDLPresentAlertOperationSpec.m
+++ b/SmartDeviceLinkTests/SDLPresentAlertOperationSpec.m
@@ -637,7 +637,7 @@ describe(@"SDLPresentAlertOperation", ^{
                 OCMVerifyAll(strictMockCurrentWindowCapability);
             });
 
-            fit(@"should not upload the image if the alert icon is a static icon", ^{
+            it(@"should not upload the image if the alert icon is a static icon", ^{
                 SDLAlertView *alertView = [[SDLAlertView alloc] initWithText:@"Test" secondaryText:nil tertiaryText:nil timeout:nil showWaitIndicator:nil audioIndication:nil buttons:nil icon:[SDLArtwork artworkWithStaticIcon:SDLStaticIconNameKey]];
                 testPresentAlertOperation = [[SDLPresentAlertOperation alloc] initWithConnectionManager:mockConnectionManager fileManager:strictMockFileManager systemCapabilityManager:strictMockSystemCapabilityManager currentWindowCapability:strictMockCurrentWindowCapability alertView:alertView cancelID:testCancelID];
 

--- a/SmartDeviceLinkTests/SDLPresentAlertOperationSpec.m
+++ b/SmartDeviceLinkTests/SDLPresentAlertOperationSpec.m
@@ -42,7 +42,7 @@
 @property (strong, nonatomic, readwrite) SDLAlertView *alertView;
 @property (assign, nonatomic) UInt16 cancelId;
 @property (copy, nonatomic, nullable) NSError *internalError;
-@property (strong, nonatomic) NSSet<NSString *> *uploadedImageNames;
+@property (assign, nonatomic) BOOL alertIconUploaded;
 
 - (nullable NSError *)sdl_isValidAlertViewData:(SDLAlertView *)alertView;
 - (SDLAlert *)alertRPC;
@@ -372,7 +372,7 @@ describe(@"SDLPresentAlertOperation", ^{
             });
 
             it(@"should set the image if it is uploaded to the module", ^{
-                testPresentAlertOperation.uploadedImageNames = [NSSet setWithObject:testAlertView.icon.name];
+                testPresentAlertOperation.alertIconUploaded = YES;
 
                 SDLAlert *testAlert = testPresentAlertOperation.alertRPC;
                 expect(testAlert.alertIcon.value).to(equal(testAlertView.icon.name));
@@ -782,7 +782,7 @@ describe(@"SDLPresentAlertOperation", ^{
 
                 testAlertViewWithExtraSoftButtons = [[SDLAlertView alloc] initWithText:@"text" secondaryText:@"secondaryText" tertiaryText:@"tertiaryText" timeout:@(4) showWaitIndicator:@(YES) audioIndication:testAlertAudioData buttons:@[testAlertSoftButton1, testAlertSoftButton2, testAlertSoftButton3, testAlertSoftButton4, testAlertSoftButton5, testAlertSoftButton6] icon:testAlertIcon];
                 testPresentAlertOperation = [[SDLPresentAlertOperation alloc] initWithConnectionManager:mockConnectionManager fileManager:mockFileManager systemCapabilityManager:mockSystemCapabilityManager currentWindowCapability:mockCurrentWindowCapability alertView:testAlertViewWithExtraSoftButtons cancelID:testCancelID];
-                testPresentAlertOperation.uploadedImageNames = [NSSet setWithObject:testAlertViewWithExtraSoftButtons.icon.name];
+                testPresentAlertOperation.alertIconUploaded = YES;
 
                 testPresentAlertOperation.completionBlock = ^{
                     hasCalledOperationCompletionHandler = YES;


### PR DESCRIPTION
Fixes #2109

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Updated the present alert operation tests to handle the new checks.

#### Core Tests
* Uploaded an image with a particular name, then tried to present an alert with a new overwriting image with the same name.

[sdl_ios-9-18-01-AM.patch.zip](https://github.com/smartdevicelink/sdl_ios/files/9626109/sdl_ios-9-18-01-AM.patch.zip)

Core version / branch / commit hash / module tested against: Manticore (Core v8.1)
HMI name / version / branch / commit hash / module tested against: Manticore (Generic_HMI v0.12.0

### Summary
This PR changes some logic around how the present alert operation handles showing the alert icon image to fix an issue with showing overwriting images.

### Changelog
##### Bug Fixes
* Fixes screen manager present alert not showing the icon if it was marked to overwrite another.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
