### PR TITLE
Fix iAP write data range error

### DIFF
--- a/SmartDeviceLink/private/SDLIAPDataSession.m
+++ b/SmartDeviceLink/private/SDLIAPDataSession.m
@@ -58,10 +58,14 @@ NS_ASSUME_NONNULL_BEGIN
             if (bytesWritten >= 0) {
                 if (bytesWritten == bytesRemaining) {
                     [self.sendDataQueue popBuffer];
-                } else {
+                } else if (bytesRemaining > bytesWritten) {
                     // Cleave the sent bytes from the data, the remainder will sit at the head of the queue
                     SDLLogV(@"SDLIAPDataSession writeDataToSessionStream bytes written %ld", (long)bytesWritten);
                     [remainder replaceBytesInRange:NSMakeRange(0, (NSUInteger)bytesWritten) withBytes:NULL length:0];
+                } else {
+                    // Error processing current data. Remove corrupted buffer
+                    SDLLogE(@"Unable to remove sent bytes. Bytes remaining is less than bytes written %lu < %lu. Clearing buffer", bytesRemaining, bytesWritten);
+                    [self.sendDataQueue popBuffer];
                 }
             } else {
                 // The write operation failed but there is no further information about the error. This can occur when disconnecting from an external accessory.


### PR DESCRIPTION
Fixes #2112

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
No unit tests added to this PR

#### Core Tests
Connected sdl example app on ford tdk via iAP. In debug mode made an instance when `bytesRemaining` was less than `bytesWritten` and verified that error messaging and correction would run.

Core version / branch / commit hash / module tested against: TDK Sync 3.4
HMI name / version / branch / commit hash / module tested against: TDK Sync 3.4

### Summary
Added a check `writeDataToSessionStream` to verify that the `bytesRemaining` was greather than `bytesWritten` when trying to send the value back to the `sendDataQueue`.  Also, added error messaging in the case when `bytesWritten` is greater than `bytesRemaining` and added functionality to pop the current buffer if this happens.

### Changelog
##### Bug Fixes
* Add check when trying to make a valid range
* Add error handling and correction when trying to make an invalid range.

### Tasks Remaining:
- [ ] Test on older sync hardware. Was unable reproduce issue on TDK Sync 3.4. (This Friday potentially 10/14/22)

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
