### PR TITLE
Fixed SDL App Crash - index out of range in replaceBytesInRange

### DIFF
--- a/SmartDeviceLink/private/SDLIAPDataSession.m
+++ b/SmartDeviceLink/private/SDLIAPDataSession.m
@@ -62,7 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
                     // Cleave the sent bytes from the data, the remainder will sit at the head of the queue
                     @try {
                         SDLLogV(@"SDLIAPDataSession writeDataToSessionStream bytes written %ld", (long)bytesWritten);
-                        NSData *rem = [remainder subdataWithRange:NSMakeRange((NSUInteger)bytesWritten, remainder.length - 1)];
+                        NSData *rem = [remainder subdataWithRange:NSMakeRange((NSUInteger)bytesWritten, remainder.length - (NSUInteger)bytesWritten)];
                         [remainder setLength:[rem length]];
                         [remainder setData:rem];
                     } @catch (NSException __unused *exception) {

--- a/SmartDeviceLink/private/SDLIAPDataSession.m
+++ b/SmartDeviceLink/private/SDLIAPDataSession.m
@@ -58,10 +58,24 @@ NS_ASSUME_NONNULL_BEGIN
             if (bytesWritten >= 0) {
                 if (bytesWritten == bytesRemaining) {
                     [self.sendDataQueue popBuffer];
-                } else if (bytesRemaining > bytesWritten) {
+                } else if (bytesRemaining > bytesWritten && remainder.length > bytesWritten) {
                     // Cleave the sent bytes from the data, the remainder will sit at the head of the queue
-                    SDLLogV(@"SDLIAPDataSession writeDataToSessionStream bytes written %ld", (long)bytesWritten);
-                    [remainder replaceBytesInRange:NSMakeRange(0, (NSUInteger)bytesWritten) withBytes:NULL length:0];
+                    @try {
+                        SDLLogV(@"SDLIAPDataSession writeDataToSessionStream bytes written %ld", (long)bytesWritten);
+                        NSData *rem = [remainder subdataWithRange:NSMakeRange((NSUInteger)bytesWritten, remainder.length - 1)];
+                        [remainder setLength:[rem length]];
+                        [remainder setData:rem];
+                    } @catch (NSException __unused *exception) {
+                        SDLLogE(@"Unable to remove sent bytes using the subDataWithRange method. Will try with replaceBytesInRange:");
+                        @try {
+                            SDLLogV(@"SDLIAPDataSession writeDataToSessionStream bytes written %ld", (long)bytesWritten);
+                            [remainder replaceBytesInRange:NSMakeRange(0, (NSUInteger)bytesWritten) withBytes:NULL length:0];
+                        } @catch (NSException *exception) {
+                            // Error processing current data. Remove corrupted buffer
+                            SDLLogE(@"Unable to remove sent bytes. Bytes remaining is less than bytes written %lu < %lu. Clearing buffer", bytesRemaining, bytesWritten);
+                            [self.sendDataQueue popBuffer];
+                        }
+                    }
                 } else {
                     // Error processing current data. Remove corrupted buffer
                     SDLLogE(@"Unable to remove sent bytes. Bytes remaining is less than bytes written %lu < %lu. Clearing buffer", bytesRemaining, bytesWritten);


### PR DESCRIPTION
Fixes #2112 

### Risk
This PR makes **[minor]** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [ ] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
N/A

#### Core Tests
Run these changes with the example navigation app test app and forced this crash into occurinng.

Core version / branch / commit hash / module tested against: 8.2.0 | WorkBench
HMI name / version / branch / commit hash / module tested against: generic_hmi 0.13 | Workbench

### Summary
Add safety blocks on the unsent bytes process to avoid crashes

### Changelog
##### Breaking Changes
- Implemented an alternative for `replaceBytesInRange:` func.
- Added try/catch to wrap the exception

##### Enhancements
* N/A

##### Bug Fixes
* N/A

### Tasks Remaining:
- [x] Retest on workbench

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
